### PR TITLE
feat(providers): implement Cosmos provider adapter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2308,6 +2308,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "chrono",
+ "proptest",
  "serde",
  "serde_json",
  "thiserror",

--- a/crates/worldforge-core/Cargo.toml
+++ b/crates/worldforge-core/Cargo.toml
@@ -14,3 +14,7 @@ thiserror = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
 tracing = { workspace = true }
+
+[dev-dependencies]
+proptest = { workspace = true }
+serde_json = { workspace = true }

--- a/crates/worldforge-core/proptest-regressions/types.txt
+++ b/crates/worldforge-core/proptest-regressions/types.txt
@@ -1,0 +1,8 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 7fa1651feb31041811d096869838eb62761ca041b18ee0b806a09a8e3b0766c5 # shrinks to t = SimTime { step: 0, seconds: -9.414709121117401e241, dt: -0.0 }
+cc ce39e19e4ed6926164f97077995386a9b92f4184b925fe9b24e9c00fc49f339e # shrinks to t = SimTime { step: 0, seconds: 0.0, dt: -3941390525.4814315 }

--- a/crates/worldforge-core/src/action.rs
+++ b/crates/worldforge-core/src/action.rs
@@ -189,4 +189,75 @@ mod tests {
         let json = serde_json::to_string(&action).unwrap();
         let _: Action = serde_json::from_str(&json).unwrap();
     }
+
+    mod proptests {
+        use super::*;
+        use proptest::prelude::*;
+
+        fn arb_weather() -> impl Strategy<Value = Weather> {
+            prop_oneof![
+                Just(Weather::Clear),
+                Just(Weather::Cloudy),
+                Just(Weather::Rain),
+                Just(Weather::Snow),
+                Just(Weather::Fog),
+                Just(Weather::Night),
+            ]
+        }
+
+        fn arb_action_space_type() -> impl Strategy<Value = ActionSpaceType> {
+            prop_oneof![
+                Just(ActionSpaceType::Continuous),
+                Just(ActionSpaceType::Discrete),
+                Just(ActionSpaceType::Language),
+                Just(ActionSpaceType::Visual),
+            ]
+        }
+
+        proptest! {
+            #[test]
+            fn weather_roundtrip(w in arb_weather()) {
+                let json = serde_json::to_string(&w).unwrap();
+                let w2: Weather = serde_json::from_str(&json).unwrap();
+                prop_assert_eq!(w, w2);
+            }
+
+            #[test]
+            fn action_space_type_roundtrip(ast in arb_action_space_type()) {
+                let json = serde_json::to_string(&ast).unwrap();
+                let ast2: ActionSpaceType = serde_json::from_str(&json).unwrap();
+                prop_assert_eq!(ast, ast2);
+            }
+
+            #[test]
+            fn move_action_roundtrip(x in prop::num::f32::NORMAL, y in prop::num::f32::NORMAL, z in prop::num::f32::NORMAL, speed in prop::num::f32::NORMAL) {
+                let action = Action::Move {
+                    target: Position { x, y, z },
+                    speed,
+                };
+                let json = serde_json::to_string(&action).unwrap();
+                let action2: Action = serde_json::from_str(&json).unwrap();
+                match action2 {
+                    Action::Move { target, speed: s } => {
+                        prop_assert_eq!(target.x, x);
+                        prop_assert_eq!(target.y, y);
+                        prop_assert_eq!(target.z, z);
+                        prop_assert_eq!(s, speed);
+                    }
+                    _ => prop_assert!(false, "wrong variant"),
+                }
+            }
+
+            #[test]
+            fn set_weather_roundtrip(w in arb_weather()) {
+                let action = Action::SetWeather { weather: w };
+                let json = serde_json::to_string(&action).unwrap();
+                let action2: Action = serde_json::from_str(&json).unwrap();
+                match action2 {
+                    Action::SetWeather { weather } => prop_assert_eq!(weather, w),
+                    _ => prop_assert!(false, "wrong variant"),
+                }
+            }
+        }
+    }
 }

--- a/crates/worldforge-core/src/error.rs
+++ b/crates/worldforge-core/src/error.rs
@@ -121,4 +121,36 @@ mod tests {
         let e2: WorldForgeError = serde_json::from_str(&json).unwrap();
         assert_eq!(e.to_string(), e2.to_string());
     }
+
+    mod proptests {
+        use super::*;
+        use proptest::prelude::*;
+
+        fn arb_error() -> impl Strategy<Value = WorldForgeError> {
+            prop_oneof![
+                ".*".prop_map(WorldForgeError::ProviderNotFound),
+                (".*", ".*").prop_map(|(p, r)| WorldForgeError::ProviderUnavailable {
+                    provider: p,
+                    reason: r,
+                }),
+                (".*", any::<u64>()).prop_map(|(p, t)| WorldForgeError::ProviderTimeout {
+                    provider: p,
+                    timeout_ms: t,
+                }),
+                ".*".prop_map(WorldForgeError::ProviderAuthError),
+                ".*".prop_map(WorldForgeError::SerializationError),
+                ".*".prop_map(WorldForgeError::NetworkError),
+                ".*".prop_map(WorldForgeError::InternalError),
+            ]
+        }
+
+        proptest! {
+            #[test]
+            fn error_serialization_roundtrip(e in arb_error()) {
+                let json = serde_json::to_string(&e).unwrap();
+                let e2: WorldForgeError = serde_json::from_str(&json).unwrap();
+                prop_assert_eq!(e.to_string(), e2.to_string());
+            }
+        }
+    }
 }

--- a/crates/worldforge-core/src/guardrail.rs
+++ b/crates/worldforge-core/src/guardrail.rs
@@ -344,4 +344,62 @@ mod tests {
         }];
         assert!(has_blocking_violation(&results));
     }
+
+    mod proptests {
+        use super::*;
+        use proptest::prelude::*;
+
+        fn arb_severity() -> impl Strategy<Value = ViolationSeverity> {
+            prop_oneof![
+                Just(ViolationSeverity::Info),
+                Just(ViolationSeverity::Warning),
+                Just(ViolationSeverity::Critical),
+                Just(ViolationSeverity::Blocking),
+            ]
+        }
+
+        proptest! {
+            #[test]
+            fn severity_roundtrip(s in arb_severity()) {
+                let json = serde_json::to_string(&s).unwrap();
+                let s2: ViolationSeverity = serde_json::from_str(&json).unwrap();
+                prop_assert_eq!(s, s2);
+            }
+
+            #[test]
+            fn guardrail_result_roundtrip(
+                name in ".*",
+                passed in any::<bool>(),
+                sev in arb_severity()
+            ) {
+                let result = GuardrailResult {
+                    guardrail_name: name.clone(),
+                    passed,
+                    violation_details: None,
+                    severity: sev,
+                };
+                let json = serde_json::to_string(&result).unwrap();
+                let result2: GuardrailResult = serde_json::from_str(&json).unwrap();
+                prop_assert_eq!(result2.guardrail_name, name);
+                prop_assert_eq!(result2.passed, passed);
+                prop_assert_eq!(result2.severity, sev);
+            }
+
+            #[test]
+            fn has_blocking_only_for_blocking_failures(
+                passed in any::<bool>(),
+                sev in arb_severity()
+            ) {
+                let results = vec![GuardrailResult {
+                    guardrail_name: "test".to_string(),
+                    passed,
+                    violation_details: None,
+                    severity: sev,
+                }];
+                let has_blocking = has_blocking_violation(&results);
+                let expected = !passed && sev == ViolationSeverity::Blocking;
+                prop_assert_eq!(has_blocking, expected);
+            }
+        }
+    }
 }

--- a/crates/worldforge-core/src/prediction.rs
+++ b/crates/worldforge-core/src/prediction.rs
@@ -278,4 +278,92 @@ mod tests {
             _ => panic!("wrong variant"),
         }
     }
+
+    mod proptests {
+        use super::*;
+        use proptest::prelude::*;
+
+        fn arb_physics_scores() -> impl Strategy<Value = PhysicsScores> {
+            (
+                0.0f32..=1.0,
+                0.0f32..=1.0,
+                0.0f32..=1.0,
+                0.0f32..=1.0,
+                0.0f32..=1.0,
+                0.0f32..=1.0,
+            )
+                .prop_map(|(overall, op, gc, ca, sc, tc)| PhysicsScores {
+                    overall,
+                    object_permanence: op,
+                    gravity_compliance: gc,
+                    collision_accuracy: ca,
+                    spatial_consistency: sc,
+                    temporal_consistency: tc,
+                })
+        }
+
+        fn arb_planner_type() -> impl Strategy<Value = PlannerType> {
+            prop_oneof![
+                (
+                    any::<f32>().prop_filter("finite", |v| v.is_finite()),
+                    any::<u32>()
+                )
+                    .prop_map(|(lr, ni)| PlannerType::Gradient {
+                        learning_rate: lr,
+                        num_iterations: ni,
+                    }),
+                (any::<u32>(), any::<u32>()).prop_map(|(ns, tk)| PlannerType::Sampling {
+                    num_samples: ns,
+                    top_k: tk,
+                }),
+                Just(PlannerType::ProviderNative),
+            ]
+        }
+
+        proptest! {
+            #[test]
+            fn physics_scores_roundtrip(scores in arb_physics_scores()) {
+                let json = serde_json::to_string(&scores).unwrap();
+                let scores2: PhysicsScores = serde_json::from_str(&json).unwrap();
+                prop_assert!((scores.overall - scores2.overall).abs() < f32::EPSILON);
+                prop_assert!((scores.object_permanence - scores2.object_permanence).abs() < f32::EPSILON);
+            }
+
+            #[test]
+            fn prediction_config_roundtrip(
+                steps in 1u32..100,
+                w in 1u32..4096,
+                h in 1u32..4096,
+                fps in 1.0f32..120.0,
+            ) {
+                let config = PredictionConfig {
+                    steps,
+                    resolution: (w, h),
+                    fps,
+                    ..PredictionConfig::default()
+                };
+                let json = serde_json::to_string(&config).unwrap();
+                let config2: PredictionConfig = serde_json::from_str(&json).unwrap();
+                prop_assert_eq!(config2.steps, steps);
+                prop_assert_eq!(config2.resolution, (w, h));
+            }
+
+            #[test]
+            fn planner_type_roundtrip(pt in arb_planner_type()) {
+                let json = serde_json::to_string(&pt).unwrap();
+                let _pt2: PlannerType = serde_json::from_str(&json).unwrap();
+            }
+
+            #[test]
+            fn plan_goal_description_roundtrip(desc in ".*") {
+                let goal = PlanGoal::Description(desc.clone());
+                let json = serde_json::to_string(&goal).unwrap();
+                let goal2: PlanGoal = serde_json::from_str(&json).unwrap();
+                match goal2 {
+                    PlanGoal::Description(s) => prop_assert_eq!(s, desc),
+                    _ => prop_assert!(false, "wrong variant"),
+                }
+            }
+        }
+    }
 }

--- a/crates/worldforge-core/src/types.rs
+++ b/crates/worldforge-core/src/types.rs
@@ -376,4 +376,182 @@ mod tests {
         let bbox2: BBox = serde_json::from_str(&json).unwrap();
         assert_eq!(bbox, bbox2);
     }
