### PR TITLE
[codex] Add LeWorldModel score planning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,10 +44,10 @@ jobs:
         run: uv sync --group dev
 
       - name: Lint
-        run: uv run ruff check src tests examples
+        run: uv run ruff check src tests examples scripts
 
       - name: Check formatting
-        run: uv run ruff format --check src tests examples
+        run: uv run ruff format --check src tests examples scripts
 
       - name: Run tests with coverage
         run: uv run pytest --cov=src/worldforge --cov-report=term-missing --cov-fail-under=90

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,8 +49,8 @@ Run these from the repository root:
 ```bash
 uv sync --group dev
 uv lock --check
-uv run ruff check src tests examples
-uv run ruff format --check src tests examples
+uv run ruff check src tests examples scripts
+uv run ruff format --check src tests examples scripts
 uv run pytest
 uv run pytest --cov=src/worldforge --cov-report=term-missing --cov-fail-under=90
 bash scripts/test_package.sh
@@ -108,6 +108,9 @@ rm -f "$tmp_req"
 - LeWorldModel expects preprocessed pixel/action/goal tensors or rectangular nested numeric
   arrays shaped for the configured checkpoint. WorldForge validates the adapter boundary but does
   not infer task-specific image transforms.
+- `scripts/smoke_leworldmodel.py` is an optional real-checkpoint smoke. Run it from an isolated
+  Python 3.10 environment with the upstream GitHub `stable-worldmodel[train,env]` runtime; do not
+  add those dependencies to WorldForge's base package.
 - `RUNWAYML_API_SECRET` is preferred, but `RUNWAY_API_SECRET` remains supported as a legacy alias.
 
 ## Current State

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ releases may still include breaking changes when the public API needs to tighten
 - Added `leworldmodel` as a first-class optional provider for LeWorldModel JEPA cost models,
   including the `score` capability, `ActionScoreResult`, `WorldForge.score_actions(...)`, typed
   input validation, score-output validation, provider profile metadata, and fixture-driven tests.
+- Added score-based planning support so `World.plan(...)` can select candidate action plans from
+  `ActionScoreResult.best_index`, plus a real-checkpoint LeWorldModel smoke script.
 
 ### Security
 

--- a/README.md
+++ b/README.md
@@ -199,6 +199,9 @@ environment, place checkpoints under `$STABLEWM_HOME` or set `LEWORLDMODEL_CACHE
 `LEWORLDMODEL_POLICY` to the checkpoint run name without the `_object.ckpt` suffix, for example
 `pusht/lewm`. The adapter expects tensors or nested numeric arrays that already match the
 checkpoint's task preprocessing contract; WorldForge does not infer raw-image transforms.
+Use `scripts/smoke_leworldmodel.py` from an isolated environment with the upstream
+`stable-worldmodel[train,env]` runtime to download the public `quentinll/lewm-pusht` weights,
+prepare the object checkpoint, and run a real `score_actions(...)` smoke.
 
 ## Development
 
