### PR TITLE
feat(workspace): add agentic context layer — CLAUDE.md, agents.md, and skills

### DIFF
--- a/.agents/skills
+++ b/.agents/skills
@@ -1,0 +1,1 @@
+../.codex/skills

--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../.codex/skills

--- a/.codex/skills/_index.md
+++ b/.codex/skills/_index.md
@@ -1,0 +1,17 @@
+# Skill Registry
+
+Last updated: 2026-03-14
+
+| Skill                      | File                          | Triggers                                                    | Priority |
+|----------------------------|-------------------------------|-------------------------------------------------------------|----------|
+| Rust Development           | rust-development.md           | implement, code, type, struct, enum, trait, module           | Core     |
+| Provider Integration       | provider-integration.md       | provider, cosmos, runway, jepa, genie, adapter, API          | Core     |
+| Testing Strategy           | testing-strategy.md           | test, spec, coverage, proptest, criterion, benchmark, mock   | Core     |
+| Specification-Driven Dev   | specification-driven-dev.md   | specification, spec, design, types, implement from spec      | Core     |
+
+## Missing Skills (Recommended)
+- [ ] debugging.md — Rust debugging, tracing analysis, common worldforge error patterns
+- [ ] zk-verification.md — ZK proof generation patterns, Cairo/STARK integration
+- [ ] python-bindings.md — PyO3 patterns, Python API design, type marshaling
+- [ ] deployment.md — CI/CD, release process, crate publishing
+- [ ] performance.md — Criterion benchmarks, profiling, latency budget compliance

--- a/.codex/skills/provider-integration.md
+++ b/.codex/skills/provider-integration.md
@@ -1,0 +1,116 @@
+---
+name: provider-integration
+description: How to implement a WorldModelProvider adapter for WorldForge. Activate when creating a new provider (Cosmos, Runway, JEPA, Genie), modifying provider logic, or working with external world model APIs. Also activate when discussing provider capabilities, action translation, or multi-provider comparison.
+prerequisites: worldforge-core types compiled, provider API access or docs
+---
+
+# Provider Integration
+
+<purpose>
+Guides implementation of provider adapters that connect WorldForge to external world model APIs (NVIDIA Cosmos, Runway GWM, Meta JEPA, Google Genie). Each provider implements the WorldModelProvider trait from worldforge-core.
+</purpose>
+
+<context>
+— Provider trait defined in SPECIFICATION.md section 4.
+— Provider mappings in SPECIFICATION.md section 13.
+— All provider code lives in crates/worldforge-providers/src/.
+— Each provider is a separate module (cosmos.rs, runway.rs, jepa.rs, genie.rs).
+— Providers must handle: authentication, HTTP calls, action translation, response parsing.
+— Provider capabilities are introspectable via ProviderCapabilities struct.
+</context>
+
+<procedure>
+1. Read SPECIFICATION.md section 4 (Provider Trait) and section 13 (Provider Specs) for the target provider.
+2. Create module file: `crates/worldforge-providers/src/{provider_name}.rs`.
+3. Define provider struct with config fields (api_key, endpoint, model enum).
+4. Implement `WorldModelProvider` trait:
+   — `name()` → static provider name
+   — `capabilities()` → what this provider can do
+   — `predict()` → main inference call
+   — `generate()` → video generation (if supported)
+   — `reason()` → VLM-style reasoning (if supported)
+   — `transfer()` → spatial control to video (if supported)
+   — `health_check()` → verify connectivity
+   — `estimate_cost()` → cost estimation
+5. Implement `ActionTranslator` for provider-specific action mapping.
+6. Handle authentication (API keys from environment or config).
+7. Write integration tests with mock HTTP responses.
+8. Re-export from `crates/worldforge-providers/src/lib.rs`.
+</procedure>
+
+<patterns>
+<do>
+  — Return `WorldForgeError::UnsupportedCapability` for operations the provider doesn't support.
+  — Use reqwest with timeout and retry logic for HTTP calls.
+  — Log all provider calls with tracing (request metadata, latency, response status).
+  — Implement `health_check()` as a lightweight ping (not a full inference call).
+  — Map provider-specific errors to WorldForgeError variants.
+  — Use `#[cfg(test)]` mocks — don't require live API access for unit tests.
+</do>
+<dont>
+  — Don't hardcode API keys — read from config or environment variables.
+  — Don't add provider-specific types to worldforge-core — keep them in the provider module.
+  — Don't panic on provider errors — always return Result.
+  — Don't skip capability checking — verify the provider supports the requested operation.
+</dont>
+</patterns>
+
+<examples>
+Example: Provider struct and capability declaration
+
+```rust
+use worldforge_core::provider::{WorldModelProvider, ProviderCapabilities};
+
+pub struct CosmosProvider {
+    model: CosmosModel,
+    api_key: String,
+    endpoint: String,
+    client: reqwest::Client,
+}
+
+impl CosmosProvider {
+    pub fn new(model: CosmosModel, api_key: String) -> Self {
+        Self {
+            model,
+            api_key,
+            endpoint: "https://ai.api.nvidia.com".into(),
+            client: reqwest::Client::new(),
+        }
+    }
+}
+
+#[async_trait]
+impl WorldModelProvider for CosmosProvider {
+    fn name(&self) -> &str { "cosmos" }
+
+    fn capabilities(&self) -> ProviderCapabilities {
+        ProviderCapabilities {
+            predict: true,
+            generate: true,
+            reason: matches!(self.model, CosmosModel::Reason2),
+            transfer: matches!(self.model, CosmosModel::Transfer2_5),
+            // ...
+        }
+    }
+    // ...
+}
+```
+</examples>
+
+<troubleshooting>
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| Provider timeout | API latency > configured timeout | Increase timeout in PredictionConfig, check provider health |
+| 401 Unauthorized | Invalid or expired API key | Verify key, check provider dashboard |
+| UnsupportedCapability error | Calling predict() on a reason-only model | Check capabilities() before calling |
+| Serialization error on response | Provider API changed response format | Update response parsing, check provider changelog |
+
+</troubleshooting>
+
+<references>
+— SPECIFICATION.md section 4: Provider trait definition
+— SPECIFICATION.md section 13: Provider-specific mappings
+— crates/worldforge-core/src/provider.rs: trait definition (to be implemented)
+— crates/worldforge-providers/src/: provider implementations
+</references>