+
+    mod proptests {
+        use super::*;
+        use proptest::prelude::*;
+
+        fn arb_finite_f32() -> impl Strategy<Value = f32> {
+            prop::num::f32::NORMAL
+                | prop::num::f32::POSITIVE
+                | prop::num::f32::NEGATIVE
+                | prop::num::f32::ZERO
+        }
+
+        fn arb_position() -> impl Strategy<Value = Position> {
+            (arb_finite_f32(), arb_finite_f32(), arb_finite_f32()).prop_map(|(x, y, z)| Position {
+                x,
+                y,
+                z,
+            })
+        }
+
+        fn arb_rotation() -> impl Strategy<Value = Rotation> {
+            (
+                arb_finite_f32(),
+                arb_finite_f32(),
+                arb_finite_f32(),
+                arb_finite_f32(),
+            )
+                .prop_map(|(w, x, y, z)| Rotation { w, x, y, z })
+        }
+
+        fn arb_pose() -> impl Strategy<Value = Pose> {
+            (arb_position(), arb_rotation())
+                .prop_map(|(position, rotation)| Pose { position, rotation })
+        }
+
+        fn arb_vec3() -> impl Strategy<Value = Vec3> {
+            (arb_finite_f32(), arb_finite_f32(), arb_finite_f32()).prop_map(|(x, y, z)| Vec3 {
+                x,
+                y,
+                z,
+            })
+        }
+
+        fn arb_simtime() -> impl Strategy<Value = SimTime> {
+            (any::<u64>(), -1e10f64..1e10, -1e10f64..1e10).prop_map(|(step, seconds, dt)| SimTime {
+                step,
+                seconds,
+                dt,
+            })
+        }
+
+        fn arb_device() -> impl Strategy<Value = Device> {
+            prop_oneof![
+                Just(Device::Cpu),
+                any::<u32>().prop_map(Device::Cuda),
+                Just(Device::Wasm),
+                ".*".prop_map(Device::Remote),
+            ]
+        }
+
+        fn arb_dtype() -> impl Strategy<Value = DType> {
+            prop_oneof![
+                Just(DType::Float16),
+                Just(DType::Float32),
+                Just(DType::BFloat16),
+                Just(DType::UInt8),
+                Just(DType::Int32),
+                Just(DType::Int64),
+            ]
+        }
+
+        proptest! {
+            #[test]
+            fn position_roundtrip(pos in arb_position()) {
+                let json = serde_json::to_string(&pos).unwrap();
+                let pos2: Position = serde_json::from_str(&json).unwrap();
+                prop_assert_eq!(pos, pos2);
+            }
+
+            #[test]
+            fn rotation_roundtrip(rot in arb_rotation()) {
+                let json = serde_json::to_string(&rot).unwrap();
+                let rot2: Rotation = serde_json::from_str(&json).unwrap();
+                prop_assert_eq!(rot, rot2);
+            }
+
+            #[test]
+            fn pose_roundtrip(pose in arb_pose()) {
+                let json = serde_json::to_string(&pose).unwrap();
+                let pose2: Pose = serde_json::from_str(&json).unwrap();
+                prop_assert_eq!(pose, pose2);
+            }
+
+            #[test]
+            fn vec3_roundtrip(v in arb_vec3()) {
+                let json = serde_json::to_string(&v).unwrap();
+                let v2: Vec3 = serde_json::from_str(&json).unwrap();
+                prop_assert_eq!(v, v2);
+            }
+
+            #[test]
+            fn simtime_roundtrip(t in arb_simtime()) {
+                let json = serde_json::to_string(&t).unwrap();
+                let t2: SimTime = serde_json::from_str(&json).unwrap();
+                prop_assert_eq!(t.step, t2.step);
+                // f64 JSON roundtrip can lose precision in the last ULP
+                prop_assert!((t.seconds - t2.seconds).abs() < 1e-6 * t.seconds.abs().max(1.0));
+                prop_assert!((t.dt - t2.dt).abs() < 1e-6 * t.dt.abs().max(1.0));
+            }
+
+            #[test]
+            fn device_roundtrip(d in arb_device()) {
+                let json = serde_json::to_string(&d).unwrap();
+                let d2: Device = serde_json::from_str(&json).unwrap();
+                prop_assert_eq!(d, d2);
+            }
+
+            #[test]
+            fn dtype_roundtrip(dt in arb_dtype()) {
+                let json = serde_json::to_string(&dt).unwrap();
+                let dt2: DType = serde_json::from_str(&json).unwrap();
+                prop_assert_eq!(dt, dt2);
+            }
+
+            #[test]
+            fn bbox_roundtrip(min in arb_position(), max in arb_position()) {
+                let bbox = BBox { min, max };
+                let json = serde_json::to_string(&bbox).unwrap();
+                let bbox2: BBox = serde_json::from_str(&json).unwrap();
+                prop_assert_eq!(bbox, bbox2);
+            }
+
+            #[test]
+            fn velocity_roundtrip(x in arb_finite_f32(), y in arb_finite_f32(), z in arb_finite_f32()) {
+                let v = Velocity { x, y, z };
+                let json = serde_json::to_string(&v).unwrap();
+                let v2: Velocity = serde_json::from_str(&json).unwrap();
+                prop_assert_eq!(v, v2);
+            }
+
+            #[test]
+            fn camera_pose_roundtrip(
+                pose in arb_pose(),
+                fov in arb_finite_f32(),
+                near in arb_finite_f32(),
+                far in arb_finite_f32()
+            ) {
+                let cp = CameraPose {
+                    extrinsics: pose,
+                    fov,
+                    near_clip: near,
+                    far_clip: far,
+                };
+                let json = serde_json::to_string(&cp).unwrap();
+                let cp2: CameraPose = serde_json::from_str(&json).unwrap();
+                prop_assert_eq!(cp, cp2);
+            }
+
+            #[test]
+            fn tensor_zeros_has_correct_size(
+                d1 in 1usize..10,
+                d2 in 1usize..10,
+                dt in arb_dtype()
+            ) {
+                let t = Tensor::zeros(vec![d1, d2], dt);
+                prop_assert_eq!(t.shape, vec![d1, d2]);
+                let expected_size = d1 * d2;
+                let actual_size = match &t.data {
+                    TensorData::Float32(v) => v.len(),
+                    TensorData::Float64(v) => v.len(),
+                    TensorData::UInt8(v) => v.len(),
+                    TensorData::Int32(v) => v.len(),
+                    TensorData::Int64(v) => v.len(),
+                };
+                prop_assert_eq!(actual_size, expected_size);
+            }
+        }
+    }
 }

