### PR TITLE
[codex] Add provider scaffold generator

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,8 @@ evaluation harnesses, and testable prototypes.
 - `src/worldforge/observability.py`: composable `ProviderEvent` sinks for JSON logging, in-memory
   recording, and metrics aggregation.
 - `src/worldforge/testing/`: reusable adapter contract helpers.
+- `scripts/scaffold_provider.py`: safe scaffold generator for new provider adapter files,
+  fixture placeholders, tests, and docs stubs.
 
 ## Tech Stack
 
@@ -54,6 +56,14 @@ uv run ruff format --check src tests examples scripts
 uv run pytest
 uv run pytest --cov=src/worldforge --cov-report=term-missing --cov-fail-under=90
 bash scripts/test_package.sh
+```
+
+Generate a provider scaffold:
+
+```bash
+uv run python scripts/scaffold_provider.py "Acme WM" \
+  --taxonomy "JEPA latent predictive world model" \
+  --planned-capability score
 ```
 
 Local security audit:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ releases may still include breaking changes when the public API needs to tighten
   input validation, score-output validation, provider profile metadata, and fixture-driven tests.
 - Added score-based planning support so `World.plan(...)` can select candidate action plans from
   `ActionScoreResult.best_index`, plus a real-checkpoint LeWorldModel smoke script.
+- Added `scripts/scaffold_provider.py` to generate safe provider adapter scaffolds, fixture
+  placeholders, generated scaffold tests, and provider docs stubs from planned capabilities.
 
 ### Security
 

--- a/README.md
+++ b/README.md
@@ -232,6 +232,17 @@ bash scripts/test_package.sh
 
 Package validation builds a wheel in an isolated virtual environment and reruns the root test suite against the installed artifact.
 
+Provider scaffolding:
+
+```bash
+uv run python scripts/scaffold_provider.py "Acme WM" \
+  --taxonomy "JEPA latent predictive world model" \
+  --planned-capability score
+```
+
+The scaffold starts safe: it creates adapter, fixture, test, and docs-stub files without
+advertising public capabilities until the implementation is complete.
+
 Contribution guidance:
 
 - keep the public API typed and Pythonic

--- a/docs/src/provider-authoring-guide.md
+++ b/docs/src/provider-authoring-guide.md
@@ -13,6 +13,34 @@ Related docs:
 - [Providers](./providers/README.md)
 - [Python API](./api/python.md)
 
+## Scaffold Generator
+
+Use the scaffold generator to create the first draft of a provider adapter, fixture files, test
+file, and provider docs stub:
+
+```bash
+uv run python scripts/scaffold_provider.py "Acme WM" \
+  --taxonomy "JEPA latent predictive world model" \
+  --planned-capability score \
+  --remote \
+  --env-var ACME_WM_API_KEY
+```
+
+Generated files:
+
+```text
+src/worldforge/providers/acme_wm.py
+tests/test_acme_wm_provider.py
+tests/fixtures/providers/acme_wm_success.json
+tests/fixtures/providers/acme_wm_error.json
+docs/src/providers/acme-wm.md
+```
+
+The generated provider is safe by default: it starts as `implementation_status="scaffold"`,
+advertises no public capabilities, and raises `ProviderError` from generated method stubs. Enable
+capabilities only after the adapter calls the real upstream runtime, validates inputs and outputs,
+and has fixture-driven tests for every documented failure mode.
+
 ## Adapter Decision Tree
 
 Start with the provider's real contract, not its marketing category.

--- a/scripts/scaffold_provider.py
+++ b/scripts/scaffold_provider.py
@@ -1,0 +1,610 @@
+#!/usr/bin/env python3
+"""Generate a WorldForge provider scaffold."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import keyword
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from textwrap import dedent
+
+CAPABILITIES = ("predict", "generate", "transfer", "reason", "embed", "score")
+DEFAULT_TAXONOMY = "unclassified provider scaffold"
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderNames:
+    raw: str
+    display: str
+    slug: str
+    snake: str
+    class_name: str
+
+
+@dataclass(frozen=True, slots=True)
+class ScaffoldOptions:
+    root: Path
+    names: ProviderNames
+    taxonomy: str
+    planned_capabilities: tuple[str, ...]
+    is_local: bool
+    env_var: str | None
+    force: bool
+
+
+def _split_words(name: str) -> list[str]:
+    expanded = re.sub(r"([A-Z]+)([A-Z][a-z])", r"\1 \2", name.strip())
+    expanded = re.sub(r"([a-z0-9])([A-Z])", r"\1 \2", expanded)
+    return re.findall(r"[A-Za-z][A-Za-z0-9]*|[0-9]+", expanded)
+
+
+def normalize_provider_name(raw_name: str) -> ProviderNames:
+    words = _split_words(raw_name)
+    if not words:
+        raise ValueError("provider name must contain at least one alphanumeric word")
+    if not words[0][0].isalpha():
+        raise ValueError("provider name must start with a letter")
+
+    slug = "-".join(word.lower() for word in words)
+    snake = "_".join(word.lower() for word in words)
+    if keyword.iskeyword(snake):
+        raise ValueError(f"provider module name '{snake}' is a Python keyword")
+
+    class_name = "".join(word[:1].upper() + word[1:] for word in words) + "Provider"
+    display = " ".join(word[:1].upper() + word[1:] for word in words)
+    return ProviderNames(
+        raw=raw_name,
+        display=display,
+        slug=slug,
+        snake=snake,
+        class_name=class_name,
+    )
+
+
+def _dedupe_capabilities(capabilities: list[str]) -> tuple[str, ...]:
+    seen: set[str] = set()
+    deduped: list[str] = []
+    for capability in capabilities:
+        if capability not in seen:
+            seen.add(capability)
+            deduped.append(capability)
+    return tuple(deduped)
+
+
+def _capability_stubs(names: ProviderNames, planned_capabilities: tuple[str, ...]) -> str:
+    stubs: list[str] = []
+    if "predict" in planned_capabilities:
+        stubs.append(
+            """
+    def predict(self, world_state: JSONDict, action: Action, steps: int) -> PredictionPayload:
+        raise ProviderError(
+            f"Provider '{self.name}' predict() scaffold is not implemented yet."
+        )
+"""
+        )
+    if "generate" in planned_capabilities:
+        stubs.append(
+            """
+    def generate(
+        self,
+        prompt: str,
+        duration_seconds: float,
+        *,
+        options: GenerationOptions | None = None,
+    ) -> VideoClip:
+        raise ProviderError(
+            f"Provider '{self.name}' generate() scaffold is not implemented yet."
+        )
+"""
+        )
+    if "transfer" in planned_capabilities:
+        stubs.append(
+            """
+    def transfer(
+        self,
+        clip: VideoClip,
+        *,
+        width: int,
+        height: int,
+        fps: float,
+        prompt: str = "",
+        options: GenerationOptions | None = None,
+    ) -> VideoClip:
+        raise ProviderError(
+            f"Provider '{self.name}' transfer() scaffold is not implemented yet."
+        )
+"""
+        )
+    if "reason" in planned_capabilities:
+        stubs.append(
+            """
+    def reason(self, query: str, *, world_state: JSONDict | None = None) -> ReasoningResult:
+        raise ProviderError(
+            f"Provider '{self.name}' reason() scaffold is not implemented yet."
+        )
+"""
+        )
+    if "embed" in planned_capabilities:
+        stubs.append(
+            """
+    def embed(self, *, text: str) -> EmbeddingResult:
+        raise ProviderError(
+            f"Provider '{self.name}' embed() scaffold is not implemented yet."
+        )
+"""
+        )
+    if "score" in planned_capabilities:
+        stubs.append(
+            """
+    def score_actions(self, *, info: JSONDict, action_candidates: object) -> ActionScoreResult:
+        raise ProviderError(
+            f"Provider '{self.name}' score_actions() scaffold is not implemented yet."
+        )
+"""
+        )
+
+    if not stubs:
+        raise ValueError(f"{names.slug} scaffold requires at least one planned capability")
+    return "\n".join(stub.rstrip() for stub in stubs)
+
+
+def _provider_source(options: ScaffoldOptions) -> str:
+    names = options.names
+    env_constant = f"{names.snake.upper()}_ENV_VAR"
+    required_env_vars = f"[{env_constant}]" if options.env_var else "[]"
+    planned = ", ".join(options.planned_capabilities)
+    stubs = _capability_stubs(names, options.planned_capabilities)
+    model_imports = ["ProviderCapabilities", "ProviderEvent", "ProviderHealth"]
+    if "predict" in options.planned_capabilities:
+        model_imports.extend(["Action", "JSONDict"])
+    if "generate" in options.planned_capabilities or "transfer" in options.planned_capabilities:
+        model_imports.extend(["GenerationOptions", "VideoClip"])
+    if "reason" in options.planned_capabilities:
+        model_imports.extend(["JSONDict", "ReasoningResult"])
+    if "embed" in options.planned_capabilities:
+        model_imports.append("EmbeddingResult")
+    if "score" in options.planned_capabilities:
+        model_imports.extend(["ActionScoreResult", "JSONDict"])
+
+    deduped_model_imports = list(dict.fromkeys(model_imports))
+    base_imports = ["BaseProvider", "ProviderError"]
+    if "predict" in options.planned_capabilities:
+        base_imports.insert(1, "PredictionPayload")
+
+    lines = [
+        f'"""Provider scaffold for {names.display}.',
+        "",
+        "Generated by ``scripts/scaffold_provider.py``. Keep public capabilities disabled until",
+        "the TODO methods return validated WorldForge models and have fixture-driven tests.",
+        '"""',
+        "",
+        "from __future__ import annotations",
+        "",
+    ]
+    if options.env_var:
+        lines.append("import os")
+    lines.extend(
+        [
+            "from collections.abc import Callable",
+            "from time import perf_counter",
+            "",
+            "from worldforge.models import (",
+        ]
+    )
+    lines.extend(f"    {import_name}," for import_name in deduped_model_imports)
+    lines.extend(
+        [
+            ")",
+            "",
+            f"from .base import {', '.join(base_imports)}",
+            "",
+        ]
+    )
+    if options.env_var:
+        lines.extend([f'{env_constant} = "{options.env_var}"', ""])
+
+    lines.extend(
+        [
+            f"class {names.class_name}(BaseProvider):",
+            f'    """Generated scaffold for the {names.display} provider.',
+            "",
+            "    Planned capabilities are intentionally not advertised yet. Enable them",
+            "    only after the corresponding methods call the real upstream runtime",
+            "    and return validated public models.",
+            '    """',
+            "",
+            f"    planned_capabilities = {options.planned_capabilities!r}",
+            f"    taxonomy_category = {options.taxonomy!r}",
+            "",
+            "    def __init__(",
+            "        self,",
+            f'        name: str = "{names.slug}",',
+            "        *,",
+            "        event_handler: Callable[[ProviderEvent], None] | None = None,",
+            "    ) -> None:",
+            "        super().__init__(",
+            "            name=name,",
+            "            capabilities=ProviderCapabilities(),",
+            f"            is_local={options.is_local!r},",
+            f'            description="{names.display} provider scaffold.",',
+            '            package="worldforge",',
+            '            implementation_status="scaffold",',
+            "            deterministic=False,",
+            f"            requires_credentials={not options.is_local!r},",
+            f"            required_env_vars={required_env_vars},",
+            "            supported_modalities=[],",
+            "            artifact_types=[],",
+            "            notes=[",
+            (
+                '                "Generated scaffold; do not register as a real provider until '
+                'implemented.",'
+            ),
+            f'                "Taxonomy category: {options.taxonomy}.",',
+            f'                "Planned capabilities: {planned}.",',
+            "            ],",
+            "            event_handler=event_handler,",
+            "        )",
+            "",
+            "    def configured(self) -> bool:",
+        ]
+    )
+    if options.env_var:
+        lines.append(f"        return bool(os.environ.get({env_constant}))")
+    else:
+        lines.append("        return True")
+
+    lines.extend(
+        [
+            "",
+            "    def health(self) -> ProviderHealth:",
+            "        started = perf_counter()",
+        ]
+    )
+    if options.env_var:
+        lines.extend(
+            [
+                "        if not self.configured():",
+                "            return ProviderHealth(",
+                "                name=self.name,",
+                "                healthy=False,",
+                "                latency_ms=max(0.1, (perf_counter() - started) * 1000),",
+                f'                details=f"missing {{{env_constant}}}",',
+                "            )",
+            ]
+        )
+    lines.extend(
+        [
+            "        return ProviderHealth(",
+            "            name=self.name,",
+            "            healthy=True,",
+            "            latency_ms=max(0.1, (perf_counter() - started) * 1000),",
+            '            details="scaffold generated; implement provider before production use",',
+            "        )",
+            "",
+            stubs,
+        ]
+    )
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _test_source(options: ScaffoldOptions) -> str:
+    names = options.names
+    worldforge_imports: list[str] = []
+    if "predict" in options.planned_capabilities:
+        worldforge_imports.append("Action")
+    if "transfer" in options.planned_capabilities:
+        worldforge_imports.append("VideoClip")
+
+    lines = [
+        "from __future__ import annotations",
+        "",
+        "import pytest",
+        "",
+    ]
+    if worldforge_imports:
+        lines.append(f"from worldforge import {', '.join(worldforge_imports)}")
+    lines.extend(
+        [
+            "from worldforge.providers.base import ProviderError",
+            f"from worldforge.providers.{names.snake} import {names.class_name}",
+            "",
+            "",
+            f"def test_{names.snake}_profile_starts_as_safe_scaffold() -> None:",
+            f"    provider = {names.class_name}()",
+            "    profile = provider.profile()",
+            "",
+            f'    assert profile.name == "{names.slug}"',
+            '    assert profile.implementation_status == "scaffold"',
+            "    assert profile.capabilities.supported_tasks() == []",
+            f"    assert provider.planned_capabilities == {options.planned_capabilities!r}",
+            f"    assert provider.taxonomy_category == {options.taxonomy!r}",
+        ]
+    )
+    if options.env_var:
+        lines.extend(
+            [
+                "",
+                "",
+                (
+                    f"def test_{names.snake}_health_reports_missing_configuration"
+                    "(monkeypatch) -> None:"
+                ),
+                f'    monkeypatch.delenv("{options.env_var}", raising=False)',
+                "",
+                f"    health = {names.class_name}().health()",
+                "",
+                "    assert health.healthy is False",
+                f'    assert "{options.env_var}" in health.details',
+            ]
+        )
+    if "predict" in options.planned_capabilities:
+        lines.extend(
+            [
+                "",
+                "",
+                f"def test_{names.snake}_predict_is_not_implemented_yet() -> None:",
+                f"    provider = {names.class_name}()",
+                "",
+                '    with pytest.raises(ProviderError, match="not implemented"):',
+                "        provider.predict({}, Action.noop(), 1)",
+            ]
+        )
+    if "generate" in options.planned_capabilities:
+        lines.extend(
+            [
+                "",
+                "",
+                f"def test_{names.snake}_generate_is_not_implemented_yet() -> None:",
+                f"    provider = {names.class_name}()",
+                "",
+                '    with pytest.raises(ProviderError, match="not implemented"):',
+                '        provider.generate("prompt", 1.0)',
+            ]
+        )
+    if "transfer" in options.planned_capabilities:
+        lines.extend(
+            [
+                "",
+                "",
+                f"def test_{names.snake}_transfer_is_not_implemented_yet() -> None:",
+                f"    provider = {names.class_name}()",
+                "    clip = VideoClip(",
+                '        frames=[b"frame"],',
+                "        fps=1.0,",
+                "        resolution=(1, 1),",
+                "        duration_seconds=1.0,",
+                "    )",
+                "",
+                '    with pytest.raises(ProviderError, match="not implemented"):',
+                "        provider.transfer(clip, width=1, height=1, fps=1.0)",
+            ]
+        )
+    if "reason" in options.planned_capabilities:
+        lines.extend(
+            [
+                "",
+                "",
+                f"def test_{names.snake}_reason_is_not_implemented_yet() -> None:",
+                f"    provider = {names.class_name}()",
+                "",
+                '    with pytest.raises(ProviderError, match="not implemented"):',
+                '        provider.reason("query")',
+            ]
+        )
+    if "embed" in options.planned_capabilities:
+        lines.extend(
+            [
+                "",
+                "",
+                f"def test_{names.snake}_embed_is_not_implemented_yet() -> None:",
+                f"    provider = {names.class_name}()",
+                "",
+                '    with pytest.raises(ProviderError, match="not implemented"):',
+                '        provider.embed(text="query")',
+            ]
+        )
+    if "score" in options.planned_capabilities:
+        lines.extend(
+            [
+                "",
+                "",
+                f"def test_{names.snake}_score_actions_is_not_implemented_yet() -> None:",
+                f"    provider = {names.class_name}()",
+                "",
+                '    with pytest.raises(ProviderError, match="not implemented"):',
+                "        provider.score_actions(info={}, action_candidates=[])",
+            ]
+        )
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _docs_source(options: ScaffoldOptions) -> str:
+    names = options.names
+    capability_rows = "\n".join(
+        f"- [ ] `{capability}` implemented, advertised, and tested"
+        for capability in options.planned_capabilities
+    )
+    env_section = (
+        "- Required environment variable: none yet.\n"
+        if options.env_var is None
+        else f"- Required environment variable: `{options.env_var}`.\n"
+    )
+    return dedent(
+        f"""\
+        # {names.display} Provider
+
+        Status: scaffold
+
+        Taxonomy category: {options.taxonomy}
+
+        This file was generated by `scripts/scaffold_provider.py`. Treat it as a checklist, not as
+        proof that the provider is implemented.
+
+        ## Planned Capabilities
+
+        {capability_rows}
+
+        ## Configuration
+
+        {env_section}
+        - Optional dependencies: document runtime packages, model checkpoints, and cache paths.
+        - Registration rule: document the environment variables required before auto-registration.
+
+        ## Contract To Define
+
+        - Input shape, range, and semantic constraints.
+        - Output schema and score direction, if applicable.
+        - Provider-specific limits such as duration, resolution, action tensor shape, file size,
+          content type, timeout, retry, and polling behavior.
+        - Failure modes for malformed upstream payloads, partial task output, expired artifacts,
+          unsupported content types, missing credentials, and unavailable local checkpoints.
+
+        ## Tests To Add
+
+        - Fixture-driven happy path.
+        - Malformed upstream payload.
+        - Provider-specific input limit.
+        - Event emission for success and failure.
+        - Contract test with `worldforge.testing.assert_provider_contract(...)` when the provider
+          advertises public capabilities.
+
+        ## Release Checklist
+
+        - [ ] Provider capabilities are narrow and truthful.
+        - [ ] Provider profile metadata is complete.
+        - [ ] Public API docs mention new failure modes.
+        - [ ] `docs/src/providers/README.md` links this provider page.
+        - [ ] `AGENTS.md` documents any new commands, dependencies, or gotchas.
+        - [ ] `CHANGELOG.md` records the user-visible behavior.
+        """
+    )
+
+
+def _fixture_payload(options: ScaffoldOptions, *, success: bool) -> str:
+    payload = {
+        "provider": options.names.slug,
+        "taxonomy_category": options.taxonomy,
+        "planned_capabilities": list(options.planned_capabilities),
+    }
+    if success:
+        payload["status"] = "replace-with-real-success-payload"
+    else:
+        payload["error"] = {
+            "type": "replace-with-real-provider-error",
+            "message": "Replace this scaffold fixture with a real malformed upstream response.",
+        }
+    return json.dumps(payload, indent=2, sort_keys=True) + "\n"
+
+
+def scaffold_files(options: ScaffoldOptions) -> dict[Path, str]:
+    names = options.names
+    return {
+        options.root / "src" / "worldforge" / "providers" / f"{names.snake}.py": _provider_source(
+            options
+        ),
+        options.root / "tests" / f"test_{names.snake}_provider.py": _test_source(options),
+        options.root / "tests" / "fixtures" / "providers" / f"{names.snake}_success.json": (
+            _fixture_payload(options, success=True)
+        ),
+        options.root / "tests" / "fixtures" / "providers" / f"{names.snake}_error.json": (
+            _fixture_payload(options, success=False)
+        ),
+        options.root / "docs" / "src" / "providers" / f"{names.slug}.md": _docs_source(options),
+    }
+
+
+def write_scaffold(options: ScaffoldOptions) -> list[Path]:
+    files = scaffold_files(options)
+    existing = [path for path in files if path.exists()]
+    if existing and not options.force:
+        joined = "\n".join(f"- {path}" for path in existing)
+        raise FileExistsError(f"refusing to overwrite existing scaffold files:\n{joined}")
+
+    written: list[Path] = []
+    for path, content in files.items():
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+        written.append(path)
+    return written
+
+
+def parse_args(argv: list[str]) -> ScaffoldOptions:
+    parser = argparse.ArgumentParser(
+        description="Generate a safe WorldForge provider scaffold.",
+    )
+    parser.add_argument("name", help="Provider display name, e.g. 'Acme WM'.")
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=Path.cwd(),
+        help="Repository root to write into. Defaults to the current directory.",
+    )
+    parser.add_argument(
+        "--taxonomy",
+        default=DEFAULT_TAXONOMY,
+        help="Taxonomy category from docs/src/world-model-taxonomy.md.",
+    )
+    parser.add_argument(
+        "--planned-capability",
+        action="append",
+        choices=CAPABILITIES,
+        required=True,
+        help="Capability stub to generate. Repeat for multiple planned capabilities.",
+    )
+    parser.add_argument(
+        "--env-var",
+        help="Optional environment variable required by the provider.",
+    )
+    locality = parser.add_mutually_exclusive_group()
+    locality.add_argument("--local", action="store_true", help="Scaffold a local provider.")
+    locality.add_argument("--remote", action="store_true", help="Scaffold a remote provider.")
+    parser.add_argument("--force", action="store_true", help="Overwrite generated scaffold files.")
+
+    args = parser.parse_args(argv)
+    names = normalize_provider_name(args.name)
+    planned_capabilities = _dedupe_capabilities(args.planned_capability or [])
+    if not planned_capabilities:
+        parser.error("at least one --planned-capability is required")
+    env_var = args.env_var.strip() if args.env_var else None
+    if env_var == "":
+        parser.error("--env-var must not be empty")
+    is_local = not args.remote
+    if args.remote and env_var is None:
+        env_var = f"{names.snake.upper()}_API_KEY"
+
+    return ScaffoldOptions(
+        root=args.root.expanduser().resolve(),
+        names=names,
+        taxonomy=args.taxonomy.strip() or DEFAULT_TAXONOMY,
+        planned_capabilities=planned_capabilities,
+        is_local=is_local,
+        env_var=env_var,
+        force=bool(args.force),
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    try:
+        options = parse_args(sys.argv[1:] if argv is None else argv)
+        written = write_scaffold(options)
+    except (FileExistsError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    print(f"Generated provider scaffold for {options.names.display}:")
+    for path in written:
+        print(f"- {path.relative_to(options.root)}")
+    print("\nNext steps:")
+    print("- implement the TODO methods before advertising capabilities")
+    print("- add the provider to src/worldforge/providers/__init__.py when it is ready")
+    print("- register it in WorldForge._known_providers only after the adapter is tested")
+    print("- link the docs stub from docs/src/providers/README.md")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_provider_scaffold_script.py
+++ b/tests/test_provider_scaffold_script.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import py_compile
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "scaffold_provider.py"
+
+
+def test_scaffold_provider_script_generates_safe_adapter_files(tmp_path: Path) -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "Acme WM",
+            "--root",
+            str(tmp_path),
+            "--taxonomy",
+            "JEPA latent predictive world model",
+            "--planned-capability",
+            "score",
+            "--planned-capability",
+            "generate",
+            "--remote",
+            "--env-var",
+            "ACME_WM_API_KEY",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    provider_path = tmp_path / "src" / "worldforge" / "providers" / "acme_wm.py"
+    test_path = tmp_path / "tests" / "test_acme_wm_provider.py"
+    success_fixture = tmp_path / "tests" / "fixtures" / "providers" / "acme_wm_success.json"
+    error_fixture = tmp_path / "tests" / "fixtures" / "providers" / "acme_wm_error.json"
+    docs_path = tmp_path / "docs" / "src" / "providers" / "acme-wm.md"
+
+    assert "Generated provider scaffold for Acme WM" in result.stdout
+    assert provider_path.exists()
+    assert test_path.exists()
+    assert success_fixture.exists()
+    assert error_fixture.exists()
+    assert docs_path.exists()
+
+    provider_source = provider_path.read_text(encoding="utf-8")
+    assert "class AcmeWMProvider(BaseProvider)" in provider_source
+    assert "capabilities=ProviderCapabilities()" in provider_source
+    assert "planned_capabilities = ('score', 'generate')" in provider_source
+    assert 'ACME_WM_ENV_VAR = "ACME_WM_API_KEY"' in provider_source
+
+    test_source = test_path.read_text(encoding="utf-8")
+    assert "score_actions_is_not_implemented_yet" in test_source
+    assert "generate_is_not_implemented_yet" in test_source
+
+    docs_source = docs_path.read_text(encoding="utf-8")
+    assert "Taxonomy category: JEPA latent predictive world model" in docs_source
+    assert "`score` implemented, advertised, and tested" in docs_source
+
+    py_compile.compile(str(provider_path), doraise=True)
+    py_compile.compile(str(test_path), doraise=True)
+
+
+def test_scaffold_provider_script_refuses_to_overwrite_files(tmp_path: Path) -> None:
+    command = [
+        sys.executable,
+        str(SCRIPT),
+        "Acme WM",
+        "--root",
+        str(tmp_path),
+        "--planned-capability",
+        "score",
+    ]
+
+    subprocess.run(command, check=True, capture_output=True, text=True)
+    second = subprocess.run(command, capture_output=True, text=True)
+
+    assert second.returncode == 2
+    assert "refusing to overwrite existing scaffold files" in second.stderr


### PR DESCRIPTION
## Summary

- Add `scripts/scaffold_provider.py` to generate safe provider adapter scaffolds from planned capabilities.
- Generated scaffolds include an adapter file, provider test file, success/error fixture placeholders, and a provider docs stub.
- Keep generated provider capabilities disabled by default until real implementation and fixture-driven validation are added.
- Document the scaffold command in README, AGENTS, and the provider authoring guide.

## Validation

- `git diff --check`
- `uv run ruff check src tests examples scripts`
- `uv run ruff format --check src tests examples scripts`
- `uv run pytest`
- `uv run python -m py_compile scripts/scaffold_provider.py`