--- a/.codex/skills/rust-development.md
+++ b/.codex/skills/rust-development.md
@@ -1,0 +1,107 @@
+---
+name: rust-development
+description: Rust coding patterns, idioms, and workspace conventions for WorldForge. Activate when implementing any Rust code, adding types, writing modules, or working with the Cargo workspace. Also activate for refactoring, fixing clippy warnings, or reviewing Rust code.
+prerequisites: Rust 1.80+, cargo
+---
+
+# Rust Development
+
+<purpose>
+Guides implementation of Rust code within the WorldForge workspace. Covers type design, error handling, async patterns, and workspace conventions.
+</purpose>
+
+<context>
+— Workspace with 6 crates in crates/ directory.
+— All shared dependencies pinned in root Cargo.toml [workspace.dependencies].
+— Core crate (worldforge-core) defines all public types and traits.
+— Other crates depend on worldforge-core.
+— Async runtime: Tokio with full features.
+— Error pattern: thiserror for library errors, anyhow only in binaries.
+</context>
+
+<procedure>
+1. Identify which crate the code belongs in (core types → worldforge-core, provider code → worldforge-providers, etc.).
+2. Check if types/traits are defined in SPECIFICATION.md — implement to match.
+3. Add derives: `#[derive(Debug, Clone, Serialize, Deserialize)]` minimum for data types.
+4. Add `///` doc comments on all public items.
+5. Use `pub(crate)` for internal-only items.
+6. Write unit tests in `#[cfg(test)] mod tests {}` at bottom of file.
+7. Run `cargo clippy -- -D warnings` and `cargo fmt`.
+</procedure>
+
+<patterns>
+<do>
+  — Use `Result<T, WorldForgeError>` for all fallible operations in library code.
+  — Use `?` operator for error propagation — avoid explicit match on Result when possible.
+  — Use `#[instrument]` from tracing on async functions.
+  — Use workspace dependency references: `dep = { workspace = true }` in crate Cargo.toml.
+  — Use `impl From<ExternalError> for WorldForgeError` for error conversion.
+  — Use builder pattern for config structs with many optional fields.
+  — Group imports: std → external → workspace → local, separated by blank lines.
+</do>
+<dont>
+  — Don't use `.unwrap()` or `.expect()` in library code — propagate errors.
+  — Don't use `println!` — use `tracing::{info, debug, warn, error}`.
+  — Don't add deps to individual crate Cargo.toml without adding to workspace first.
+  — Don't use `Box<dyn Error>` — use the typed WorldForgeError enum.
+  — Don't make fields `pub` by default — use accessor methods for encapsulation.
+</dont>
+</patterns>
+
+<examples>
+Example: Adding a new type to worldforge-core
+
+```rust
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// Unique identifier for a world instance.
+pub type WorldId = Uuid;
+
+/// Complete state of a simulated world at a point in time.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorldState {
+    /// Unique world identifier.
+    pub id: WorldId,
+    /// Current simulation time.
+    pub time: SimTime,
+    /// Scene graph with all objects.
+    pub scene: SceneGraph,
+    /// History of previous states.
+    pub history: StateHistory,
+    /// Additional metadata.
+    pub metadata: WorldMetadata,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn world_state_serialization_roundtrip() {
+        let state = WorldState { /* ... */ };
+        let json = serde_json::to_string(&state).unwrap();
+        let deserialized: WorldState = serde_json::from_str(&json).unwrap();
+        assert_eq!(state.id, deserialized.id);
+    }
+}
+```
+</examples>
+
+<troubleshooting>
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `workspace dependency not found` | Dep not in root Cargo.toml | Add to `[workspace.dependencies]` first |
+| `trait bound not satisfied: Send` | Holding non-Send type across await | Use `Arc<Mutex<T>>` or restructure to drop before await |
+| `lifetime error on async trait` | Missing `async-trait` macro | Add `#[async_trait]` to trait and impl |
+| `unused import` warning | Over-importing | Remove unused, run `cargo fix` |
+
+</troubleshooting>
+
+<references>
+— Cargo.toml (workspace root): workspace dependency definitions
+— crates/worldforge-core/Cargo.toml: core crate dependencies
+— SPECIFICATION.md: type definitions and API contracts
+— architecture/ADR.md: rationale for architectural decisions
+</references>

