### PR TITLE
[codex] Add provider authoring guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ releases may still include breaking changes when the public API needs to tighten
 - Added a world-model taxonomy and vision document, plus expanded architecture docs with text and
   Mermaid diagrams for provider injection, predictive planning, score-based planning, observability,
   and the LeWorldModel-shaped runtime pipeline.
+- Added a provider authoring guide that turns the taxonomy into capability, validation, testing,
+  observability, and documentation checklists for new adapters.
 
 ## 0.3.0 - 2026-04-08
 

--- a/README.md
+++ b/README.md
@@ -25,8 +25,10 @@ also mean video generation, spatial 3D reconstruction, simulation infrastructure
 inference systems. WorldForge supports those systems through explicit provider capabilities, but
 LeWorldModel is the reference provider shaping the core score-planning architecture.
 
-Read [docs/src/world-model-taxonomy.md](./docs/src/world-model-taxonomy.md) for the taxonomy and
-[docs/src/architecture.md](./docs/src/architecture.md) for the end-to-end provider pipeline.
+Read [docs/src/world-model-taxonomy.md](./docs/src/world-model-taxonomy.md) for the taxonomy,
+[docs/src/architecture.md](./docs/src/architecture.md) for the end-to-end provider pipeline, and
+[docs/src/provider-authoring-guide.md](./docs/src/provider-authoring-guide.md) before adding a new
+adapter.
 
 ## Status
 
@@ -193,7 +195,7 @@ Operational invariants:
 - local `mock` and scaffold adapters emit structured success events for provider operations
 - the deterministic mock path remains available for local tests and examples
 
-More detail lives in [docs/src/world-model-taxonomy.md](./docs/src/world-model-taxonomy.md), [docs/src/architecture.md](./docs/src/architecture.md), [docs/src/providers/README.md](./docs/src/providers/README.md), and [docs/src/operations.md](./docs/src/operations.md).
+More detail lives in [docs/src/world-model-taxonomy.md](./docs/src/world-model-taxonomy.md), [docs/src/architecture.md](./docs/src/architecture.md), [docs/src/provider-authoring-guide.md](./docs/src/provider-authoring-guide.md), [docs/src/providers/README.md](./docs/src/providers/README.md), and [docs/src/operations.md](./docs/src/operations.md).
 
 ## Provider Matrix
 

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -5,6 +5,7 @@
 - [World Model Taxonomy](./world-model-taxonomy.md)
 - [Architecture](./architecture.md)
 - [Providers](./providers/README.md)
+- [Provider Authoring Guide](./provider-authoring-guide.md)
 - [Python API](./api/python.md)
 - [Evaluation](./evaluation.md)
 - [Benchmarking](./benchmarking.md)

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -18,4 +18,5 @@ that helps a caller evaluate, rank, or roll out possible futures from observatio
 and goals. That definition is narrower than the current hype cycle, where the same term may refer
 to video generators, 3D scene tools, simulation platforms, or cognitive architectures. Read
 [World Model Taxonomy](./world-model-taxonomy.md) before evaluating provider semantics, then read
-[Architecture](./architecture.md) for the end-to-end runtime pipeline.
+[Architecture](./architecture.md) for the end-to-end runtime pipeline. New adapters should follow
+the [Provider Authoring Guide](./provider-authoring-guide.md).

