### PR TITLE
[codex] Add JEPA-WMS torch-hub runtime planning

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,9 +23,9 @@ evaluation harnesses, and testable prototypes.
   retry, polling, download policies, and response parsers.
 - `src/worldforge/providers/leworldmodel.py`: real optional LeWorldModel JEPA cost-model adapter
   for scoring action candidates through `stable_worldmodel.policy.AutoCostModel`.
-- `src/worldforge/providers/jepa_wms.py`: candidate contract scaffold for future
-  `facebookresearch/jepa-wms` score-provider work; it supports injected fake/runtime scoring but
-  is intentionally not exported or registered.
+- `src/worldforge/providers/jepa_wms.py`: candidate contract scaffold for
+  `facebookresearch/jepa-wms` score-provider work; it supports injected fake/runtime scoring and a
+  host-owned torch-hub runtime but is intentionally not exported or registered.
 - `src/worldforge/providers/remote.py`: credential-gated scaffold providers for `jepa` and
   `genie`; these intentionally use deterministic mock behavior after credential checks.
 - `src/worldforge/evaluation/`: built-in generation, physics, planning, reasoning, and transfer
@@ -98,9 +98,9 @@ rm -f "$tmp_req"
 
 - Do not replace scaffold providers with claims of real JEPA/Genie integration; they are
   credential-gated mock-backed adapters until real provider behavior is implemented.
-- Do not export or auto-register `JEPAWMSProvider` until it calls the real `facebookresearch/jepa-wms`
-  runtime and documents provider-specific limits. The current fake-runtime path is only a contract
-  harness for validation, result parsing, and event behavior.
+- Do not export or auto-register `JEPAWMSProvider` until provider-specific limits are validated
+  against real upstream weights. The current torch-hub path is direct-construction only and keeps
+  PyTorch plus JEPA-WMS dependencies host-owned.
 - Do not add `stable_worldmodel`, `torch`, checkpoint archives, or downloaded datasets to the base
   dependency set or repository. Keep LeWorldModel optional and host-owned.
 - Do not auto-register optional providers unless their required environment variables are present.
@@ -127,13 +127,14 @@ rm -f "$tmp_req"
 - `scripts/smoke_leworldmodel.py` is an optional real-checkpoint smoke. Run it from an isolated
   Python 3.10 environment with the upstream GitHub `stable-worldmodel[train,env]` runtime; do not
   add those dependencies to WorldForge's base package.
-- `JEPA_WMS_MODEL_PATH` is documented by the `jepa-wms` candidate only. It does not make
-  `JEPAWMSProvider` available through `WorldForge`; direct tests must inject `runtime=`.
+- `JEPA_WMS_MODEL_PATH`, `JEPA_WMS_MODEL_NAME`, and `JEPA_WMS_DEVICE` are documented by the
+  `jepa-wms` candidate only. They do not make `JEPAWMSProvider` available through `WorldForge`;
+  direct tests must inject `runtime=` or use `JEPAWMSProvider.from_torch_hub(...)`.
 - `RUNWAYML_API_SECRET` is preferred, but `RUNWAY_API_SECRET` remains supported as a legacy alias.
 
 ## Current State
 
-As of 2026-04-16, WorldForge is alpha. It is suitable for local development, adapter contract
+As of 2026-04-17, WorldForge is alpha. It is suitable for local development, adapter contract
 testing, deterministic evaluation, and provider-prototype workflows. It is not suitable for
 unattended production operation against third-party providers without host-level monitoring,
 credential management, persistence strategy, and operational safeguards.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,10 @@ releases may still include breaking changes when the public API needs to tighten
   `ActionScoreResult.best_index`, plus a real-checkpoint LeWorldModel smoke script.
 - Added `scripts/scaffold_provider.py` to generate safe provider adapter scaffolds, fixture
   placeholders, generated scaffold tests, and provider docs stubs from planned capabilities.
-- Added a `jepa-wms` provider candidate scaffold with fake-runtime score contract tests, parser
-  fixtures, event assertions, and docs for future `facebookresearch/jepa-wms` integration without
-  exporting or auto-registering it as a working provider.
+- Added a `jepa-wms` provider candidate scaffold with fake-runtime and host-owned torch-hub score
+  contract tests, parser fixtures, `World.plan(...)` coverage, event assertions, and docs for
+  future `facebookresearch/jepa-wms` integration without exporting or auto-registering it as a
+  working provider.
 
 ### Security
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ adapter.
 
 ## Status
 