--- a/.codex/skills/specification-driven-dev.md
+++ b/.codex/skills/specification-driven-dev.md
@@ -1,0 +1,106 @@
+---
+name: specification-driven-dev
+description: How to translate SPECIFICATION.md into working Rust implementation. Activate when implementing types from the spec, cross-referencing spec sections, or resolving ambiguities between spec and code. Also activate when the spec needs updating after implementation discoveries.
+prerequisites: SPECIFICATION.md read, worldforge-core crate
+---
+
+# Specification-Driven Development
+
+<purpose>
+WorldForge's implementation is driven by SPECIFICATION.md, which defines all types, traits, APIs, and behaviors. This skill guides the process of faithfully translating spec sections into Rust code while handling ambiguities and edge cases.
+</purpose>
+
+<context>
+— SPECIFICATION.md is the source of truth (32K+ words, 15 sections).
+— All modules in worldforge-core are currently stubs referencing the spec.
+— Types in the spec use Rust syntax — implement them as-is unless there's a compile-time reason to deviate.
+— Any deviation from spec must be documented in architecture/ADR.md.
+</context>
+
+<procedure>
+1. Identify the spec section for the module you're implementing:
+   — types.rs → Section 3 (Core Type System: Tensor, Spatial, Temporal, Media)
+   — error.rs → Section 14 (Error Handling)
+   — scene.rs → Section 5.1 (Scene Graph, SceneObject, PhysicsProperties, SpatialRelationship)
+   — state.rs → Section 5.2-5.3 (State Persistence, State History)
+   — action.rs → Section 6 (Action System)
+   — provider.rs → Section 4 (Provider Trait, Registry, Capabilities)
+   — prediction.rs → Section 7 (Prediction Engine)
+   — guardrail.rs → Section 10 (Guardrails & Safety)
+   — world.rs → Section 5.1 (WorldState) + orchestration logic
+2. Read the entire relevant section — don't cherry-pick.
+3. Copy type definitions from spec into Rust code.
+4. Add necessary derives: Debug, Clone, Serialize, Deserialize.
+5. Resolve spec ambiguities:
+   — If spec uses `Box<dyn Trait>`, consider if a generic parameter works better.
+   — If spec uses `String` for IDs, consider if a newtype wrapper is better.
+   — If spec has `Option<Vec<T>>`, consider if `Vec<T>` (empty = none) is simpler.
+6. Document any deviation with a comment: `// DEVIATION from spec: [reason]`.
+7. Write tests that validate the type matches spec behavior.
+8. Cross-reference with other spec sections for consistency.
+</procedure>
+
+<patterns>
+<do>
+  — Implement types exactly as specified unless there's a Rust-specific reason to deviate.
+  — Keep spec section numbers as comments in code: `// Spec §3.2: Spatial Types`.
+  — Implement all enum variants listed in the spec — don't skip "for later".
+  — Use the same field names as the spec for API consistency.
+  — When the spec defines a trait, implement it as a Rust trait with async-trait if async.
+</do>
+<dont>
+  — Don't rename spec types without documenting why (breaks API contracts).
+  — Don't add fields/variants not in the spec (scope creep).
+  — Don't implement "improvements" over the spec — file an issue instead.
+  — Don't skip spec sections because they seem complex — implement stubs at minimum.
+  — Don't modify SPECIFICATION.md without approval — it's a gated file.
+</dont>
+</patterns>
+
+<examples>
+Example: Translating spec §3.2 (Spatial Types)
+
+Spec says:
+```rust
+pub struct Position { pub x: f32, pub y: f32, pub z: f32 }
+```
+
+Implementation:
+```rust
+// Spec §3.2: Spatial Types
+
+/// 3D position in world coordinates.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct Position {
+    pub x: f32,
+    pub y: f32,
+    pub z: f32,
+}
+
+impl Position {
+    /// Origin point (0, 0, 0).
+    pub fn origin() -> Self {
+        Self { x: 0.0, y: 0.0, z: 0.0 }
+    }
+}
+```
+
+Note: Added `Copy` (small struct), `PartialEq` (testing), constructor. These are additive, not deviations.
+</examples>
+
+<troubleshooting>
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| Spec type doesn't compile | Missing import or dependency | Check workspace deps, add to crate Cargo.toml |
+| Spec uses `Box<dyn CostFn>` but trait isn't defined | Spec references forward-declared types | Implement a placeholder trait, mark with TODO |
+| Circular dependency between spec types | Types in different modules reference each other | Use the types.rs module as the shared type foundation |
+| Spec enum has too many variants for one file | Large enum like Action | Keep in one file — split only if >500 lines |
+
+</troubleshooting>
+
+<references>
+— SPECIFICATION.md: all type definitions and API contracts
+— architecture/ADR.md: rationale for deviations
+— crates/worldforge-core/src/: implementation targets
+</references>