--- a/docs/src/provider-authoring-guide.md
+++ b/docs/src/provider-authoring-guide.md
@@ -1,0 +1,446 @@
+# Provider Authoring Guide
+
+This guide turns the WorldForge world-model taxonomy into an implementation checklist for new
+provider adapters. Use it before writing code. The goal is to keep adapters honest: every provider
+must say what kind of "world model" it is, expose only capabilities it implements, validate every
+boundary, and document failure modes clearly enough that users can operate it without reading the
+adapter source.
+
+Related docs:
+
+- [World Model Taxonomy](./world-model-taxonomy.md)
+- [Architecture](./architecture.md)
+- [Providers](./providers/README.md)
+- [Python API](./api/python.md)
+
+## Adapter Decision Tree
+
+Start with the provider's real contract, not its marketing category.
+
+```text
+New upstream provider
+  |
+  |-- Can it rank action candidates from observations/goals?
+  |     `-- expose score_actions(...) -> ActionScoreResult
+  |
+  |-- Can it roll a WorldForge state forward from an Action?
+  |     `-- expose predict(...) -> PredictionPayload
+  |
+  |-- Can it generate a video artifact from prompt/options?
+  |     `-- expose generate(...) -> VideoClip
+  |
+  |-- Can it transform one video artifact into another?
+  |     `-- expose transfer(...) -> VideoClip
+  |
+  |-- Can it answer questions about a world/prompt?
+  |     `-- expose reason(...) -> ReasoningResult
+  |
+  |-- Can it embed text or another explicit input?
+  |     `-- expose embed(...) -> EmbeddingResult
+  |
+  `-- If none are true, do not add a provider yet.
+      Write host integration code or a design issue first.
+```
+
+Mermaid equivalent:
+
+```mermaid
+flowchart TD
+    Upstream[New upstream provider]
+    Upstream --> Score{Ranks action candidates?}
+    Score -- yes --> ScoreApi[score_actions -> ActionScoreResult]
+    Score -- no --> Predict{Rolls state forward?}
+    Predict -- yes --> PredictApi[predict -> PredictionPayload]
+    Predict -- no --> Generate{Generates video artifact?}
+    Generate -- yes --> GenerateApi[generate -> VideoClip]
+    Generate -- no --> Transfer{Transforms video artifact?}
+    Transfer -- yes --> TransferApi[transfer -> VideoClip]
+    Transfer -- no --> Reason{Answers questions?}
+    Reason -- yes --> ReasonApi[reason -> ReasoningResult]
+    Reason -- no --> Embed{Embeds explicit input?}
+    Embed -- yes --> EmbedApi[embed -> EmbeddingResult]
+    Embed -- no --> NoProvider[Do not add provider yet]
+```
+
+## Step 1: Classify the Provider
+
+Every provider doc and profile should identify the provider's taxonomy category.
+
+| Category | Typical provider surface | WorldForge expectation |
+| --- | --- | --- |
+| JEPA latent predictive world model | `score`, future `predict` or latent rollout | First-class planning path. Follow the LeWorldModel pattern. |
+| Model-based RL latent dynamics | `predict`, `score`, maybe future policy selection | Expose the exported control surface, not the whole trainer. |
+| Generative video simulator | `generate`, maybe future action-conditioned `predict` | Do not imply controllable planning unless the API supports it. |
+| Spatial / 3D world model | future scene or asset surfaces | Keep out of core until typed scene contracts exist. |
+| Physical AI infrastructure | `generate`, `transfer`, future data/eval adapters | Model each stable API as one capability. |
+| Active inference / structured generative model | future belief, uncertainty, or policy outputs | Preserve beliefs and uncertainty explicitly. |
+| Deterministic local surrogate | any tested local subset | Make it obvious that it is a surrogate. |
+
+Checklist:
+
+- [ ] The provider's taxonomy category is documented.
+- [ ] The provider's capabilities are derived from actual callable behavior.
+- [ ] Unsupported surfaces raise `ProviderError` through `BaseProvider`.
+- [ ] Scaffold adapters are labeled `scaffold` and do not claim real upstream behavior.
+- [ ] The provider profile notes whether it is local, remote, deterministic, beta, stable, or
+      scaffold.
+
+## Step 2: Choose Capabilities Narrowly
+
+WorldForge capabilities are not badges. They are callable contracts.
+
+```text
+capabilities.predict  -> predict(world_state, action, steps)
+capabilities.generate -> generate(prompt, duration_seconds, options)
+capabilities.transfer -> transfer(clip, width, height, fps, prompt, options)
+capabilities.reason   -> reason(query, world_state)
+capabilities.embed    -> embed(text)
+capabilities.score    -> score_actions(info, action_candidates)
+capabilities.plan     -> currently reserved for providers that implement planning directly
+```
+
+Rules:
+
+- [ ] Do not set `predict=True` unless the adapter returns a validated `PredictionPayload`.
+- [ ] Do not set `generate=True` unless the adapter returns a validated `VideoClip`.
+- [ ] Do not set `score=True` unless the adapter returns `ActionScoreResult` with finite scores
+      and a valid `best_index`.
+- [ ] Do not set `reason=True` for models that only return unstructured logs, captions, or
+      provider diagnostics.
+- [ ] Do not set `plan=True` just because a provider can score candidates. Score-based planning is
+      represented by `score=True` plus `World.plan(...)`.
+
+## Step 3: Define the Contract Before Code
+
+Write down the provider contract in the PR description or docs before implementation.
+
+```text
+Provider contract
+  name:
+  taxonomy category:
+  implementation status:
+  local or remote:
+  credentials/env vars:
+  optional dependencies:
+  default model/checkpoint:
+  supported modalities:
+  artifact types:
+  capabilities:
+  input shape/range constraints:
+  output schema:
+  score direction, if any:
+  retry/timeout behavior:
+  failure modes:
+  tests:
+```
+
+Questions to answer:
+
+- [ ] What exact upstream API, package, checkpoint format, or runtime is being wrapped?
+- [ ] What version range or installation path is expected?
+- [ ] Which environment variables trigger auto-registration?
+- [ ] Which inputs are host-preprocessed rather than inferred by WorldForge?
+- [ ] What are the provider-specific limits: duration, resolution, action shape, token budget,
+      file size, content type, polling limits, or model context?
+- [ ] What does a lower or higher score mean?
+- [ ] What does the provider return when output is partial, expired, missing, malformed, or
+      physically implausible?
+
+## Step 4: Use the Standard Adapter Shape
+
+Provider adapters should be small boundary objects.
+
+```text
+Provider class
+  |
+  |-- __init__
+  |     define identity, capabilities, profile metadata, env vars, request policy
+  |
+  |-- configured()
+  |     return whether registration/runtime config is present
+  |
+  |-- health()
+  |     validate local availability without doing expensive work
+  |
+  |-- capability method
+  |     validate WorldForge inputs
+  |     call upstream
+  |     parse upstream response
+  |     return typed WorldForge model
+  |     emit ProviderEvent
+  |
+  `-- private parser/validator helpers
+        keep upstream schemas explicit and testable
+```
+
+Minimal skeleton:
+
+```python
+from worldforge.models import ProviderCapabilities, ProviderEvent, ProviderHealth
+from worldforge.providers import BaseProvider, ProviderError
+
+
+class ExampleProvider(BaseProvider):
+    env_var = "EXAMPLE_API_KEY"
+
+    def __init__(self, *, event_handler=None):
+        super().__init__(
+            name="example",
+            capabilities=ProviderCapabilities(generate=True),
+            is_local=False,
+            description="Example provider adapter.",
+            package="worldforge",
+            implementation_status="beta",
+            deterministic=False,
+            required_env_vars=[self.env_var],
+            supported_modalities=["text"],
+            artifact_types=["video"],
+            notes=["Documents provider-specific limits here."],
+            event_handler=event_handler,
+        )
+
+    def health(self) -> ProviderHealth:
+        # Keep health cheap. Do not download large artifacts or load huge checkpoints here.
+        return super().health()
+
+    def generate(self, prompt, duration_seconds, *, options=None):
+        try:
+            self._require_credentials()
+            # validate inputs, call upstream, parse response, return VideoClip
+        except ProviderError:
+            raise
+        except Exception as exc:
+            raise ProviderError(f"Provider 'example' generation failed: {exc}") from exc
+```
+
+## Step 5: Boundary Validation Checklist
+
+Validate at the narrowest boundary. Do not let malformed upstream or caller data leak into public
+models.
+
+Caller input:
+
+- [ ] Non-empty provider name, prompt, model ID, and required env vars.
+- [ ] Positive duration, width, height, fps, step count, polling limits, and timeouts.
+- [ ] Finite numeric values for positions, scores, probabilities, latencies, and embeddings.
+- [ ] Existing local file paths before network upload.
+- [ ] Rectangular nested numeric arrays when accepting tensor-like JSON.
+- [ ] Explicit action tensor rank and shape for score providers.
+
+Upstream response:
+
+- [ ] JSON response is an object when an object is expected.
+- [ ] Required fields are present and correctly typed.
+- [ ] Task IDs are non-empty and stable across create/poll responses.
+- [ ] Terminal task states are explicit.
+- [ ] Partial outputs fail with `ProviderError` unless the public contract supports partial
+      results.
+- [ ] Artifact URLs are non-empty and sanitized before download.
+- [ ] Expired artifacts fail with context.
+- [ ] Unsupported content types fail before returning `VideoClip`.
+- [ ] Base64 media fields decode successfully.
+- [ ] Scores flatten to a non-empty finite list.
+
+State mutation:
+
+- [ ] Do not apply provider-supplied world state until it passes world-state validation.
+- [ ] Do not mutate the caller's `World` during comparison workflows.
+- [ ] Preserve history and metadata intentionally.
+
+## Step 6: LeWorldModel-Style Score Provider Checklist
+
+Use this checklist for JEPA and latent cost-model providers.
+
+```text
+host preprocessing
+  -> info tensors / arrays
+  -> action candidate tensor
+  -> candidate WorldForge Action sequences
+  -> provider.score_actions(...)
+  -> ActionScoreResult.best_index
+  -> Plan(actions=selected candidate)
+```
+
+Required behavior:
+
+- [ ] Expose `score=True` and no unrelated capabilities.
+- [ ] Keep optional heavy dependencies out of base package dependencies.
+- [ ] Import optional runtime packages lazily.
+- [ ] Health reports missing optional dependencies clearly.
+- [ ] `info` validates required fields such as `pixels`, `goal`, and `action`.
+- [ ] `action_candidates` validates provider-specific rank and shape.
+- [ ] Model output validates as non-empty finite scores.
+- [ ] `best_index` matches provider score direction.
+- [ ] `lower_is_better` is explicit.
+- [ ] `metadata` includes policy/checkpoint/model identifiers and score semantics.
+- [ ] Docs state that host code owns task preprocessing and action-space mapping.
+- [ ] Tests cover malformed tensors, missing fields, invalid ranks, non-finite scores, and
+      best-index plan selection.
+
+Do not:
+
+- [ ] Do not pretend a cost model can generate video.
+- [ ] Do not pretend a score provider can execute a plan.
+- [ ] Do not hide score direction in prose only.
+- [ ] Do not infer raw image transforms unless the adapter actually implements and tests them.
+
+## Step 7: Predictive Provider Checklist
+
+Use this checklist for providers that roll a world state forward.
+
+- [ ] Implement `predict(world_state, action, steps)`.
+- [ ] Validate `steps` and action fields before calling upstream.
+- [ ] Convert upstream output into a complete world-state JSON object.
+- [ ] Validate object IDs, metadata, history, and non-negative step.
+- [ ] Return `PredictionPayload` with confidence, physics score, frames, metadata, and latency.
+- [ ] Preserve provider identity in returned metadata where useful.
+- [ ] Tests cover malformed world state, missing scene objects, impossible actions if applicable,
+      non-finite metrics, and provider failure propagation.
+
+## Step 8: Generative and Transfer Provider Checklist
+
+Use this checklist for video or artifact providers.
+
+- [ ] Implement `generate(...)` only for prompt-to-video or equivalent artifact generation.
+- [ ] Implement `transfer(...)` only for video-to-video or artifact-to-artifact transformation.
+- [ ] Validate prompt, duration, size, ratio, fps, and file paths before the outbound request.
+- [ ] Model provider-specific options with `GenerationOptions` where possible.
+- [ ] Keep create-style mutations single-attempt unless the provider contract is idempotent.
+- [ ] Poll with bounded attempts and explicit terminal states.
+- [ ] Validate artifact content type before reading into `VideoClip`.
+- [ ] Reject empty artifact bodies.
+- [ ] Tests cover bad content types, expired artifacts, missing outputs, task failures, malformed
+      JSON, timeout, retry, and provider-specific limits.
+
+## Step 9: Observability and Failure Semantics
+
+Every real provider should emit useful `ProviderEvent` records.
+
+```text
+operation starts
+  -> upstream call or local model call
+  -> retry event, if retryable
+  -> success event with duration and key metadata
+  -> failure event with duration and sanitized message
+```
+
+Checklist:
+
+- [ ] Events include provider name, operation, phase, duration, and attempt where relevant.
+- [ ] HTTP events include status code when available.
+- [ ] Failure events do not leak secrets, bearer tokens, signed URLs, or raw credentials.
+- [ ] Retry events are emitted only for retryable operations.
+- [ ] Provider errors include operation, provider name, and the failed input class, not just
+      "request failed."
+- [ ] Unexpected exceptions are wrapped in `ProviderError` with context.
+
+## Step 10: Test Requirements
+
+Provider tests should be fixture-driven and contract-driven.
+
+Recommended layout:
+
+```text
+tests/
+|-- test_provider_name.py
+|-- fixtures/
+|   `-- providers/
+|       |-- provider_success.json
+|       |-- provider_failure.json
+|       |-- provider_partial_output.json
+|       `-- provider_malformed.json
+```
+
+Required tests:
+
+- [ ] Provider profile advertises the correct capabilities and limits.
+- [ ] `health()` reports missing credentials, missing optional dependencies, and healthy config.
+- [ ] Happy path returns the typed public model.
+- [ ] Every documented failure mode raises `ProviderError`, `WorldForgeError`, or
+      `WorldStateError` as appropriate.
+- [ ] Malformed upstream payloads are rejected.
+- [ ] Partial outputs are rejected or represented explicitly.
+- [ ] Bad content types are rejected for media artifacts.
+- [ ] Expired artifact URLs fail with context.
+- [ ] Provider-specific limits are tested.
+- [ ] Event emission is tested for success and failure.
+- [ ] `worldforge.testing.assert_provider_contract(...)` passes for the provider where applicable.
+
+Remote providers:
+
+- [ ] No tests require live credentials.
+- [ ] HTTP calls use fakes, fixtures, or local handlers.
+- [ ] Retry and timeout behavior is deterministic.
+
+Local model providers:
+
+- [ ] Heavy model dependencies are faked in unit tests.
+- [ ] A real-model smoke script is optional, documented, and not part of the default unit suite.
+- [ ] Checkpoint paths and cache directories are host-owned.
+
+## Step 11: Documentation Requirements
+
+A provider PR is incomplete without docs.
+
+- [ ] Provider matrix row in [Providers](./providers/README.md).
+- [ ] Provider-specific limits and environment variables.
+- [ ] API examples for the public methods touched.
+- [ ] Failure modes in [Python API](./api/python.md) when new public errors are introduced.
+- [ ] Architecture updates if a new capability or pipeline is introduced.
+- [ ] README update if the provider changes the main user-facing story.
+- [ ] Changelog entry for user-visible behavior.
+- [ ] `AGENTS.md` update if future AI contributors need new constraints or commands.
+
+## Pull Request Checklist
+
+Use this checklist in provider PRs.
+
+```text
+Provider identity
+  [ ] taxonomy category documented
+  [ ] capabilities are narrow and truthful
+  [ ] profile metadata is complete
+
+Runtime contract
+  [ ] env vars and optional dependencies documented
+  [ ] input shapes and limits documented
+  [ ] output schema and score direction documented
+  [ ] unsupported methods fail through BaseProvider defaults
+
+Validation and errors
+  [ ] caller inputs validated
+  [ ] upstream responses parsed by typed helpers
+  [ ] malformed/partial/expired/bad-content responses rejected
+  [ ] ProviderError messages are actionable and sanitized
+
+Observability
+  [ ] success events emitted
+  [ ] failure events emitted
+  [ ] retry events emitted when applicable
+
+Tests
+  [ ] happy path covered
+  [ ] failure modes covered with fixtures
+  [ ] provider-specific limits covered
+  [ ] contract tests run where applicable
+
+Docs
+  [ ] provider docs updated
+  [ ] API docs updated
+  [ ] changelog updated
+  [ ] agent context updated when needed
+```
+
+## Review Standard
+
+The reviewer should reject the provider if any of these are true:
+
+- The adapter advertises a capability that is not implemented end to end.
+- The provider's meaning of "world model" is vague.
+- Score direction is implicit.
+- Input shape is undocumented.
+- Remote response parsing is ad hoc and untested.
+- Optional heavy dependencies are added to the base install without a strong reason.
+- A provider failure can silently fall back to mock behavior.
+- A malformed upstream payload can become a successful public result.
+- The PR lacks fixture-driven tests for documented failure modes.

