### PR TITLE
[codex] add provider telemetry sinks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,7 @@ WorldForge is a Python library for building, persisting, evaluating, and routing
 
 - `src/worldforge/models.py`: domain models, serialization helpers, and framework-level validation errors.
 - `src/worldforge/framework.py`: `WorldForge`, `World`, persistence, planning, prediction, comparison, and diagnostics.
+- `src/worldforge/observability.py`: composable `ProviderEvent` sinks for JSON logging, in-memory recording, and lightweight metrics aggregation.
 - `src/worldforge/providers/`: provider primitives plus the in-repo `mock`, `cosmos`, `runway`, `jepa`, and `genie` adapters.
 - `src/worldforge/evaluation/`: built-in evaluation suites and report rendering.
 - `src/worldforge/testing/`: reusable provider contract assertions for adapter packages.
@@ -60,13 +61,35 @@ uv run pytest --cov=src/worldforge --cov-report=term-missing --cov-fail-under=90
 - Provider health checks may perform live network requests when the relevant provider is configured.
 - Remote provider profiles now expose a typed `ProviderRequestPolicy`; read operations retry, mutation operations do not by default.
 - `WorldForge(event_handler=...)` propagates to builtin providers and to providers later added with `register_provider()`.
+- `worldforge.observability.compose_event_handlers(...)` is the supported way to attach multiple sinks without writing a custom dispatcher.
 - Remote adapters emit `ProviderEvent` records for retry, success, and failure. Mock-backed paths emit success events only.
+- `ProviderMetricsSink.request_count` counts emitted request attempts, so retries increment both `request_count` and `retry_count`.
+
+## Observability Example
+
+```python
+import logging
+
+from worldforge import WorldForge
+from worldforge.observability import JsonLoggerSink, ProviderMetricsSink, compose_event_handlers
+
+metrics = ProviderMetricsSink()
+forge = WorldForge(
+    event_handler=compose_event_handlers(
+        JsonLoggerSink(logger=logging.getLogger("demo.worldforge")),
+        metrics,
+    )
+)
+
+forge.generate("orbiting cube", "mock", duration_seconds=1.0)
+print(metrics.get("mock", "generate").to_dict())
+```
 
 ## Current State
 
 As of 2026-04-08, the project is alpha.
 
-- Stable path: local `mock` provider, persistence, CLI, contract tests, and built-in evaluation flow.
+- Stable path: local `mock` provider, persistence, CLI, contract tests, built-in evaluation flow, and provider telemetry sinks.
 - Beta path: `cosmos` and `runway` HTTP adapters.
 - Scaffold path: `jepa` and `genie`.
-- Known gaps: heuristic planner, limited evaluation suite coverage, no benchmark/load-test harness yet, and no built-in metrics/logging sink for provider events yet.
+- Known gaps: heuristic planner, limited evaluation suite coverage, no benchmark/load-test harness yet, and no built-in exporter integration for OpenTelemetry or Prometheus yet.

--- a/README.md
+++ b/README.md
@@ -64,15 +64,31 @@ print(doctor.healthy_provider_count, doctor.provider_count)
 Provider observability:
 
 ```python
-from worldforge import ProviderEvent, WorldForge
+import logging
 
+from worldforge import WorldForge
+from worldforge.observability import (
+    InMemoryRecorderSink,
+    JsonLoggerSink,
+    ProviderMetricsSink,
+    compose_event_handlers,
+)
 
-def handle_provider_event(event: ProviderEvent) -> None:
-    print(event.to_dict())
+logger = logging.getLogger("demo.worldforge")
+metrics = ProviderMetricsSink()
+recorder = InMemoryRecorderSink()
 
-
-forge = WorldForge(event_handler=handle_provider_event)
+forge = WorldForge(
+    event_handler=compose_event_handlers(
+        JsonLoggerSink(logger=logger, extra_fields={"service": "demo"}),
+        metrics,
+        recorder,
+    )
+)
 forge.generate("orbiting cube", "mock", duration_seconds=1.0)
+
+print(metrics.get("mock", "generate").to_dict())
+print(recorder.snapshot()[0].to_dict())
 ```
 
 ## Core Workflows