--- a/.codex/skills/testing-strategy.md
+++ b/.codex/skills/testing-strategy.md
@@ -1,0 +1,124 @@
+---
+name: testing-strategy
+description: Testing approach for WorldForge — unit tests, property-based tests (proptest), integration tests, and benchmarks (criterion). Activate when writing tests, setting up test infrastructure, debugging test failures, or evaluating test coverage. Also activate when discussing mocking, test fixtures, or CI test configuration.
+prerequisites: cargo, proptest (in workspace deps), criterion (in workspace deps)
+---
+
+# Testing Strategy
+
+<purpose>
+Defines how to test WorldForge code across all crates. Covers unit tests, property-based tests with proptest, integration tests, and performance benchmarks with criterion.
+</purpose>
+
+<context>
+— proptest 1.x for property-based testing (in workspace deps).
+— criterion 0.5 for benchmarks (in workspace deps).
+— No external test runner — standard `cargo test`.
+— No mock framework specified — use hand-written mocks or conditional compilation.
+— Pre-alpha: focus on core type correctness before integration tests.
+</context>
+
+<procedure>
+1. For every new type: write serialization roundtrip test (JSON and MessagePack).
+2. For types with invariants: write proptest strategies to verify invariants hold for arbitrary inputs.
+3. For async provider code: write tests with mock HTTP responses (no live API dependency).
+4. For planning/guardrail logic: write scenario-based integration tests.
+5. Run `cargo test` after every change — all tests must pass.
+6. Run `cargo test -- --nocapture` to see tracing output during tests.
+</procedure>
+
+<patterns>
+<do>
+  — Place unit tests in `#[cfg(test)] mod tests {}` at bottom of each source file.
+  — Place integration tests in `crates/{crate}/tests/` directory.
+  — Use `proptest! {}` macro for property-based tests of core types.
+  — Test error paths — verify correct WorldForgeError variants are returned.
+  — Use `#[tokio::test]` for async test functions.
+  — Name tests descriptively: `test_{what}_{condition}_{expected}`.
+</do>
+<dont>
+  — Don't use .unwrap() in test setup without a descriptive message — use .expect("reason").
+  — Don't write tests that depend on external APIs — use mocks.
+  — Don't skip testing error cases — they're often where bugs hide.
+  — Don't write tests that depend on execution order.
+</dont>
+</patterns>
+
+<examples>
+Example: Proptest roundtrip for spatial types
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+
+    prop_compose! {
+        fn arb_position()(
+            x in -1000.0f32..1000.0,
+            y in -1000.0f32..1000.0,
+            z in -1000.0f32..1000.0,
+        ) -> Position {
+            Position { x, y, z }
+        }
+    }
+
+    proptest! {
+        #[test]
+        fn position_json_roundtrip(pos in arb_position()) {
+            let json = serde_json::to_string(&pos).unwrap();
+            let decoded: Position = serde_json::from_str(&json).unwrap();
+            prop_assert!((pos.x - decoded.x).abs() < f32::EPSILON);
+            prop_assert!((pos.y - decoded.y).abs() < f32::EPSILON);
+            prop_assert!((pos.z - decoded.z).abs() < f32::EPSILON);
+        }
+    }
+}
+```
+
+Example: Async provider test with mock
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn mock_provider() -> MockProvider {
+        MockProvider {
+            predictions: vec![/* pre-configured responses */],
+        }
+    }
+
+    #[tokio::test]
+    async fn test_predict_returns_valid_state() {
+        let provider = mock_provider();
+        let state = WorldState::default();
+        let action = Action::Move { target: Position::origin(), speed: 1.0 };
+        let config = PredictionConfig::default();
+
+        let result = provider.predict(&state, &action, &config).await;
+        assert!(result.is_ok());
+
+        let prediction = result.unwrap();
+        assert!(prediction.confidence >= 0.0 && prediction.confidence <= 1.0);
+    }
+}
+```
+</examples>
+
+<troubleshooting>
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| proptest timeout | Strategy generates too many values | Narrow ranges, reduce `PROPTEST_CASES` |
+| async test hangs | Missing tokio runtime | Use `#[tokio::test]` not `#[test]` |
+| test passes locally, fails in CI | Non-deterministic behavior | Check for time-dependent or order-dependent logic |
+| criterion benchmark won't compile | Missing bench harness config | Add `[[bench]]` section to Cargo.toml with `harness = false` |
+
+</troubleshooting>
+
+<references>
+— Cargo.toml: proptest and criterion in workspace deps
+— CONTRIBUTING.md: test commands
+— crates/worldforge-core/src/: files needing unit tests
+</references>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,259 @@
+<identity>
+WorldForge: Unified orchestration layer for world foundation models (WFMs).
+Rust core library with Python bindings (PyO3). Pre-alpha — most modules are stubs awaiting implementation per SPECIFICATION.md.
+</identity>
+
+<stack>
+
+| Layer        | Technology   | Version  | Notes                                              |
+|--------------|--------------|----------|----------------------------------------------------|
+| Language     | Rust         | 1.80+    | Edition 2021, workspace resolver v2                |
+| Async        | Tokio        | 1.x      | Full features                                      |
+| Serialization| Serde + JSON | 1.x      | + MessagePack (rmp-serde) for binary               |
+| HTTP         | Reqwest      | 0.12     | rustls-tls, JSON feature                           |
+| ML Framework | Burn         | 0.16     | ndarray + wgpu backends                            |
+| Database     | SQLx         | 0.8      | SQLite, runtime-tokio-rustls                       |
+| Python       | PyO3         | 0.22     | auto-initialize                                    |
+| Error        | thiserror    | 2.x      | Typed errors; anyhow for ad-hoc contexts           |
+| Logging      | tracing      | 0.1      | + tracing-subscriber 0.3                           |
+| CLI          | Clap         | 4.x      | Derive API                                         |
+| Testing      | proptest     | 1.x      | Property-based tests for core types                |
+| Benchmarks   | Criterion    | 0.5      | Performance benchmarks                             |
+| IDs          | UUID         | 1.x      | v4, serde-compatible                               |
+| Package mgr  | Cargo        | —        | NEVER use npm/pip for Rust code                    |
+
+</stack>
+
+<structure>
+```
+worldforge/
+├── Cargo.toml                  # Workspace root — defines all members and shared deps
+├── SPECIFICATION.md            # Detailed technical spec — the source of truth for all types and APIs
+├── CONTRIBUTING.md             # Dev setup and contribution guide
+├── architecture/
+│   └── ADR.md                  # Architecture Decision Records (8 accepted ADRs)
+├── business/
+│   └── BUSINESS_PLAN.md        # Business strategy (read-only context)
+├── go-to-market/
+│   └── 90_DAY_SPRINT.md        # Launch plan (read-only context)
+├── research/
+│   └── MARKET_INTELLIGENCE.md  # Market research (read-only context)
+├── crates/
+│   ├── worldforge-core/        # Core library: types, traits, state management [IMPLEMENT HERE]
+│   │   └── src/
+│   │       ├── lib.rs          # Crate root — WorldForge struct (stub)
+│   │       ├── types.rs        # Tensor, spatial, temporal, media types (stub)
+│   │       ├── world.rs        # World state management (stub)
+│   │       ├── action.rs       # Action type system (stub)
+│   │       ├── prediction.rs   # Prediction engine (stub)
+│   │       ├── provider.rs     # WorldModelProvider trait (stub)
+│   │       ├── scene.rs        # Scene graph (stub)
+│   │       ├── guardrail.rs    # Safety constraints (stub)
+│   │       ├── state.rs        # State persistence (stub)
+│   │       └── error.rs        # WorldForgeError enum (stub)
+│   ├── worldforge-providers/   # Provider adapters: Cosmos, GWM, JEPA, Genie [IMPLEMENT HERE]
+│   │   └── src/lib.rs          # (stub)
+│   ├── worldforge-eval/        # Evaluation framework [IMPLEMENT HERE]
+│   │   └── src/lib.rs          # (stub)
+│   ├── worldforge-verify/      # ZK verification — optional module [IMPLEMENT HERE]
+│   │   └── src/lib.rs          # (stub)
+│   ├── worldforge-server/      # REST API server [IMPLEMENT HERE]
+│   │   └── src/lib.rs          # (stub)
+│   └── worldforge-cli/         # CLI tool [IMPLEMENT HERE]
+│       └── src/lib.rs          # (stub)
+└── .codex/skills/              # Agentic skill files
+```
+
+All `src/` files in crates are currently stubs (single doc comment line). Implementation should follow SPECIFICATION.md precisely.
+</structure>
+
+<commands>
+
+| Task             | Command                              | Notes                                    |
+|------------------|--------------------------------------|------------------------------------------|
+| Build all        | `cargo build`                        | Workspace build, all crates              |
+| Build one crate  | `cargo build -p worldforge-core`     | Replace crate name as needed             |
+| Test all         | `cargo test`                         | Runs all workspace tests                 |
+| Test one crate   | `cargo test -p worldforge-core`      | Replace crate name as needed             |
+| Test specific    | `cargo test -p worldforge-core test_name` | Run a single test                   |
+| Clippy (lint)    | `cargo clippy -- -D warnings`        | Treat warnings as errors                 |
+| Format           | `cargo fmt`                          | Rustfmt — run before every commit        |
+| Format check     | `cargo fmt -- --check`               | CI mode — no modifications               |
+| Doc generation   | `cargo doc --no-deps --open`         | Generate and view docs                   |
+| Bench            | `cargo bench -p worldforge-core`     | Criterion benchmarks                     |
+
+</commands>
+
+<conventions>
+<code_style>
+  Naming: snake_case for functions/variables/modules, PascalCase for types/traits/enums, SCREAMING_SNAKE for constants.
+  Files: snake_case.rs — one module per file, match module name to filename.
+  Imports: Group as std → external crates → workspace crates → local modules. Separate groups with blank line.
+  Visibility: Prefer pub(crate) over pub unless the item is part of the public API.
+  Error handling: Use thiserror for typed errors (WorldForgeError enum). Use anyhow only in CLI/server binaries, never in library code. No .unwrap() in library code — always propagate with `?`.
+  Async: All provider interactions are async (tokio). Use async-trait for trait methods. Internal pure logic is sync.
+  Documentation: All public items must have `///` doc comments. Include `# Examples` for complex APIs.
+</code_style>
+
+<patterns>
+  <do>
+    — Implement types exactly as specified in SPECIFICATION.md sections 3-11.
+    — Use #[derive(Debug, Clone, Serialize, Deserialize)] on all data types.
+    — Use builder pattern for complex config types (PredictionConfig, PlanRequest).
+    — Use #[cfg(test)] mod tests {} in each source file for unit tests.
+    — Use proptest for property-based testing of core types (serialization roundtrip, invariant checking).
+    — Place integration tests in tests/ directory at crate root.
+    — Return Result<T, WorldForgeError> from all fallible operations.
+    — Use tracing::instrument on async functions for observability.
+    — Keep provider adapters in separate submodules (cosmos.rs, runway.rs, jepa.rs, genie.rs).
+  </do>
+  <dont>
+    — Don't deviate from SPECIFICATION.md type definitions without documenting the change in ADR.md.
+    — Don't use .unwrap(), .expect() in library code — use proper error propagation.
+    — Don't add provider-specific types to worldforge-core — keep provider details in worldforge-providers.
+    — Don't use println! — use tracing::{info, debug, warn, error}.
+    — Don't add dependencies without checking if they're already in [workspace.dependencies].
+    — Don't implement ZK features outside worldforge-verify crate.
+  </dont>
+</patterns>
+
+<commit_conventions>
+  Format: type(scope): description
+  Types: feat, fix, refactor, test, docs, chore, perf
+  Scopes: core, providers, eval, verify, server, cli, workspace
+  Examples:
+    feat(core): implement WorldState and SceneGraph types
+    test(core): add proptest roundtrip tests for spatial types
+    fix(providers): handle timeout in Cosmos API calls
+    docs(workspace): update SPECIFICATION.md with new guardrail types
+</commit_conventions>
+</conventions>
+
+<workflows>
+<implement_types>
+  1. Read the relevant section of SPECIFICATION.md for the type definitions.
+  2. Implement types in the appropriate file in worldforge-core/src/.
+  3. Add #[derive(Debug, Clone, Serialize, Deserialize)] and any other needed derives.
+  4. Add doc comments on every public item.
+  5. Write unit tests in #[cfg(test)] mod tests {} at bottom of file.
+  6. Add proptest strategies for roundtrip serialization.
+  7. Run `cargo test -p worldforge-core` — all must pass.
+  8. Run `cargo clippy -- -D warnings` — zero warnings.
+  9. Run `cargo fmt`.
+  10. Commit: feat(core): implement [type names] per specification.
+</implement_types>
+
+<implement_provider>
+  1. Read SPECIFICATION.md sections 4 and 13 for provider trait and mapping.
+  2. Create provider module in worldforge-providers/src/ (e.g., cosmos.rs).
+  3. Implement WorldModelProvider trait.
+  4. Implement ActionTranslator for provider-specific action mapping.
+  5. Add integration tests (can use mock HTTP responses).
+  6. Run full test suite: `cargo test`.
+  7. Commit: feat(providers): implement [provider name] adapter.
+</implement_provider>
+
+<add_feature>
+  1. Check SPECIFICATION.md for the feature's design.
+  2. Identify which crate(s) need changes.
+  3. Implement in the correct crate, following existing patterns.
+  4. Write tests (unit + integration as appropriate).
+  5. Run `cargo test && cargo clippy -- -D warnings && cargo fmt`.
+  6. Self-review: no secrets, no debug prints, no TODO without tracking issue.
+  7. Commit with conventional format.
+</add_feature>
+
+<fix_bug>
+  1. Write a failing test that reproduces the bug.
+  2. Fix the code.
+  3. Verify the test passes.
+  4. Run full suite: `cargo test`.
+  5. Commit: fix(scope): description of what was broken and why.
+</fix_bug>
+</workflows>
+
+<boundaries>
+<forbidden>
+  DO NOT modify under any circumstances:
+  — .env, .env.* (credentials, API keys)
+  — Any file containing API keys, secrets, or tokens
+  — LICENSE file
+</forbidden>
+
+<gated>
+  Modify ONLY with explicit human approval:
+  — Cargo.toml (workspace root) — dependency changes affect all crates
+  — SPECIFICATION.md — source of truth for the entire system
+  — architecture/ADR.md — architectural decisions
+  — business/ and go-to-market/ — business documents
+</gated>
+
+<autonomous>
+  Safe to modify without approval:
+  — All src/ files in crates/ — this is where implementation happens
+  — Test files
+  — CONTRIBUTING.md
+  — CLAUDE.md, agents.md, .codex/skills/ — agentic context
+</autonomous>
+
+<safety_checks>
+  Before ANY destructive operation (delete file, drop table, reset state):
+  1. State what you're about to do
+  2. State what could go wrong
+  3. Wait for confirmation
+</safety_checks>
+</boundaries>
+
+<troubleshooting>
+<known_issues>
+
+| Symptom                              | Cause                          | Fix                                    |
+|--------------------------------------|--------------------------------|----------------------------------------|
+| `cargo build` fails on burn          | Missing GPU drivers for wgpu   | Use `--no-default-features` or ndarray backend only |
+| PyO3 build fails                     | Python dev headers missing     | Install python3-dev / python3-devel    |
+| SQLx compile error                   | Missing SQLite dev libs        | Install libsqlite3-dev                 |
+| `unresolved import` in IDE           | Workspace not detected         | Open project from workspace root       |
+
+</known_issues>
+
+<recovery_patterns>
+  When stuck, follow this cascade:
+  1. Read the error message fully — Rust errors are verbose but precise.
+  2. Check if the type/function exists in SPECIFICATION.md.
+  3. Run `cargo clean && cargo build` (stale build artifacts).
+  4. Check Cargo.toml for missing dependencies.
+  5. If still stuck, state the problem clearly and ask for help.
+</recovery_patterns>
+</troubleshooting>
+
+<architecture_context>
+Key decisions (from ADR.md) — do not re-litigate:
+— ADR-001: Rust core + Python bindings via PyO3 (performance + ecosystem reach)
+— ADR-002: Provider trait pattern (compile-time interface verification)
+— ADR-003: Scene graph for world state (industry standard, provider-agnostic)
+— ADR-004: ZK verification as optional separate crate (keeps core lightweight)
+— ADR-005: Pluggable state stores (file, SQLite, Redis, S3)
+— ADR-006: Evaluation as first-class crate (drives adoption as reference standard)
+— ADR-007: Apache 2.0 core, proprietary cloud (open-core model)
+— ADR-008: CLI-first development (rapid experimentation, natural integration test)
+</architecture_context>
+
+<implementation_priority>
+The codebase is pre-alpha with stub modules. Implementation order should be:
+1. worldforge-core: types.rs → error.rs → scene.rs → state.rs → action.rs → provider.rs → prediction.rs → guardrail.rs → world.rs → lib.rs
+2. worldforge-providers: Start with a mock provider, then Cosmos adapter
+3. worldforge-eval: After core types are stable
+4. worldforge-cli: After core + at least one provider
+5. worldforge-server: After CLI proves the API
+6. worldforge-verify: Last — depends on stable core + JEPA provider
+</implementation_priority>
+
+<skills>
+Modular skills are in .codex/skills/ (symlinked at .claude/skills/ and .agents/skills/).
+
+Available skills:
+— rust-development.md: Rust patterns, idioms, and workspace conventions for this project
+— provider-integration.md: How to implement a WorldModelProvider adapter
+— testing-strategy.md: Testing approach — unit, property-based, integration, benchmarks
+— specification-driven-dev.md: How to translate SPECIFICATION.md into implementation
+</skills>