--- a/docs/src/providers/README.md
+++ b/docs/src/providers/README.md
@@ -2,7 +2,8 @@
 
 WorldForge providers are capability adapters, not a claim that every upstream system uses the same
 definition of "world model." See [World Model Taxonomy](../world-model-taxonomy.md) for the project
-definition and [Architecture](../architecture.md) for the end-to-end provider injection pipeline.
+definition, [Architecture](../architecture.md) for the end-to-end provider injection pipeline, and
+[Provider Authoring Guide](../provider-authoring-guide.md) before adding a new adapter.
 
 ## In-repo providers
 

--- a/docs/src/world-model-taxonomy.md
+++ b/docs/src/world-model-taxonomy.md
@@ -281,6 +281,9 @@ flowchart TD
 
 ## Design Rules for New Providers
 
+Use the full [Provider Authoring Guide](./provider-authoring-guide.md) when turning these rules
+into a new adapter PR.
+
 1. Declare capabilities narrowly.
 2. Document the provider's actual meaning of "world model."
 3. Validate input shape, range, content type, and task-specific limits at the adapter boundary.


### PR DESCRIPTION
## Summary

- Add a provider authoring guide that turns the WorldForge taxonomy into a concrete checklist for new adapters.
- Cover provider classification, capability selection, adapter shape, boundary validation, LeWorldModel-style score providers, predictive providers, generative providers, observability, tests, docs, and PR review standards.
- Link the guide from README, docs summary, introduction, provider docs, taxonomy, and changelog.

## Validation

- `git diff --check`
- `uv run ruff check src tests examples scripts`
- `uv run ruff format --check src tests examples scripts`
- `uv run pytest`