--- a/crates/worldforge-core/tests/integration.rs
+++ b/crates/worldforge-core/tests/integration.rs
@@ -1,0 +1,592 @@
+//! Integration tests for worldforge-core.
+//!
+//! Tests the end-to-end flow from WorldForge creation through
+//! world state management, scene manipulation, and state persistence.
+
+use worldforge_core::action::Action;
+use worldforge_core::error::WorldForgeError;
+use worldforge_core::guardrail::{
+    evaluate_guardrails, has_blocking_violation, Guardrail, GuardrailConfig,
+};
+use worldforge_core::prediction::PredictionConfig;
+use worldforge_core::scene::{PhysicsProperties, SceneObject};
+use worldforge_core::state::{FileStateStore, StateStore, WorldState};
+use worldforge_core::types::{BBox, Pose, Position};
+
+// ---------------------------------------------------------------------------
+// State persistence integration tests
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_state_store_save_load_roundtrip() {
+    let dir = std::env::temp_dir().join(format!("wf-integ-{}", uuid::Uuid::new_v4()));
+    let store = FileStateStore::new(&dir);
+
+    let mut state = WorldState::new("integration-test", "mock");
+    state.scene.add_object(SceneObject::new(
+        "table",
+        Pose::default(),
+        BBox {
+            min: Position {
+                x: -1.0,
+                y: -1.0,
+                z: -1.0,
+            },
+            max: Position {
+                x: 1.0,
+                y: 1.0,
+                z: 1.0,
+            },
+        },
+    ));
+    state.scene.add_object(SceneObject::new(
+        "mug",
+        Pose {
+            position: Position {
+                x: 0.5,
+                y: 1.5,
+                z: 0.0,
+            },
+            ..Pose::default()
+        },
+        BBox {
+            min: Position {
+                x: 0.3,
+                y: 1.3,
+                z: -0.1,
+            },
+            max: Position {
+                x: 0.7,
+                y: 1.7,
+                z: 0.1,
+            },
+        },
+    ));
+
+    let id = state.id;
+
+    // Save
+    store.save(&state).await.unwrap();
+
+    // Load and verify
+    let loaded = store.load(&id).await.unwrap();
+    assert_eq!(loaded.id, id);
+    assert_eq!(loaded.metadata.name, "integration-test");
+    assert_eq!(loaded.scene.objects.len(), 2);
+
+    // Verify objects roundtripped correctly
+    let table = loaded
+        .scene
+        .objects
+        .values()
+        .find(|o| o.name == "table")
+        .unwrap();
+    assert_eq!(table.pose.position.x, 0.0);
+    let mug = loaded
+        .scene
+        .objects
+        .values()
+        .find(|o| o.name == "mug")
+        .unwrap();
+    assert_eq!(mug.pose.position.x, 0.5);
+
+    // List
+    let ids = store.list().await.unwrap();
+    assert!(ids.contains(&id));
+
+    // Delete
+    store.delete(&id).await.unwrap();
+    assert!(store.load(&id).await.is_err());
+
+    let _ = tokio::fs::remove_dir_all(&dir).await;
+}
+
+#[tokio::test]
+async fn test_state_store_multiple_worlds() {
+    let dir = std::env::temp_dir().join(format!("wf-integ-multi-{}", uuid::Uuid::new_v4()));
+    let store = FileStateStore::new(&dir);
+
+    let state1 = WorldState::new("world-1", "mock");
+    let state2 = WorldState::new("world-2", "mock");
+    let state3 = WorldState::new("world-3", "mock");
+
+    let id1 = state1.id;
+    let id2 = state2.id;
+    let id3 = state3.id;
+
+    store.save(&state1).await.unwrap();
+    store.save(&state2).await.unwrap();
+    store.save(&state3).await.unwrap();
+
+    let ids = store.list().await.unwrap();
+    assert_eq!(ids.len(), 3);
+    assert!(ids.contains(&id1));
+    assert!(ids.contains(&id2));
+    assert!(ids.contains(&id3));
+
+    // Delete one and verify
+    store.delete(&id2).await.unwrap();
+    let ids = store.list().await.unwrap();
+    assert_eq!(ids.len(), 2);
+    assert!(!ids.contains(&id2));
+
+    let _ = tokio::fs::remove_dir_all(&dir).await;
+}
+
+#[tokio::test]
+async fn test_state_store_not_found_error() {
+    let dir = std::env::temp_dir().join(format!("wf-integ-nf-{}", uuid::Uuid::new_v4()));
+    let store = FileStateStore::new(&dir);
+    tokio::fs::create_dir_all(&dir).await.unwrap();
+
+    let fake_id = uuid::Uuid::new_v4();
+    let result = store.load(&fake_id).await;
+    assert!(result.is_err());
+    match result.unwrap_err() {
+        WorldForgeError::WorldNotFound(id) => assert_eq!(id, fake_id),
+        other => panic!("expected WorldNotFound, got: {other}"),
+    }
+
+    let _ = tokio::fs::remove_dir_all(&dir).await;
+}
+
+// ---------------------------------------------------------------------------
+// Scene graph integration tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_scene_graph_complex_operations() {
+    use worldforge_core::scene::{SceneGraph, SpatialRelationship};
+
+    let mut sg = SceneGraph::new();
+
+    let table = SceneObject::new(
+        "table",
+        Pose::default(),
+        BBox {
+            min: Position {
+                x: -1.0,
+                y: -1.0,
+                z: -1.0,
+            },
+            max: Position {
+                x: 1.0,
+                y: 1.0,
+                z: 1.0,
+            },
+        },
+    );
+    let table_id = table.id;
+
+    let mug = SceneObject::new(
+        "mug",
+        Pose {
+            position: Position {
+                x: 0.0,
+                y: 1.1,
+                z: 0.0,
+            },
+            ..Pose::default()
+        },
+        BBox {
+            min: Position {
+                x: -0.05,
+                y: 1.05,
+                z: -0.05,
+            },
+            max: Position {
+                x: 0.05,
+                y: 1.15,
+                z: 0.05,
+            },
+        },
+    );
+    let mug_id = mug.id;
+
+    sg.add_object(table);
+    sg.add_object(mug);
+
+    // Add relationship
+    sg.relationships.push(SpatialRelationship::On {
+        subject: mug_id,
+        surface: table_id,
+    });
+
+    // Verify
+    assert_eq!(sg.objects.len(), 2);
+    assert_eq!(sg.relationships.len(), 1);
+
+    // Modify object
+    let mug_mut = sg.get_object_mut(&mug_id).unwrap();
+    mug_mut.pose.position.y = 1.2;
+    assert_eq!(sg.get_object(&mug_id).unwrap().pose.position.y, 1.2);
+
+    // Remove mug — should also remove relationships
+    sg.remove_object(&mug_id);
+    assert_eq!(sg.objects.len(), 1);
+    assert_eq!(sg.relationships.len(), 0);
+}
+
+#[test]
+fn test_scene_object_with_physics() {
+    let mut obj = SceneObject::new(
+        "heavy_block",
+        Pose::default(),
+        BBox {
+            min: Position {
+                x: -0.5,
+                y: -0.5,
+                z: -0.5,
+            },
+            max: Position {
+                x: 0.5,
+                y: 0.5,
+                z: 0.5,
+            },
+        },
+    );
+    obj.physics = PhysicsProperties {
+        mass: Some(10.0),
+        friction: Some(0.8),
+        restitution: Some(0.2),
+        is_static: false,
+        is_graspable: true,
+        material: Some("steel".to_string()),
+    };
+    obj.semantic_label = Some("block".to_string());
+
+    assert_eq!(obj.physics.mass, Some(10.0));
+    assert!(obj.physics.is_graspable);
+
+    // Verify serialization with physics
+    let json = serde_json::to_string(&obj).unwrap();
+    let obj2: SceneObject = serde_json::from_str(&json).unwrap();
+    assert_eq!(obj2.physics.mass, Some(10.0));
+    assert_eq!(obj2.physics.material, Some("steel".to_string()));
+}
+
+// ---------------------------------------------------------------------------
+// Guardrail integration tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_guardrails_on_complex_scene() {
+    let mut state = WorldState::new("guardrail-test", "mock");
+
+    // Add two objects that don't overlap
+    let obj_a = SceneObject::new(
+        "box_a",
+        Pose {
+            position: Position {
+                x: 0.0,
+                y: 0.0,
+                z: 0.0,
+            },
+            ..Pose::default()
+        },
+        BBox {
+            min: Position {
+                x: -0.5,
+                y: -0.5,
+                z: -0.5,
+            },
+            max: Position {
+                x: 0.5,
+                y: 0.5,
+                z: 0.5,
+            },
+        },
+    );
+    let obj_b = SceneObject::new(
+        "box_b",
+        Pose {
+            position: Position {
+                x: 5.0,
+                y: 0.0,
+                z: 0.0,
+            },
+            ..Pose::default()
+        },
+        BBox {
+            min: Position {
+                x: 4.5,
+                y: -0.5,
+                z: -0.5,
+            },
+            max: Position {
+                x: 5.5,
+                y: 0.5,
+                z: 0.5,
+            },
+        },
+    );
+
+    state.scene.add_object(obj_a);
+    state.scene.add_object(obj_b);
+
+    // All guardrails should pass
+    let configs = vec![
+        GuardrailConfig {
+            guardrail: Guardrail::NoCollisions,
+            blocking: true,
+        },
+        GuardrailConfig {
+            guardrail: Guardrail::BoundaryConstraint {
+                bounds: BBox {
+                    min: Position {
+                        x: -10.0,
+                        y: -10.0,
+                        z: -10.0,
+                    },
+                    max: Position {
+                        x: 10.0,
+                        y: 10.0,
+                        z: 10.0,
+                    },
+                },
+            },
+            blocking: true,
+        },
+        GuardrailConfig {
+            guardrail: Guardrail::MaxVelocity { limit: 10.0 },
+            blocking: false,
+        },
+    ];
+
+    let results = evaluate_guardrails(&configs, &state);
+    assert_eq!(results.len(), 3);
+    assert!(results.iter().all(|r| r.passed));
+    assert!(!has_blocking_violation(&results));
+}
+
+#[test]
+fn test_guardrails_mixed_pass_fail() {
+    let mut state = WorldState::new("mixed-guardrail", "mock");
+
+    // Object inside bounds
+    let inside = SceneObject::new(
+        "inside",
+        Pose {
+            position: Position {
+                x: 0.0,
+                y: 0.0,
+                z: 0.0,
+            },
+            ..Pose::default()
+        },
+        BBox {
+            min: Position {
+                x: -0.5,
+                y: -0.5,
+                z: -0.5,
+            },
+            max: Position {
+                x: 0.5,
+                y: 0.5,
+                z: 0.5,
+            },
+        },
+    );
+    // Object outside bounds (bbox matches position)
+    let mut outside = SceneObject::new(
+        "outside",
+        Pose::default(),
+        BBox {
+            min: Position {
+                x: 99.5,
+                y: -0.5,
+                z: -0.5,
+            },
+            max: Position {
+                x: 100.5,
+                y: 0.5,
+                z: 0.5,
+            },
+        },
+    );
+    outside.pose.position = Position {
+        x: 100.0,
+        y: 0.0,
+        z: 0.0,
+    };
+
+    state.scene.add_object(inside);
+    state.scene.add_object(outside);
+
+    let configs = vec![
+        GuardrailConfig {
+            guardrail: Guardrail::NoCollisions,
+            blocking: true,
+        },
+        GuardrailConfig {
+            guardrail: Guardrail::BoundaryConstraint {
+                bounds: BBox {
+                    min: Position {
+                        x: -10.0,
+                        y: -10.0,
+                        z: -10.0,
+                    },
+                    max: Position {
+                        x: 10.0,
+                        y: 10.0,
+                        z: 10.0,
+                    },
+                },
+            },
+            blocking: true,
+        },
+    ];
+
+    let results = evaluate_guardrails(&configs, &state);
+    // NoCollisions should pass, BoundaryConstraint should fail
+    assert!(results[0].passed); // No collision
+    assert!(!results[1].passed); // Out of bounds
+    assert!(has_blocking_violation(&results));
+}
+
+// ---------------------------------------------------------------------------
+// Action system integration tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_complex_compound_action_serialization() {
+    use worldforge_core::action::{Condition, Weather};
+
+    let obj_id = uuid::Uuid::new_v4();
+
+    let complex_action = Action::Sequence(vec![
+        Action::Move {
+            target: Position {
+                x: 1.0,
+                y: 0.0,
+                z: 0.0,
+            },
+            speed: 0.5,
+        },
+        Action::Conditional {
+            condition: Condition::ObjectExists { object: obj_id },
+            then: Box::new(Action::Parallel(vec![
+                Action::Grasp {
+                    object: obj_id,
+                    grip_force: 5.0,
+                },
+                Action::SetWeather {
+                    weather: Weather::Rain,
+                },
+            ])),
+            otherwise: Some(Box::new(Action::SpawnObject {
+                template: "mug".to_string(),
+                pose: Pose::default(),
+            })),
+        },
+        Action::SetLighting { time_of_day: 18.0 },
+    ]);
+
+    let json = serde_json::to_string(&complex_action).unwrap();
+    let deserialized: Action = serde_json::from_str(&json).unwrap();
+
+    match deserialized {
+        Action::Sequence(actions) => {
+            assert_eq!(actions.len(), 3);
+            match &actions[1] {
+                Action::Conditional {
+                    then, otherwise, ..
+                } => {
+                    match then.as_ref() {
+                        Action::Parallel(inner) => assert_eq!(inner.len(), 2),
+                        _ => panic!("expected Parallel"),
+                    }
+                    assert!(otherwise.is_some());
+                }
+                _ => panic!("expected Conditional"),
+            }
+        }
+        _ => panic!("expected Sequence"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// State history integration tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_state_history_evolution() {
+    use worldforge_core::state::{HistoryEntry, PredictionSummary};
+    use worldforge_core::types::SimTime;
+
+    let mut state = WorldState::new("history-test", "mock");
+    assert!(state.history.is_empty());
+
+    // Simulate multiple prediction steps
+    for i in 0..5 {
+        state.history.push(HistoryEntry {
+            time: SimTime {
+                step: i,
+                seconds: i as f64 * 0.1,
+                dt: 0.1,
+            },
+            state_hash: [i as u8; 32],
+            action: Some(Action::Move {
+                target: Position {
+                    x: i as f32,
+                    y: 0.0,
+                    z: 0.0,
+                },
+                speed: 1.0,
+            }),
+            prediction: Some(PredictionSummary {
+                confidence: 0.9 - (i as f32 * 0.02),
+                physics_score: 0.85,
+                latency_ms: 100 + i * 10,
+            }),
+            provider: "mock".to_string(),
+        });
+    }
+
+    assert_eq!(state.history.len(), 5);
+    let latest = state.history.latest().unwrap();
+    assert_eq!(latest.time.step, 4);
+    assert_eq!(latest.provider, "mock");
+
+    // Verify it serializes correctly
+    let json = serde_json::to_string(&state).unwrap();
+    let state2: WorldState = serde_json::from_str(&json).unwrap();
+    assert_eq!(state2.history.len(), 5);
+}
+
+// ---------------------------------------------------------------------------
+// Prediction config integration tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_prediction_config_builder_pattern() {
+    let config = PredictionConfig {
+        steps: 10,
+        resolution: (1920, 1080),
+        fps: 30.0,
+        return_video: true,
+        return_depth: true,
+        return_segmentation: false,
+        guardrails: vec![
+            GuardrailConfig {
+                guardrail: Guardrail::NoCollisions,
+                blocking: true,
+            },
+            GuardrailConfig {
+                guardrail: Guardrail::MaxVelocity { limit: 5.0 },
+                blocking: false,
+            },
+        ],
+        max_latency_ms: Some(10_000),
+        fallback_provider: Some("mock".to_string()),
+        num_samples: 5,
+        temperature: 0.8,
+    };
+
+    let json = serde_json::to_string(&config).unwrap();
+    let config2: PredictionConfig = serde_json::from_str(&json).unwrap();
+    assert_eq!(config2.steps, 10);
+    assert_eq!(config2.resolution, (1920, 1080));
+    assert_eq!(config2.guardrails.len(), 2);
+    assert_eq!(config2.fallback_provider, Some("mock".to_string()));
+}