@@ -106,6 +122,7 @@ worldforge/
 │   ├── cli.py
 │   ├── framework.py
 │   ├── models.py
+│   ├── observability.py
 │   ├── evaluation/
 │   ├── providers/
 │   └── testing/
@@ -123,6 +140,7 @@ Module responsibilities:
 | --- | --- |
 | `src/worldforge/models.py` | Typed domain models, serialization helpers, and framework-level validation errors |
 | `src/worldforge/framework.py` | `WorldForge`, `World`, persistence, planning, prediction, comparison, and diagnostics |
+| `src/worldforge/observability.py` | Composable `ProviderEvent` sinks for JSON logging, in-memory recording, and metrics aggregation |
 | `src/worldforge/providers/` | Provider primitives plus `mock`, `cosmos`, `runway`, `jepa`, and `genie` adapters |
 | `src/worldforge/evaluation/` | Built-in evaluation suites and report rendering |
 | `src/worldforge/testing/` | Reusable provider contract assertions for adapter packages |
@@ -135,9 +153,10 @@ Operational invariants:
 - provider adapters must report only capabilities they actually implement
 - missing local assets for remote providers fail before the outbound request
 - remote adapters expose a typed `ProviderRequestPolicy` for health, request, polling, and download operations
-- `WorldForge(event_handler=...)` propagates a single provider event callback to builtin and manually registered providers
+- `WorldForge(event_handler=...)` propagates a single provider event callback, including composed observability sinks, to builtin and manually registered providers
 - retryable read operations are retried with backoff; mutation requests stay single-attempt by default
 - remote HTTP adapters emit structured `ProviderEvent` records for `retry`, `success`, and `failure`
+- `ProviderMetricsSink.request_count` tracks emitted request attempts, so retry events increment both `request_count` and `retry_count`
 - local `mock` and scaffold adapters emit structured success events for provider operations
 - the deterministic mock path remains available for local tests and examples
 

--- a/docs/src/api/python.md
+++ b/docs/src/api/python.md
@@ -29,6 +29,26 @@ print(profiles[0].supported_tasks)
 print(doctor.issues)
 ```
 
+## Observability
+
+```python
+import logging
+
+from worldforge import WorldForge
+from worldforge.observability import JsonLoggerSink, ProviderMetricsSink, compose_event_handlers
+
+metrics = ProviderMetricsSink()
+forge = WorldForge(
+    event_handler=compose_event_handlers(
+        JsonLoggerSink(logger=logging.getLogger("demo.worldforge")),
+        metrics,
+    )
+)
+
+forge.generate("orbiting cube", "mock", duration_seconds=1.0)
+print(metrics.get("mock", "generate").to_dict())
+```
+
 ## `World`
 
 Stateful runtime object responsible for:

--- a/docs/src/architecture.md
+++ b/docs/src/architecture.md
@@ -8,6 +8,7 @@ src/worldforge/
 ├── cli.py
 ├── framework.py
 ├── models.py
+├── observability.py
 ├── evaluation/
 └── providers/
 ```
@@ -29,6 +30,13 @@ Framework runtime and persistence:
 - `Plan`
 - import/export and local JSON world storage
 
+### `observability.py`
+
+Composable provider telemetry sinks built on `ProviderEvent`. This module provides
+`JsonLoggerSink`, `InMemoryRecorderSink`, `ProviderMetricsSink`, and
+`compose_event_handlers(...)` for host-side logging, local debugging, and
+lightweight request aggregation.
+
 ### `providers/`
 
 Provider primitives and adapters. The mock provider is the reference implementation. `cosmos`