@@ -206,8 +209,8 @@ Primary commands:
 
 ```bash
 uv sync --group dev
-uv run ruff check src tests examples
-uv run ruff format --check src tests examples
+uv run ruff check src tests examples scripts
+uv run ruff format --check src tests examples scripts
 uv run pytest
 uv run pytest --cov=src/worldforge --cov-report=term-missing --cov-fail-under=90
 bash scripts/test_package.sh

--- a/docs/src/api/python.md
+++ b/docs/src/api/python.md
@@ -80,6 +80,32 @@ print(result.best_index, result.best_score)
 `ActionScoreResult` validates finite scores, exposes `best_index` and `best_score`, and includes
 `lower_is_better` so callers do not have to infer score direction from provider-specific docs.
 
+The planner can consume the same score surface when callers provide the model-shaped payload and
+the WorldForge actions that correspond to each scored candidate:
+
+```python
+from worldforge import Action
+
+plan = world.plan(
+    goal="choose the lowest-cost LeWorldModel action",
+    provider="leworldmodel",
+    planner="leworldmodel-mpc",
+    candidate_actions=[
+        [Action.move_to(0.1, 0.5, 0.0)],
+        [Action.move_to(0.4, 0.5, 0.0)],
+    ],
+    score_info=info,
+    score_action_candidates=action_candidates,
+    execution_provider="mock",
+)
+
+print(plan.actions, plan.metadata["score_result"]["best_index"])
+```
+
+Score-based plans do not ask the score provider to predict state. `Plan.predicted_states` stays
+empty, score details are stored in `Plan.metadata`, and `execute_plan(...)` uses
+`execution_provider` when the scoring provider does not implement `predict()`.
+
 ## `World`
 
 Stateful runtime object responsible for:

--- a/docs/src/operations.md
+++ b/docs/src/operations.md
@@ -91,6 +91,9 @@ include those IDs in surrounding application logs.
 - For LeWorldModel failures, run `worldforge provider health leworldmodel`, verify
   `stable-worldmodel[env]` and `torch` are installed in the host environment, then confirm the
   configured policy exists under `$STABLEWM_HOME` or `LEWORLDMODEL_CACHE_DIR`.
+- To smoke-test a real LeWorldModel checkpoint, install the upstream
+  `stable-worldmodel[train,env]` runtime in an isolated environment and run
+  `python scripts/smoke_leworldmodel.py --stablewm-home /path/to/stablewm-home`.
 
 ## Release Checklist
 

--- a/docs/src/providers/README.md
+++ b/docs/src/providers/README.md
@@ -131,3 +131,6 @@ LeWorldModel:
 - `action_candidates` must be a tensor or rectangular nested numeric sequence shaped as
   `(batch, samples, horizon, action_dim)`.
 - Model output must flatten to at least one finite numeric score.
+- `scripts/smoke_leworldmodel.py` can run a local end-to-end smoke against
+  `quentinll/lewm-pusht`; it requires the upstream GitHub version of `stable-worldmodel[train,env]`
+  because the PyPI package may lag the LeWM module.

--- a/scripts/smoke_leworldmodel.py
+++ b/scripts/smoke_leworldmodel.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python
+"""Run a LeWorldModel provider smoke test with a real checkpoint."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+
+from worldforge.providers import LeWorldModelProvider
+
+
+def _checkpoint_path(cache_dir: Path, policy: str) -> Path:
+    return cache_dir / f"{policy}_object.ckpt"
+
+
+def _prepare_object_checkpoint(
+    *,
+    policy: str,
+    hf_repo: str,
+    stablewm_home: Path,
+    cache_dir: Path,
+) -> Path:
+    object_path = _checkpoint_path(cache_dir, policy)
+    if object_path.exists():
+        return object_path
+
+    try:
+        import torch
+        from stable_worldmodel.wm.utils import load_pretrained
+    except ImportError as exc:  # pragma: no cover - exercised by host smoke usage
+        raise SystemExit(
+            "Preparing a LeWorldModel object checkpoint requires torch and the upstream "
+            "stable_worldmodel.wm.utils.load_pretrained helper. Install the upstream "
+            "stable-worldmodel[train,env] runtime before running this script."
+        ) from exc
+
+    model = load_pretrained(hf_repo, cache_dir=str(stablewm_home))
+    object_path.parent.mkdir(parents=True, exist_ok=True)
+    torch.save(model, object_path)
+    return object_path
+
+
+def _build_inputs(
+    *,
+    batch: int,
+    samples: int,
+    history: int,
+    horizon: int,
+    action_dim: int,
+    image_size: int,
+):
+    import torch
+
+    if horizon <= history:
+        raise SystemExit("horizon must be greater than history for LeWorldModel rollout.")
+    info = {
+        "pixels": torch.rand(batch, 1, history, 3, image_size, image_size),
+        "goal": torch.rand(batch, 1, history, 3, image_size, image_size),
+        "action": torch.rand(batch, 1, history, action_dim),
+    }
+    action_candidates = torch.rand(batch, samples, horizon, action_dim)
+    return info, action_candidates
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--policy", default=os.environ.get("LEWORLDMODEL_POLICY", "pusht/lewm"))
+    parser.add_argument("--hf-repo", default="quentinll/lewm-pusht")
+    parser.add_argument(
+        "--stablewm-home",
+        type=Path,
+        default=Path(os.environ.get("STABLEWM_HOME", "~/.stable_worldmodel")).expanduser(),
+    )
+    parser.add_argument(
+        "--cache-dir",
+        type=Path,
+        default=None,
+        help=(
+            "Checkpoint root passed to LeWorldModelProvider. Defaults to STABLEWM_HOME/checkpoints."
+        ),
+    )
+    parser.add_argument("--device", default=os.environ.get("LEWORLDMODEL_DEVICE", "cpu"))
+    parser.add_argument("--batch", type=int, default=1)
+    parser.add_argument("--samples", type=int, default=3)
+    parser.add_argument("--history", type=int, default=3)
+    parser.add_argument("--horizon", type=int, default=4)
+    parser.add_argument("--action-dim", type=int, default=10)
+    parser.add_argument("--image-size", type=int, default=224)
+    return parser
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    cache_dir = args.cache_dir or (args.stablewm_home / "checkpoints")
+    object_path = _prepare_object_checkpoint(
+        policy=args.policy,
+        hf_repo=args.hf_repo,
+        stablewm_home=args.stablewm_home,
+        cache_dir=cache_dir,
+    )
+    info, action_candidates = _build_inputs(
+        batch=args.batch,
+        samples=args.samples,
+        history=args.history,
+        horizon=args.horizon,
+        action_dim=args.action_dim,
+        image_size=args.image_size,
+    )
+    provider = LeWorldModelProvider(
+        policy=args.policy,
+        cache_dir=str(cache_dir),
+        device=args.device,
+    )
+    result = provider.score_actions(info=info, action_candidates=action_candidates)
+    print(
+        json.dumps(
+            {
+                "checkpoint": str(object_path),
+                "health": provider.health().to_dict(),
+                "result": result.to_dict(),
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/worldforge/framework.py
+++ b/src/worldforge/framework.py
@@ -62,6 +62,32 @@ def _normalize_provider_name(provider: str | None, fallback: str) -> str:
     return provider or fallback
 
 
+def _is_sequence_of_actions(value: object) -> bool:
+    return isinstance(value, Sequence) and not isinstance(value, str | bytes)
+
+
+def _normalize_candidate_action_plans(
+    candidate_actions: Sequence[Action | Sequence[Action]],
+) -> list[list[Action]]:
+    if not _is_sequence_of_actions(candidate_actions) or not candidate_actions:
+        raise WorldForgeError("candidate_actions must be a non-empty sequence.")
+
+    normalized: list[list[Action]] = []
+    for index, candidate in enumerate(candidate_actions):
+        if isinstance(candidate, Action):
+            normalized.append([candidate])
+            continue
+        if not _is_sequence_of_actions(candidate) or not candidate:
+            raise WorldForgeError(
+                f"candidate_actions[{index}] must be an Action or non-empty sequence of Actions."
+            )
+        actions = list(candidate)
+        if not all(isinstance(action, Action) for action in actions):
+            raise WorldForgeError(f"candidate_actions[{index}] must contain only Action instances.")
+        normalized.append(actions)
+    return normalized
+
+
 def _world_file(state_dir: Path, world_id: str) -> Path:
     return state_dir / f"{world_id}.json"
 
@@ -219,6 +245,7 @@ class Plan:
         predicted_states: Sequence[JSONDict],
         success_probability: float,
         goal_spec: JSONDict | None = None,
+        metadata: JSONDict | None = None,
     ) -> None:
         self.goal = goal
         self.planner = planner
@@ -227,6 +254,7 @@ class Plan:
         self.predicted_states = [_clone_state(state) for state in predicted_states]
         self.success_probability = success_probability
         self.goal_spec = _clone_state(goal_spec) if goal_spec is not None else None
+        self.metadata = _clone_state(metadata or {})
 
     @property
     def action_count(self) -> int:
@@ -242,6 +270,7 @@ class Plan:
             "action_count": self.action_count,
             "success_probability": self.success_probability,
             "predicted_states": self.predicted_states,
+            "metadata": self.metadata,
         }
 
     def to_json(self) -> str:
@@ -606,6 +635,10 @@ class World:
         planner: str = "cem",
         max_steps: int = 20,
         provider: str | None = None,
+        candidate_actions: Sequence[Action | Sequence[Action]] | None = None,
+        score_info: JSONDict | None = None,
+        score_action_candidates: object | None = None,
+        execution_provider: str | None = None,
         **_: Any,
     ) -> Plan:
         require_positive_int(max_steps, name="max_steps")
@@ -616,6 +649,21 @@ class World:
         if goal is not None and not goal.strip():
             raise WorldForgeError("goal must not be empty when provided.")
         selected_provider = _normalize_provider_name(provider, self.provider)
+        selected_provider_instance = self._provider(selected_provider)
+        uses_score_planning = any(
+            item is not None for item in (candidate_actions, score_info, score_action_candidates)
+        )
+        if uses_score_planning:
+            if not selected_provider_instance.capabilities.score:
+                raise WorldForgeError(
+                    f"Provider '{selected_provider}' does not support score-based planning."
+                )
+            if candidate_actions is None or score_info is None or score_action_candidates is None:
+                raise WorldForgeError(
+                    "Score-based planning requires candidate_actions, score_info, "
+                    "and score_action_candidates."
+                )
+
         resolved_goal_spec = goal_spec
         if goal_json is not None:
             resolved_goal_spec = StructuredGoal.from_json(goal_json)
@@ -631,6 +679,42 @@ class World:
             serialized_goal_spec = None
             actions = self._goal_actions(resolved_goal)
         actions = actions[: min(max_steps, len(actions))]
+
+        if uses_score_planning:
+            assert candidate_actions is not None
+            assert score_info is not None
+            candidate_action_plans = _normalize_candidate_action_plans(candidate_actions)
+            score_result = selected_provider_instance.score_actions(
+                info=score_info,
+                action_candidates=score_action_candidates,
+            )
+            if score_result.best_index >= len(candidate_action_plans):
+                raise WorldForgeError(
+                    f"Provider '{selected_provider}' selected candidate index "
+                    f"{score_result.best_index}, but only {len(candidate_action_plans)} "
+                    "candidate action plan(s) were provided."
+                )
+            selected_actions = candidate_action_plans[score_result.best_index][:max_steps]
+            best_score = max(0.0, score_result.best_score)
+            success_probability = 1.0 / (1.0 + best_score)
+            metadata: JSONDict = {
+                "planning_mode": "score",
+                "score_result": score_result.to_dict(),
+                "candidate_count": len(candidate_action_plans),
+                "success_probability_source": "inverse_best_cost_heuristic",
+            }
+            if execution_provider is not None:
+                metadata["execution_provider"] = execution_provider
+            return Plan(
+                goal=resolved_goal,
+                goal_spec=serialized_goal_spec,
+                planner=planner,
+                provider=selected_provider,
+                actions=selected_actions,
+                predicted_states=[],
+                success_probability=max(0.0, min(1.0, success_probability)),
+                metadata=metadata,
+            )
 
         simulated_state = self._snapshot()
         predicted_states: list[JSONDict] = []
@@ -649,12 +733,28 @@ class World:
             actions=actions,
             predicted_states=predicted_states,
             success_probability=max(0.65, min(0.98, average(scores) if scores else 0.7)),
+            metadata={"planning_mode": "predict"},
         )
 
-    def execute_plan(self, plan: Plan, *_: Any) -> PlanExecution:
+    def execute_plan(
+        self,
+        plan: Plan,
+        *args: Any,
+        provider: str | None = None,
+    ) -> PlanExecution:
+        selected_provider = provider
+        if selected_provider is None:
+            selected_provider = next((arg for arg in args if isinstance(arg, str)), None)
+        if selected_provider is None:
+            selected_provider = str(plan.metadata.get("execution_provider") or plan.provider)
+        if not self._provider(selected_provider).capabilities.predict:
+            raise WorldForgeError(
+                f"Provider '{selected_provider}' cannot execute plans because it does not "
+                "support predict(). Pass an execution provider that supports predict()."
+            )
         executed_world = World.from_state(self._forge, self.to_dict())
         for action in plan.actions:
-            executed_world.predict(action, steps=1, provider=plan.provider)
+            executed_world.predict(action, steps=1, provider=selected_provider)
         return PlanExecution(executed_world, plan.actions)
 
     def evaluate(self, suite: str = "physics") -> EvaluationReport:

--- a/tests/test_leworldmodel_provider.py
+++ b/tests/test_leworldmodel_provider.py
@@ -6,7 +6,7 @@ from typing import Any
 
 import pytest
 
-from worldforge import ActionScoreResult, WorldForge
+from worldforge import Action, ActionScoreResult, WorldForge, WorldForgeError
 from worldforge.providers import LeWorldModelProvider, ProviderError
 
 FIXTURE_DIR = Path(__file__).parent / "fixtures" / "providers"
@@ -141,6 +141,62 @@ def test_leworldmodel_provider_scores_fixture_payload_and_routes_through_forge(t
     assert len(model.calls) == 1
     assert events[-1].operation == "score"
     assert events[-1].phase == "success"
+
+
+def test_leworldmodel_score_planning_selects_best_candidate_and_execution_provider(
+    tmp_path,
+) -> None:
+    payload = _fixture("leworldmodel_score_request.json")
+    provider = LeWorldModelProvider(
+        policy="pusht/lewm",
+        model_loader=lambda _policy, _cache_dir: FakeLeWorldModel([0.7, 0.15, 0.4]),
+        tensor_module=FakeTorch(),
+    )
+    forge = WorldForge(state_dir=tmp_path, auto_register_remote=False)
+    forge.register_provider(provider)
+    world = forge.create_world_from_prompt("room with cube", provider="mock")
+
+    candidate_plans = [
+        [Action.move_to(0.1, 0.5, 0.0)],
+        [Action.move_to(0.4, 0.5, 0.0)],
+        [Action.move_to(0.7, 0.5, 0.0)],
+    ]
+    plan = world.plan(
+        goal="choose the lowest-cost LeWorldModel action",
+        provider="leworldmodel",
+        planner="leworldmodel-mpc",
+        candidate_actions=candidate_plans,
+        score_info=payload["info"],
+        score_action_candidates=payload["action_candidates"],
+        execution_provider="mock",
+    )
+
+    assert plan.provider == "leworldmodel"
+    assert plan.actions == candidate_plans[1]
+    assert plan.predicted_states == []
+    assert plan.metadata["planning_mode"] == "score"
+    assert plan.metadata["score_result"]["best_index"] == 1
+    assert plan.metadata["execution_provider"] == "mock"
+
+    execution = world.execute_plan(plan)
+    assert execution.actions_applied == candidate_plans[1]
+    assert execution.final_world().provider == "mock"
+
+    with pytest.raises(WorldForgeError, match="requires candidate_actions"):
+        world.plan(
+            goal="incomplete score plan",
+            provider="leworldmodel",
+            score_info=payload["info"],
+        )
+
+    with pytest.raises(WorldForgeError, match="does not support score-based planning"):
+        world.plan(
+            goal="wrong provider",
+            provider="mock",
+            candidate_actions=candidate_plans,
+            score_info=payload["info"],
+            score_action_candidates=payload["action_candidates"],
+        )
 
 
 def test_leworldmodel_provider_reports_profile_health_and_auto_registration(


### PR DESCRIPTION
## Summary

Adds planner-level LeWorldModel integration and a reproducible real-checkpoint smoke.

The change introduces:

- Score-based `World.plan(...)` inputs (`candidate_actions`, `score_info`, `score_action_candidates`, `execution_provider`) that use `ActionScoreResult.best_index` to select the candidate action plan.
- `Plan.metadata` for score details and planning mode, while leaving legacy prediction planning behavior intact.
- `execute_plan(..., provider=...)` / legacy positional provider handling so score-only providers can choose actions while a prediction-capable provider executes them.
- `scripts/smoke_leworldmodel.py`, which prepares a `pusht/lewm_object.ckpt` from the public `quentinll/lewm-pusht` Hugging Face weights and runs a real `LeWorldModelProvider.score_actions(...)` smoke.
- Docs and agent guidance for score planning and the smoke script.

## Real LeWorldModel Smoke

Ran in an isolated Python 3.10 environment with the upstream GitHub `stable-worldmodel[train,env]` runtime:

```bash
STABLEWM_HOME=/tmp/worldforge-lewm-home \
PYTHONPATH=/Users/abdel/dev/me/world-models/worldforge/src \
/tmp/worldforge-lewm-smoke/bin/python scripts/smoke_leworldmodel.py \
  --stablewm-home /tmp/worldforge-lewm-home \
  --policy pusht/lewm \
  --hf-repo quentinll/lewm-pusht \
  --samples 2
```

Result: prepared `/tmp/worldforge-lewm-home/checkpoints/pusht/lewm_object.ckpt`, provider health was healthy, returned finite costs `[10.362086296081543, 10.317288398742676]`, and selected `best_index=1`.

## Validation

- `uv lock --check`
- `uv run ruff check src tests examples scripts`
- `uv run ruff format --check src tests examples scripts`
- `uv run pytest --cov=src/worldforge --cov-report=term-missing --cov-fail-under=90`
- `bash scripts/test_package.sh`