### PR TITLE
[codex] Document world model architecture and taxonomy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,9 @@ releases may still include breaking changes when the public API needs to tighten
 - Added this changelog and linked it from the README.
 - Documented the Provider Hardening RC persistence decision, provider limits, and provider
   workflow failure modes.
+- Added a world-model taxonomy and vision document, plus expanded architecture docs with text and
+  Mermaid diagrams for provider injection, predictive planning, score-based planning, observability,
+  and the LeWorldModel-shaped runtime pipeline.
 
 ## 0.3.0 - 2026-04-08
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,18 @@ World-model experiments usually start as notebooks and one-off provider scripts.
 
 WorldForge is for Python developers building world-model tooling, provider adapters, local evaluation flows, and testable prototypes. It is not an end-user application and it does not ship a hosted control plane.
 
+## World Model Definition
+
+WorldForge uses a narrow, planning-oriented definition of world model: an action-conditioned
+predictive model that helps a caller evaluate, rank, or roll out possible futures from
+observations, state, actions, and goals. The term is overloaded in the broader market, where it can
+also mean video generation, spatial 3D reconstruction, simulation infrastructure, or active
+inference systems. WorldForge supports those systems through explicit provider capabilities, but
+LeWorldModel is the reference provider shaping the core score-planning architecture.
+
+Read [docs/src/world-model-taxonomy.md](./docs/src/world-model-taxonomy.md) for the taxonomy and
+[docs/src/architecture.md](./docs/src/architecture.md) for the end-to-end provider pipeline.
+
 ## Status
 
 As of 2026-04-16, WorldForge is **alpha**. It is suitable for local development, contract testing, provider adapter prototyping, deterministic evaluation flows, and single-writer JSON persistence. It is not yet suitable for claiming real-world physics fidelity, running unattended production workloads against third-party providers without host-level operational safeguards, or presenting scaffold adapters as fully implemented integrations. Known limitations are listed in [Current limitations](#current-limitations). User-visible changes are tracked in [CHANGELOG.md](./CHANGELOG.md).
@@ -181,7 +193,7 @@ Operational invariants:
 - local `mock` and scaffold adapters emit structured success events for provider operations
 - the deterministic mock path remains available for local tests and examples
 
-More detail lives in [docs/src/architecture.md](./docs/src/architecture.md), [docs/src/providers/README.md](./docs/src/providers/README.md), and [docs/src/operations.md](./docs/src/operations.md).
+More detail lives in [docs/src/world-model-taxonomy.md](./docs/src/world-model-taxonomy.md), [docs/src/architecture.md](./docs/src/architecture.md), [docs/src/providers/README.md](./docs/src/providers/README.md), and [docs/src/operations.md](./docs/src/operations.md).
 
 ## Provider Matrix
 

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -2,6 +2,7 @@
 
 - [Introduction](./introduction.md)
 - [Quick Start](./quickstart.md)
+- [World Model Taxonomy](./world-model-taxonomy.md)
 - [Architecture](./architecture.md)
 - [Providers](./providers/README.md)
 - [Python API](./api/python.md)

--- a/docs/src/architecture.md
+++ b/docs/src/architecture.md
@@ -1,93 +1,500 @@
 # Architecture
 
-WorldForge follows a standard `src/` layout:
+WorldForge is a local-first orchestration library for world-model workflows. Its job is not to
+declare that every provider means the same thing by "world model." Its job is to expose each
+provider through an honest typed capability surface, validate the boundary, and let host
+applications compose planning, prediction, generation, evaluation, persistence, and observability.
+
+The current architecture is shaped around LeWorldModel as the first real latent predictive world
+model provider. LeWorldModel does not generate videos and does not mutate WorldForge state
+directly. It scores action candidates from observations, actions, and goals. WorldForge treats that
+as a first-class planning surface instead of forcing it through a fake video or text interface.
+
+## System Map
+
+Repository layout:
 
 ```text
-src/worldforge/
-├── __init__.py
-├── benchmark.py
-├── cli.py
-├── framework.py
-├── models.py
-├── observability.py
-├── evaluation/
-└── providers/
+worldforge/
+|-- src/worldforge/
+|   |-- framework.py       # WorldForge facade, World runtime, planning, persistence
+|   |-- models.py          # public data contracts and validation
+|   |-- providers/
+|   |   |-- base.py        # provider interface, ProviderError, PredictionPayload
+|   |   |-- mock.py        # deterministic reference provider
+|   |   |-- leworldmodel.py# local JEPA cost-model adapter
+|   |   |-- cosmos.py      # HTTP video generation adapter
+|   |   |-- runway.py      # HTTP video generation/transfer adapter
+|   |   `-- remote.py      # scaffold adapters for JEPA and Genie
+|   |-- observability.py   # ProviderEvent sinks
+|   |-- benchmark.py       # provider benchmark harness
+|   |-- evaluation/        # built-in suites and report rendering
+|   `-- testing/           # reusable provider contract assertions
+|-- docs/
+|-- examples/
+|-- scripts/
+`-- tests/
 ```
 
-## Module responsibilities
+Runtime layers:
 
-### `models.py`
+```text
+Host application
+  |
+  |  Python API / CLI
+  v
++-------------------+
+| WorldForge facade |
+| provider registry |
+| diagnostics       |
++---------+---------+
+          |
+          | owns
+          v
++-------------------+
+| World runtime     |
+| state/history     |
+| planning/execution|
++---------+---------+
+          |
+          | dispatches by capability
+          v
++-------------------+       +---------------------------+
+| Provider adapter  | ----> | upstream model/API/runtime|
+| validation/events | <---- | checkpoint/task/artifact  |
++-------------------+       +---------------------------+
+          |
+          v
++-------------------+
+| typed result      |
+| Prediction        |
+| VideoClip         |
+| ActionScoreResult |
+| ReasoningResult   |
++-------------------+
+```
 
-Core domain objects and JSON serialization helpers.
+Mermaid equivalent:
 
-### `benchmark.py`
+```mermaid
+flowchart TD
+    Host[Host app or CLI]
+    Forge[WorldForge facade\nregistry, diagnostics, persistence]
+    World[World\nstate, history, planning]
+    Provider[Provider adapter\ncapability contract]
+    Upstream[Upstream runtime or API\nLeWM, Cosmos, Runway, mock]
+    Models[Typed public models\nPrediction, VideoClip, ActionScoreResult]
+    Obs[ProviderEvent sinks\nlogs, recorder, metrics]
+    Store[Local JSON state]
 
-Capability-aware benchmark harness for provider latency, retries, and throughput.
+    Host --> Forge
+    Forge --> World
+    World --> Provider
+    Provider --> Upstream
+    Upstream --> Provider
+    Provider --> Models
+    Provider --> Obs
+    World --> Store
+    Forge --> Store
+```
 
-### `framework.py`
+## Module Responsibilities
 
-Framework runtime and persistence:
+`framework.py`
 
-- `WorldForge`
-- `World`
-- `Prediction`
-- `Comparison`
-- `Plan`
-- import/export and local JSON world storage
+- `WorldForge`: top-level object for provider registration, diagnostics, persistence helpers, and
+  provider-wide operations such as `generate(...)`, `transfer(...)`, `reason(...)`, `embed(...)`,
+  and `score_actions(...)`.
+- `World`: mutable world state with scene objects, history, prediction, comparison, planning, plan
+  execution, and evaluation entry points.
+- `Prediction`, `Plan`, `PlanExecution`, and `Comparison`: workflow-level result objects.
 
-### `observability.py`
+`models.py`
 
-Composable provider telemetry sinks built on `ProviderEvent`. This module provides
-`JsonLoggerSink`, `InMemoryRecorderSink`, `ProviderMetricsSink`, and
-`compose_event_handlers(...)` for host-side logging, local debugging, and
-lightweight request aggregation.
+- Public data contracts such as `Action`, `SceneObject`, `StructuredGoal`, `VideoClip`,
+  `ProviderProfile`, `ProviderHealth`, `ProviderEvent`, and `ActionScoreResult`.
+- Validation helpers and public framework errors: `WorldForgeError` and `WorldStateError`.
 
-### `providers/`
+`providers/base.py`
 
-Provider primitives and adapters. The mock provider is the reference implementation. `cosmos`
-and `runway` are live HTTP adapters. `leworldmodel` is a real optional local adapter for
-LeWorldModel JEPA cost-model scoring. `jepa` and `genie` are scaffold adapters.
+- `BaseProvider`, which defines the common capability surface.
+- `ProviderError`, the public provider/runtime failure type.
+- `PredictionPayload`, the validated payload returned by `predict(...)` implementations.
 
-### `evaluation/`
+`providers/leworldmodel.py`
 
-Evaluation suites, scenario runners, and report rendering.
+- Optional local adapter for `stable_worldmodel.policy.AutoCostModel`.
+- Exposes only `score=True`.
+- Validates `pixels`, `goal`, `action`, four-dimensional action candidates, finite cost outputs,
+  and `best_index`.
 
-## Data flow
+`providers/cosmos.py` and `providers/runway.py`
 
-1. `WorldForge` resolves or registers a provider.
-2. `World` snapshots the current state and sends it to the provider.
-3. Prediction/generation providers return a `PredictionPayload` or `VideoClip`; score providers
-   return an `ActionScoreResult`.
-4. The framework validates and applies returned world state when prediction is involved.
-5. Optional provider event callbacks receive structured `ProviderEvent` records from local and remote provider operations.
-6. Host apps can fan those events out to logging, recording, and metrics sinks through `worldforge.observability.compose_event_handlers(...)`.
-7. History, persistence, evaluation, benchmarks, and CLI output are derived from that validated state.
+- Real HTTP adapters with typed request policy, parser boundaries, retry events, and artifact
+  validation.
 
-## Invariants
+`observability.py`
 
-- persisted worlds must contain `id`, `name`, and `provider`
+- Host-side provider event composition through `JsonLoggerSink`, `InMemoryRecorderSink`,
+  `ProviderMetricsSink`, and `compose_event_handlers(...)`.
+
+`evaluation/` and `benchmark.py`
+
+- Deterministic evaluation suites and capability-aware benchmark reports for adapter comparison.
+
+## End-to-End Pipeline
+
+The shortest accurate pipeline is:
+
+```text
+configure providers
+  -> create/load a World
+  -> choose a workflow
+  -> dispatch through a capability-specific provider method
+  -> validate provider result
+  -> return a typed result
+  -> optionally persist, observe, evaluate, or benchmark
+```
+
+Expanded:
+
+```text
+1. Provider discovery
+   - mock registers unconditionally
+   - optional providers register only when their env vars are present
+   - hosts may call register_provider(...) for custom adapters
+
+2. World setup
+   - create_world(...) starts from empty typed state
+   - create_world_from_prompt(...) creates a deterministic local seed scene
+   - load_world(...) restores local JSON state after validation
+
+3. Workflow call
+   - world.predict(...) requires a provider with predict=True
+   - forge.generate(...) requires generate=True
+   - forge.transfer(...) requires transfer=True
+   - world.plan(...) can use predictive planning or score-based planning
+   - world.evaluate(...) and benchmark harnesses select operations by capability
+
+4. Provider boundary
+   - provider receives a JSON world snapshot, media request, query, embedding request, or score
+     payload
+   - adapter validates local inputs before network/model calls when possible
+   - provider emits ProviderEvent records for success, failure, and retries where supported
+
+5. Result boundary
+   - PredictionPayload updates world state only after validation
+   - VideoClip validates media metadata and bytes/source paths
+   - ActionScoreResult validates finite scores and an in-range best_index
+   - ProviderError surfaces provider/runtime failures with context
+
+6. Host-owned operation
+   - JSON persistence is single-writer local storage
+   - production logging, metrics export, trace IDs, dashboards, and locks remain host-owned
+```
+
+## Provider Injection
+
+There are three injection points.
+
+```text
+Construction-time auto-registration
+
+WorldForge(auto_register_remote=True)
+  |
+  |-- mock              always registered
+  |-- cosmos            if COSMOS_BASE_URL is set
+  |-- runway            if RUNWAYML_API_SECRET or RUNWAY_API_SECRET is set
+  |-- leworldmodel      if LEWORLDMODEL_POLICY or LEWM_POLICY is set
+  |-- jepa              if JEPA_MODEL_PATH is set
+  `-- genie             if GENIE_API_KEY is set
+```
+
+```text
+Manual registration
+
+forge = WorldForge(auto_register_remote=False)
+forge.register_provider(MyProvider(...))
+world = forge.create_world("lab", provider="my-provider")
+```
+
+```text
+Call-site override
+
+world = forge.create_world("lab", provider="mock")
+
+world.predict(action)                         # uses world.provider
+world.predict(action, provider="other")       # overrides for this call
+world.plan(..., provider="leworldmodel")      # planner/scorer provider
+world.execute_plan(plan, provider="mock")     # execution provider
+```
+
+Provider lookup is name-based. Provider dispatch is capability-based. A provider should never
+advertise a capability unless the corresponding method is implemented end to end.
+
+```mermaid
+flowchart LR
+    Env[Environment variables] --> Auto[WorldForge auto-registration]
+    Custom[Custom adapter instance] --> Manual[register_provider]
+    Auto --> Registry[Provider registry]
+    Manual --> Registry
+    WorldProvider[world.provider default] --> Resolve[provider resolution]
+    CallOverride[method provider override] --> Resolve
+    PlanExec[Plan metadata execution_provider] --> Resolve
+    Registry --> Resolve
+    Resolve --> Capability{capability supported?}
+    Capability -- yes --> Invoke[call provider method]
+    Capability -- no --> Error[WorldForgeError or ProviderError]
+```
+
+## Predictive Planning Pipeline
+
+Predictive planning is the older WorldForge path. It is useful for providers that can take a world
+state plus an action and return a future world state.
+
+```text
+World.plan(goal_spec=..., provider="mock")
+  |
+  |-- parse goal_spec or goal_json into StructuredGoal
+  |-- resolve scene object selectors
+  |-- create one or more WorldForge Action objects
+  |-- for each action:
+  |     provider.predict(simulated_state, action, steps=1)
+  |     validate PredictionPayload
+  |     append predicted state and physics score
+  |
+  `-- return Plan(
+        planning_mode="predict",
+        actions=[...],
+        predicted_states=[...],
+        success_probability=heuristic average of physics scores
+      )
+```
+
+Mermaid sequence:
+
+```mermaid
+sequenceDiagram
+    participant App as Host app
+    participant World
+    participant Provider
+    participant Plan
+
+    App->>World: plan(goal_spec, provider)
+    World->>World: normalize StructuredGoal
+    loop per action
+        World->>Provider: predict(snapshot, action, steps=1)
+        Provider-->>World: PredictionPayload
+        World->>World: validate and collect predicted state
+    end
+    World-->>Plan: Plan(planning_mode="predict")
+    Plan-->>App: actions + predicted_states
+```
+
+## Score-Based Planning Pipeline
+
+Score-based planning is the LeWorldModel-shaped path. It separates model-native tensors from
+WorldForge-native actions.
+
+```text
+Host owns task preprocessing
+  |
+  |-- score_info
+  |     |-- pixels    task-shaped observation history
+  |     |-- goal      task-shaped goal observation
+  |     `-- action    task-shaped action history
+  |
+  |-- score_action_candidates
+  |     `-- tensor or nested numeric array shaped:
+  |         (batch, samples, horizon, action_dim)
+  |
+  `-- candidate_actions
+        `-- WorldForge Action sequences, one sequence per scored candidate
+
+World.plan(..., provider="leworldmodel", execution_provider="mock")
+  |
+  |-- require provider.capabilities.score
+  |-- call provider.score_actions(info, action_candidates)
+  |-- receive ActionScoreResult(scores, best_index, lower_is_better=True)
+  |-- choose candidate_actions[best_index]
+  |-- return Plan(planning_mode="score", predicted_states=[])
+
+World.execute_plan(plan)
+  |
+  |-- choose execution_provider from explicit arg or plan metadata
+  |-- require execution provider supports predict
+  `-- apply selected WorldForge actions through predict(...)
+```
+
+The separation is intentional:
+
+- LeWorldModel ranks action tensors in its own task space.
+- WorldForge stores and executes `Action` objects in its own public API.
+- The host supplies the mapping between those two spaces because task preprocessing is model- and
+  checkpoint-specific.
+- A score provider is allowed to be a planner without being a predictor, generator, or reasoner.
+
+```mermaid
+sequenceDiagram
+    participant Host
+    participant World
+    participant LeWM as LeWorldModelProvider
+    participant Exec as Execution Provider
+
+    Host->>World: plan(provider="leworldmodel", candidate_actions, score_info, score_action_candidates)
+    World->>World: validate score planning inputs
+    World->>LeWM: score_actions(info, action_candidates)
+    LeWM->>LeWM: load AutoCostModel, tensorize inputs, get_cost(...)
+    LeWM-->>World: ActionScoreResult(best_index)
+    World-->>Host: Plan(actions=candidate_actions[best_index], planning_mode="score")
+    Host->>World: execute_plan(plan)
+    World->>Exec: predict(snapshot, selected action, steps=1)
+    Exec-->>World: PredictionPayload
+    World-->>Host: PlanExecution(final_world)
+```
+
+Concrete score-planning shape:
+
+```python
+from worldforge import Action
+
+plan = world.plan(
+    goal="select the lowest-cost LeWorldModel candidate",
+    provider="leworldmodel",
+    planner="leworldmodel-mpc",
+    candidate_actions=[
+        [Action.move_to(0.1, 0.5, 0.0)],
+        [Action.move_to(0.4, 0.5, 0.0)],
+    ],
+    score_info={
+        "pixels": pixels,
+        "goal": goal_pixels,
+        "action": action_history,
+    },
+    score_action_candidates=action_candidate_tensor,
+    execution_provider="mock",
+)
+
+print(plan.metadata["score_result"]["best_index"])
+execution = world.execute_plan(plan)
+```
+
+## Provider Capability Surface
+
+WorldForge does not ask "is this a world model?" at runtime. It asks which operations a provider
+can honestly perform.
+
+```text
+BaseProvider
+|-- predict(world_state, action, steps) -> PredictionPayload
+|-- generate(prompt, duration_seconds, options) -> VideoClip
+|-- transfer(clip, width, height, fps, prompt, options) -> VideoClip
+|-- reason(query, world_state) -> ReasoningResult
+|-- embed(text) -> EmbeddingResult
+`-- score_actions(info, action_candidates) -> ActionScoreResult
+```
+
+Current in-repo mapping:
+
+| Provider | Real integration | Primary capability | Runtime kind |
+| --- | --- | --- | --- |
+| `mock` | yes | predict, generate, reason, embed, plan, transfer | deterministic local surrogate |
+| `leworldmodel` | yes | score | local JEPA cost model |
+| `cosmos` | yes | generate | remote physical-AI video foundation model API |
+| `runway` | yes | generate, transfer | remote video generation API |
+| `jepa` | scaffold | mock-backed | placeholder for future JEPA provider work |
+| `genie` | scaffold | mock-backed | placeholder for future interactive simulator work |
+
+Provider profiles expose the same information through Python and CLI diagnostics. `doctor()` also
+includes known but unregistered optional providers by default, so missing local dependencies and
+missing credentials show up before a workflow fails.
+
+## Data Contracts
+
+Important public result contracts:
+
+```text
+PredictionPayload
+  state: JSON object
+  confidence: probability
+  physics_score: probability
+  frames: list[bytes]
+  metadata: JSON object
+  latency_ms: finite non-negative number
+
+ActionScoreResult
+  provider: non-empty string
+  scores: non-empty list of finite numbers
+  best_index: index into scores
+  best_score: scores[best_index]
+  lower_is_better: bool
+  metadata: JSON object
+
+Plan
+  goal: string
+  planner: string
+  provider: planner/scorer/predictor provider name
+  actions: list[Action]
+  predicted_states: list[JSON objects]
+  success_probability: probability
+  metadata: JSON object
+```
+
+State invariants:
+
+- persisted worlds contain `id`, `name`, and `provider`
 - world `step` is always a non-negative integer
+- `scene.objects` is a JSON object keyed by object ID
+- embedded scene object IDs must match their map keys
+- metadata and history are JSON containers
 - invalid public inputs fail explicitly instead of being silently coerced
-- provider capability metadata must match the implemented surface
-- score providers must return finite scores and an in-range `best_index`
-- missing local asset files fail before network I/O
-- remote provider reads use typed retry/backoff policy; mutation requests default to single-attempt behavior
-- forge-level event handlers propagate to builtin providers and to providers later registered at runtime
-- `ProviderMetricsSink.request_count` tracks emitted request attempts; retries increment both `request_count` and `retry_count`
-- `StructuredGoal` is the typed contract for structured planning inputs, including relocation, neighbor, spawn, and swap goals
+- score providers return finite scores and an in-range `best_index`
+- remote media artifacts reject unsupported content types before returning a `VideoClip`
 
-## Failure model
+## Failure Boundaries
 
-- invalid caller input raises `WorldForgeError`
-- malformed persisted state raises `WorldStateError`
-- provider/runtime integration failures raise `ProviderError`
-- remote health checks may fail due to missing credentials, invalid endpoints, or upstream errors
-- LeWorldModel health may fail because optional `stable_worldmodel` / `torch` dependencies are
-  absent, the policy is unset, or the checkpoint cannot be loaded at scoring time
-- remote HTTP adapters share one typed request policy contract for timeout, polling, download, and retry behavior
-- provider event callbacks surface structured retry, success, and failure records but do not replace host-level logging or metrics sinks
+WorldForge uses three public failure families:
 
-## Observability example
+```text
+WorldForgeError
+  invalid caller input, unsupported local operation, invalid public model values
+
+WorldStateError
+  malformed persisted state or provider-supplied state that cannot be restored
+
+ProviderError
+  provider credentials, optional dependency failures, transport failures, malformed upstream
+  responses, provider-specific input limits, expired artifacts, invalid downloaded media,
+  unsupported provider operations, malformed model outputs
+```
+
+Boundary rule:
+
+```text
+caller input error     -> fail before provider call when possible
+provider/runtime error -> ProviderError with provider-specific context
+state mutation         -> only after provider output validates
+remote artifact        -> content type and body validated before VideoClip is returned
+score output           -> finite scores + valid best_index before Plan is returned
+```
+
+## Observability
+
+Provider events are deliberately small. They are not a complete production telemetry stack; they
+are the framework-level hook that host applications can fan out to their own logging and metrics.
+
+```text
+Provider operation
+  |
+  |-- ProviderEvent(provider, operation, phase, duration_ms, attempt, status_code, message, metadata)
+  |
+  `-- host event_handler
+        |-- JsonLoggerSink
+        |-- InMemoryRecorderSink
+        `-- ProviderMetricsSink
+```
+
+Example:
 
 ```python
 import logging
@@ -107,11 +514,38 @@ forge.generate("orbiting cube", "mock", duration_seconds=1.0)
 print(metrics.get("mock", "generate").to_dict())
 ```
 
-## Design principles
+## Persistence Ownership
 
-- Python-native API surface
-- typed public models
-- simple JSON persistence
-- honest provider capability reporting
-- deterministic local development path
-- fail fast on invalid state and invalid inputs
+Persistence is intentionally host-owned beyond local JSON state.
+
+```text
+WorldForge today
+  local JSON files
+  single-writer assumption
+  import/export validation
+
+Host application owns
+  locks
+  transactions
+  database adapters
+  object storage
+  retention policy
+  multi-writer coordination
+  production backup/restore
+```
+
+This keeps the library small and makes the alpha contract explicit. A future persistence adapter
+must preserve the same state validation invariants before it becomes a supported runtime surface.
+
+## Design Implications
+
+- Capability reporting is part of correctness. A provider that only scores must not be presented
+  as a generator or predictor.
+- LeWorldModel defines the canonical score-planning path: model-native candidate tensors in,
+  `ActionScoreResult.best_index` out, WorldForge `Action` sequence selected.
+- Generative video providers are useful, but video output is not the core abstraction of
+  WorldForge.
+- Host applications own preprocessing between sensors, robot task tensors, and WorldForge actions.
+- The framework should stay strict at boundaries and flexible in provider registration.
+- New provider integrations should add tests for every advertised capability and every documented
+  failure mode.

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -10,4 +10,12 @@ The project is structured as a framework first:
 - framework primitives for state, planning, comparison, evaluation, and benchmarking
 - action-scoring support for cost-model providers such as LeWorldModel
 
-The goal is to provide a clean, public-facing framework surface that fits naturally into the Python ML ecosystem.
+The goal is to provide a clean, public-facing framework surface that fits naturally into the
+Python ML ecosystem.
+
+WorldForge uses a precise definition of "world model": an action-conditioned predictive model
+that helps a caller evaluate, rank, or roll out possible futures from observations, state, actions,
+and goals. That definition is narrower than the current hype cycle, where the same term may refer
+to video generators, 3D scene tools, simulation platforms, or cognitive architectures. Read
+[World Model Taxonomy](./world-model-taxonomy.md) before evaluating provider semantics, then read
+[Architecture](./architecture.md) for the end-to-end runtime pipeline.

--- a/docs/src/providers/README.md
+++ b/docs/src/providers/README.md
@@ -1,5 +1,9 @@
 # Providers
 
+WorldForge providers are capability adapters, not a claim that every upstream system uses the same
+definition of "world model." See [World Model Taxonomy](../world-model-taxonomy.md) for the project
+definition and [Architecture](../architecture.md) for the end-to-end provider injection pipeline.
+
 ## In-repo providers
 
 | Provider | Status | Auto-registration rule | Notes |
@@ -78,6 +82,11 @@ Providers can declare support for:
 `score` providers return `ActionScoreResult` from `score_actions(...)`. The result contains the
 provider name, one score per candidate, `best_index`, `best_score`, and explicit score direction.
 For `leworldmodel`, scores are costs and lower values are better.
+
+LeWorldModel is the architectural reference provider for score-based planning. It is first class
+because it matches the JEPA planning contract WorldForge is designed to support: observations,
+goals, and action candidates in; ranked futures out. WorldForge therefore models it as `score`
+instead of pretending it can generate video, reason over text, or mutate world state directly.
 
 ## Operational notes
 

--- a/docs/src/world-model-taxonomy.md
+++ b/docs/src/world-model-taxonomy.md
@@ -1,0 +1,312 @@
+# World Model Taxonomy
+
+"World model" is an overloaded term. In current AI discourse it can mean a learned dynamics model,
+a video generator, a robot policy, a 3D scene generator, a simulation platform, or a cognitive
+architecture. Those systems overlap, but they are not interchangeable.
+
+WorldForge uses a narrower operational definition:
+
+```text
+A world model is an action-conditioned predictive model that helps a caller evaluate, rank, or
+roll out possible futures from observations, state, actions, and goals.
+```
+
+That definition is closer to Yann LeCun's JEPA-oriented planning view than to the broad marketing
+usage of "any model that emits a world-like artifact." WorldForge can still integrate video
+generators and simulation APIs, but the architecture is centered on planning surfaces: candidate
+actions, predicted or latent future states, costs, scores, uncertainty, and explicit provider
+capabilities.
+
+## One Term, Many Systems
+
+Text diagram:
+
+```text
+                           "world model"
+                                  |
+          +-----------------------+-----------------------+
+          |                       |                       |
+  planning model           world generator         world infrastructure
+          |                       |                       |
+  predicts/ranks futures   emits pixels/3D scenes  creates data, tokens,
+  for action selection     or interactive worlds   simulation, eval tooling
+```
+
+WorldForge cares most about the left branch, supports the middle branch as provider artifacts, and
+expects the right branch to be integrated through adapters rather than absorbed into the core.
+
+Mermaid view:
+
+```mermaid
+flowchart TD
+    WM[World model terminology]
+    WM --> Latent[Latent predictive planning]
+    WM --> Video[Generative video simulation]
+    WM --> Spatial[Spatial / 3D world generation]
+    WM --> Infra[Physical AI infrastructure]
+    WM --> Active[Active inference / structured generative models]
+
+    Latent --> JEPA[JEPA / V-JEPA / LeWorldModel]
+    Latent --> RL[Dreamer-style model-based RL]
+    Video --> Sora[Sora-style video simulators]
+    Video --> Genie[Genie-style interactive worlds]
+    Spatial --> Marble[World Labs Marble]
+    Infra --> Cosmos[NVIDIA Cosmos platform]
+```
+
+## WorldForge's Center of Gravity
+
+WorldForge is built around this loop:
+
+```text
+observe state
+  -> propose candidate action sequences
+  -> score or roll out futures
+  -> choose the best candidate
+  -> execute the first action or selected action sequence
+  -> observe again
+```
+
+This is the model-predictive-control shape described in LeCun's architecture proposal: an actor
+proposes actions, a world model predicts future state representations, costs evaluate candidate
+futures, and the loop repeats after acting. In that proposal, JEPA-style models learn abstractions
+that make prediction feasible by avoiding unnecessary pixel-level detail.
+
+WorldForge's corresponding runtime shape is:
+
+```text
+World state / observation tensors
+  |
+  |-- candidate_actions            # public WorldForge Action sequences
+  |-- score_action_candidates      # model-native tensor candidates
+  |-- score_info                   # model-native observation/action/goal context
+  v
+provider.score_actions(...)
+  |
+  v
+ActionScoreResult(scores, best_index)
+  |
+  v
+Plan(actions=candidate_actions[best_index])
+  |
+  v
+execute through a provider that supports predict(...)
+```
+
+LeWorldModel is the first-class provider for this design because it is a JEPA-based world model
+that plans in latent space from pixels, exposes a cost surface, and naturally fits the
+`score_actions(...) -> ActionScoreResult.best_index` contract. It should shape WorldForge's
+provider architecture more than generic video-generation providers do.
+
+## Taxonomy
+
+| Category | Main question | Representation | Typical output | WorldForge stance |
+| --- | --- | --- | --- | --- |
+| Explicit simulation | What happens under known physics and geometry? | Equations, meshes, contacts, engines | State rollouts, sensor renders | Adapter target, not core runtime |
+| Model-based RL latent dynamics | Can an agent learn inside imagined futures? | Compact latent state | Rollouts, values, policies | Fits `predict`, `score`, and evaluation |
+| JEPA latent predictive world models | Which action makes the latent future match a goal or low cost? | Learned embeddings | Scores, costs, latent rollouts | Architectural center |
+| Generative video simulators | Can a model synthesize plausible future pixels or interactive frames? | Pixels, latents, video tokens | Video clips, interactive frames | Fits `generate`, `transfer`, maybe future `predict` |
+| Spatial / 3D world models | What persistent 3D world can be reconstructed or generated? | Geometry, depth, radiance, assets | 3D scenes, meshes, camera paths | Future provider family |
+| Physical AI infrastructure | How do teams produce data, tokenizers, fine-tunes, and evaluation at scale? | Platform stack | Models, synthetic data, APIs | Provider/platform adapters |
+| Active inference / structured generative models | How should beliefs, objects, uncertainty, and action be updated online? | Probabilistic structured state | Beliefs, policies, expected free energy | Conceptual influence, future adapter target |
+
+## Category Notes
+
+### JEPA and LeCun-style Planning
+
+JEPA predicts in representation space rather than reconstructing every future pixel. The point is
+not just compression. It is to let the model ignore unpredictable details while retaining task-
+relevant structure for prediction and planning.
+
+In LeCun's architecture proposal, this becomes a broader cognitive architecture:
+
+```text
+perception -> encoder -> world-state representation
+                          |
+actor proposes actions -> world model predicts futures
+                          |
+cost / critic scores predicted futures
+                          |
+planner selects low-cost action sequence
+                          |
+act, observe, store, repeat
+```
+
+That is the WorldForge north star. The library should make it easy to plug in a model that can
+rank futures, compare providers, evaluate failures, and keep the host in control of execution and
+persistence.
+
+### LeWorldModel
+
+LeWorldModel is a concrete JEPA implementation authored by Lucas Maes, Quentin Le Lidec, Damien
+Scieur, Yann LeCun, and Randall Balestriero. The project describes LeWM as an end-to-end JEPA from
+raw pixels with two loss terms: a next-embedding prediction loss and a Gaussian latent regularizer.
+Its public description emphasizes pixel-to-latent prediction, cost-based planning, and efficient
+candidate evaluation.
+
+For WorldForge this means:
+
+- LeWM is not modeled as a text reasoner.
+- LeWM is not modeled as a video generator.
+- LeWM is modeled as a local score provider.
+- Hosts own task preprocessing from sensor data into checkpoint-shaped tensors.
+- WorldForge owns provider registration, score result validation, plan selection, plan metadata,
+  observability, and execution handoff.
+
+### V-JEPA 2 and jepa-wms
+
+Meta's V-JEPA 2 work shows the same family of ideas at larger scale: self-supervised video
+pretraining, then action-conditioned post-training for robotic planning with image goals. The
+`facebookresearch/jepa-wms` repository is directly relevant to future WorldForge provider work
+because it contains code, data, weights, training loops, shared planning components, and simulation
+planning evaluations for joint-embedding predictive world models.
+
+WorldForge's current `jepa` provider is only a scaffold. A real JEPA provider should follow the
+LeWorldModel pattern: do not advertise generation or reasoning unless implemented; expose score,
+latent rollout, or prediction capabilities explicitly; document tensor shapes and task contracts.
+
+### Dreamer-style Model-Based RL
+
+Dreamer-style agents learn a latent dynamics model from observations and improve behavior by
+imagining future scenarios. This lineage fits WorldForge conceptually because it treats the world
+model as a control component, not just an artifact generator. A Dreamer provider could expose
+`predict`, `score`, or a future policy-selection capability depending on how much of the agent loop
+is exported.
+
+### Generative Video Simulators
+
+Sora-style and Genie-style systems use video generation to simulate physical or digital worlds.
+OpenAI explicitly frames Sora as a step toward simulators of physical and digital worlds while also
+documenting simulator limitations. Google DeepMind describes Genie 3 as a real-time interactive
+world model that generates controllable worlds from text.
+
+These systems are valuable, but they are not the same interface as LeWorldModel:
+
+```text
+video simulator:
+  prompt + frame/action context -> pixels or frames
+
+latent planner:
+  observation + goal + action candidates -> costs or future latent states
+```
+
+WorldForge can use video models for data synthesis, transfer, evaluation, red teaming, and
+eventual predictive planning. It should not treat "generated plausible video" as proof that a
+provider exposes controllable planning semantics.
+
+### Spatial Intelligence and 3D World Models
+
+World Labs' Marble is a good example of the spatial-intelligence meaning of world model: generate
+or reconstruct persistent 3D worlds from text, images, video, or 3D structure. This is close to
+scene creation and spatial memory. It is important for robotics and simulation, but its primary
+contract is a persistent spatial artifact rather than an action-conditioned planning cost.
+
+A future WorldForge spatial provider might expose:
+
+- scene import/export
+- camera-path generation
+- geometry validation
+- collision or affordance metadata
+- synthetic observation generation for planners
+
+### Physical AI Infrastructure
+
+NVIDIA Cosmos is best understood as a physical-AI platform: world foundation models, tokenizers,
+guardrails, video processing, synthetic data generation, fine-tuning, and deployment routes. It can
+feed world-model workflows, but it is not a single narrow model contract.
+
+WorldForge should integrate platform pieces through explicit provider capabilities:
+
+- `generate` for video synthesis
+- `transfer` for video-to-video transformation
+- future data-curation or tokenizer adapters if they become library scope
+- future evaluation adapters if upstream APIs expose stable contracts
+
+### Active Inference
+
+Active inference uses structured generative models, beliefs, and expected free energy rather than
+the usual reward-maximization framing. It is not currently implemented in WorldForge, but it
+matters because it keeps the architecture honest about uncertainty, beliefs, object structure, and
+online replanning. A future provider in this family should expose beliefs and uncertainty as typed
+outputs rather than hiding them inside generic scores.
+
+## Provider Taxonomy in WorldForge
+
+```text
+mock
+  deterministic local surrogate
+  useful for contracts, examples, and tests
+
+leworldmodel
+  JEPA latent cost model
+  score provider
+  first-class architectural reference
+
+cosmos
+  remote physical-AI video foundation model adapter
+  generation provider
+  useful for synthetic video and physical-AI artifacts
+
+runway
+  remote video generation and transfer adapter
+  generation/transfer provider
+  useful for artifact workflows
+
+jepa
+  scaffold
+  future home for real JEPA provider work
+
+genie
+  scaffold
+  future home for real interactive simulator provider work
+```
+
+Mermaid:
+
+```mermaid
+flowchart TD
+    WF[WorldForge provider registry]
+    WF --> Mock[mock\nreference runtime]
+    WF --> LeWM[leworldmodel\nJEPA score provider]
+    WF --> Cosmos[cosmos\nvideo generation platform adapter]
+    WF --> Runway[runway\nvideo generation/transfer adapter]
+    WF --> JEPA[jepa\nscaffold]
+    WF --> Genie[genie\nscaffold]
+
+    LeWM --> Score[score_actions -> ActionScoreResult]
+    Cosmos --> Generate[generate -> VideoClip]
+    Runway --> Transfer[generate/transfer -> VideoClip]
+    Mock --> Predict[predict -> PredictionPayload]
+```
+
+## Design Rules for New Providers
+
+1. Declare capabilities narrowly.
+2. Document the provider's actual meaning of "world model."
+3. Validate input shape, range, content type, and task-specific limits at the adapter boundary.
+4. Return typed outputs that preserve score direction, uncertainty, model name, and provider
+   metadata.
+5. Do not hide task preprocessing inside vague dictionaries when the contract can be named.
+6. Add fixture-driven tests for malformed payloads, missing artifacts, partial outputs, and
+   provider-specific limits.
+7. Keep host-owned concerns host-owned: secrets, locks, databases, long-running orchestration,
+   production metrics, and real robot safety interlocks.
+
+## Sources
+
+Primary sources used to shape this taxonomy:
+
+- [Yann LeCun, A Path Towards Autonomous Machine Intelligence](https://openreview.net/pdf/315d43ba26f55357a84cec9a7ed15a6610094f79.pdf)
+- [LeWorldModel project page](https://le-wm.github.io/)
+- [LeWorldModel paper](https://arxiv.org/abs/2603.19312)
+- [LeWorldModel code](https://github.com/lucas-maes/le-wm)
+- [V-JEPA 2 paper](https://arxiv.org/abs/2506.09985)
+- [Meta announcement for V-JEPA 2](https://about.fb.com/news/2025/06/our-new-model-helps-ai-think-before-it-acts/)
+- [facebookresearch/jepa-wms](https://github.com/facebookresearch/jepa-wms)
+- [Ha and Schmidhuber, World Models](https://arxiv.org/abs/1803.10122)
+- [Dreamer introduction](https://research.google/blog/introducing-dreamer-scalable-reinforcement-learning-using-world-models/)
+- [DreamerV3 paper](https://arxiv.org/abs/2301.04104)
+- [OpenAI, Video generation models as world simulators](https://openai.com/index/video-generation-models-as-world-simulators/)
+- [Google DeepMind Genie 3](https://deepmind.google/models/genie/)
+- [NVIDIA Cosmos announcement](https://nvidianews.nvidia.com/news/nvidia-launches-cosmos-world-foundation-model-platform-to-accelerate-physical-ai-development)
+- [World Labs Marble documentation](https://docs.worldlabs.ai/)


### PR DESCRIPTION
## Summary

- Add a dedicated World Model taxonomy and vision page that distinguishes JEPA/latent planning, model-based RL, generative video simulators, spatial/3D world models, physical AI infrastructure, and active inference.
- Expand the architecture guide with text and Mermaid diagrams covering the end-to-end WorldForge pipeline, provider injection, predictive planning, score-based LeWorldModel planning, capability contracts, failure boundaries, observability, and persistence ownership.
- Link the new documentation from README, the docs summary, introduction, provider docs, and changelog.

## Validation

- `git diff --check`
- `uv run ruff check src tests examples scripts`
- `uv run ruff format --check src tests examples scripts`
- `uv run pytest`