@@ -45,7 +53,8 @@ Evaluation suites, scenario runners, and report rendering.
 3. The provider returns a `PredictionPayload` or `VideoClip`.
 4. The framework validates and applies the returned state.
 5. Optional provider event callbacks receive structured `ProviderEvent` records from local and remote provider operations.
-6. History, persistence, evaluation, and CLI output are derived from that validated state.
+6. Host apps can fan those events out to logging, recording, and metrics sinks through `worldforge.observability.compose_event_handlers(...)`.
+7. History, persistence, evaluation, and CLI output are derived from that validated state.
 
 ## Invariants
 
@@ -56,6 +65,7 @@ Evaluation suites, scenario runners, and report rendering.
 - missing local asset files fail before network I/O
 - remote provider reads use typed retry/backoff policy; mutation requests default to single-attempt behavior
 - forge-level event handlers propagate to builtin providers and to providers later registered at runtime
+- `ProviderMetricsSink.request_count` tracks emitted request attempts; retries increment both `request_count` and `retry_count`
 
 ## Failure model
 
@@ -65,6 +75,26 @@ Evaluation suites, scenario runners, and report rendering.
 - remote health checks may fail due to missing credentials, invalid endpoints, or upstream errors
 - remote HTTP adapters share one typed request policy contract for timeout, polling, download, and retry behavior
 - provider event callbacks surface structured retry, success, and failure records but do not replace host-level logging or metrics sinks
+
+## Observability example
+
+```python
+import logging
+
+from worldforge import WorldForge
+from worldforge.observability import JsonLoggerSink, ProviderMetricsSink, compose_event_handlers
+
+metrics = ProviderMetricsSink()
+forge = WorldForge(
+    event_handler=compose_event_handlers(
+        JsonLoggerSink(logger=logging.getLogger("demo.worldforge")),
+        metrics,
+    )
+)
+
+forge.generate("orbiting cube", "mock", duration_seconds=1.0)
+print(metrics.get("mock", "generate").to_dict())
+```
 
 ## Design principles
 

--- a/docs/src/providers/README.md
+++ b/docs/src/providers/README.md
@@ -25,16 +25,33 @@ Every provider exposes a profile describing:
 Programmatically:
 
 ```python
-from worldforge import ProviderEvent, WorldForge
+import logging
 
+from worldforge import WorldForge
+from worldforge.observability import (
+    InMemoryRecorderSink,
+    JsonLoggerSink,
+    ProviderMetricsSink,
+    compose_event_handlers,
+)
 
-def handle_provider_event(event: ProviderEvent) -> None:
-    print(event.phase, event.operation, event.provider)
+logger = logging.getLogger("demo.worldforge")
+metrics = ProviderMetricsSink()
+recorder = InMemoryRecorderSink()
 
-
-forge = WorldForge(event_handler=handle_provider_event)
+forge = WorldForge(
+    event_handler=compose_event_handlers(
+        JsonLoggerSink(logger=logger),
+        metrics,
+        recorder,
+    )
+)
 profile = forge.provider_profile("mock")
+forge.generate("orbiting cube", "mock", duration_seconds=1.0)
+
 print(profile.supported_tasks, profile.deterministic)
+print(metrics.get("mock", "generate").to_dict())
+print(recorder.snapshot()[0].phase)
 ```
 
 From the CLI:
@@ -63,5 +80,7 @@ Providers can declare support for:
 - `cosmos` and `runway` expose a typed `ProviderRequestPolicy` through `provider_profile()` and CLI JSON output.
 - Health checks, polling, and downloads retry with backoff by default. Create-style POST requests remain single-attempt unless a caller passes a custom policy.
 - `WorldForge(event_handler=...)` and provider constructor `event_handler=` arguments accept a `ProviderEvent` callback for host-side logging and metrics.