--- a/agents.md
+++ b/agents.md
@@ -1,0 +1,125 @@
+# WorldForge Multi-Agent Orchestration
+
+<applicability>
+This project benefits from multi-agent coordination because:
+— 6 crates with distinct domains (core types, providers, eval, verify, server, CLI)
+— Tasks frequently decompose: implement types → write tests → implement provider → integration test
+— Multiple skill domains intersect: Rust systems, ML/AI provider APIs, ZK cryptography, REST APIs
+</applicability>
+
+<roles>
+
+| Role           | Model Tier | Responsibility                                        | Boundaries                                   |
+|----------------|------------|-------------------------------------------------------|----------------------------------------------|
+| Orchestrator   | Frontier   | Decompose tasks, plan implementation order, review     | NEVER writes implementation code directly    |
+| Implementer    | Mid-tier   | Write Rust code, implement types/traits, fix bugs      | NEVER makes architectural decisions          |
+| Tester         | Mid-tier   | Write tests, run test suite, verify correctness        | NEVER modifies non-test production code      |
+| Spec Reviewer  | Frontier   | Cross-reference implementation against SPECIFICATION.md| NEVER modifies code — only reports deviations|
+
+</roles>
+
+<delegation_protocol>
+The Orchestrator follows this decision tree:
+
+1. ANALYZE: What crate and module does the task affect?
+2. DECOMPOSE: Break into atomic sub-tasks scoped to single files.
+3. CLASSIFY:
+   — Type implementation (well-defined in spec) → Implementer
+   — Test writing → Tester
+   — Spec compliance check → Spec Reviewer
+   — Architectural question → Orchestrator handles or escalates
+4. PLAN: Determine dependency order:
+   — types.rs must be done before scene.rs, state.rs, action.rs
+   — provider.rs trait must be done before any provider adapter
+   — error.rs should be done early (all modules depend on it)
+5. DELEGATE: Issue task with context package (see format below).
+6. REVIEW: Verify implementation matches spec before marking complete.
+</delegation_protocol>
+
+<task_format>
+Every delegated task must include:
+
+## Task: [Clear, actionable title]
+
+**Objective**: [What "done" looks like — one sentence]
+
+**Context**:
+- Spec section: [SPECIFICATION.md section number and title]
+- Files to read: [exact paths]
+- Files to modify: [exact paths]
+- Dependencies: [what must be implemented first]
+
+**Acceptance criteria**:
+- [ ] Types match SPECIFICATION.md definitions
+- [ ] All public items have doc comments
+- [ ] Unit tests in #[cfg(test)] mod tests {}
+- [ ] `cargo test -p [crate]` passes
+- [ ] `cargo clippy -- -D warnings` passes
+- [ ] `cargo fmt -- --check` passes
+
+**Constraints**:
+- Do NOT modify files outside the specified crate
+- Do NOT deviate from spec without documenting in ADR.md
+- Do NOT add dependencies not in workspace Cargo.toml
+
+**Handoff**: Report completion with list of types implemented and test count.
+</task_format>
+
+<parallel_execution>
+Safe to parallelize:
+— types.rs and error.rs (no mutual dependency)
+— Tests for different modules (after types are stable)
+— Provider adapters (independent of each other, depend only on core trait)
+— Documentation updates
+
+Must serialize:
+— types.rs → scene.rs, state.rs (depend on spatial/temporal types)
+— provider.rs trait → provider implementations
+— core crate → all other crates
+— Any Cargo.toml changes (workspace-wide impact)
+</parallel_execution>
+
+<implementation_waves>
+Recommended implementation sequence:
+
+**Wave 1 — Foundation** (parallelize within wave):
+  — types.rs: Tensor, Spatial, Temporal, Media types (Spec §3)
+  — error.rs: WorldForgeError enum (Spec §14)
+
+**Wave 2 — Scene & State** (depends on Wave 1):
+  — scene.rs: SceneGraph, SceneObject, PhysicsProperties (Spec §5.1)
+  — action.rs: Action enum, ActionTranslator trait (Spec §6)
+  — state.rs: StateStore trait, StateHistory (Spec §5.2-5.3)
+
+**Wave 3 — Provider & Prediction** (depends on Wave 2):
+  — provider.rs: WorldModelProvider trait, ProviderRegistry (Spec §4)
+  — prediction.rs: Prediction, PredictionConfig, PhysicsScores (Spec §7)
+  — guardrail.rs: Guardrail enum, GuardrailResult (Spec §10)
+
+**Wave 4 — World Orchestration** (depends on Wave 3):
+  — world.rs: World struct, plan(), predict() orchestration (Spec §5, §8)
+  — lib.rs: WorldForge entry point
+
+**Wave 5 — Outer Crates** (depends on Wave 4):
+  — worldforge-providers: Mock provider, then Cosmos adapter
+  — worldforge-eval: EvalSuite, EvalScenario (Spec §9)
+  — worldforge-cli: CLI commands via clap
+  — worldforge-server: REST API
+  — worldforge-verify: ZK verification (last)
+</implementation_waves>
+
+<escalation>
+Escalate to human when:
+— Spec is ambiguous or contradictory (e.g., type referenced but never defined)
+— A dependency (burn, PyO3, sqlx) has a breaking change or won't compile
+— ZK verification design requires cryptographic expertise
+— Provider API requires paid access for testing
+— Blocked for >30 minutes without progress
+
+Escalation format:
+**ESCALATION**: [one-line summary]
+**Context**: [what was being done]
+**Blocker**: [specific issue]
+**Options**: [numbered alternatives with tradeoffs]
+**Recommendation**: [which option and why]
+</escalation>


### PR DESCRIPTION
Establish the complete agentic context engineering framework:

- CLAUDE.md: Primary cognitive context with stack, structure, commands,
  conventions, workflows, boundaries, and troubleshooting
- agents.md: Multi-agent orchestration protocol with roles, delegation,
  parallel execution rules, and 5-wave implementation plan
- .codex/skills/: 4 core skills (rust-development, provider-integration,
  testing-strategy, specification-driven-dev) with registry
- Symlinks at .claude/skills/ and .agents/skills/ for cross-tool compat

https://claude.ai/code/session_01Dqykg8xyozG2miPPtrK5yp