-As of 2026-04-16, WorldForge is **alpha**. It is suitable for local development, contract testing, provider adapter prototyping, deterministic evaluation flows, and single-writer JSON persistence. It is not yet suitable for claiming real-world physics fidelity, running unattended production workloads against third-party providers without host-level operational safeguards, or presenting scaffold adapters as fully implemented integrations. Known limitations are listed in [Current limitations](#current-limitations). User-visible changes are tracked in [CHANGELOG.md](./CHANGELOG.md).
+As of 2026-04-17, WorldForge is **alpha**. It is suitable for local development, contract testing, provider adapter prototyping, deterministic evaluation flows, and single-writer JSON persistence. It is not yet suitable for claiming real-world physics fidelity, running unattended production workloads against third-party providers without host-level operational safeguards, or presenting scaffold adapters as fully implemented integrations. Known limitations are listed in [Current limitations](#current-limitations). User-visible changes are tracked in [CHANGELOG.md](./CHANGELOG.md).
 
 ## Installation
 
@@ -210,7 +210,8 @@ More detail lives in [docs/src/world-model-taxonomy.md](./docs/src/world-model-t
 
 Provider candidate scaffolds are kept outside package exports and auto-registration until they have
 a real runtime adapter. The current candidate is [`jepa-wms`](./docs/src/providers/jepa-wms.md), a
-local fake-runtime contract scaffold for future `facebookresearch/jepa-wms` score-provider work.
+local fake-runtime and host-owned torch-hub contract scaffold for future `facebookresearch/jepa-wms`
+score-provider work.
 
 LeWorldModel is a local optional integration. Install the upstream runtime in the host
 environment, place checkpoints under `$STABLEWM_HOME` or set `LEWORLDMODEL_CACHE_DIR`, then set

--- a/docs/src/providers/README.md
+++ b/docs/src/providers/README.md
@@ -24,7 +24,7 @@ exist to make future integrations explicit without claiming runtime support.
 
 | Provider | Status | Registration rule | Notes |
 | --- | --- | --- | --- |
-| [`jepa-wms`](./jepa-wms.md) | scaffold candidate | none; not exported or registered | local candidate with fake-runtime `score` contract tests for future `facebookresearch/jepa-wms` integration |
+| [`jepa-wms`](./jepa-wms.md) | scaffold candidate | none; not exported or registered | local candidate with fake-runtime and host-owned torch-hub `score` contract tests for future `facebookresearch/jepa-wms` integration |
 
 ## Provider profiles
 

--- a/docs/src/providers/jepa-wms.md
+++ b/docs/src/providers/jepa-wms.md
@@ -1,6 +1,6 @@
 # JEPA WMS Provider
 
-Status: scaffold candidate with fake-runtime contract tests
+Status: scaffold candidate with fake-runtime and host-owned torch-hub contract tests
 
 Taxonomy category: JEPA latent predictive world model
 
@@ -10,25 +10,27 @@ data, weights, training loops, shared planning components, and planning evaluati
 joint-embedding predictive world models.
 
 It is not exported from `worldforge.providers`, not registered by `WorldForge._known_providers`,
-and does not import the upstream research repository. Keep it that way until the adapter calls the
-real upstream runtime and returns validated WorldForge models.
+and does not auto-import the upstream research repository. Keep it that way until the adapter calls
+the real upstream runtime and returns validated WorldForge models.
 
 By default the provider advertises no public capabilities. When a test or host experiment injects
-`runtime=`, it advertises `score` and exercises the WorldForge-side contract with fake runtime
-responses. That fake-runtime path exists to harden validation before upstream integration, not to
-claim production readiness.
+`runtime=` or uses `JEPAWMSProvider.from_torch_hub(...)`, it advertises `score` and exercises the
+WorldForge-side scoring contract. These direct construction paths are intentionally not wired into
+auto-registration.
 
 The scaffold health check remains unhealthy when only `JEPA_WMS_MODEL_PATH` is set because a path
 does not prove the integration can execute. It becomes healthy only when both `JEPA_WMS_MODEL_PATH`
-or `model_path=` and an injected `runtime=` are present.
+or `model_path=` and an injected runtime, including the torch-hub runtime, are present.
 
 ## Contract Status
 
 - [x] `score` contract implemented behind injected fake/runtime object.
 - [x] Fixture-driven tests for malformed input, upstream error payloads, non-finite scores, score
   count mismatches, provider contract checks, and event emission.
-- [ ] Real `facebookresearch/jepa-wms` runtime adapter implemented.
-- [ ] Real upstream import path, checkpoint loader, and task preprocessing contract documented.
+- [x] Host-owned torch-hub runtime shim for `facebookresearch/jepa-wms` model loading and
+  encode/unroll/latent-distance scoring.
+- [x] `World.plan(...)` score-planning coverage through the JEPA-WMS candidate.
+- [ ] Real upstream smoke against downloaded `facebook/jepa-wms` weights completed.
 - [ ] Auto-registration decision made.
 
 The intended public surface is `score_actions(...) -> ActionScoreResult`, matching the
@@ -40,6 +42,8 @@ internal to JEPA-WMS.
 ## Configuration
 
 - Required environment variable: `JEPA_WMS_MODEL_PATH`.
+- Optional torch-hub model name: `JEPA_WMS_MODEL_NAME`, for example `jepa_wm_pusht`.
+- Optional torch device: `JEPA_WMS_DEVICE`, for example `cpu` or `cuda:0`.
 
 - Optional dependencies: expected to be host-owned until a real adapter is implemented. Do not add
   `jepa-wms`, PyTorch, datasets, checkpoints, or simulator dependencies to WorldForge's base
@@ -108,9 +112,55 @@ The runtime failure response must be a JSON object:
 Failure responses are converted to `ProviderError` and emit a `ProviderEvent` with
 `operation="score"` and `phase="failure"`.
 
+## Host-Owned Torch-Hub Runtime
+
+The candidate includes a lazy torch-hub runtime shim:
+
+```python
+from worldforge.providers.jepa_wms import JEPAWMSProvider
+
+provider = JEPAWMSProvider.from_torch_hub(
+    model_name="jepa_wm_pusht",
+    device="cpu",
+)
+```
+
+This follows the upstream loading pattern:
+
+```python
+model, preprocessor = torch.hub.load(
+    "facebookresearch/jepa-wms",
+    "jepa_wm_pusht",
+)
+```
+
+The runtime lazily imports `torch` and lazily calls `torch.hub.load(...)` only when
+`score_actions(...)` is invoked. It first delegates to a model-native
+`score_actions(...)`, `score_action_candidates(...)`, or `compute_scores(...)` method if a host
+wraps one. If the loaded model does not expose a scoring method, it uses the JEPA-WMS planning
+shape described upstream:
+
+```text
+observation -> model.encode(..., act=True) -> z_init
+goal        -> model.encode(..., act=False) -> z_goal
+actions     -> model.unroll(z_init, act_suffix=actions)
+score       -> latent L1/L2 distance between final predicted latent and goal latent
+```
+
+The torch-hub runtime expects `action_candidates` shaped as
+`(1, samples, horizon, action_dim)`. WorldForge returns one score per sample and rejects multi-batch
+payloads until the public `ActionScoreResult` contract defines batched score semantics.
+
+Current `score_info` keys:
+
+- `observation`: tensor-like or nested numeric observation payload accepted by the upstream model.
+- `goal`: tensor-like or nested numeric goal payload accepted by the upstream model.
+- `objective`: optional, `l2` by default; `l1` is also supported.
+- `actions_are_normalized`: optional, `true` by default. Set `false` only when the loaded
+  preprocessor exposes `normalize_actions(...)`.
+
 ## Remaining Upstream Contract To Define
 
-- Exact upstream entry point: Python package import path, checkpoint loader, and scoring function.
 - Mapping between JEPA-WMS candidate tensors and WorldForge `Action` sequences.
 - Provider-specific limits such as context window, rollout horizon, action dimension, batch size,
   device placement, dataset/task family, and checkpoint compatibility.
@@ -121,7 +171,8 @@ Failure responses are converted to `ProviderError` and emit a `ProviderEvent` wi
 
 - `tests/test_jepa_wms_provider.py` covers the fake-runtime happy path, provider contract helper,
   missing model path, missing runtime, upstream error payloads, malformed fixtures, non-finite
-  score output, score-count mismatches, and success/failure event emission.
+  score output, score-count mismatches, torch-hub runtime delegation, score-planning through
+  `World.plan(...)`, and success/failure event emission.
 - `tests/fixtures/providers/jepa_wms_*.json` defines the current contract fixtures.
 
 ## Release Checklist

--- a/docs/src/world-model-taxonomy.md
+++ b/docs/src/world-model-taxonomy.md
@@ -165,8 +165,8 @@ WorldForge's current `jepa` provider is only a scaffold. A real JEPA provider sh
 LeWorldModel pattern: do not advertise generation or reasoning unless implemented; expose score,
 latent rollout, or prediction capabilities explicitly; document tensor shapes and task contracts.
 WorldForge also carries a [`jepa-wms` provider candidate scaffold](./providers/jepa-wms.md) with
-fake-runtime contract tests for future work against `facebookresearch/jepa-wms`; it is intentionally
-not exported or registered until a real runtime adapter exists.
+fake-runtime and host-owned torch-hub contract tests for future work against
+`facebookresearch/jepa-wms`; it is intentionally not exported or registered.
 
 ### Dreamer-style Model-Based RL
 

--- a/src/worldforge/providers/jepa_wms.py
+++ b/src/worldforge/providers/jepa_wms.py
@@ -8,10 +8,12 @@ added.
 
 from __future__ import annotations
 
+import importlib
 import os
 from collections.abc import Callable
+from contextlib import nullcontext
 from time import perf_counter
-from typing import Protocol
+from typing import Any, Protocol
 
 from worldforge.models import (
     ActionScoreResult,
@@ -26,8 +28,13 @@ from worldforge.models import (
 from .base import BaseProvider, ProviderError
 
 JEPA_WMS_ENV_VAR = "JEPA_WMS_MODEL_PATH"
+JEPA_WMS_MODEL_NAME_ENV_VAR = "JEPA_WMS_MODEL_NAME"
+JEPA_WMS_DEVICE_ENV_VAR = "JEPA_WMS_DEVICE"
+DEFAULT_JEPA_WMS_HUB_REPO = "facebookresearch/jepa-wms"
 REQUIRED_INFO_FIELDS = ("observation", "goal")
 OPTIONAL_NUMERIC_INFO_FIELDS = ("action_history",)
+
+HubLoader = Callable[..., object]
 
 
 class JEPAWMSRuntime(Protocol):
@@ -147,6 +154,309 @@ def _flatten_numeric(value: object, *, name: str) -> list[float]:
         raise ProviderError(f"{name} must contain only finite numbers.") from exc
 
 
+def _tensor_shape(value: object) -> tuple[int, ...] | None:
+    shape = getattr(value, "shape", None)
+    if shape is None:
+        return None
+    try:
+        return tuple(int(dimension) for dimension in shape)
+    except (TypeError, ValueError):
+        return None
+
+
+class TorchHubJEPAWMSRuntime:
+    """Host-owned runtime shim for upstream JEPA-WMS torch-hub models.
+
+    The shim lazily imports ``torch`` and lazily calls ``torch.hub.load``. It is deliberately not
+    used by auto-registration; hosts must instantiate it explicitly or use
+    ``JEPAWMSProvider.from_torch_hub(...)``.
+    """
+
+    def __init__(
+        self,
+        *,
+        model_name: str,
+        hub_repo: str = DEFAULT_JEPA_WMS_HUB_REPO,
+        device: str | None = None,
+        pretrained: bool = True,
+        trust_repo: bool | None = None,
+        hub_loader: HubLoader | None = None,
+        torch_module: Any | None = None,
+    ) -> None:
+        self.model_name = _optional_non_empty(model_name, name="JEPA-WMS model_name")
+        if self.model_name is None:
+            raise WorldForgeError("JEPA-WMS model_name must be provided.")
+        self.hub_repo = _optional_non_empty(hub_repo, name="JEPA-WMS hub_repo")
+        if self.hub_repo is None:
+            raise WorldForgeError("JEPA-WMS hub_repo must be provided.")
+        self.device = _optional_non_empty(device, name="JEPA-WMS device")
+        if not isinstance(pretrained, bool):
+            raise WorldForgeError("JEPA-WMS pretrained must be a boolean.")
+        if trust_repo is not None and not isinstance(trust_repo, bool):
+            raise WorldForgeError("JEPA-WMS trust_repo must be a boolean when provided.")
+        self.pretrained = pretrained
+        self.trust_repo = trust_repo
+        self._hub_loader = hub_loader
+        self._torch_module = torch_module
+        self._model: Any | None = None
+        self._preprocessor: Any | None = None
+
+    def _torch(self) -> Any:
+        if self._torch_module is not None:
+            return self._torch_module
+        try:
+            return importlib.import_module("torch")
+        except ImportError as exc:
+            raise ProviderError(
+                "JEPA-WMS torch-hub runtime requires optional dependency torch in the host "
+                "environment."
+            ) from exc
+
+    def _load_model(self, torch: Any) -> tuple[Any, Any | None]:
+        if self._model is not None:
+            return self._model, self._preprocessor
+
+        loader = self._hub_loader
+        if loader is None:
+            hub = getattr(torch, "hub", None)
+            loader = getattr(hub, "load", None)
+        if not callable(loader):
+            raise ProviderError("JEPA-WMS torch module does not expose torch.hub.load().")
+
+        kwargs: dict[str, object] = {
+            "pretrained": self.pretrained,
+        }
+        if self.device is not None:
+            kwargs["device"] = self.device
+        if self.trust_repo is not None:
+            kwargs["trust_repo"] = self.trust_repo
+
+        try:
+            loaded = loader(self.hub_repo, self.model_name, **kwargs)
+        except Exception as exc:
+            raise ProviderError(
+                f"Failed to load JEPA-WMS torch-hub model '{self.model_name}' "
+                f"from '{self.hub_repo}': {exc}"
+            ) from exc
+
+        if isinstance(loaded, tuple):
+            if not loaded:
+                raise ProviderError("JEPA-WMS torch-hub loader returned an empty tuple.")
+            model = loaded[0]
+            preprocessor = loaded[1] if len(loaded) > 1 else None
+        else:
+            model = loaded
+            preprocessor = getattr(model, "preprocessor", None)
+
+        if self.device is not None and hasattr(model, "to"):
+            model = model.to(self.device)
+        if hasattr(model, "eval"):
+            model = model.eval()
+
+        self._model = model
+        self._preprocessor = preprocessor
+        return model, preprocessor
+
+    def _as_tensor(self, torch: Any, value: object, *, name: str) -> Any:
+        if hasattr(value, "to") and _tensor_shape(value) is not None:
+            tensor = value
+        else:
+            as_tensor = getattr(torch, "as_tensor", None)
+            if not callable(as_tensor):
+                raise ProviderError("JEPA-WMS torch module does not expose as_tensor().")
+            try:
+                tensor = as_tensor(value)
+            except Exception as exc:
+                raise ProviderError(f"{name} could not be converted to a tensor: {exc}") from exc
+        if self.device is not None and hasattr(tensor, "to"):
+            tensor = tensor.to(self.device)
+        return tensor
+
+    def _normalize_actions_if_requested(
+        self,
+        *,
+        action_tensor: Any,
+        preprocessor: Any | None,
+        actions_are_normalized: bool,
+    ) -> Any:
+        if actions_are_normalized:
+            return action_tensor
+        normalize = getattr(preprocessor, "normalize_actions", None)
+        if not callable(normalize):
+            raise ProviderError(
+                "JEPA-WMS runtime received unnormalized actions but the loaded preprocessor does "
+                "not expose normalize_actions()."
+            )
+        try:
+            return normalize(action_tensor)
+        except Exception as exc:
+            raise ProviderError(f"JEPA-WMS action normalization failed: {exc}") from exc
+
+    def _no_grad_context(self, torch: Any) -> Any:
+        no_grad = getattr(torch, "no_grad", None)
+        if callable(no_grad):
+            return no_grad()
+        return nullcontext()
+
+    def _score_via_model_method(
+        self,
+        *,
+        model: Any,
+        model_path: str,
+        info: JSONDict,
+        action_candidates: object,
+    ) -> object | None:
+        for method_name in ("score_actions", "score_action_candidates", "compute_scores"):
+            method = getattr(model, method_name, None)
+            if callable(method):
+                return method(
+                    model_path=model_path,
+                    info=info,
+                    action_candidates=action_candidates,
+                )
+        return None
+
+    def _select_last_timestep(self, value: Any) -> Any:
+        if isinstance(value, dict):
+            return {key: self._select_last_timestep(child) for key, child in value.items()}
+        try:
+            return value[-1]
+        except Exception:
+            return value
+
+    def _distance_scores(
+        self, torch: Any, predicted: Any, target: Any, *, objective: str
+    ) -> list[float]:
+        if isinstance(predicted, dict) and isinstance(target, dict):
+            total: Any | None = None
+            for key in sorted(predicted):
+                if key not in target:
+                    continue
+                component = self._distance_scores_tensor(
+                    torch,
+                    predicted[key],
+                    target[key],
+                    objective=objective,
+                )
+                total = component if total is None else total + component
+            if total is None:
+                raise ProviderError("JEPA-WMS encoded dictionaries had no shared keys to score.")
+            return _flatten_numeric(total, name="JEPA-WMS scores")
+        return _flatten_numeric(
+            self._distance_scores_tensor(torch, predicted, target, objective=objective),
+            name="JEPA-WMS scores",
+        )
+
+    def _distance_scores_tensor(
+        self, torch: Any, predicted: Any, target: Any, *, objective: str
+    ) -> Any:
+        if objective not in {"l1", "l2"}:
+            raise ProviderError("JEPA-WMS objective must be 'l1' or 'l2'.")
+        diff = predicted - target
+        if objective == "l1":
+            abs_fn = getattr(torch, "abs", None)
+            diff = abs_fn(diff) if callable(abs_fn) else abs(diff)
+        else:
+            pow_method = getattr(diff, "pow", None)
+            diff = pow_method(2) if callable(pow_method) else diff * diff
+
+        ndim = getattr(diff, "ndim", None)
+        if ndim is None:
+            shape = _tensor_shape(diff)
+            ndim = len(shape) if shape is not None else None
+        if ndim is None or int(ndim) <= 1:
+            return diff
+        mean = getattr(diff, "mean", None)
+        if not callable(mean):
+            raise ProviderError("JEPA-WMS distance tensor does not expose mean().")
+        return mean(dim=tuple(range(1, int(ndim))))
+
+    def _encode(self, model: Any, value: Any, *, act: bool) -> Any:
+        encode = getattr(model, "encode", None)
+        if not callable(encode):
+            raise ProviderError("JEPA-WMS loaded model does not expose encode().")
+        try:
+            return encode(value, act=act)
+        except TypeError:
+            return encode(value)
+        except Exception as exc:
+            raise ProviderError(f"JEPA-WMS model encoding failed: {exc}") from exc
+
+    def _unroll(self, model: Any, z_init: Any, action_suffix: Any) -> Any:
+        unroll = getattr(model, "unroll", None)
+        if not callable(unroll):
+            raise ProviderError("JEPA-WMS loaded model does not expose unroll().")
+        try:
+            return unroll(z_init, act_suffix=action_suffix)
+        except Exception as exc:
+            raise ProviderError(f"JEPA-WMS model unroll failed: {exc}") from exc
+
+    def score_actions(
+        self,
+        *,
+        model_path: str,
+        info: JSONDict,
+        action_candidates: object,
+    ) -> object:
+        torch = self._torch()
+        model, preprocessor = self._load_model(torch)
+
+        direct_result = self._score_via_model_method(
+            model=model,
+            model_path=model_path,
+            info=info,
+            action_candidates=action_candidates,
+        )
+        if direct_result is not None:
+            return direct_result
+
+        objective = str(info.get("objective", "l2")).lower()
+        actions_are_normalized = bool(info.get("actions_are_normalized", True))
+
+        observation = self._as_tensor(torch, info["observation"], name="JEPA-WMS observation")
+        goal = self._as_tensor(torch, info["goal"], name="JEPA-WMS goal")
+        action_tensor = self._as_tensor(
+            torch,
+            action_candidates,
+            name="JEPA-WMS action_candidates",
+        )
+        try:
+            model_actions = action_tensor[0]
+            model_actions = self._normalize_actions_if_requested(
+                action_tensor=model_actions,
+                preprocessor=preprocessor,
+                actions_are_normalized=actions_are_normalized,
+            )
+            model_actions = model_actions.permute(1, 0, 2)
+        except ProviderError:
+            raise
+        except Exception as exc:
+            raise ProviderError(f"JEPA-WMS action tensor preparation failed: {exc}") from exc
+
+        with self._no_grad_context(torch):
+            z_init = self._encode(model, observation, act=True)
+            target = self._encode(model, goal, act=False)
+            predicted = self._unroll(model, z_init, model_actions)
+
+        scores = self._distance_scores(
+            torch,
+            self._select_last_timestep(predicted),
+            self._select_last_timestep(target),
+            objective=objective,
+        )
+        return {
+            "scores": scores,
+            "lower_is_better": True,
+            "metadata": {
+                "runtime": "torchhub",
+                "hub_repo": self.hub_repo,
+                "model_name": self.model_name,
+                "objective": objective,
+                "actions_are_normalized": actions_are_normalized,
+            },
+        }
+
+
 class JEPAWMSProvider(BaseProvider):
     """Candidate adapter for JEPA-WMS action-candidate scoring.
 
@@ -188,12 +498,55 @@ class JEPAWMSProvider(BaseProvider):
             artifact_types=["action_scores"] if runtime else [],
             notes=[
                 "Candidate contract only; not exported or auto-registered.",
-                "No upstream facebookresearch/jepa-wms import is performed by WorldForge.",
-                "Inject runtime= in tests or host experiments before implementing a real adapter.",
+                "The optional torch-hub runtime is host-owned and lazily imported only when used.",
+                "Inject runtime= in tests or use from_torch_hub(...) for host experiments.",
                 "Runtime scores default to costs: lower values are better.",
             ],
             default_model=self.model_path,
             supported_models=[self.model_path] if self.model_path else [],
+            event_handler=event_handler,
+        )
+
+    @classmethod
+    def from_torch_hub(
+        cls,
+        *,
+        model_name: str | None = None,
+        model_path: str | None = None,
+        hub_repo: str = DEFAULT_JEPA_WMS_HUB_REPO,
+        device: str | None = None,
+        pretrained: bool = True,
+        trust_repo: bool | None = None,
+        hub_loader: HubLoader | None = None,
+        torch_module: Any | None = None,
+        event_handler: Callable[[ProviderEvent], None] | None = None,
+    ) -> JEPAWMSProvider:
+        """Create a direct JEPA-WMS provider backed by an explicit torch-hub runtime."""
+
+        resolved_model_name = _optional_non_empty(
+            model_name if model_name is not None else _env_value(JEPA_WMS_MODEL_NAME_ENV_VAR),
+            name="JEPA-WMS model_name",
+        )
+        if resolved_model_name is None:
+            raise WorldForgeError(
+                f"JEPA-WMS torch-hub runtime requires model_name or {JEPA_WMS_MODEL_NAME_ENV_VAR}."
+            )
+        resolved_device = _optional_non_empty(
+            device if device is not None else _env_value(JEPA_WMS_DEVICE_ENV_VAR),
+            name="JEPA-WMS device",
+        )
+        runtime = TorchHubJEPAWMSRuntime(
+            model_name=resolved_model_name,
+            hub_repo=hub_repo,
+            device=resolved_device,
+            pretrained=pretrained,
+            trust_repo=trust_repo,
+            hub_loader=hub_loader,
+            torch_module=torch_module,
+        )
+        return cls(
+            model_path=model_path or resolved_model_name,
+            runtime=runtime,
             event_handler=event_handler,
         )
 
@@ -248,6 +601,11 @@ class JEPAWMSProvider(BaseProvider):
             raise ProviderError(
                 "JEPA-WMS action_candidates must be four-dimensional: "
                 "(batch, samples, horizon, action_dim)."
+            )
+        if shape[0] != 1:
+            raise ProviderError(
+                "JEPA-WMS action_candidates currently supports exactly one batch for "
+                "WorldForge score planning."
             )
         candidate_count = shape[1]
         if candidate_count <= 0:

--- a/tests/test_jepa_wms_provider.py
+++ b/tests/test_jepa_wms_provider.py
@@ -6,9 +6,9 @@ from typing import Any
 
 import pytest
 
-from worldforge import ActionScoreResult, WorldForgeError
+from worldforge import Action, ActionScoreResult, WorldForge, WorldForgeError
 from worldforge.providers.base import ProviderError
-from worldforge.providers.jepa_wms import JEPAWMSProvider
+from worldforge.providers.jepa_wms import JEPAWMSProvider, TorchHubJEPAWMSRuntime
 from worldforge.testing import assert_provider_contract
 
 FIXTURE_DIR = Path(__file__).parent / "fixtures" / "providers"
@@ -38,6 +38,207 @@ class FakeJEPAWMSRuntime:
             }
         )
         return self.response
+
+
+class FakeHubScoringModel:
+    def __init__(self, response: object) -> None:
+        self.response = response
+        self.device: str | None = None
+        self.eval_called = False
+        self.calls: list[dict[str, Any]] = []
+
+    def to(self, device: str) -> FakeHubScoringModel:
+        self.device = device
+        return self
+
+    def eval(self) -> FakeHubScoringModel:
+        self.eval_called = True
+        return self
+
+    def score_actions(
+        self,
+        *,
+        model_path: str,
+        info: dict[str, Any],
+        action_candidates: object,
+    ) -> object:
+        self.calls.append(
+            {
+                "model_path": model_path,
+                "info": info,
+                "action_candidates": action_candidates,
+            }
+        )
+        return self.response
+
+
+class FakeHub:
+    def __init__(self, response: object) -> None:
+        self.response = response
+        self.calls: list[dict[str, Any]] = []
+
+    def load(self, hub_repo: str, model_name: str, **kwargs: object) -> object:
+        self.calls.append(
+            {
+                "hub_repo": hub_repo,
+                "model_name": model_name,
+                "kwargs": kwargs,
+            }
+        )
+        return self.response
+
+
+def _shape(value: object) -> tuple[int, ...]:
+    if isinstance(value, list) and value:
+        return (len(value), *_shape(value[0]))
+    if isinstance(value, list):
+        return (0,)
+    return ()
+
+
+def _transpose_3d_102(value: list) -> list:
+    first, second, third = _shape(value)
+    return [[[value[j][i][k] for k in range(third)] for j in range(first)] for i in range(second)]
+
+
+def _map_nested(value: object, fn) -> object:
+    if isinstance(value, list):
+        return [_map_nested(item, fn) for item in value]
+    return fn(value)
+
+
+def _subtract_nested(left: object, right: object) -> object:
+    if isinstance(left, list) and isinstance(right, list):
+        if left and not isinstance(left[0], list) and right and not isinstance(right[0], list):
+            return [l_value - r_value for l_value, r_value in zip(left, right, strict=True)]
+        if left and isinstance(left[0], list) and right and not isinstance(right[0], list):
+            return [_subtract_nested(row, right) for row in left]
+        return [
+            _subtract_nested(l_value, r_value) for l_value, r_value in zip(left, right, strict=True)
+        ]
+    return left - right
+
+
+class FakeTensor:
+    def __init__(self, value: object) -> None:
+        self.value = value
+        self.shape = _shape(value)
+        self.ndim = len(self.shape)
+        self.device: str | None = None
+
+    def to(self, device: str) -> FakeTensor:
+        self.device = device
+        return self
+
+    def __getitem__(self, index: int) -> FakeTensor:
+        return FakeTensor(self.value[index])  # type: ignore[index]
+
+    def permute(self, *order: int) -> FakeTensor:
+        if order == (1, 0, 2):
+            return FakeTensor(_transpose_3d_102(self.value))  # type: ignore[arg-type]
+        raise AssertionError(f"unexpected permute order {order}")
+
+    def __sub__(self, other: object) -> FakeTensor:
+        other_value = other.value if isinstance(other, FakeTensor) else other
+        return FakeTensor(_subtract_nested(self.value, other_value))
+
+    def __mul__(self, other: object) -> FakeTensor:
+        other_value = other.value if isinstance(other, FakeTensor) else other
+        if isinstance(other_value, int | float):
+            return FakeTensor(_map_nested(self.value, lambda item: item * other_value))
+        raise AssertionError("fake tensor only multiplies by scalars")
+
+    def pow(self, exponent: int) -> FakeTensor:
+        return FakeTensor(_map_nested(self.value, lambda item: item**exponent))
+
+    def mean(self, *, dim: tuple[int, ...]) -> FakeTensor:
+        if dim != (1,):
+            raise AssertionError(f"unexpected mean dims {dim}")
+        return FakeTensor([sum(row) / len(row) for row in self.value])  # type: ignore[arg-type]
+
+    def tolist(self) -> object:
+        return self.value
+
+
+class FakeTorch:
+    def __init__(self, hub_response: object | None = None) -> None:
+        self.hub = FakeHub(hub_response) if hub_response is not None else None
+
+    def as_tensor(self, value: object) -> FakeTensor:
+        return value if isinstance(value, FakeTensor) else FakeTensor(value)
+
+    def abs(self, value: FakeTensor) -> FakeTensor:
+        return FakeTensor(_map_nested(value.value, abs))
+
+    def no_grad(self):
+        class NoGrad:
+            def __enter__(self) -> None:
+                return None
+
+            def __exit__(self, *_args: object) -> bool:
+                return False
+
+        return NoGrad()
+
+
+class FakePreprocessor:
+    def __init__(self) -> None:
+        self.normalized_actions: object | None = None
+
+    def normalize_actions(self, actions: object) -> object:
+        self.normalized_actions = actions
+        return actions
+
+
+class FakeHubEncodeUnrollModel:
+    def __init__(self) -> None:
+        self.device: str | None = None
+        self.eval_called = False
+        self.encoded_act_values: list[bool] = []
+        self.unroll_actions: object | None = None
+
+    def to(self, device: str) -> FakeHubEncodeUnrollModel:
+        self.device = device
+        return self
+
+    def eval(self) -> FakeHubEncodeUnrollModel:
+        self.eval_called = True
+        return self
+
+    def encode(self, _value: object, *, act: bool) -> FakeTensor:
+        self.encoded_act_values.append(act)
+        if act:
+            return FakeTensor([[0.0, 0.0]])
+        return FakeTensor([[3.0, 5.0]])
+
+    def unroll(self, _z_init: object, *, act_suffix: object) -> FakeTensor:
+        self.unroll_actions = act_suffix
+        return FakeTensor([[[1.0, 1.0], [3.0, 5.0], [7.0, 9.0]]])
+
+
+class FakeHubEncodeWithoutActModel:
+    def __init__(self) -> None:
+        self.encode_calls = 0
+
+    def encode(self, _value: object) -> FakeTensor:
+        self.encode_calls += 1
+        if self.encode_calls == 1:
+            return FakeTensor([[0.0, 0.0]])
+        return FakeTensor([[1.0, 2.0]])
+
+    def unroll(self, _z_init: object, *, act_suffix: object) -> FakeTensor:
+        return FakeTensor([[[0.0, 2.0], [3.0, 2.0], [1.0, 0.0]]])
+
+
+class BrokenActionTensor:
+    shape = (1, 3, 1, 3)
+    ndim = 4
+
+    def to(self, _device: str) -> BrokenActionTensor:
+        return self
+
+    def __getitem__(self, _index: int) -> object:
+        return object()
 
 
 def test_jepa_wms_profile_starts_as_safe_scaffold() -> None:
@@ -110,6 +311,260 @@ def test_jepa_wms_fake_runtime_scores_fixture_payload_and_contract() -> None:
     assert events[-1].phase == "success"
 
 
+def test_jepa_wms_torchhub_runtime_scores_and_plans_through_world(tmp_path) -> None:
+    payload = _fixture("jepa_wms_success.json")
+    model = FakeHubScoringModel(payload["runtime_response"])
+    loader_calls: list[dict[str, Any]] = []
+
+    def load_from_hub(hub_repo: str, model_name: str, **kwargs: object) -> object:
+        loader_calls.append(
+            {
+                "hub_repo": hub_repo,
+                "model_name": model_name,
+                "kwargs": kwargs,
+            }
+        )
+        return model, object()
+
+    provider = JEPAWMSProvider.from_torch_hub(
+        model_name="jepa_wm_pusht",
+        device="cpu",
+        hub_loader=load_from_hub,
+        torch_module=object(),
+    )
+    forge = WorldForge(state_dir=tmp_path, auto_register_remote=False)
+    forge.register_provider(provider)
+    world = forge.create_world_from_prompt("tabletop Push-T scene", provider="mock")
+    candidate_plans = [
+        [Action.move_to(0.1, 0.5, 0.0)],
+        [Action.move_to(0.4, 0.5, 0.0)],
+        [Action.move_to(0.7, 0.5, 0.0)],
+    ]
+
+    plan = world.plan(
+        goal="choose the lowest JEPA-WMS latent cost",
+        provider="jepa-wms",
+        planner="jepa-wms-mpc",
+        candidate_actions=candidate_plans,
+        score_info=payload["info"],
+        score_action_candidates=payload["action_candidates"],
+        execution_provider="mock",
+    )
+
+    assert plan.provider == "jepa-wms"
+    assert plan.actions == candidate_plans[1]
+    assert plan.metadata["planning_mode"] == "score"
+    assert plan.metadata["score_result"]["best_index"] == 1
+    assert plan.metadata["score_result"]["metadata"]["runtime"] == "fake-jepa-wms"
+    assert plan.metadata["execution_provider"] == "mock"
+    assert loader_calls == [
+        {
+            "hub_repo": "facebookresearch/jepa-wms",
+            "model_name": "jepa_wm_pusht",
+            "kwargs": {"pretrained": True, "device": "cpu"},
+        }
+    ]
+    assert model.device == "cpu"
+    assert model.eval_called is True
+    assert model.calls[-1]["model_path"] == "jepa_wm_pusht"
+    assert model.calls[-1]["info"] == payload["info"]
+
+    execution = world.execute_plan(plan)
+    assert execution.actions_applied == candidate_plans[1]
+    assert execution.final_world().provider == "mock"
+
+
+def test_jepa_wms_torchhub_runtime_falls_back_to_encode_unroll_distance() -> None:
+    payload = _fixture("jepa_wms_success.json")
+    model = FakeHubEncodeUnrollModel()
+    preprocessor = FakePreprocessor()
+
+    def load_from_hub(_hub_repo: str, _model_name: str, **_kwargs: object) -> object:
+        return model, preprocessor
+
+    provider = JEPAWMSProvider.from_torch_hub(
+        model_name="jepa_wm_pusht",
+        device="cpu",
+        hub_loader=load_from_hub,
+        torch_module=FakeTorch(),
+    )
+    score_info = {
+        **payload["info"],
+        "actions_are_normalized": False,
+        "objective": "l2",
+    }
+
+    result = provider.score_actions(
+        info=score_info,
+        action_candidates=payload["action_candidates"],
+    )
+
+    assert result.scores == [10.0, 0.0, 16.0]
+    assert result.best_index == 1
+    assert result.metadata["runtime"] == "torchhub"
+    assert result.metadata["model_name"] == "jepa_wm_pusht"
+    assert result.metadata["objective"] == "l2"
+    assert result.metadata["actions_are_normalized"] is False
+    assert model.device == "cpu"
+    assert model.eval_called is True
+    assert model.encoded_act_values == [True, False]
+    assert isinstance(model.unroll_actions, FakeTensor)
+    assert preprocessor.normalized_actions is not None
+
+
+def test_jepa_wms_torchhub_runtime_loads_from_torch_module_and_caches_model() -> None:
+    payload = _fixture("jepa_wms_success.json")
+    model = FakeHubScoringModel(payload["runtime_response"])
+    torch = FakeTorch(model)
+
+    provider = JEPAWMSProvider.from_torch_hub(
+        model_name="jepa_wm_droid",
+        device="cuda:0",
+        pretrained=False,
+        trust_repo=True,
+        torch_module=torch,
+    )
+
+    first = provider.score_actions(
+        info=payload["info"],
+        action_candidates=payload["action_candidates"],
+    )
+    second = provider.score_actions(
+        info=payload["info"],
+        action_candidates=payload["action_candidates"],
+    )
+
+    assert first.best_index == 1
+    assert second.best_index == 1
+    assert torch.hub is not None
+    assert torch.hub.calls == [
+        {
+            "hub_repo": "facebookresearch/jepa-wms",
+            "model_name": "jepa_wm_droid",
+            "kwargs": {
+                "pretrained": False,
+                "device": "cuda:0",
+                "trust_repo": True,
+            },
+        }
+    ]
+    assert model.device == "cuda:0"
+    assert model.eval_called is True
+
+
+def test_jepa_wms_torchhub_runtime_scores_l1_with_encode_signature_fallback() -> None:
+    payload = _fixture("jepa_wms_success.json")
+    model = FakeHubEncodeWithoutActModel()
+
+    provider = JEPAWMSProvider.from_torch_hub(
+        model_name="jepa_wm_pusht",
+        hub_loader=lambda *_args, **_kwargs: (model, object()),
+        torch_module=FakeTorch(),
+    )
+
+    result = provider.score_actions(
+        info={**payload["info"], "objective": "l1"},
+        action_candidates=payload["action_candidates"],
+    )
+
+    assert result.scores == [0.5, 1.0, 1.0]
+    assert result.best_index == 0
+    assert result.metadata["objective"] == "l1"
+
+
+def test_jepa_wms_torchhub_runtime_reports_loader_failures() -> None:
+    payload = _fixture("jepa_wms_success.json")
+
+    def fail_loader(_hub_repo: str, _model_name: str, **_kwargs: object) -> object:
+        raise RuntimeError("checkpoint unavailable")
+
+    provider = JEPAWMSProvider.from_torch_hub(
+        model_name="jepa_wm_pusht",
+        hub_loader=fail_loader,
+        torch_module=FakeTorch(),
+    )
+
+    with pytest.raises(ProviderError, match="checkpoint unavailable"):
+        provider.score_actions(
+            info=payload["info"],
+            action_candidates=payload["action_candidates"],
+        )
+
+
+def test_jepa_wms_torchhub_runtime_requires_hub_loader() -> None:
+    payload = _fixture("jepa_wms_success.json")
+    provider = JEPAWMSProvider.from_torch_hub(
+        model_name="jepa_wm_pusht",
+        torch_module=FakeTorch(),
+    )
+
+    with pytest.raises(ProviderError, match="torch.hub.load"):
+        provider.score_actions(
+            info=payload["info"],
+            action_candidates=payload["action_candidates"],
+        )
+
+
+def test_jepa_wms_torchhub_runtime_rejects_empty_loader_tuple() -> None:
+    payload = _fixture("jepa_wms_success.json")
+    provider = JEPAWMSProvider.from_torch_hub(
+        model_name="jepa_wm_pusht",
+        hub_loader=lambda *_args, **_kwargs: (),
+        torch_module=FakeTorch(),
+    )
+
+    with pytest.raises(ProviderError, match="empty tuple"):
+        provider.score_actions(
+            info=payload["info"],
+            action_candidates=payload["action_candidates"],
+        )
+
+
+def test_jepa_wms_torchhub_runtime_requires_preprocessor_for_raw_actions() -> None:
+    payload = _fixture("jepa_wms_success.json")
+    provider = JEPAWMSProvider.from_torch_hub(
+        model_name="jepa_wm_pusht",
+        hub_loader=lambda *_args, **_kwargs: (FakeHubEncodeUnrollModel(), None),
+        torch_module=FakeTorch(),
+    )
+
+    with pytest.raises(ProviderError, match="normalize_actions"):
+        provider.score_actions(
+            info={**payload["info"], "actions_are_normalized": False},
+            action_candidates=payload["action_candidates"],
+        )
+
+
+def test_jepa_wms_torchhub_runtime_rejects_unknown_objective() -> None:
+    payload = _fixture("jepa_wms_success.json")
+    provider = JEPAWMSProvider.from_torch_hub(
+        model_name="jepa_wm_pusht",
+        hub_loader=lambda *_args, **_kwargs: (FakeHubEncodeUnrollModel(), object()),
+        torch_module=FakeTorch(),
+    )
+
+    with pytest.raises(ProviderError, match="objective must be 'l1' or 'l2'"):
+        provider.score_actions(
+            info={**payload["info"], "objective": "cosine"},
+            action_candidates=payload["action_candidates"],
+        )
+
+
+def test_jepa_wms_torchhub_runtime_reports_action_preparation_failures() -> None:
+    payload = _fixture("jepa_wms_success.json")
+    provider = JEPAWMSProvider.from_torch_hub(
+        model_name="jepa_wm_pusht",
+        hub_loader=lambda *_args, **_kwargs: (FakeHubEncodeUnrollModel(), object()),
+        torch_module=FakeTorch(),
+    )
+
+    with pytest.raises(ProviderError, match="action tensor preparation failed"):
+        provider.score_actions(
+            info=payload["info"],
+            action_candidates=BrokenActionTensor(),
+        )
+
+
 def test_jepa_wms_callable_runtime_can_return_utility_scores() -> None:
     payload = _fixture("jepa_wms_success.json")
 
@@ -178,6 +633,7 @@ def test_jepa_wms_runtime_error_response_emits_failure_event() -> None:
     [
         ("not-a-json-object", "response must be a JSON object"),
         ({"error": "bad-error"}, "error response must be a JSON object"),
+        ({"lower_is_better": True}, "missing required scores"),
         ({"scores": []}, "returned no action scores"),
         (
             {"scores": [0.4, 0.12, 0.9], "lower_is_better": "yes"},
@@ -190,6 +646,14 @@ def test_jepa_wms_runtime_error_response_emits_failure_event() -> None:
         (
             {"scores": [0.4, 0.12, 0.9], "best_index": 3},
             "best_index is out of range",
+        ),
+        (
+            ActionScoreResult(provider="other", scores=[0.4, 0.12, 0.9], best_index=1),
+            "result provider",
+        ),
+        (
+            ActionScoreResult(provider="jepa-wms", scores=[0.4], best_index=0),
+            "score count",
         ),
     ],
 )
@@ -254,16 +718,39 @@ def test_jepa_wms_rejects_invalid_model_path() -> None:
         JEPAWMSProvider(model_path=" ")
 
 
+def test_jepa_wms_torchhub_runtime_requires_model_name() -> None:
+    with pytest.raises(WorldForgeError, match="model_name"):
+        JEPAWMSProvider.from_torch_hub(model_name=" ", torch_module=object())
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "match"),
+    [
+        ({"hub_repo": " "}, "hub_repo"),
+        ({"pretrained": "yes"}, "pretrained"),
+        ({"trust_repo": "yes"}, "trust_repo"),
+    ],
+)
+def test_jepa_wms_torchhub_runtime_rejects_invalid_configuration(
+    kwargs: dict[str, object],
+    match: str,
+) -> None:
+    with pytest.raises(WorldForgeError, match=match):
+        TorchHubJEPAWMSRuntime(model_name="jepa_wm_pusht", **kwargs)
+
+
 @pytest.mark.parametrize(
     ("bad_info", "match"),
     [
+        ("bad", "info must be a JSON object"),
         ({"observation": [], "goal": [[1.0]]}, "empty sequences"),
         ({"observation": [[0.0], [0.1, 0.2]], "goal": [[1.0]]}, "rectangular"),
         ({"observation": "bad", "goal": [[1.0]]}, "tensor-like object"),
+        ({1: [[0.0]], "observation": [[0.0]], "goal": [[1.0]]}, "field names"),
     ],
 )
 def test_jepa_wms_rejects_malformed_info_values(
-    bad_info: dict[str, object],
+    bad_info: object,
     match: str,
 ) -> None:
     payload = _fixture("jepa_wms_success.json")
@@ -274,6 +761,83 @@ def test_jepa_wms_rejects_malformed_info_values(
 
     with pytest.raises(ProviderError, match=match):
         provider.score_actions(
-            info=bad_info,
+            info=bad_info,  # type: ignore[arg-type]
+            action_candidates=payload["action_candidates"],
+        )
+
+
+def test_jepa_wms_rejects_zero_candidate_tensor() -> None:
+    payload = _fixture("jepa_wms_success.json")
+    provider = JEPAWMSProvider(
+        model_path=payload["model_path"],
+        runtime=FakeJEPAWMSRuntime(payload["runtime_response"]),
+    )
+
+    with pytest.raises(ProviderError, match="at least one sample"):
+        provider.score_actions(
+            info=payload["info"],
+            action_candidates=type("UnknownCandidates", (), {"shape": (1, -1, 1, 1)})(),
+        )
+
+
+def test_jepa_wms_rejects_multi_batch_action_candidates() -> None:
+    payload = _fixture("jepa_wms_success.json")
+    provider = JEPAWMSProvider(
+        model_path=payload["model_path"],
+        runtime=FakeJEPAWMSRuntime(payload["runtime_response"]),
+    )
+
+    with pytest.raises(ProviderError, match="one batch"):
+        provider.score_actions(
+            info=payload["info"],
+            action_candidates=[payload["action_candidates"][0], payload["action_candidates"][0]],
+        )
+
+
+def test_jepa_wms_rejects_unconfigured_score_calls(monkeypatch) -> None:
+    payload = _fixture("jepa_wms_success.json")
+    monkeypatch.delenv("JEPA_WMS_MODEL_PATH", raising=False)
+    provider = JEPAWMSProvider(runtime=FakeJEPAWMSRuntime(payload["runtime_response"]))
+
+    with pytest.raises(ProviderError, match="missing JEPA_WMS_MODEL_PATH"):
+        provider.score_actions(
+            info=payload["info"],
+            action_candidates=payload["action_candidates"],
+        )
+
+
+def test_jepa_wms_rejects_missing_runtime_score_calls() -> None:
+    payload = _fixture("jepa_wms_success.json")
+    provider = JEPAWMSProvider(model_path=payload["model_path"])
+
+    with pytest.raises(ProviderError, match="no runtime adapter"):
+        provider.score_actions(
+            info=payload["info"],
+            action_candidates=payload["action_candidates"],
+        )
+
+
+def test_jepa_wms_rejects_runtime_without_score_contract() -> None:
+    payload = _fixture("jepa_wms_success.json")
+    provider = JEPAWMSProvider(model_path=payload["model_path"], runtime=object())
+
+    with pytest.raises(ProviderError, match="runtime must be callable"):
+        provider.score_actions(
+            info=payload["info"],
+            action_candidates=payload["action_candidates"],
+        )
+
+
+def test_jepa_wms_wraps_unexpected_runtime_failures() -> None:
+    payload = _fixture("jepa_wms_success.json")
+
+    def runtime(**_kwargs: object) -> object:
+        raise RuntimeError("native runtime exploded")
+
+    provider = JEPAWMSProvider(model_path=payload["model_path"], runtime=runtime)
+
+    with pytest.raises(ProviderError, match="native runtime exploded"):
+        provider.score_actions(
+            info=payload["info"],
             action_candidates=payload["action_candidates"],
         )


### PR DESCRIPTION
## Summary

Adds a host-owned JEPA-WMS torch-hub runtime path while keeping the provider non-exported and non-auto-registered. The provider can now be constructed directly with `JEPAWMSProvider.from_torch_hub(...)`, lazily loads `facebookresearch/jepa-wms` via torch hub, delegates to model-native scoring methods when available, and falls back to JEPA-style encode/unroll latent-distance scoring.

This also adds `World.plan(...)` score-planning coverage through the `jepa-wms` candidate and expands runtime/parser tests for malformed payloads, loader failures, config validation, action tensor failures, and malformed score results.

## Validation

- `uv run ruff check src tests examples scripts`
- `uv run ruff format --check src tests examples scripts`
- `git diff --check`
- `uv run python -m py_compile src/worldforge/providers/jepa_wms.py tests/test_jepa_wms_provider.py`
- `uv run pytest tests/test_jepa_wms_provider.py`
- `uv run pytest --cov=src/worldforge --cov-report=term-missing --cov-fail-under=90`
- `bash scripts/test_package.sh`