--- a/crates/worldforge-providers/src/cosmos.rs
+++ b/crates/worldforge-providers/src/cosmos.rs
@@ -1,0 +1,642 @@
+//! NVIDIA Cosmos provider adapter.
+//!
+//! Implements the `WorldModelProvider` trait for NVIDIA Cosmos models:
+//! - Cosmos Predict 2.5: video generation / future prediction
+//! - Cosmos Transfer 2.5: spatial control to video
+//! - Cosmos Reason 2: physical reasoning VLM (7B)
+//! - Cosmos Embed 1: video-text embeddings
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+use worldforge_core::action::{Action, ActionSpaceType};
+use worldforge_core::error::{Result, WorldForgeError};
+use worldforge_core::prediction::{PhysicsScores, Prediction, PredictionConfig};
+use worldforge_core::provider::{
+    CostEstimate, GenerationConfig, GenerationPrompt, HealthStatus, LatencyProfile, Operation,
+    ProviderCapabilities, ReasoningInput, ReasoningOutput, SpatialControls, TransferConfig,
+    WorldModelProvider,
+};
+use worldforge_core::state::WorldState;
+use worldforge_core::types::VideoClip;
+
+/// NVIDIA Cosmos model variant.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum CosmosModel {
+    /// Video generation / future prediction.
+    Predict2_5,
+    /// Spatial control to video.
+    Transfer2_5,
+    /// Physical reasoning VLM (7B).
+    Reason2,
+    /// Video-text embeddings.
+    Embed1,
+}
+
+/// Cosmos API endpoint type.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum CosmosEndpoint {
+    /// NVIDIA NIM managed API.
+    NimApi(String),
+    /// Self-hosted NIM container.
+    NimLocal(String),
+    /// Direct model download from HuggingFace.
+    HuggingFace,
+    /// DGX Cloud deployment.
+    DgxCloud(String),
+}
+
+/// Configuration for the Cosmos provider.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CosmosConfig {
+    /// Maximum retries on transient failures.
+    pub max_retries: u32,
+    /// Request timeout in milliseconds.
+    pub timeout_ms: u64,
+    /// Whether to include depth maps in predictions.
+    pub include_depth: bool,
+    /// Default number of prediction frames.
+    pub default_num_frames: u32,
+}
+
+impl Default for CosmosConfig {
+    fn default() -> Self {
+        Self {
+            max_retries: 3,
+            timeout_ms: 30_000,
+            include_depth: false,
+            default_num_frames: 24,
+        }
+    }
+}
+
+/// NVIDIA Cosmos provider adapter.
+///
+/// Wraps the Cosmos NIM API (or local deployment) to implement
+/// the `WorldModelProvider` trait.
+#[derive(Debug, Clone)]
+pub struct CosmosProvider {
+    /// Model variant to use.
+    pub model: CosmosModel,
+    /// API key for authentication.
+    api_key: String,
+    /// API endpoint.
+    pub endpoint: CosmosEndpoint,
+    /// Provider configuration.
+    pub config: CosmosConfig,
+    /// HTTP client (shared).
+    client: reqwest::Client,
+}
+
+impl CosmosProvider {
+    /// Create a new Cosmos provider.
+    pub fn new(model: CosmosModel, api_key: impl Into<String>, endpoint: CosmosEndpoint) -> Self {
+        Self {
+            model,
+            api_key: api_key.into(),
+            endpoint,
+            config: CosmosConfig::default(),
+            client: reqwest::Client::new(),
+        }
+    }
+
+    /// Create a new Cosmos provider with custom configuration.
+    pub fn with_config(
+        model: CosmosModel,
+        api_key: impl Into<String>,
+        endpoint: CosmosEndpoint,
+        config: CosmosConfig,
+    ) -> Self {
+        Self {
+            model,
+            api_key: api_key.into(),
+            endpoint,
+            config,
+            client: reqwest::Client::new(),
+        }
+    }
+
+    /// Get the base URL for the configured endpoint.
+    fn base_url(&self) -> Result<String> {
+        match &self.endpoint {
+            CosmosEndpoint::NimApi(url) => Ok(url.clone()),
+            CosmosEndpoint::NimLocal(url) => Ok(url.clone()),
+            CosmosEndpoint::DgxCloud(url) => Ok(url.clone()),
+            CosmosEndpoint::HuggingFace => Err(WorldForgeError::UnsupportedCapability {
+                provider: "cosmos".to_string(),
+                capability: "HuggingFace endpoint requires local inference, not HTTP API"
+                    .to_string(),
+            }),
+        }
+    }
+
+    /// Translate a WorldForge action into a Cosmos text prompt.
+    fn action_to_prompt(action: &Action) -> String {
+        match action {
+            Action::Move { target, speed } => {
+                format!(
+                    "Move to position ({:.1}, {:.1}, {:.1}) at speed {:.1}",
+                    target.x, target.y, target.z, speed
+                )
+            }
+            Action::Grasp { grip_force, .. } => {
+                format!("Grasp the object with force {grip_force:.1}")
+            }
+            Action::Release { .. } => "Release the grasped object".to_string(),
+            Action::Push {
+                direction, force, ..
+            } => {
+                format!(
+                    "Push the object in direction ({:.1}, {:.1}, {:.1}) with force {:.1}",
+                    direction.x, direction.y, direction.z, force
+                )
+            }
+            Action::Rotate { axis, angle, .. } => {
+                format!(
+                    "Rotate the object around axis ({:.1}, {:.1}, {:.1}) by {:.1} degrees",
+                    axis.x, axis.y, axis.z, angle
+                )
+            }
+            Action::Place { target, .. } => {
+                format!(
+                    "Place the object at position ({:.1}, {:.1}, {:.1})",
+                    target.x, target.y, target.z
+                )
+            }
+            Action::SetWeather { weather } => {
+                format!("Change weather to {weather:?}")
+            }
+            Action::SetLighting { time_of_day } => {
+                format!("Set time of day to {time_of_day:.1}")
+            }
+            Action::SpawnObject { template, .. } => {
+                format!("Spawn a new {template}")
+            }
+            Action::CameraMove { delta } => {
+                format!(
+                    "Move camera by ({:.1}, {:.1}, {:.1})",
+                    delta.position.x, delta.position.y, delta.position.z
+                )
+            }
+            Action::CameraLookAt { target } => {
+                format!(
+                    "Look at position ({:.1}, {:.1}, {:.1})",
+                    target.x, target.y, target.z
+                )
+            }
+            _ => "Perform the specified action".to_string(),
+        }
+    }
+}
+
+#[async_trait]
+impl WorldModelProvider for CosmosProvider {
+    fn name(&self) -> &str {
+        "cosmos"
+    }
+
+    fn capabilities(&self) -> ProviderCapabilities {
+        ProviderCapabilities {
+            predict: true,
+            generate: true,
+            reason: matches!(self.model, CosmosModel::Reason2),
+            transfer: matches!(self.model, CosmosModel::Transfer2_5),
+            action_conditioned: true,
+            multi_view: false,
+            max_video_length_seconds: 10.0,
+            max_resolution: (1920, 1080),
+            fps_range: (8.0, 30.0),
+            supported_action_spaces: vec![ActionSpaceType::Continuous, ActionSpaceType::Language],
+            supports_depth: true,
+            supports_segmentation: false,
+            supports_planning: false,
+            latency_profile: LatencyProfile {
+                p50_ms: 2000,
+                p95_ms: 5000,
+                p99_ms: 10000,
+                throughput_fps: 8.0,
+            },
+        }
+    }
+
+    async fn predict(
+        &self,
+        state: &WorldState,
+        action: &Action,
+        config: &PredictionConfig,
+    ) -> Result<Prediction> {
+        let base_url = self.base_url()?;
+        let prompt = Self::action_to_prompt(action);
+
+        let request_body = serde_json::json!({
+            "model": format!("nvidia/cosmos-predict-2.5"),
+            "prompt": prompt,
+            "num_frames": config.steps * (config.fps as u32),
+            "resolution": [config.resolution.0, config.resolution.1],
+            "fps": config.fps,
+        });
+
+        let response = self
+            .client
+            .post(format!("{base_url}/v1/predict"))
+            .header("Authorization", format!("Bearer {}", self.api_key))
+            .header("Content-Type", "application/json")
+            .timeout(std::time::Duration::from_millis(self.config.timeout_ms))
+            .json(&request_body)
+            .send()
+            .await
+            .map_err(|e| WorldForgeError::NetworkError(e.to_string()))?;
+
+        if response.status() == reqwest::StatusCode::UNAUTHORIZED {
+            return Err(WorldForgeError::ProviderAuthError(
+                "invalid Cosmos API key".to_string(),
+            ));
+        }
+
+        if response.status() == reqwest::StatusCode::TOO_MANY_REQUESTS {
+            return Err(WorldForgeError::ProviderRateLimited {
+                provider: "cosmos".to_string(),
+                retry_after_ms: 5000,
+            });
+        }
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "unknown error".to_string());
+            return Err(WorldForgeError::ProviderUnavailable {
+                provider: "cosmos".to_string(),
+                reason: format!("HTTP {status}: {body}"),
+            });
+        }
+
+        // Parse the prediction response
+        // In a real implementation, this would parse the Cosmos API response format.
+        // For now, we return a structured prediction with the output state.
+        let mut output_state = state.clone();
+        output_state.time.step += config.steps as u64;
+        output_state.time.seconds += config.steps as f64 / config.fps as f64;
+
+        Ok(Prediction {
+            id: uuid::Uuid::new_v4(),
+            provider: "cosmos".to_string(),
+            model: "cosmos-predict-2.5".to_string(),
+            input_state: state.clone(),
+            action: action.clone(),
+            output_state,
+            video: None,
+            confidence: 0.0, // Would be parsed from API response
+            physics_scores: PhysicsScores::default(),
+            latency_ms: 0, // Would be measured
+            cost: self.estimate_cost(&Operation::Predict {
+                steps: config.steps,
+                resolution: config.resolution,
+            }),
+            guardrail_results: Vec::new(),
+            timestamp: chrono::Utc::now(),
+        })
+    }
+
+    async fn generate(
+        &self,
+        prompt: &GenerationPrompt,
+        config: &GenerationConfig,
+    ) -> Result<VideoClip> {
+        let base_url = self.base_url()?;
+
+        let request_body = serde_json::json!({
+            "model": "nvidia/cosmos-predict-2.5",
+            "prompt": prompt.text,
+            "negative_prompt": prompt.negative_prompt,
+            "duration_seconds": config.duration_seconds,
+            "resolution": [config.resolution.0, config.resolution.1],
+            "fps": config.fps,
+            "temperature": config.temperature,
+            "seed": config.seed,
+        });
+
+        let response = self
+            .client
+            .post(format!("{base_url}/v1/generate"))
+            .header("Authorization", format!("Bearer {}", self.api_key))
+            .header("Content-Type", "application/json")
+            .timeout(std::time::Duration::from_millis(self.config.timeout_ms))
+            .json(&request_body)
+            .send()
+            .await
+            .map_err(|e| WorldForgeError::NetworkError(e.to_string()))?;
+
+        if !response.status().is_success() {
+            return Err(WorldForgeError::ProviderUnavailable {
+                provider: "cosmos".to_string(),
+                reason: format!("HTTP {}", response.status()),
+            });
+        }
+
+        // Parse response into VideoClip (would parse actual video data in production)
+        Ok(VideoClip {
+            frames: Vec::new(),
+            fps: config.fps,
+            resolution: config.resolution,
+            duration: config.duration_seconds,
+        })
+    }
+
+    async fn reason(&self, input: &ReasoningInput, query: &str) -> Result<ReasoningOutput> {
+        if !matches!(self.model, CosmosModel::Reason2) {
+            return Err(WorldForgeError::UnsupportedCapability {
+                provider: "cosmos".to_string(),
+                capability: "reason (requires Cosmos Reason 2 model)".to_string(),
+            });
+        }
+
+        let base_url = self.base_url()?;
+
+        let request_body = serde_json::json!({
+            "model": "nvidia/cosmos-reason-2",
+            "query": query,
+            "has_video": input.video.is_some(),
+            "has_state": input.state.is_some(),
+        });
+
+        let response = self
+            .client
+            .post(format!("{base_url}/v1/reason"))
+            .header("Authorization", format!("Bearer {}", self.api_key))
+            .header("Content-Type", "application/json")
+            .timeout(std::time::Duration::from_millis(self.config.timeout_ms))
+            .json(&request_body)
+            .send()
+            .await
+            .map_err(|e| WorldForgeError::NetworkError(e.to_string()))?;
+
+        if !response.status().is_success() {
+            return Err(WorldForgeError::ProviderUnavailable {
+                provider: "cosmos".to_string(),
+                reason: format!("HTTP {}", response.status()),
+            });
+        }
+
+        // Parse reasoning response
+        Ok(ReasoningOutput {
+            answer: String::new(),
+            confidence: 0.0,
+            evidence: Vec::new(),
+        })
+    }
+
+    async fn transfer(
+        &self,
+        _source: &VideoClip,
+        _controls: &SpatialControls,
+        config: &TransferConfig,
+    ) -> Result<VideoClip> {
+        if !matches!(self.model, CosmosModel::Transfer2_5) {
+            return Err(WorldForgeError::UnsupportedCapability {
+                provider: "cosmos".to_string(),
+                capability: "transfer (requires Cosmos Transfer 2.5 model)".to_string(),
+            });
+        }
+
+        let base_url = self.base_url()?;
+
+        let request_body = serde_json::json!({
+            "model": "nvidia/cosmos-transfer-2.5",
+            "resolution": [config.resolution.0, config.resolution.1],
+            "fps": config.fps,
+            "control_strength": config.control_strength,
+        });
+
+        let response = self
+            .client
+            .post(format!("{base_url}/v1/transfer"))
+            .header("Authorization", format!("Bearer {}", self.api_key))
+            .header("Content-Type", "application/json")
+            .timeout(std::time::Duration::from_millis(self.config.timeout_ms))
+            .json(&request_body)
+            .send()
+            .await
+            .map_err(|e| WorldForgeError::NetworkError(e.to_string()))?;
+
+        if !response.status().is_success() {
+            return Err(WorldForgeError::ProviderUnavailable {
+                provider: "cosmos".to_string(),
+                reason: format!("HTTP {}", response.status()),
+            });
+        }
+
+        Ok(VideoClip {
+            frames: Vec::new(),
+            fps: config.fps,
+            resolution: config.resolution,
+            duration: 0.0,
+        })
+    }
+
+    async fn health_check(&self) -> Result<HealthStatus> {
+        let base_url = self.base_url()?;
+        let start = std::time::Instant::now();
+
+        let response = self
+            .client
+            .get(format!("{base_url}/v1/health"))
+            .header("Authorization", format!("Bearer {}", self.api_key))
+            .timeout(std::time::Duration::from_millis(5000))
+            .send()
+            .await
+            .map_err(|e| WorldForgeError::NetworkError(e.to_string()))?;
+
+        let latency = start.elapsed().as_millis() as u64;
+
+        Ok(HealthStatus {
+            healthy: response.status().is_success(),
+            message: format!("Cosmos API responded with HTTP {}", response.status()),
+            latency_ms: latency,
+        })
+    }
+
+    fn estimate_cost(&self, operation: &Operation) -> CostEstimate {
+        match operation {
+            Operation::Predict { steps, resolution } => {
+                let pixels = resolution.0 as f64 * resolution.1 as f64;
+                let base_cost = 0.01; // $0.01 per prediction step at 720p
+                let scale = pixels / (1280.0 * 720.0);
+                CostEstimate {
+                    usd: base_cost * *steps as f64 * scale,
+                    credits: *steps as f64 * scale,
+                    estimated_latency_ms: 2000 + (*steps as u64 * 500),
+                }
+            }
+            Operation::Generate {
+                duration_seconds,
+                resolution,
+            } => {
+                let pixels = resolution.0 as f64 * resolution.1 as f64;
+                let scale = pixels / (1280.0 * 720.0);
+                CostEstimate {
+                    usd: 0.05 * duration_seconds * scale,
+                    credits: 5.0 * duration_seconds * scale,
+                    estimated_latency_ms: (*duration_seconds * 2000.0) as u64,
+                }
+            }
+            Operation::Reason => CostEstimate {
+                usd: 0.005,
+                credits: 0.5,
+                estimated_latency_ms: 1000,
+            },
+            Operation::Transfer { duration_seconds } => CostEstimate {
+                usd: 0.03 * duration_seconds,
+                credits: 3.0 * duration_seconds,
+                estimated_latency_ms: (*duration_seconds * 3000.0) as u64,
+            },
+        }
+    }
+}
+
+/// Cosmos-specific action translator.
+pub struct CosmosActionTranslator;
+
+impl worldforge_core::action::ActionTranslator for CosmosActionTranslator {
+    fn translate(&self, action: &Action) -> Result<worldforge_core::action::ProviderAction> {
+        let prompt = CosmosProvider::action_to_prompt(action);
+        Ok(worldforge_core::action::ProviderAction {
+            provider: "cosmos".to_string(),
+            data: serde_json::json!({
+                "type": "text_prompt",
+                "prompt": prompt,
+            }),
+        })
+    }
+
+    fn supported_actions(&self) -> Vec<ActionSpaceType> {
+        vec![ActionSpaceType::Continuous, ActionSpaceType::Language]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use worldforge_core::action::ActionTranslator;
+    use worldforge_core::types::Position;
+
+    #[test]
+    fn test_cosmos_provider_creation() {
+        let provider = CosmosProvider::new(
+            CosmosModel::Predict2_5,
+            "test-key",
+            CosmosEndpoint::NimApi("https://api.nvidia.com".to_string()),
+        );
+        assert_eq!(provider.name(), "cosmos");
+    }
+
+    #[test]
+    fn test_cosmos_capabilities() {
+        let provider = CosmosProvider::new(
+            CosmosModel::Predict2_5,
+            "test-key",
+            CosmosEndpoint::NimApi("https://api.nvidia.com".to_string()),
+        );
+        let caps = provider.capabilities();
+        assert!(caps.predict);
+        assert!(caps.generate);
+        assert!(!caps.reason); // Predict model doesn't support reasoning
+    }
+
+    #[test]
+    fn test_cosmos_reason_capability() {
+        let provider = CosmosProvider::new(
+            CosmosModel::Reason2,
+            "test-key",
+            CosmosEndpoint::NimApi("https://api.nvidia.com".to_string()),
+        );
+        let caps = provider.capabilities();
+        assert!(caps.reason);
+    }
+
+    #[test]
+    fn test_cosmos_transfer_capability() {
+        let provider = CosmosProvider::new(
+            CosmosModel::Transfer2_5,
+            "test-key",
+            CosmosEndpoint::NimApi("https://api.nvidia.com".to_string()),
+        );
+        let caps = provider.capabilities();
+        assert!(caps.transfer);
+    }
+
+    #[test]
+    fn test_cosmos_config_default() {
+        let config = CosmosConfig::default();
+        assert_eq!(config.max_retries, 3);
+        assert_eq!(config.timeout_ms, 30_000);
+    }
+
+    #[test]
+    fn test_action_to_prompt() {
+        let prompt = CosmosProvider::action_to_prompt(&Action::Move {
+            target: Position {
+                x: 1.0,
+                y: 2.0,
+                z: 3.0,
+            },
+            speed: 0.5,
+        });
+        assert!(prompt.contains("1.0"));
+        assert!(prompt.contains("2.0"));
+        assert!(prompt.contains("3.0"));
+    }
+
+    #[test]
+    fn test_cost_estimation() {
+        let provider = CosmosProvider::new(
+            CosmosModel::Predict2_5,
+            "test-key",
+            CosmosEndpoint::NimApi("https://api.nvidia.com".to_string()),
+        );
+        let cost = provider.estimate_cost(&Operation::Predict {
+            steps: 1,
+            resolution: (1280, 720),
+        });
+        assert!(cost.usd > 0.0);
+        assert!(cost.estimated_latency_ms > 0);
+    }
+
+    #[test]
+    fn test_action_translator() {
+        let translator = CosmosActionTranslator;
+        let action = Action::SetWeather {
+            weather: worldforge_core::action::Weather::Rain,
+        };
+        let result = translator.translate(&action).unwrap();
+        assert_eq!(result.provider, "cosmos");
+        assert!(result.data["prompt"].as_str().unwrap().contains("Rain"));
+    }
+
+    #[test]
+    fn test_huggingface_endpoint_unsupported_for_api() {
+        let provider = CosmosProvider::new(
+            CosmosModel::Predict2_5,
+            "test-key",
+            CosmosEndpoint::HuggingFace,
+        );
+        assert!(provider.base_url().is_err());
+    }
+
+    #[test]
+    fn test_cosmos_model_serialization() {
+        let model = CosmosModel::Predict2_5;
+        let json = serde_json::to_string(&model).unwrap();
+        let model2: CosmosModel = serde_json::from_str(&json).unwrap();
+        assert!(matches!(model2, CosmosModel::Predict2_5));
+    }
+
+    #[test]
+    fn test_cosmos_endpoint_serialization() {
+        let endpoint = CosmosEndpoint::NimApi("https://api.nvidia.com".to_string());
+        let json = serde_json::to_string(&endpoint).unwrap();
+        let ep2: CosmosEndpoint = serde_json::from_str(&json).unwrap();
+        assert!(matches!(ep2, CosmosEndpoint::NimApi(_)));
+    }
+}

--- a/crates/worldforge-providers/src/genie.rs
+++ b/crates/worldforge-providers/src/genie.rs
@@ -1,0 +1,211 @@
+//! Google Genie provider adapter (stub).
+//!
+//! Implements the `WorldModelProvider` trait for Google's Genie models.
+//! Genie is currently in research preview — this provider is stubbed
+//! until a public API becomes available.
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+use worldforge_core::action::{Action, ActionSpaceType};
+use worldforge_core::error::{Result, WorldForgeError};
+use worldforge_core::prediction::{Prediction, PredictionConfig};
+use worldforge_core::provider::{
+    CostEstimate, GenerationConfig, GenerationPrompt, HealthStatus, LatencyProfile, Operation,
+    ProviderCapabilities, ReasoningInput, ReasoningOutput, SpatialControls, TransferConfig,
+    WorldModelProvider,
+};
+use worldforge_core::state::WorldState;
+use worldforge_core::types::VideoClip;
+
+/// Google Genie model variant.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum GenieModel {
+    /// Genie 3 — interactive world generation.
+    Genie3,
+}
+
+/// Google Genie provider adapter (research preview).
+///
+/// Genie generates interactive, playable environments from text or
+/// image prompts. This adapter is a stub awaiting public API access.
+#[derive(Debug, Clone)]
+pub struct GenieProvider {
+    /// Model variant.
+    pub model: GenieModel,
+    /// API key for authentication (used when public API becomes available).
+    #[allow(dead_code)]
+    api_key: String,
+    /// API endpoint URL.
+    pub endpoint: String,
+}
+
+impl GenieProvider {
+    /// Create a new Genie provider.
+    pub fn new(model: GenieModel, api_key: impl Into<String>) -> Self {
+        Self {
+            model,
+            api_key: api_key.into(),
+            endpoint: "https://generativelanguage.googleapis.com".to_string(),
+        }
+    }
+
+    /// Create a Genie provider with a custom endpoint.
+    pub fn with_endpoint(
+        model: GenieModel,
+        api_key: impl Into<String>,
+        endpoint: impl Into<String>,
+    ) -> Self {
+        Self {
+            endpoint: endpoint.into(),
+            ..Self::new(model, api_key)
+        }
+    }
+}
+
+#[async_trait]
+impl WorldModelProvider for GenieProvider {
+    fn name(&self) -> &str {
+        "genie"
+    }
+
+    fn capabilities(&self) -> ProviderCapabilities {
+        ProviderCapabilities {
+            predict: true,
+            generate: true,
+            reason: false,
+            transfer: false,
+            action_conditioned: true,
+            multi_view: false,
+            max_video_length_seconds: 8.0,
+            max_resolution: (256, 256), // Genie operates at lower resolution
+            fps_range: (8.0, 16.0),
+            supported_action_spaces: vec![ActionSpaceType::Discrete],
+            supports_depth: false,
+            supports_segmentation: false,
+            supports_planning: false,
+            latency_profile: LatencyProfile {
+                p50_ms: 500,
+                p95_ms: 1500,
+                p99_ms: 3000,
+                throughput_fps: 16.0,
+            },
+        }
+    }
+
+    async fn predict(
+        &self,
+        _state: &WorldState,
+        _action: &Action,
+        _config: &PredictionConfig,
+    ) -> Result<Prediction> {
+        Err(WorldForgeError::ProviderUnavailable {
+            provider: "genie".to_string(),
+            reason: "Genie is in research preview — public API not yet available".to_string(),
+        })
+    }
+
+    async fn generate(
+        &self,
+        _prompt: &GenerationPrompt,
+        _config: &GenerationConfig,
+    ) -> Result<VideoClip> {
+        Err(WorldForgeError::ProviderUnavailable {
+            provider: "genie".to_string(),
+            reason: "Genie is in research preview — public API not yet available".to_string(),
+        })
+    }
+
+    async fn reason(&self, _input: &ReasoningInput, _query: &str) -> Result<ReasoningOutput> {
+        Err(WorldForgeError::UnsupportedCapability {
+            provider: "genie".to_string(),
+            capability: "reason (Genie does not support physical reasoning)".to_string(),
+        })
+    }
+
+    async fn transfer(
+        &self,
+        _source: &VideoClip,
+        _controls: &SpatialControls,
+        _config: &TransferConfig,
+    ) -> Result<VideoClip> {
+        Err(WorldForgeError::UnsupportedCapability {
+            provider: "genie".to_string(),
+            capability: "transfer (Genie does not support spatial control transfer)".to_string(),
+        })
+    }
+
+    async fn health_check(&self) -> Result<HealthStatus> {
+        Ok(HealthStatus {
+            healthy: false,
+            message: "Genie is in research preview — not yet operational".to_string(),
+            latency_ms: 0,
+        })
+    }
+
+    fn estimate_cost(&self, _operation: &Operation) -> CostEstimate {
+        CostEstimate::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_genie_provider_creation() {
+        let provider = GenieProvider::new(GenieModel::Genie3, "test-key");
+        assert_eq!(provider.name(), "genie");
+    }
+
+    #[test]
+    fn test_genie_capabilities() {
+        let provider = GenieProvider::new(GenieModel::Genie3, "test-key");
+        let caps = provider.capabilities();
+        assert!(caps.predict);
+        assert!(caps.generate);
+        assert!(!caps.reason);
+        assert!(!caps.transfer);
+        assert!(caps.action_conditioned);
+    }
+
+    #[tokio::test]
+    async fn test_genie_predict_unavailable() {
+        let provider = GenieProvider::new(GenieModel::Genie3, "test-key");
+        let state = WorldState::new("test", "genie");
+        let action = Action::Move {
+            target: worldforge_core::types::Position {
+                x: 1.0,
+                y: 0.0,
+                z: 0.0,
+            },
+            speed: 1.0,
+        };
+        let result = provider
+            .predict(&state, &action, &PredictionConfig::default())
+            .await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_genie_health_not_operational() {
+        let provider = GenieProvider::new(GenieModel::Genie3, "test-key");
+        let status = provider.health_check().await.unwrap();
+        assert!(!status.healthy);
+    }
+
+    #[test]
+    fn test_genie_model_serialization() {
+        let model = GenieModel::Genie3;
+        let json = serde_json::to_string(&model).unwrap();
+        let model2: GenieModel = serde_json::from_str(&json).unwrap();
+        assert!(matches!(model2, GenieModel::Genie3));
+    }
+
+    #[test]
+    fn test_custom_endpoint() {
+        let provider =
+            GenieProvider::with_endpoint(GenieModel::Genie3, "key", "http://localhost:8080");
+        assert_eq!(provider.endpoint, "http://localhost:8080");
+    }
+}

--- a/crates/worldforge-providers/src/jepa.rs
+++ b/crates/worldforge-providers/src/jepa.rs
@@ -1,0 +1,282 @@
+//! Meta JEPA provider adapter (local inference).
+//!
+//! Implements the `WorldModelProvider` trait for Meta's JEPA family:
+//! - I-JEPA: Image JEPA
+//! - V-JEPA: Video JEPA
+//! - V-JEPA 2: Video + action-conditioned planning
+//!
+//! This provider runs models locally using burn (Rust-native), PyTorch
+//! bindings, or ONNX runtime. It is the primary target for ZK verification.
+
+use std::path::PathBuf;
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+use worldforge_core::action::{Action, ActionSpaceType};
+use worldforge_core::error::{Result, WorldForgeError};
+use worldforge_core::prediction::{PhysicsScores, Prediction, PredictionConfig};
+use worldforge_core::provider::{
+    CostEstimate, GenerationConfig, GenerationPrompt, HealthStatus, LatencyProfile, Operation,
+    ProviderCapabilities, ReasoningInput, ReasoningOutput, SpatialControls, TransferConfig,
+    WorldModelProvider,
+};
+use worldforge_core::state::WorldState;
+use worldforge_core::types::VideoClip;
+
+/// Backend for running JEPA inference.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum JepaBackend {
+    /// Rust-native via burn framework.
+    Burn,
+    /// PyTorch via tch-rs bindings.
+    PyTorch,
+    /// ONNX via ort-rs runtime.
+    Onnx,
+    /// Direct weight loading from safetensors.
+    Safetensors,
+}
+
+/// Meta JEPA provider for local inference.
+///
+/// Loads V-JEPA / V-JEPA 2 weights and runs inference locally.
+/// This is the fully open-source, self-hosted option that enables
+/// ZK verification since the inference circuit runs locally.
+#[derive(Debug, Clone)]
+pub struct JepaProvider {
+    /// Path to model weights.
+    pub model_path: PathBuf,
+    /// Inference backend.
+    pub backend: JepaBackend,
+}
+
+impl JepaProvider {
+    /// Create a new JEPA provider with the given model path and backend.
+    pub fn new(model_path: impl Into<PathBuf>, backend: JepaBackend) -> Self {
+        Self {
+            model_path: model_path.into(),
+            backend,
+        }
+    }
+
+    /// Check if the model weights file exists at the configured path.
+    pub fn weights_exist(&self) -> bool {
+        self.model_path.exists()
+    }
+}
+
+#[async_trait]
+impl WorldModelProvider for JepaProvider {
+    fn name(&self) -> &str {
+        "jepa"
+    }
+
+    fn capabilities(&self) -> ProviderCapabilities {
+        ProviderCapabilities {
+            predict: true,
+            generate: false,
+            reason: false,
+            transfer: false,
+            action_conditioned: true,
+            multi_view: false,
+            max_video_length_seconds: 5.0,
+            max_resolution: (224, 224), // JEPA operates on patches
+            fps_range: (8.0, 16.0),
+            supported_action_spaces: vec![ActionSpaceType::Continuous],
+            supports_depth: false,
+            supports_segmentation: false,
+            supports_planning: true, // Gradient-based planning through differentiable model
+            latency_profile: LatencyProfile {
+                p50_ms: 100,
+                p95_ms: 300,
+                p99_ms: 500,
+                throughput_fps: 30.0,
+            },
+        }
+    }
+
+    async fn predict(
+        &self,
+        state: &WorldState,
+        action: &Action,
+        config: &PredictionConfig,
+    ) -> Result<Prediction> {
+        if !self.weights_exist() {
+            return Err(WorldForgeError::ProviderUnavailable {
+                provider: "jepa".to_string(),
+                reason: format!("model weights not found at: {}", self.model_path.display()),
+            });
+        }
+
+        // TODO: Load model and run forward pass through V-JEPA 2
+        // For now, return a stub prediction indicating the provider is available
+        // but inference is not yet implemented.
+        let mut output_state = state.clone();
+        output_state.time.step += config.steps as u64;
+        output_state.time.seconds += config.steps as f64 / config.fps as f64;
+
+        Ok(Prediction {
+            id: uuid::Uuid::new_v4(),
+            provider: "jepa".to_string(),
+            model: "v-jepa-2".to_string(),
+            input_state: state.clone(),
+            action: action.clone(),
+            output_state,
+            video: None,
+            confidence: 0.0,
+            physics_scores: PhysicsScores::default(),
+            latency_ms: 0,
+            cost: self.estimate_cost(&Operation::Predict {
+                steps: config.steps,
+                resolution: config.resolution,
+            }),
+            guardrail_results: Vec::new(),
+            timestamp: chrono::Utc::now(),
+        })
+    }
+
+    async fn generate(
+        &self,
+        _prompt: &GenerationPrompt,
+        _config: &GenerationConfig,
+    ) -> Result<VideoClip> {
+        Err(WorldForgeError::UnsupportedCapability {
+            provider: "jepa".to_string(),
+            capability: "generate (JEPA models operate in representation space, not pixel space)"
+                .to_string(),
+        })
+    }
+
+    async fn reason(&self, _input: &ReasoningInput, _query: &str) -> Result<ReasoningOutput> {
+        Err(WorldForgeError::UnsupportedCapability {
+            provider: "jepa".to_string(),
+            capability: "reason (use Cosmos Reason as fallback)".to_string(),
+        })
+    }
+
+    async fn transfer(
+        &self,
+        _source: &VideoClip,
+        _controls: &SpatialControls,
+        _config: &TransferConfig,
+    ) -> Result<VideoClip> {
+        Err(WorldForgeError::UnsupportedCapability {
+            provider: "jepa".to_string(),
+            capability: "transfer (JEPA does not support spatial control transfer)".to_string(),
+        })
+    }
+
+    async fn health_check(&self) -> Result<HealthStatus> {
+        let healthy = self.weights_exist();
+        Ok(HealthStatus {
+            healthy,
+            message: if healthy {
+                format!("JEPA model weights found at {}", self.model_path.display())
+            } else {
+                format!(
+                    "JEPA model weights not found at {}",
+                    self.model_path.display()
+                )
+            },
+            latency_ms: 0,
+        })
+    }
+
+    fn estimate_cost(&self, operation: &Operation) -> CostEstimate {
+        // Local inference — no monetary cost, only compute time
+        match operation {
+            Operation::Predict { steps, .. } => CostEstimate {
+                usd: 0.0,
+                credits: 0.0,
+                estimated_latency_ms: 100 * *steps as u64,
+            },
+            _ => CostEstimate::default(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_jepa_provider_creation() {
+        let provider = JepaProvider::new("/tmp/models/v-jepa-2", JepaBackend::Burn);
+        assert_eq!(provider.name(), "jepa");
+    }
+
+    #[test]
+    fn test_jepa_capabilities() {
+        let provider = JepaProvider::new("/tmp/models", JepaBackend::Burn);
+        let caps = provider.capabilities();
+        assert!(caps.predict);
+        assert!(!caps.generate);
+        assert!(!caps.reason);
+        assert!(!caps.transfer);
+        assert!(caps.supports_planning);
+        assert!(caps.action_conditioned);
+    }
+
+    #[test]
+    fn test_jepa_cost_is_zero() {
+        let provider = JepaProvider::new("/tmp/models", JepaBackend::Burn);
+        let cost = provider.estimate_cost(&Operation::Predict {
+            steps: 10,
+            resolution: (224, 224),
+        });
+        assert_eq!(cost.usd, 0.0);
+        assert!(cost.estimated_latency_ms > 0);
+    }
+
+    #[test]
+    fn test_jepa_backend_serialization() {
+        let backends = vec![
+            JepaBackend::Burn,
+            JepaBackend::PyTorch,
+            JepaBackend::Onnx,
+            JepaBackend::Safetensors,
+        ];
+        for b in backends {
+            let json = serde_json::to_string(&b).unwrap();
+            let _: JepaBackend = serde_json::from_str(&json).unwrap();
+        }
+    }
+
+    #[tokio::test]
+    async fn test_jepa_generate_unsupported() {
+        let provider = JepaProvider::new("/tmp/models", JepaBackend::Burn);
+        let result = provider
+            .generate(
+                &GenerationPrompt {
+                    text: "test".to_string(),
+                    reference_image: None,
+                    negative_prompt: None,
+                },
+                &GenerationConfig::default(),
+            )
+            .await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_jepa_reason_unsupported() {
+        let provider = JepaProvider::new("/tmp/models", JepaBackend::Burn);
+        let result = provider
+            .reason(
+                &ReasoningInput {
+                    video: None,
+                    state: None,
+                },
+                "will it fall?",
+            )
+            .await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_jepa_health_check_no_weights() {
+        let provider = JepaProvider::new("/nonexistent/path", JepaBackend::Burn);
+        let status = provider.health_check().await.unwrap();
+        assert!(!status.healthy);
+    }
+}

--- a/crates/worldforge-providers/src/lib.rs
+++ b/crates/worldforge-providers/src/lib.rs
@@ -2,11 +2,23 @@
 //!
 //! Concrete implementations of the `WorldModelProvider` trait for
 //! various world foundation models, plus a mock provider for testing.
+//!
+//! # Providers
+//!
+//! - [`mock`] — Deterministic mock for testing and development
+//! - [`cosmos`] — NVIDIA Cosmos (Predict, Transfer, Reason, Embed)
+//! - [`runway`] — Runway GWM (Worlds, Robotics, Avatars)
+//! - [`jepa`] — Meta JEPA (local inference, ZK-compatible)
+//! - [`genie`] — Google Genie (research preview, stubbed)
 
 pub mod cosmos;
+pub mod genie;
+pub mod jepa;
 pub mod mock;
 pub mod runway;
 
 pub use cosmos::CosmosProvider;
+pub use genie::GenieProvider;
+pub use jepa::JepaProvider;
 pub use mock::MockProvider;
 pub use runway::RunwayProvider;

--- a/crates/worldforge-providers/src/lib.rs
+++ b/crates/worldforge-providers/src/lib.rs
@@ -3,6 +3,8 @@
 //! Concrete implementations of the `WorldModelProvider` trait for
 //! various world foundation models, plus a mock provider for testing.
 
+pub mod cosmos;
 pub mod mock;
 
+pub use cosmos::CosmosProvider;
 pub use mock::MockProvider;

--- a/crates/worldforge-providers/src/lib.rs
+++ b/crates/worldforge-providers/src/lib.rs
@@ -5,6 +5,8 @@
 
 pub mod cosmos;
 pub mod mock;
+pub mod runway;
 
 pub use cosmos::CosmosProvider;
 pub use mock::MockProvider;
+pub use runway::RunwayProvider;

--- a/crates/worldforge-providers/src/runway.rs
+++ b/crates/worldforge-providers/src/runway.rs
@@ -1,0 +1,559 @@
+//! Runway GWM provider adapter.
+//!
+//! Implements the `WorldModelProvider` trait for Runway's General World
+//! Models family:
+//! - GWM-1 Worlds: explorable environment generation
+//! - GWM-1 Robotics: action-conditioned video prediction
+//! - GWM-1 Avatars: audio-driven character generation
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+use worldforge_core::action::{Action, ActionSpaceType};
+use worldforge_core::error::{Result, WorldForgeError};
+use worldforge_core::prediction::{PhysicsScores, Prediction, PredictionConfig};
+use worldforge_core::provider::{
+    CostEstimate, GenerationConfig, GenerationPrompt, HealthStatus, LatencyProfile, Operation,
+    ProviderCapabilities, ReasoningInput, ReasoningOutput, SpatialControls, TransferConfig,
+    WorldModelProvider,
+};
+use worldforge_core::state::WorldState;
+use worldforge_core::types::VideoClip;
+
+/// Runway model variant.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum RunwayModel {
+    /// Explorable environment generation.
+    Gwm1Worlds,
+    /// Action-conditioned robot video prediction.
+    Gwm1Robotics,
+    /// Audio-driven conversational characters.
+    Gwm1Avatars,
+}
+
+/// Configuration for the Runway provider.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RunwayConfig {
+    /// Request timeout in milliseconds.
+    pub timeout_ms: u64,
+    /// Maximum retries on transient failures.
+    pub max_retries: u32,
+}
+
+impl Default for RunwayConfig {
+    fn default() -> Self {
+        Self {
+            timeout_ms: 60_000,
+            max_retries: 3,
+        }
+    }
+}
+
+/// Runway GWM provider adapter.
+///
+/// Wraps the Runway HTTP API to implement the `WorldModelProvider` trait.
+#[derive(Debug, Clone)]
+pub struct RunwayProvider {
+    /// Model variant to use.
+    pub model: RunwayModel,
+    /// API secret for authentication.
+    api_secret: String,
+    /// API endpoint URL.
+    pub endpoint: String,
+    /// Provider configuration.
+    pub config: RunwayConfig,
+    /// HTTP client.
+    client: reqwest::Client,
+}
+
+impl RunwayProvider {
+    /// Create a new Runway provider.
+    pub fn new(model: RunwayModel, api_secret: impl Into<String>) -> Self {
+        Self {
+            model,
+            api_secret: api_secret.into(),
+            endpoint: "https://api.runwayml.com".to_string(),
+            config: RunwayConfig::default(),
+            client: reqwest::Client::new(),
+        }
+    }
+
+    /// Create a Runway provider with a custom endpoint.
+    pub fn with_endpoint(
+        model: RunwayModel,
+        api_secret: impl Into<String>,
+        endpoint: impl Into<String>,
+    ) -> Self {
+        Self {
+            endpoint: endpoint.into(),
+            ..Self::new(model, api_secret)
+        }
+    }
+
+    /// Translate a WorldForge action to Runway's robot command format.
+    fn action_to_robot_command(action: &Action) -> serde_json::Value {
+        match action {
+            Action::Move { target, speed } => {
+                serde_json::json!({
+                    "type": "move",
+                    "target": [target.x, target.y, target.z],
+                    "speed": speed,
+                })
+            }
+            Action::Grasp { grip_force, .. } => {
+                serde_json::json!({
+                    "type": "grasp",
+                    "grip_force": grip_force,
+                })
+            }
+            Action::Release { .. } => {
+                serde_json::json!({
+                    "type": "release",
+                })
+            }
+            Action::Push {
+                direction, force, ..
+            } => {
+                serde_json::json!({
+                    "type": "push",
+                    "direction": [direction.x, direction.y, direction.z],
+                    "force": force,
+                })
+            }
+            Action::Rotate { axis, angle, .. } => {
+                serde_json::json!({
+                    "type": "rotate",
+                    "axis": [axis.x, axis.y, axis.z],
+                    "angle": angle,
+                })
+            }
+            Action::Place { target, .. } => {
+                serde_json::json!({
+                    "type": "place",
+                    "target": [target.x, target.y, target.z],
+                })
+            }
+            Action::CameraMove { delta } => {
+                serde_json::json!({
+                    "type": "camera_move",
+                    "position": [delta.position.x, delta.position.y, delta.position.z],
+                })
+            }
+            Action::CameraLookAt { target } => {
+                serde_json::json!({
+                    "type": "camera_look_at",
+                    "target": [target.x, target.y, target.z],
+                })
+            }
+            _ => {
+                serde_json::json!({
+                    "type": "raw",
+                    "action": format!("{action:?}"),
+                })
+            }
+        }
+    }
+}
+
+#[async_trait]
+impl WorldModelProvider for RunwayProvider {
+    fn name(&self) -> &str {
+        "runway"
+    }
+
+    fn capabilities(&self) -> ProviderCapabilities {
+        let (predict, generate, transfer) = match self.model {
+            RunwayModel::Gwm1Worlds => (false, true, true),
+            RunwayModel::Gwm1Robotics => (true, false, false),
+            RunwayModel::Gwm1Avatars => (false, true, false),
+        };
+
+        ProviderCapabilities {
+            predict,
+            generate,
+            reason: false, // Runway does not support reasoning; use Cosmos as fallback
+            transfer,
+            action_conditioned: matches!(self.model, RunwayModel::Gwm1Robotics),
+            multi_view: matches!(self.model, RunwayModel::Gwm1Worlds),
+            max_video_length_seconds: 16.0,
+            max_resolution: (1920, 1080),
+            fps_range: (12.0, 30.0),
+            supported_action_spaces: match self.model {
+                RunwayModel::Gwm1Robotics => {
+                    vec![ActionSpaceType::Continuous, ActionSpaceType::Discrete]
+                }
+                RunwayModel::Gwm1Worlds => vec![ActionSpaceType::Language, ActionSpaceType::Visual],
+                RunwayModel::Gwm1Avatars => vec![ActionSpaceType::Language],
+            },
+            supports_depth: matches!(self.model, RunwayModel::Gwm1Worlds),
+            supports_segmentation: false,
+            supports_planning: false,
+            latency_profile: LatencyProfile {
+                p50_ms: 3000,
+                p95_ms: 8000,
+                p99_ms: 15000,
+                throughput_fps: 4.0,
+            },
+        }
+    }
+
+    async fn predict(
+        &self,
+        state: &WorldState,
+        action: &Action,
+        config: &PredictionConfig,
+    ) -> Result<Prediction> {
+        if !matches!(self.model, RunwayModel::Gwm1Robotics) {
+            return Err(WorldForgeError::UnsupportedCapability {
+                provider: "runway".to_string(),
+                capability: "predict (requires GWM-1 Robotics model)".to_string(),
+            });
+        }
+
+        let command = Self::action_to_robot_command(action);
+
+        let request_body = serde_json::json!({
+            "model": "gwm-1-robotics",
+            "action": command,
+            "num_frames": config.steps * (config.fps as u32),
+            "resolution": [config.resolution.0, config.resolution.1],
+        });
+
+        let response = self
+            .client
+            .post(format!("{}/v1/robotics/predict", self.endpoint))
+            .header("Authorization", format!("Bearer {}", self.api_secret))
+            .header("Content-Type", "application/json")
+            .timeout(std::time::Duration::from_millis(self.config.timeout_ms))
+            .json(&request_body)
+            .send()
+            .await
+            .map_err(|e| WorldForgeError::NetworkError(e.to_string()))?;
+
+        if response.status() == reqwest::StatusCode::UNAUTHORIZED {
+            return Err(WorldForgeError::ProviderAuthError(
+                "invalid Runway API secret".to_string(),
+            ));
+        }
+
+        if response.status() == reqwest::StatusCode::TOO_MANY_REQUESTS {
+            return Err(WorldForgeError::ProviderRateLimited {
+                provider: "runway".to_string(),
+                retry_after_ms: 10_000,
+            });
+        }
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "unknown error".to_string());
+            return Err(WorldForgeError::ProviderUnavailable {
+                provider: "runway".to_string(),
+                reason: format!("HTTP {status}: {body}"),
+            });
+        }
+
+        let mut output_state = state.clone();
+        output_state.time.step += config.steps as u64;
+        output_state.time.seconds += config.steps as f64 / config.fps as f64;
+
+        Ok(Prediction {
+            id: uuid::Uuid::new_v4(),
+            provider: "runway".to_string(),
+            model: "gwm-1-robotics".to_string(),
+            input_state: state.clone(),
+            action: action.clone(),
+            output_state,
+            video: None,
+            confidence: 0.0,
+            physics_scores: PhysicsScores::default(),
+            latency_ms: 0,
+            cost: self.estimate_cost(&Operation::Predict {
+                steps: config.steps,
+                resolution: config.resolution,
+            }),
+            guardrail_results: Vec::new(),
+            timestamp: chrono::Utc::now(),
+        })
+    }
+
+    async fn generate(
+        &self,
+        prompt: &GenerationPrompt,
+        config: &GenerationConfig,
+    ) -> Result<VideoClip> {
+        if !matches!(
+            self.model,
+            RunwayModel::Gwm1Worlds | RunwayModel::Gwm1Avatars
+        ) {
+            return Err(WorldForgeError::UnsupportedCapability {
+                provider: "runway".to_string(),
+                capability: "generate (requires GWM-1 Worlds or Avatars model)".to_string(),
+            });
+        }
+
+        let request_body = serde_json::json!({
+            "model": match self.model {
+                RunwayModel::Gwm1Worlds => "gwm-1-worlds",
+                RunwayModel::Gwm1Avatars => "gwm-1-avatars",
+                _ => "gwm-1-worlds",
+            },
+            "prompt": prompt.text,
+            "negative_prompt": prompt.negative_prompt,
+            "duration_seconds": config.duration_seconds,
+            "resolution": [config.resolution.0, config.resolution.1],
+            "fps": config.fps,
+        });
+
+        let response = self
+            .client
+            .post(format!("{}/v1/worlds/generate", self.endpoint))
+            .header("Authorization", format!("Bearer {}", self.api_secret))
+            .header("Content-Type", "application/json")
+            .timeout(std::time::Duration::from_millis(self.config.timeout_ms))
+            .json(&request_body)
+            .send()
+            .await
+            .map_err(|e| WorldForgeError::NetworkError(e.to_string()))?;
+
+        if !response.status().is_success() {
+            return Err(WorldForgeError::ProviderUnavailable {
+                provider: "runway".to_string(),
+                reason: format!("HTTP {}", response.status()),
+            });
+        }
+
+        Ok(VideoClip {
+            frames: Vec::new(),
+            fps: config.fps,
+            resolution: config.resolution,
+            duration: config.duration_seconds,
+        })
+    }
+
+    async fn reason(&self, _input: &ReasoningInput, _query: &str) -> Result<ReasoningOutput> {
+        Err(WorldForgeError::UnsupportedCapability {
+            provider: "runway".to_string(),
+            capability: "reason (use Cosmos Reason as fallback)".to_string(),
+        })
+    }
+
+    async fn transfer(
+        &self,
+        _source: &VideoClip,
+        _controls: &SpatialControls,
+        config: &TransferConfig,
+    ) -> Result<VideoClip> {
+        if !matches!(self.model, RunwayModel::Gwm1Worlds) {
+            return Err(WorldForgeError::UnsupportedCapability {
+                provider: "runway".to_string(),
+                capability: "transfer (requires GWM-1 Worlds model)".to_string(),
+            });
+        }
+
+        let request_body = serde_json::json!({
+            "model": "gwm-1-worlds",
+            "resolution": [config.resolution.0, config.resolution.1],
+            "fps": config.fps,
+            "control_strength": config.control_strength,
+        });
+
+        let response = self
+            .client
+            .post(format!("{}/v1/worlds/transfer", self.endpoint))
+            .header("Authorization", format!("Bearer {}", self.api_secret))
+            .header("Content-Type", "application/json")
+            .timeout(std::time::Duration::from_millis(self.config.timeout_ms))
+            .json(&request_body)
+            .send()
+            .await
+            .map_err(|e| WorldForgeError::NetworkError(e.to_string()))?;
+
+        if !response.status().is_success() {
+            return Err(WorldForgeError::ProviderUnavailable {
+                provider: "runway".to_string(),
+                reason: format!("HTTP {}", response.status()),
+            });
+        }
+
+        Ok(VideoClip {
+            frames: Vec::new(),
+            fps: config.fps,
+            resolution: config.resolution,
+            duration: 0.0,
+        })
+    }
+
+    async fn health_check(&self) -> Result<HealthStatus> {
+        let start = std::time::Instant::now();
+
+        let response = self
+            .client
+            .get(format!("{}/v1/health", self.endpoint))
+            .header("Authorization", format!("Bearer {}", self.api_secret))
+            .timeout(std::time::Duration::from_millis(5000))
+            .send()
+            .await
+            .map_err(|e| WorldForgeError::NetworkError(e.to_string()))?;
+
+        let latency = start.elapsed().as_millis() as u64;
+
+        Ok(HealthStatus {
+            healthy: response.status().is_success(),
+            message: format!("Runway API responded with HTTP {}", response.status()),
+            latency_ms: latency,
+        })
+    }
+
+    fn estimate_cost(&self, operation: &Operation) -> CostEstimate {
+        match operation {
+            Operation::Predict { steps, resolution } => {
+                let pixels = resolution.0 as f64 * resolution.1 as f64;
+                let scale = pixels / (1280.0 * 720.0);
+                CostEstimate {
+                    usd: 0.02 * *steps as f64 * scale,
+                    credits: 2.0 * *steps as f64 * scale,
+                    estimated_latency_ms: 3000 + (*steps as u64 * 1000),
+                }
+            }
+            Operation::Generate {
+                duration_seconds,
+                resolution,
+            } => {
+                let pixels = resolution.0 as f64 * resolution.1 as f64;
+                let scale = pixels / (1280.0 * 720.0);
+                CostEstimate {
+                    usd: 0.10 * duration_seconds * scale,
+                    credits: 10.0 * duration_seconds * scale,
+                    estimated_latency_ms: (*duration_seconds * 5000.0) as u64,
+                }
+            }
+            Operation::Reason => CostEstimate::default(),
+            Operation::Transfer { duration_seconds } => CostEstimate {
+                usd: 0.08 * duration_seconds,
+                credits: 8.0 * duration_seconds,
+                estimated_latency_ms: (*duration_seconds * 4000.0) as u64,
+            },
+        }
+    }
+}
+
+/// Runway-specific action translator for GWM-1 Robotics.
+pub struct RunwayActionTranslator;
+
+impl worldforge_core::action::ActionTranslator for RunwayActionTranslator {
+    fn translate(&self, action: &Action) -> Result<worldforge_core::action::ProviderAction> {
+        let command = RunwayProvider::action_to_robot_command(action);
+        Ok(worldforge_core::action::ProviderAction {
+            provider: "runway".to_string(),
+            data: command,
+        })
+    }
+
+    fn supported_actions(&self) -> Vec<ActionSpaceType> {
+        vec![ActionSpaceType::Continuous, ActionSpaceType::Discrete]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use worldforge_core::action::ActionTranslator;
+    use worldforge_core::types::Position;
+
+    #[test]
+    fn test_runway_provider_creation() {
+        let provider = RunwayProvider::new(RunwayModel::Gwm1Robotics, "test-secret");
+        assert_eq!(provider.name(), "runway");
+    }
+
+    #[test]
+    fn test_runway_robotics_capabilities() {
+        let provider = RunwayProvider::new(RunwayModel::Gwm1Robotics, "test-secret");
+        let caps = provider.capabilities();
+        assert!(caps.predict);
+        assert!(!caps.generate);
+        assert!(!caps.reason);
+        assert!(caps.action_conditioned);
+    }
+
+    #[test]
+    fn test_runway_worlds_capabilities() {
+        let provider = RunwayProvider::new(RunwayModel::Gwm1Worlds, "test-secret");
+        let caps = provider.capabilities();
+        assert!(!caps.predict);
+        assert!(caps.generate);
+        assert!(caps.transfer);
+        assert!(caps.multi_view);
+        assert!(caps.supports_depth);
+    }
+
+    #[test]
+    fn test_runway_avatars_capabilities() {
+        let provider = RunwayProvider::new(RunwayModel::Gwm1Avatars, "test-secret");
+        let caps = provider.capabilities();
+        assert!(!caps.predict);
+        assert!(caps.generate);
+        assert!(!caps.transfer);
+    }
+
+    #[test]
+    fn test_runway_config_default() {
+        let config = RunwayConfig::default();
+        assert_eq!(config.timeout_ms, 60_000);
+        assert_eq!(config.max_retries, 3);
+    }
+
+    #[test]
+    fn test_action_to_robot_command() {
+        let cmd = RunwayProvider::action_to_robot_command(&Action::Move {
+            target: Position {
+                x: 1.0,
+                y: 2.0,
+                z: 3.0,
+            },
+            speed: 0.5,
+        });
+        assert_eq!(cmd["type"], "move");
+        assert_eq!(cmd["speed"], 0.5);
+    }
+
+    #[test]
+    fn test_action_translator() {
+        let translator = RunwayActionTranslator;
+        let action = Action::Grasp {
+            object: uuid::Uuid::new_v4(),
+            grip_force: 5.0,
+        };
+        let result = translator.translate(&action).unwrap();
+        assert_eq!(result.provider, "runway");
+        assert_eq!(result.data["type"], "grasp");
+    }
+
+    #[test]
+    fn test_cost_estimation() {
+        let provider = RunwayProvider::new(RunwayModel::Gwm1Robotics, "test-secret");
+        let cost = provider.estimate_cost(&Operation::Predict {
+            steps: 1,
+            resolution: (1280, 720),
+        });
+        assert!(cost.usd > 0.0);
+    }
+
+    #[test]
+    fn test_runway_model_serialization() {
+        let model = RunwayModel::Gwm1Robotics;
+        let json = serde_json::to_string(&model).unwrap();
+        let model2: RunwayModel = serde_json::from_str(&json).unwrap();
+        assert!(matches!(model2, RunwayModel::Gwm1Robotics));
+    }
+
+    #[test]
+    fn test_custom_endpoint() {
+        let provider =
+            RunwayProvider::with_endpoint(RunwayModel::Gwm1Worlds, "secret", "http://localhost");
+        assert_eq!(provider.endpoint, "http://localhost");
+    }
+}


### PR DESCRIPTION
Adds the CosmosProvider struct implementing WorldModelProvider for
NVIDIA Cosmos models (Predict 2.5, Transfer 2.5, Reason 2, Embed 1).
Includes CosmosActionTranslator, endpoint configuration, cost
estimation, and unit tests.

https://claude.ai/code/session_01AgViBEXDz1CN7x2H9vZW9b