+- `worldforge.observability.compose_event_handlers(...)` lets host apps attach multiple sinks without writing a custom dispatcher.
+- `ProviderMetricsSink.request_count` counts emitted request attempts, so retry events increment both `request_count` and `retry_count`.
 - `cosmos` and `runway` emit `retry`, `success`, and `failure` events for HTTP operations. `mock`, `jepa`, and `genie` emit success events for local provider operations.
 - `cosmos` and `runway` are the only in-repo adapters that currently perform real HTTP requests.

--- a/src/worldforge/observability.py
+++ b/src/worldforge/observability.py
@@ -1,0 +1,239 @@
+"""Ready-to-use provider telemetry sinks built on ProviderEvent."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from copy import deepcopy
+from dataclasses import dataclass, field
+from threading import Lock
+
+from worldforge.models import JSONDict, ProviderEvent, WorldForgeError, dump_json
+
+ProviderEventHandler = Callable[[ProviderEvent], None]
+
+
+def _copy_event(event: ProviderEvent) -> ProviderEvent:
+    return ProviderEvent(
+        provider=event.provider,
+        operation=event.operation,
+        phase=event.phase,
+        attempt=event.attempt,
+        max_attempts=event.max_attempts,
+        method=event.method,
+        target=event.target,
+        status_code=event.status_code,
+        duration_ms=event.duration_ms,
+        message=event.message,
+        metadata=deepcopy(event.metadata),
+    )
+
+
+@dataclass(slots=True)
+class _EventHandlerFanout:
+    handlers: tuple[ProviderEventHandler, ...]
+
+    def __post_init__(self) -> None:
+        if not self.handlers:
+            raise WorldForgeError("Event handler fanout requires at least one handler.")
+
+    def __call__(self, event: ProviderEvent) -> None:
+        for handler in self.handlers:
+            handler(_copy_event(event))
+
+
+def compose_event_handlers(*handlers: ProviderEventHandler | None) -> ProviderEventHandler | None:
+    """Return a single provider event handler composed from zero or more handlers."""
+
+    resolved_handlers: list[ProviderEventHandler] = []
+    for handler in handlers:
+        if handler is None:
+            continue
+        if isinstance(handler, _EventHandlerFanout):
+            resolved_handlers.extend(handler.handlers)
+            continue
+        resolved_handlers.append(handler)
+    if not resolved_handlers:
+        return None
+    if len(resolved_handlers) == 1:
+        return resolved_handlers[0]
+    return _EventHandlerFanout(tuple(resolved_handlers))
+
+
+@dataclass(slots=True)
+class JsonLoggerSink:
+    """Log provider events as a single structured JSON record."""
+
+    logger: logging.Logger = field(
+        default_factory=lambda: logging.getLogger("worldforge.providers")
+    )
+    level: int = logging.INFO
+    extra_fields: JSONDict = field(default_factory=dict)
+
+    def __call__(self, event: ProviderEvent) -> None:
+        payload = {"event_type": "provider_event", **deepcopy(self.extra_fields), **event.to_dict()}
+        self.logger.log(self.level, dump_json(payload))
+
+
+@dataclass(slots=True)
+class InMemoryRecorderSink:
+    """Record provider events in memory for tests and local debugging."""
+
+    _events: list[ProviderEvent] = field(default_factory=list, init=False, repr=False)
+    _lock: Lock = field(default_factory=Lock, init=False, repr=False)
+
+    def __call__(self, event: ProviderEvent) -> None:
+        with self._lock:
+            self._events.append(_copy_event(event))
+
+    @property
+    def events(self) -> list[ProviderEvent]:
+        return self.snapshot()
+
+    def clear(self) -> None:
+        with self._lock:
+            self._events.clear()
+
+    def snapshot(self) -> list[ProviderEvent]:
+        with self._lock:
+            return [_copy_event(event) for event in self._events]
+
+
+@dataclass(slots=True, frozen=True)
+class LatencySummary:
+    """Aggregate latency measurements for a provider operation."""
+
+    sample_count: int = 0
+    total_ms: float = 0.0
+    average_ms: float | None = None
+    min_ms: float | None = None
+    max_ms: float | None = None
+
+    def to_dict(self) -> JSONDict:
+        return {
+            "sample_count": self.sample_count,
+            "total_ms": self.total_ms,
+            "average_ms": self.average_ms,
+            "min_ms": self.min_ms,
+            "max_ms": self.max_ms,
+        }
+
+
+@dataclass(slots=True, frozen=True)
+class ProviderOperationMetrics:
+    """Aggregated provider telemetry for a single provider/operation pair."""
+
+    provider: str
+    operation: str
+    request_count: int = 0
+    error_count: int = 0
+    retry_count: int = 0
+    latency: LatencySummary = field(default_factory=LatencySummary)
+
+    def to_dict(self) -> JSONDict:
+        return {
+            "provider": self.provider,
+            "operation": self.operation,
+            "request_count": self.request_count,
+            "error_count": self.error_count,
+            "retry_count": self.retry_count,
+            "latency": self.latency.to_dict(),
+        }
+
+
+@dataclass(slots=True)
+class _ProviderOperationAccumulator:
+    request_count: int = 0
+    error_count: int = 0
+    retry_count: int = 0
+    latency_sample_count: int = 0
+    total_latency_ms: float = 0.0
+    min_latency_ms: float | None = None
+    max_latency_ms: float | None = None
+
+    def record(self, event: ProviderEvent) -> None:
+        self.request_count += 1
+        if event.phase == "failure":
+            self.error_count += 1
+        if event.phase == "retry":
+            self.retry_count += 1
+        if event.duration_ms is None:
+            return
+        self.latency_sample_count += 1
+        self.total_latency_ms += event.duration_ms
+        if self.min_latency_ms is None or event.duration_ms < self.min_latency_ms:
+            self.min_latency_ms = event.duration_ms
+        if self.max_latency_ms is None or event.duration_ms > self.max_latency_ms:
+            self.max_latency_ms = event.duration_ms
+
+    def snapshot(self, *, provider: str, operation: str) -> ProviderOperationMetrics:
+        average_ms: float | None = None
+        if self.latency_sample_count:
+            average_ms = self.total_latency_ms / self.latency_sample_count
+        return ProviderOperationMetrics(
+            provider=provider,
+            operation=operation,
+            request_count=self.request_count,
+            error_count=self.error_count,
+            retry_count=self.retry_count,
+            latency=LatencySummary(
+                sample_count=self.latency_sample_count,
+                total_ms=self.total_latency_ms,
+                average_ms=average_ms,
+                min_ms=self.min_latency_ms,
+                max_ms=self.max_latency_ms,
+            ),
+        )
+
+
+@dataclass(slots=True)
+class ProviderMetricsSink:
+    """Aggregate provider request attempts, errors, retries, and latency."""
+
+    _metrics: dict[tuple[str, str], _ProviderOperationAccumulator] = field(
+        default_factory=dict,
+        init=False,
+        repr=False,
+    )
+    _lock: Lock = field(default_factory=Lock, init=False, repr=False)
+
+    def __call__(self, event: ProviderEvent) -> None:
+        key = (event.provider, event.operation)
+        with self._lock:
+            accumulator = self._metrics.setdefault(key, _ProviderOperationAccumulator())
+            accumulator.record(event)
+
+    def clear(self) -> None:
+        with self._lock:
+            self._metrics.clear()
+
+    def get(self, provider: str, operation: str) -> ProviderOperationMetrics:
+        with self._lock:
+            accumulator = self._metrics.get((provider, operation), _ProviderOperationAccumulator())
+            return accumulator.snapshot(provider=provider, operation=operation)
+
+    def snapshot(self) -> list[ProviderOperationMetrics]:
+        with self._lock:
+            items = [
+                accumulator.snapshot(provider=provider, operation=operation)
+                for (provider, operation), accumulator in self._metrics.items()
+            ]
+        return sorted(items, key=lambda item: (item.provider, item.operation))
+
+    def to_dict(self) -> JSONDict:
+        payload: JSONDict = {}
+        for metric in self.snapshot():
+            provider_metrics = payload.setdefault(metric.provider, {})
+            provider_metrics[metric.operation] = metric.to_dict()
+        return payload
+
+
+__all__ = [
+    "InMemoryRecorderSink",
+    "JsonLoggerSink",
+    "LatencySummary",
+    "ProviderEventHandler",
+    "ProviderMetricsSink",
+    "ProviderOperationMetrics",
+    "compose_event_handlers",
+]

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+import json
+import logging
+
+import pytest
+
+from worldforge import Action, ProviderEvent, WorldForge
+from worldforge.observability import (
+    InMemoryRecorderSink,
+    JsonLoggerSink,
+    ProviderMetricsSink,
+    compose_event_handlers,
+)
+from worldforge.providers import MockProvider
+
+
+def test_json_logger_sink_emits_structured_json(caplog) -> None:
+    logger = logging.getLogger("worldforge.tests.observability")
+    sink = JsonLoggerSink(logger=logger, extra_fields={"service": "api"})
+
+    with caplog.at_level(logging.INFO, logger=logger.name):
+        sink(
+            ProviderEvent(
+                provider="mock",
+                operation="predict",
+                phase="success",
+                duration_ms=12.5,
+                metadata={"steps": 2},
+            )
+        )
+
+    records = [record for record in caplog.records if record.name == logger.name]
+    assert len(records) == 1
+    payload = json.loads(records[0].message)
+    assert payload == {
+        "attempt": 1,
+        "duration_ms": 12.5,
+        "event_type": "provider_event",
+        "max_attempts": 1,
+        "message": "",
+        "metadata": {"steps": 2},
+        "method": None,
+        "operation": "predict",
+        "phase": "success",
+        "provider": "mock",
+        "service": "api",
+        "status_code": None,
+        "target": None,
+    }
+
+
+def test_in_memory_recorder_sink_records_isolated_event_snapshots() -> None:
+    sink = InMemoryRecorderSink()
+    event = ProviderEvent(
+        provider="mock",
+        operation="predict",
+        phase="success",
+        duration_ms=8.0,
+        metadata={"nested": {"steps": [1]}},
+    )
+
+    sink(event)
+    event.metadata["nested"]["steps"].append(2)
+
+    assert sink.events[0].metadata == {"nested": {"steps": [1]}}
+    sink.clear()
+    assert sink.events == []
+
+
+def test_compose_event_handlers_fans_out_and_isolates_sink_mutation() -> None:
+    first = InMemoryRecorderSink()
+    second = InMemoryRecorderSink()
+
+    def mutating_sink(event: ProviderEvent) -> None:
+        event.metadata["mutated"] = True
+
+    handler = compose_event_handlers(first, compose_event_handlers(mutating_sink), None, second)
+    assert handler is not None
+
+    handler(
+        ProviderEvent(
+            provider="mock",
+            operation="predict",
+            phase="success",
+            duration_ms=5.0,
+            metadata={"steps": 2},
+        )
+    )
+
+    assert first.snapshot()[0].metadata == {"steps": 2}
+    assert second.snapshot()[0].metadata == {"steps": 2}
+
+
+def test_provider_metrics_sink_aggregates_counts_and_latency_by_operation() -> None:
+    sink = ProviderMetricsSink()
+
+    sink(
+        ProviderEvent(
+            provider="runway",
+            operation="task poll",
+            phase="retry",
+            duration_ms=10.0,
+        )
+    )
+    sink(
+        ProviderEvent(
+            provider="runway",
+            operation="task poll",
+            phase="success",
+            duration_ms=20.0,
+        )
+    )
+    sink(
+        ProviderEvent(
+            provider="runway",
+            operation="task poll",
+            phase="failure",
+            duration_ms=30.0,
+        )
+    )
+    sink(
+        ProviderEvent(
+            provider="mock",
+            operation="predict",
+            phase="success",
+        )
+    )
+
+    task_poll = sink.get("runway", "task poll")
+    assert task_poll.request_count == 3
+    assert task_poll.error_count == 1
+    assert task_poll.retry_count == 1
+    assert task_poll.latency.sample_count == 3
+    assert task_poll.latency.total_ms == pytest.approx(60.0)
+    assert task_poll.latency.average_ms == pytest.approx(20.0)
+    assert task_poll.latency.min_ms == pytest.approx(10.0)
+    assert task_poll.latency.max_ms == pytest.approx(30.0)
+
+    predict = sink.get("mock", "predict")
+    assert predict.request_count == 1
+    assert predict.error_count == 0
+    assert predict.retry_count == 0
+    assert predict.latency.sample_count == 0
+    assert predict.latency.average_ms is None
+    assert predict.latency.min_ms is None
+    assert predict.latency.max_ms is None
+
+    assert [(metric.provider, metric.operation) for metric in sink.snapshot()] == [
+        ("mock", "predict"),
+        ("runway", "task poll"),
+    ]
+    assert sink.to_dict()["runway"]["task poll"]["latency"]["sample_count"] == 3
+
+
+def test_worldforge_composed_event_handlers_support_builtin_and_manual_providers(tmp_path) -> None:
+    recorder = InMemoryRecorderSink()
+    metrics = ProviderMetricsSink()
+    forge = WorldForge(
+        state_dir=tmp_path,
+        auto_register_remote=False,
+        event_handler=compose_event_handlers(recorder, metrics),
+    )
+    world = forge.create_world_from_prompt("empty room", provider="mock")
+
+    world.predict(Action.move_to(0.2, 0.5, 0.0), steps=2)
+    manual_provider = MockProvider(name="manual")
+    forge.register_provider(manual_provider)
+    forge.reason("manual", "where is the cube?", world=world)
+
+    assert manual_provider.event_handler is not None
+    assert [(event.provider, event.operation, event.phase) for event in recorder.snapshot()] == [
+        ("mock", "predict", "success"),
+        ("manual", "reason", "success"),
+    ]
+    assert metrics.get("mock", "predict").request_count == 1
+    assert metrics.get("manual", "reason").request_count == 1

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import worldforge
+import worldforge.observability as observability
 from worldforge.evaluation import EvaluationSuite
 from worldforge.providers import MockProvider
 
@@ -18,3 +19,7 @@ def test_top_level_exports_and_subpackages_import() -> None:
     assert worldforge.SceneObjectPatch is not None
     assert EvaluationSuite is not None
     assert MockProvider is not None
+    assert observability.JsonLoggerSink is not None
+    assert observability.InMemoryRecorderSink is not None
+    assert observability.ProviderMetricsSink is not None
+    assert observability.compose_event_handlers is not None


### PR DESCRIPTION
## Summary

Adds an operator-facing observability module built on `ProviderEvent`.

- add `worldforge.observability` with composable fan-out, structured JSON logging, in-memory recording, and lightweight metrics aggregation
- add regression coverage for sink behavior, fan-out isolation, and metrics aggregation across retry, success, and failure events
- update README, architecture docs, provider docs, Python API docs, and agent context with concrete usage examples and metrics semantics

## Why

Host applications needed a ready-to-use way to attach logging and metrics to `WorldForge(event_handler=...)` without writing their own dispatcher glue.

## Validation

- `uv run ruff check src tests examples`
- `uv run ruff format --check src tests examples`
- `uv run pytest`
- `uv run pytest --cov=src/worldforge --cov-report=term-missing --cov-fail-under=90`
- `bash scripts/test_package.sh`