### PR TITLE
[codex] Add GR00T policy provider

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,8 @@ evaluation harnesses, and testable prototypes.
   retry, polling, download policies, and response parsers.
 - `src/worldforge/providers/leworldmodel.py`: real optional LeWorldModel JEPA cost-model adapter
   for scoring action candidates through `stable_worldmodel.policy.AutoCostModel`.
+- `src/worldforge/providers/gr00t.py`: experimental host-owned NVIDIA Isaac GR00T PolicyClient
+  adapter for selecting embodied action chunks through the `policy` capability.
 - `src/worldforge/providers/jepa_wms.py`: candidate contract scaffold for
   `facebookresearch/jepa-wms` score-provider work; it supports injected fake/runtime scoring and a
   host-owned torch-hub runtime but is intentionally not exported or registered.
@@ -44,6 +46,8 @@ evaluation harnesses, and testable prototypes.
 - Runtime dependency: `httpx`.
 - Optional LeWorldModel runtime: `stable-worldmodel[env]` and `torch`, supplied by the host
   environment only when using `leworldmodel`.
+- Optional GR00T runtime: `gr00t.policy.server_client.PolicyClient`, CUDA/TensorRT/checkpoints,
+  and robot-specific dependencies supplied by the host environment only when using `gr00t`.
 - Development tools: `pytest`, `pytest-cov`, `ruff`, `pip-audit` in CI.
 - License: MIT.
 
@@ -85,6 +89,8 @@ rm -f "$tmp_req"
 - Provider capabilities must only advertise operations that are implemented end to end.
 - `leworldmodel` exposes `score`, not `predict`, `generate`, or `reason`; do not fake those
   capabilities around a cost model.
+- `gr00t` exposes `policy`, not `predict`, `score`, or `generate`; do not call an embodied policy
+  a predictive world model.
 - Remote create/mutation requests are single-attempt by default; health, polling, and downloads
   use retry/backoff policy.
 - Keep public API models typed and serializable. Validate boundary values before persistence or
@@ -103,6 +109,8 @@ rm -f "$tmp_req"
   PyTorch plus JEPA-WMS dependencies host-owned.
 - Do not add `stable_worldmodel`, `torch`, checkpoint archives, or downloaded datasets to the base
   dependency set or repository. Keep LeWorldModel optional and host-owned.
+- Do not add Isaac GR00T, CUDA, TensorRT, robot checkpoints, or robot controller dependencies to
+  the base dependency set. Keep GR00T host-owned and require explicit action translators.
 - Do not auto-register optional providers unless their required environment variables are present.
 - Do not add hardcoded credentials, test secrets, or environment-specific endpoints.
 - Do not weaken coverage gates or remove package validation from CI.
@@ -124,6 +132,10 @@ rm -f "$tmp_req"
 - LeWorldModel expects preprocessed pixel/action/goal tensors or rectangular nested numeric
   arrays shaped for the configured checkpoint. WorldForge validates the adapter boundary but does
   not infer task-specific image transforms.
+- GR00T returns embodiment-specific raw action arrays. WorldForge preserves those raw actions but
+  requires a host-supplied `action_translator` before it can return executable `Action` objects.
+- Policy+score planning uses `policy_provider="gr00t"` plus `score_provider="leworldmodel"` or
+  another score provider; score tensors remain host-preprocessed and provider-native.
 - `scripts/smoke_leworldmodel.py` is an optional real-checkpoint smoke. Run it from an isolated
   Python 3.10 environment with the upstream GitHub `stable-worldmodel[train,env]` runtime; do not
   add those dependencies to WorldForge's base package.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ releases may still include breaking changes when the public API needs to tighten
   contract tests, parser fixtures, `World.plan(...)` coverage, event assertions, and docs for
   future `facebookresearch/jepa-wms` integration without exporting or auto-registering it as a
   working provider.
+- Added a `policy` capability, `ActionPolicyResult`, `WorldForge.select_actions(...)`, and an
+  experimental host-owned `gr00t` provider for NVIDIA Isaac GR00T PolicyClient action selection,
+  including policy-only and policy+score planning support.
 
 ### Security
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ also mean video generation, spatial 3D reconstruction, simulation infrastructure
 inference systems. WorldForge supports those systems through explicit provider capabilities, but
 LeWorldModel is the reference provider shaping the core score-planning architecture.
 
+Embodied policies such as NVIDIA Isaac GR00T are modeled separately as action-policy providers:
+they propose robot action chunks from observations and instructions, then can be paired with a
+score provider such as LeWorldModel or JEPA-WMS for policy+score planning.
+
 Read [docs/src/world-model-taxonomy.md](./docs/src/world-model-taxonomy.md) for the taxonomy,
 [docs/src/architecture.md](./docs/src/architecture.md) for the end-to-end provider pipeline, and
 [docs/src/provider-authoring-guide.md](./docs/src/provider-authoring-guide.md) before adding a new

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -5,6 +5,8 @@
 - [World Model Taxonomy](./world-model-taxonomy.md)
 - [Architecture](./architecture.md)
 - [Providers](./providers/README.md)
+  - [GR00T](./providers/gr00t.md)
+  - [JEPA-WMS](./providers/jepa-wms.md)
 - [Provider Authoring Guide](./provider-authoring-guide.md)
 - [Python API](./api/python.md)
 - [Evaluation](./evaluation.md)

--- a/docs/src/api/python.md
+++ b/docs/src/api/python.md
@@ -3,7 +3,7 @@
 ## Entry points
 
 ```python
-from worldforge import Action, ActionScoreResult, World, WorldForge
+from worldforge import Action, ActionPolicyResult, ActionScoreResult, World, WorldForge
 ```
 
 ## `WorldForge`
@@ -12,7 +12,7 @@ Top-level framework object responsible for:
 
 - provider registration
 - world creation and persistence
-- generation, transfer, reasoning, embedding, and action-scoring helpers
+- generation, transfer, reasoning, embedding, action-scoring, and action-policy helpers
 - provider profiles and environment diagnostics
 
 Common inspection helpers:
@@ -80,8 +80,10 @@ print(result.best_index, result.best_score)
 `ActionScoreResult` validates finite scores, exposes `best_index` and `best_score`, and includes
 `lower_is_better` so callers do not have to infer score direction from provider-specific docs.
 
-The planner can consume the same score surface when callers provide the model-shaped payload and
-the WorldForge actions that correspond to each scored candidate:
+The planner can consume the same score surface when callers provide WorldForge actions that
+correspond to each scored candidate. By default, those actions are serialized and passed to the
+score provider. Pass `score_action_candidates` when the scorer expects a provider-native tensor or
+latent candidate payload:
 
 ```python
 from worldforge import Action
@@ -105,6 +107,62 @@ print(plan.actions, plan.metadata["score_result"]["best_index"])
 Score-based plans do not ask the score provider to predict state. `Plan.predicted_states` stays
 empty, score details are stored in `Plan.metadata`, and `execute_plan(...)` uses
 `execution_provider` when the scoring provider does not implement `predict()`.
+
+## Action Policy
+
+Providers that expose the `policy` capability select executable action chunks from observations.
+NVIDIA Isaac GR00T uses this surface because it is an embodied VLA policy, not a predictive world
+model.
+
+```python
+result = forge.select_actions(
+    "gr00t",
+    info={
+        "observation": {
+            "video": {"front": video_array},
+            "state": {"eef": state_array},
+            "language": {"task": [["pick up the cube"]]},
+        },
+        "embodiment_tag": "LIBERO_PANDA",
+        "action_horizon": 16,
+    },
+)
+
+print(result.actions, result.raw_actions)
+```
+
+`ActionPolicyResult` validates that the provider returned at least one WorldForge `Action`,
+preserves provider-native raw actions for debugging, and can carry multiple candidate action
+chunks for downstream scoring.
+
+Policy-only planning:
+
+```python
+plan = world.plan(
+    goal="pick up the cube",
+    provider="gr00t",
+    policy_info=policy_info,
+    execution_provider="mock",
+)
+```
+
+Policy plus score planning:
+
+```python
+plan = world.plan(
+    goal="choose the lowest-cost policy candidate",
+    policy_provider="gr00t",
+    score_provider="leworldmodel",
+    policy_info=policy_info,
+    score_info=lewm_info,
+    execution_provider="mock",
+)
+```
+
+By default, WorldForge serializes the policy candidates as lists of `Action.to_dict()` payloads
+before calling the score provider. Pass `score_action_candidates` when the scorer needs a
+provider-native tensor or latent candidate format. The host still owns embodiment-specific action
+translation and any model-native mapping.
 
 ## `World`
 
@@ -178,6 +236,12 @@ report = assert_provider_contract(
     score_info={"observation": [[0.0]], "goal": [[1.0]]},
     score_action_candidates=[[[[0.0]]]],
 )
+```
+
+For policy providers, pass provider-specific policy observations:
+
+```python
+report = assert_provider_contract(provider, policy_info=policy_info)
 ```
 
 ## Public failure modes

--- a/docs/src/architecture.md
+++ b/docs/src/architecture.md
@@ -24,6 +24,7 @@ worldforge/
 |   |   |-- mock.py        # deterministic reference provider
 |   |   |-- leworldmodel.py# local JEPA cost-model adapter
 |   |   |-- cosmos.py      # HTTP video generation adapter
+|   |   |-- gr00t.py       # host-owned embodied policy client adapter
 |   |   |-- runway.py      # HTTP video generation/transfer adapter
 |   |   `-- remote.py      # scaffold adapters for JEPA and Genie
 |   |-- observability.py   # ProviderEvent sinks
@@ -70,6 +71,7 @@ Host application
 | Prediction        |
 | VideoClip         |
 | ActionScoreResult |
+| ActionPolicyResult|
 | ReasoningResult   |
 +-------------------+
 ```
@@ -82,8 +84,8 @@ flowchart TD
     Forge[WorldForge facade\nregistry, diagnostics, persistence]
     World[World\nstate, history, planning]
     Provider[Provider adapter\ncapability contract]
-    Upstream[Upstream runtime or API\nLeWM, Cosmos, Runway, mock]
-    Models[Typed public models\nPrediction, VideoClip, ActionScoreResult]
+    Upstream[Upstream runtime or API\nLeWM, GR00T, Cosmos, Runway, mock]
+    Models[Typed public models\nPrediction, VideoClip, ActionScoreResult, ActionPolicyResult]
     Obs[ProviderEvent sinks\nlogs, recorder, metrics]
     Store[Local JSON state]
 
@@ -104,7 +106,7 @@ flowchart TD
 
 - `WorldForge`: top-level object for provider registration, diagnostics, persistence helpers, and
   provider-wide operations such as `generate(...)`, `transfer(...)`, `reason(...)`, `embed(...)`,
-  and `score_actions(...)`.
+  `score_actions(...)`, and `select_actions(...)`.
 - `World`: mutable world state with scene objects, history, prediction, comparison, planning, plan
   execution, and evaluation entry points.
 - `Prediction`, `Plan`, `PlanExecution`, and `Comparison`: workflow-level result objects.
@@ -112,7 +114,8 @@ flowchart TD
 `models.py`
 
 - Public data contracts such as `Action`, `SceneObject`, `StructuredGoal`, `VideoClip`,
-  `ProviderProfile`, `ProviderHealth`, `ProviderEvent`, and `ActionScoreResult`.
+  `ProviderProfile`, `ProviderHealth`, `ProviderEvent`, `ActionScoreResult`, and
+  `ActionPolicyResult`.
 - Validation helpers and public framework errors: `WorldForgeError` and `WorldStateError`.
 
 `providers/base.py`
@@ -132,6 +135,12 @@ flowchart TD
 
 - Real HTTP adapters with typed request policy, parser boundaries, retry events, and artifact
   validation.
+
+`providers/gr00t.py`
+
+- Experimental host-owned adapter for NVIDIA Isaac GR00T PolicyClient inference.
+- Exposes only `policy=True`.
+- Requires an explicit action translator because robot actions are embodiment-specific.
 
 `observability.py`
 
@@ -173,12 +182,13 @@ Expanded:
    - world.predict(...) requires a provider with predict=True
    - forge.generate(...) requires generate=True
    - forge.transfer(...) requires transfer=True
-   - world.plan(...) can use predictive planning or score-based planning
+   - forge.select_actions(...) requires policy=True
+   - world.plan(...) can use predictive, score-based, policy, or policy+score planning
    - world.evaluate(...) and benchmark harnesses select operations by capability
 
 4. Provider boundary
-   - provider receives a JSON world snapshot, media request, query, embedding request, or score
-     payload
+   - provider receives a JSON world snapshot, media request, query, embedding request, score
+     payload, or policy observation
    - adapter validates local inputs before network/model calls when possible
    - provider emits ProviderEvent records for success, failure, and retries where supported
 
@@ -186,6 +196,7 @@ Expanded:
    - PredictionPayload updates world state only after validation
    - VideoClip validates media metadata and bytes/source paths
    - ActionScoreResult validates finite scores and an in-range best_index
+   - ActionPolicyResult validates executable actions and JSON-compatible raw actions
    - ProviderError surfaces provider/runtime failures with context
 
 6. Host-owned operation
@@ -206,6 +217,7 @@ WorldForge(auto_register_remote=True)
   |-- cosmos            if COSMOS_BASE_URL is set
   |-- runway            if RUNWAYML_API_SECRET or RUNWAY_API_SECRET is set
   |-- leworldmodel      if LEWORLDMODEL_POLICY or LEWM_POLICY is set
+  |-- gr00t             if GROOT_POLICY_HOST is set
   |-- jepa              if JEPA_MODEL_PATH is set
   `-- genie             if GENIE_API_KEY is set
 ```
@@ -293,8 +305,8 @@ sequenceDiagram
 
 ## Score-Based Planning Pipeline
 
-Score-based planning is the LeWorldModel-shaped path. It separates model-native tensors from
-WorldForge-native actions.
+Score-based planning is the LeWorldModel-shaped path. It keeps WorldForge-native actions separate
+from optional model-native scorer payloads.
 
 ```text
 Host owns task preprocessing
@@ -304,9 +316,9 @@ Host owns task preprocessing
   |     |-- goal      task-shaped goal observation
   |     `-- action    task-shaped action history
   |
-  |-- score_action_candidates
-  |     `-- tensor or nested numeric array shaped:
-  |         (batch, samples, horizon, action_dim)
+  |-- score_action_candidates (optional)
+  |     |-- omitted: WorldForge serializes candidate_actions with Action.to_dict()
+  |     `-- provided: tensor or nested numeric array shaped for the score provider
   |
   `-- candidate_actions
         `-- WorldForge Action sequences, one sequence per scored candidate
@@ -379,6 +391,62 @@ print(plan.metadata["score_result"]["best_index"])
 execution = world.execute_plan(plan)
 ```
 
+## Policy Planning Pipeline
+
+Policy planning is the GR00T-shaped path. It treats a VLA policy as an actor that proposes
+executable action chunks from observations and instructions.
+
+```text
+policy_info
+  |
+  |-- observation
+  |     |-- video       camera streams or image history
+  |     |-- state       proprioception or environment state
+  |     `-- language    task instruction
+  |
+  |-- embodiment_tag
+  `-- action_horizon
+
+World.plan(..., provider="gr00t", policy_info=...)
+  |
+  |-- require provider.capabilities.policy
+  |-- call provider.select_actions(info)
+  |-- receive ActionPolicyResult(actions, raw_actions, action_candidates)
+  |-- return Plan(planning_mode="policy", predicted_states=[])
+```
+
+Policy plus score planning composes an actor with a world-model scorer:
+
+```text
+GR00T policy provider
+  -> proposes one or more candidate action chunks
+
+LeWorldModel / JEPA-WMS score provider
+  -> scores serialized policy candidates or a host-supplied model-native candidate tensor
+
+WorldForge
+  -> selects policy_candidates[score_result.best_index]
+```
+
+Concrete shape:
+
+```python
+plan = world.plan(
+    goal="choose the lowest-cost policy candidate",
+    policy_provider="gr00t",
+    score_provider="leworldmodel",
+    policy_info=policy_info,
+    score_info=lewm_info,
+    execution_provider="mock",
+)
+```
+
+WorldForge passes serialized policy candidates to the score provider by default. Pass
+`score_action_candidates=...` when the scorer requires native tensors or latents. The host still
+owns the mapping between GR00T raw actions, WorldForge `Action` objects, and score-provider native
+payloads. WorldForge validates that each provider returns a typed result and that the selected
+candidate index is in range.
+
 ## Provider Capability Surface
 
 WorldForge does not ask "is this a world model?" at runtime. It asks which operations a provider
@@ -391,7 +459,8 @@ BaseProvider
 |-- transfer(clip, width, height, fps, prompt, options) -> VideoClip
 |-- reason(query, world_state) -> ReasoningResult
 |-- embed(text) -> EmbeddingResult
-`-- score_actions(info, action_candidates) -> ActionScoreResult
+|-- score_actions(info, action_candidates) -> ActionScoreResult
+`-- select_actions(info) -> ActionPolicyResult
 ```
 
 Current in-repo mapping:
@@ -400,6 +469,7 @@ Current in-repo mapping:
 | --- | --- | --- | --- |
 | `mock` | yes | predict, generate, reason, embed, plan, transfer | deterministic local surrogate |
 | `leworldmodel` | yes | score | local JEPA cost model |
+| `gr00t` | yes | policy | host-owned embodied VLA policy client |
 | `cosmos` | yes | generate | remote physical-AI video foundation model API |
 | `runway` | yes | generate, transfer | remote video generation API |
 | `jepa` | scaffold | mock-backed | placeholder for future JEPA provider work |
@@ -430,6 +500,15 @@ ActionScoreResult
   lower_is_better: bool
   metadata: JSON object
 
+ActionPolicyResult
+  provider: non-empty string
+  actions: non-empty list of Action objects
+  raw_actions: JSON object
+  action_horizon: optional positive integer
+  embodiment_tag: optional non-empty string
+  metadata: JSON object
+  action_candidates: non-empty list of action plans
+
 Plan
   goal: string
   planner: string
@@ -449,6 +528,7 @@ State invariants:
 - metadata and history are JSON containers
 - invalid public inputs fail explicitly instead of being silently coerced
 - score providers return finite scores and an in-range `best_index`
+- policy providers return executable actions and preserve raw provider actions
 - remote media artifacts reject unsupported content types before returning a `VideoClip`
 
 ## Failure Boundaries
@@ -543,6 +623,8 @@ must preserve the same state validation invariants before it becomes a supported
   as a generator or predictor.
 - LeWorldModel defines the canonical score-planning path: model-native candidate tensors in,
   `ActionScoreResult.best_index` out, WorldForge `Action` sequence selected.
+- GR00T defines the first embodied-policy path: multimodal observation in, action chunk out, with
+  host-owned translation from embodiment-specific raw actions to WorldForge actions.
 - Generative video providers are useful, but video output is not the core abstraction of
   WorldForge.
 - Host applications own preprocessing between sensors, robot task tensors, and WorldForge actions.

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -9,6 +9,7 @@ The project is structured as a framework first:
 - a provider registry for real, optional, and scaffold adapters
 - framework primitives for state, planning, comparison, evaluation, and benchmarking
 - action-scoring support for cost-model providers such as LeWorldModel
+- action-policy support for embodied VLA providers such as NVIDIA Isaac GR00T
 
 The goal is to provide a clean, public-facing framework surface that fits naturally into the
 Python ML ecosystem.
@@ -20,3 +21,7 @@ to video generators, 3D scene tools, simulation platforms, or cognitive architec
 [World Model Taxonomy](./world-model-taxonomy.md) before evaluating provider semantics, then read
 [Architecture](./architecture.md) for the end-to-end runtime pipeline. New adapters should follow
 the [Provider Authoring Guide](./provider-authoring-guide.md).
+
+Embodied policies are intentionally separate from predictive world models. GR00T proposes action
+chunks from observations and instructions; WorldForge can execute those actions directly or pair
+them with a score provider for policy+score planning.

--- a/docs/src/provider-authoring-guide.md
+++ b/docs/src/provider-authoring-guide.md
@@ -51,6 +51,9 @@ New upstream provider
   |-- Can it rank action candidates from observations/goals?
   |     `-- expose score_actions(...) -> ActionScoreResult
   |
+  |-- Can it choose robot action chunks from observations/instructions?
+  |     `-- expose select_actions(...) -> ActionPolicyResult
+  |
   |-- Can it roll a WorldForge state forward from an Action?
   |     `-- expose predict(...) -> PredictionPayload
   |
@@ -77,7 +80,9 @@ flowchart TD
     Upstream[New upstream provider]
     Upstream --> Score{Ranks action candidates?}
     Score -- yes --> ScoreApi[score_actions -> ActionScoreResult]
-    Score -- no --> Predict{Rolls state forward?}
+    Score -- no --> Policy{Selects robot action chunks?}
+    Policy -- yes --> PolicyApi[select_actions -> ActionPolicyResult]
+    Policy -- no --> Predict{Rolls state forward?}
     Predict -- yes --> PredictApi[predict -> PredictionPayload]
     Predict -- no --> Generate{Generates video artifact?}
     Generate -- yes --> GenerateApi[generate -> VideoClip]
@@ -101,6 +106,7 @@ Every provider doc and profile should identify the provider's taxonomy category.
 | Generative video simulator | `generate`, maybe future action-conditioned `predict` | Do not imply controllable planning unless the API supports it. |
 | Spatial / 3D world model | future scene or asset surfaces | Keep out of core until typed scene contracts exist. |
 | Physical AI infrastructure | `generate`, `transfer`, future data/eval adapters | Model each stable API as one capability. |
+| Embodied policy / VLA action model | `policy`, maybe paired with a score provider | Treat as an actor. Do not claim it predicts futures. |
 | Active inference / structured generative model | future belief, uncertainty, or policy outputs | Preserve beliefs and uncertainty explicitly. |
 | Deterministic local surrogate | any tested local subset | Make it obvious that it is a surrogate. |
 
@@ -124,6 +130,7 @@ capabilities.transfer -> transfer(clip, width, height, fps, prompt, options)
 capabilities.reason   -> reason(query, world_state)
 capabilities.embed    -> embed(text)
 capabilities.score    -> score_actions(info, action_candidates)
+capabilities.policy   -> select_actions(info)
 capabilities.plan     -> currently reserved for providers that implement planning directly
 ```
 
@@ -133,6 +140,8 @@ Rules:
 - [ ] Do not set `generate=True` unless the adapter returns a validated `VideoClip`.
 - [ ] Do not set `score=True` unless the adapter returns `ActionScoreResult` with finite scores
       and a valid `best_index`.
+- [ ] Do not set `policy=True` unless the adapter returns `ActionPolicyResult` with at least one
+      executable WorldForge `Action`.
 - [ ] Do not set `reason=True` for models that only return unstructured logs, captions, or
       provider diagnostics.
 - [ ] Do not set `plan=True` just because a provider can score candidates. Score-based planning is
@@ -171,6 +180,7 @@ Questions to answer:
 - [ ] What are the provider-specific limits: duration, resolution, action shape, token budget,
       file size, content type, polling limits, or model context?
 - [ ] What does a lower or higher score mean?
+- [ ] If this is a policy, who owns embodiment-specific action translation?
 - [ ] What does the provider return when output is partial, expired, missing, malformed, or
       physically implausible?
 
@@ -254,6 +264,7 @@ Caller input:
 - [ ] Existing local file paths before network upload.
 - [ ] Rectangular nested numeric arrays when accepting tensor-like JSON.
 - [ ] Explicit action tensor rank and shape for score providers.
+- [ ] Explicit observation modalities and action translator requirements for policy providers.
 
 Upstream response:
 
@@ -268,6 +279,8 @@ Upstream response:
 - [ ] Unsupported content types fail before returning `VideoClip`.
 - [ ] Base64 media fields decode successfully.
 - [ ] Scores flatten to a non-empty finite list.
+- [ ] Policy action chunks preserve raw provider output and translate to executable
+      WorldForge `Action` objects.
 
 State mutation:
 
@@ -312,7 +325,40 @@ Do not:
 - [ ] Do not hide score direction in prose only.
 - [ ] Do not infer raw image transforms unless the adapter actually implements and tests them.
 
-## Step 7: Predictive Provider Checklist
+## Step 7: Embodied Policy Provider Checklist
+
+Use this checklist for VLA and robot policy providers such as NVIDIA Isaac GR00T.
+
+```text
+host sensors / simulation state
+  -> policy observation dict
+  -> provider.select_actions(...)
+  -> ActionPolicyResult(actions, raw_actions, action_candidates)
+  -> optional score provider filters candidates
+  -> Plan(actions=selected candidate)
+```
+
+Required behavior:
+
+- [ ] Expose `policy=True` and no unrelated capabilities unless separately implemented.
+- [ ] Keep GR00T, CUDA, checkpoints, TensorRT, and robot runtime dependencies host-owned.
+- [ ] Import optional runtime packages lazily or accept an injected client/runtime.
+- [ ] `info["observation"]` names the modalities it contains, such as `video`, `state`, and
+      `language`.
+- [ ] Raw provider actions are preserved in `ActionPolicyResult.raw_actions` for debugging.
+- [ ] Embodiment tags, action horizons, and provider-native info are preserved in metadata.
+- [ ] Embodiment-specific action translation is explicit. Do not guess robot action semantics.
+- [ ] Tests cover missing translator, malformed observations, malformed provider output, policy
+      plan selection, and policy+score plan selection.
+
+Do not:
+
+- [ ] Do not call a policy a world model just because it is trained for embodied control.
+- [ ] Do not set `predict=True` unless the provider returns a validated future WorldForge state.
+- [ ] Do not set `score=True` unless it ranks candidates with explicit score semantics.
+- [ ] Do not hide real-robot safety checks inside WorldForge. Safety interlocks are host-owned.
+
+## Step 8: Predictive Provider Checklist
 
 Use this checklist for providers that roll a world state forward.
 
@@ -325,7 +371,7 @@ Use this checklist for providers that roll a world state forward.
 - [ ] Tests cover malformed world state, missing scene objects, impossible actions if applicable,
       non-finite metrics, and provider failure propagation.
 
-## Step 8: Generative and Transfer Provider Checklist
+## Step 9: Generative and Transfer Provider Checklist
 
 Use this checklist for video or artifact providers.
 
@@ -340,7 +386,7 @@ Use this checklist for video or artifact providers.
 - [ ] Tests cover bad content types, expired artifacts, missing outputs, task failures, malformed
       JSON, timeout, retry, and provider-specific limits.
 
-## Step 9: Observability and Failure Semantics
+## Step 10: Observability and Failure Semantics
 
 Every real provider should emit useful `ProviderEvent` records.
 
@@ -362,7 +408,7 @@ Checklist:
       "request failed."
 - [ ] Unexpected exceptions are wrapped in `ProviderError` with context.
 
-## Step 10: Test Requirements
+## Step 11: Test Requirements
 
 Provider tests should be fixture-driven and contract-driven.
 
@@ -406,7 +452,7 @@ Local model providers:
 - [ ] A real-model smoke script is optional, documented, and not part of the default unit suite.
 - [ ] Checkpoint paths and cache directories are host-owned.
 
-## Step 11: Documentation Requirements
+## Step 12: Documentation Requirements
 
 A provider PR is incomplete without docs.
 

--- a/docs/src/providers/README.md
+++ b/docs/src/providers/README.md
@@ -13,6 +13,7 @@ definition, [Architecture](../architecture.md) for the end-to-end provider injec
 | `cosmos` | beta | register when `COSMOS_BASE_URL` is set | real HTTP adapter for Cosmos NIM; `NVIDIA_API_KEY` is optional and sent as bearer auth when present |
 | `runway` | beta | register when `RUNWAYML_API_SECRET` or `RUNWAY_API_SECRET` is set | real HTTP adapter for Runway image-to-video and video-to-video APIs |
 | `leworldmodel` | beta | register when `LEWORLDMODEL_POLICY` or `LEWM_POLICY` is set | real optional adapter for LeWorldModel JEPA cost models through `stable_worldmodel.policy.AutoCostModel` |
+| [`gr00t`](./gr00t.md) | experimental | register when `GROOT_POLICY_HOST` is set | host-owned NVIDIA Isaac GR00T PolicyClient adapter for embodied action selection |
 | `jepa` | scaffold | register when `JEPA_MODEL_PATH` is set | credential-gated stub backed by deterministic mock behavior |
 | `genie` | scaffold | register when `GENIE_API_KEY` is set | credential-gated stub backed by deterministic mock behavior |
 
@@ -89,10 +90,18 @@ Providers can declare support for:
 - `plan`
 - `transfer`
 - `score`
+- `policy`
 
 `score` providers return `ActionScoreResult` from `score_actions(...)`. The result contains the
 provider name, one score per candidate, `best_index`, `best_score`, and explicit score direction.
-For `leworldmodel`, scores are costs and lower values are better.
+For `leworldmodel`, scores are costs and lower values are better. `World.plan(...)` serializes
+WorldForge action candidates for scoring by default; hosts can pass provider-native tensors through
+`score_action_candidates` when an adapter needs them.
+
+`policy` providers return `ActionPolicyResult` from `select_actions(...)`. The result preserves raw
+provider actions, selected WorldForge actions, candidate action chunks, embodiment metadata, and
+provider-native info. `gr00t` uses this surface because Isaac GR00T is an embodied VLA policy, not
+a future-state predictor.
 
 LeWorldModel is the architectural reference provider for score-based planning. It is first class
 because it matches the JEPA planning contract WorldForge is designed to support: observations,
@@ -108,6 +117,8 @@ instead of pretending it can generate video, reason over text, or mutate world s
 - `runway` validates organization, task creation, task polling, task output, artifact content type, and expired artifact responses before returning a `VideoClip`.
 - `leworldmodel` validates required `pixels`, `goal`, and `action` fields plus four-dimensional
   action-candidate payloads before invoking the cost model.
+- `gr00t` validates policy observations, preserves raw policy actions, and requires a host-owned
+  action translator before returning executable WorldForge actions.
 - Health checks, polling, and downloads retry with backoff by default. Create-style POST requests remain single-attempt unless a caller passes a custom policy.
 - `WorldForge(event_handler=...)` and provider constructor `event_handler=` arguments accept a `ProviderEvent` callback for host-side logging and metrics.
 - `worldforge.observability.compose_event_handlers(...)` lets host apps attach multiple sinks without writing a custom dispatcher.
@@ -154,3 +165,15 @@ LeWorldModel:
 - `scripts/smoke_leworldmodel.py` can run a local end-to-end smoke against
   `quentinll/lewm-pusht`; it requires the upstream GitHub version of `stable-worldmodel[train,env]`
   because the PyPI package may lag the LeWM module.
+
+GR00T:
+
+- `GROOT_POLICY_HOST` points at a running Isaac GR00T policy server.
+- `GROOT_POLICY_PORT` defaults to `5555`; `GROOT_POLICY_TIMEOUT_MS` defaults to `15000`.
+- `GROOT_POLICY_API_TOKEN`, `GROOT_POLICY_STRICT`, and `GROOT_EMBODIMENT_TAG` are optional.
+- The adapter lazily imports `gr00t.policy.server_client.PolicyClient` only when a non-injected
+  client is used.
+- `info["observation"]` must be a JSON object containing at least one of `video`, `state`, or
+  `language`.
+- A host-supplied `action_translator` maps GR00T's embodiment-specific raw actions to WorldForge
+  `Action` objects.

--- a/docs/src/providers/gr00t.md
+++ b/docs/src/providers/gr00t.md
@@ -1,0 +1,187 @@
+# GR00T Provider
+
+Status: experimental host-owned policy-client adapter
+
+Taxonomy category: embodied policy / VLA action model
+
+This adapter wraps NVIDIA Isaac GR00T's policy-client shape. GR00T is modeled as an actor: it
+accepts multimodal observations and language instructions, then returns robot action chunks. It is
+not modeled as a predictive world model, video generator, or candidate scorer.
+
+```text
+observation + language instruction -> action chunk
+```
+
+WorldForge keeps the boundary explicit:
+
+```text
+GR00T policy client
+  -> raw embodiment-specific action arrays
+  -> host-supplied action_translator
+  -> ActionPolicyResult
+  -> World.plan(... planning_mode="policy")
+```
+
+For actor plus world-model planning:
+
+```text
+GR00T proposes candidate action chunks
+  -> LeWorldModel / JEPA-WMS / another score provider ranks candidates
+  -> World.plan(... planning_mode="policy+score")
+  -> execution_provider runs the chosen WorldForge actions
+```
+
+## Configuration
+
+- `GROOT_POLICY_HOST`: required for auto-registration. Hostname or IP of a running GR00T policy
+  server.
+- `GROOT_POLICY_PORT`: optional, defaults to `5555`.
+- `GROOT_POLICY_TIMEOUT_MS`: optional, defaults to `15000`.
+- `GROOT_POLICY_API_TOKEN`: optional token passed to the policy client.
+- `GROOT_POLICY_STRICT`: optional boolean. Defaults to `false` on the client.
+- `GROOT_EMBODIMENT_TAG`: optional profile metadata for the robot embodiment.
+
+The adapter does not add Isaac GR00T, PyTorch, CUDA, TensorRT, checkpoints, or robot runtime
+dependencies to WorldForge's base install. Those dependencies remain host-owned.
+
+## Policy Runtime Contract
+
+Direct construction with a fake or host-owned client:
+
+```python
+from worldforge.providers import GrootPolicyClientProvider
+
+provider = GrootPolicyClientProvider(
+    policy_client=client,
+    embodiment_tag="LIBERO_PANDA",
+    action_translator=translate_actions,
+)
+```
+
+The injected or lazily created client must expose:
+
+```python
+get_action(observation, options=None) -> actions | (actions, info)
+```
+
+If no client is injected, WorldForge lazily imports:
+
+```python
+from gr00t.policy.server_client import PolicyClient
+```
+
+and creates:
+
+```python
+PolicyClient(
+    host=GROOT_POLICY_HOST,
+    port=GROOT_POLICY_PORT or 5555,
+    timeout_ms=GROOT_POLICY_TIMEOUT_MS or 15000,
+    api_token=GROOT_POLICY_API_TOKEN,
+    strict=GROOT_POLICY_STRICT or False,
+)
+```
+
+## Input Shape
+
+`select_actions(...)` expects:
+
+```python
+provider.select_actions(
+    info={
+        "observation": {
+            "video": {"front": video_array},
+            "state": {"eef": state_array},
+            "language": {"task": [["pick up the cube"]]},
+        },
+        "embodiment_tag": "LIBERO_PANDA",
+        "action_horizon": 16,
+        "options": {},
+    }
+)
+```
+
+`info["observation"]` must be a JSON object and include at least one of `video`, `state`, or
+`language`. Arrays may be tensor-like objects with `tolist()` because the adapter normalizes raw
+provider output into JSON-compatible metadata.
+
+## Action Translation
+
+GR00T actions are embodiment-specific physical action arrays. WorldForge cannot safely infer what a
+joint position, gripper channel, or end-effector delta means for a host robot. The provider
+therefore requires an `action_translator` before it can return executable WorldForge `Action`
+objects.
+
+```python
+from worldforge import Action
+
+def translate_actions(raw_actions, info, provider_info):
+    return [
+        Action.move_to(0.3, 0.5, 0.0),
+        Action.move_to(0.4, 0.5, 0.0),
+    ]
+```
+
+The translator may return a single action chunk:
+
+```python
+[Action.move_to(...), Action.move_to(...)]
+```
+
+or multiple candidate chunks:
+
+```python
+[
+    [Action.move_to(0.1, 0.5, 0.0)],
+    [Action.move_to(0.4, 0.5, 0.0)],
+]
+```
+
+Multiple candidates are useful when pairing GR00T with a score provider.
+
+## Planning
+
+Policy-only planning:
+
+```python
+plan = world.plan(
+    goal="pick up the cube",
+    provider="gr00t",
+    policy_info=policy_info,
+    execution_provider="mock",
+)
+```
+
+Policy plus score planning:
+
+```python
+plan = world.plan(
+    goal="choose the lowest-cost policy candidate",
+    policy_provider="gr00t",
+    score_provider="leworldmodel",
+    policy_info=policy_info,
+    score_info=lewm_info,
+    execution_provider="mock",
+)
+```
+
+WorldForge serializes policy candidates into `Action.to_dict()` payloads by default before calling
+the score provider. If the scorer needs native tensors or latents, pass
+`score_action_candidates=...`; WorldForge only requires that the number of policy candidates and
+native score candidates describe the same candidate set.
+
+## Failure Modes
+
+- Missing `GROOT_POLICY_HOST` leaves the auto-registered provider unavailable.
+- Missing `gr00t.policy.server_client.PolicyClient` is reported by `health()`.
+- Missing `action_translator` fails with `ProviderError`.
+- Malformed observations fail before invoking the policy client.
+- Non-JSON-compatible raw actions or provider info fail before returning `ActionPolicyResult`.
+- Failed policy inference is wrapped in `ProviderError`.
+- Policy+score planning fails if the score provider selects an index outside the policy candidate
+  list.
+
+## Tests
+
+- `tests/test_gr00t_provider.py` covers fake-client contract checks, event emission, malformed
+  inputs, missing translator, health failures, policy-only planning, and policy+score planning.

--- a/docs/src/world-model-taxonomy.md
+++ b/docs/src/world-model-taxonomy.md
@@ -45,6 +45,7 @@ flowchart TD
     WM --> Spatial[Spatial / 3D world generation]
     WM --> Infra[Physical AI infrastructure]
     WM --> Active[Active inference / structured generative models]
+    WM --> Policy[Embodied policy / VLA action model]
 
     Latent --> JEPA[JEPA / V-JEPA / LeWorldModel]
     Latent --> RL[Dreamer-style model-based RL]
@@ -52,6 +53,7 @@ flowchart TD
     Video --> Genie[Genie-style interactive worlds]
     Spatial --> Marble[World Labs Marble]
     Infra --> Cosmos[NVIDIA Cosmos platform]
+    Policy --> Groot[NVIDIA Isaac GR00T]
 ```
 
 ## WorldForge's Center of Gravity
@@ -78,7 +80,7 @@ WorldForge's corresponding runtime shape is:
 World state / observation tensors
   |
   |-- candidate_actions            # public WorldForge Action sequences
-  |-- score_action_candidates      # model-native tensor candidates
+  |-- score_action_candidates      # optional model-native tensor candidates
   |-- score_info                   # model-native observation/action/goal context
   v
 provider.score_actions(...)
@@ -108,6 +110,7 @@ provider architecture more than generic video-generation providers do.
 | Generative video simulators | Can a model synthesize plausible future pixels or interactive frames? | Pixels, latents, video tokens | Video clips, interactive frames | Fits `generate`, `transfer`, maybe future `predict` |
 | Spatial / 3D world models | What persistent 3D world can be reconstructed or generated? | Geometry, depth, radiance, assets | 3D scenes, meshes, camera paths | Future provider family |
 | Physical AI infrastructure | How do teams produce data, tokenizers, fine-tunes, and evaluation at scale? | Platform stack | Models, synthetic data, APIs | Provider/platform adapters |
+| Embodied policy / VLA action models | What action chunk should a robot execute from this observation and instruction? | Vision-language-action policy state | Robot action chunks | First-class actor provider family |
 | Active inference / structured generative models | How should beliefs, objects, uncertainty, and action be updated online? | Probabilistic structured state | Beliefs, policies, expected free energy | Conceptual influence, future adapter target |
 
 ## Category Notes
@@ -225,6 +228,40 @@ WorldForge should integrate platform pieces through explicit provider capabiliti
 - future data-curation or tokenizer adapters if they become library scope
 - future evaluation adapters if upstream APIs expose stable contracts
 
+### Embodied Policy / VLA Action Models
+
+NVIDIA Isaac GR00T is best classified as an embodied policy rather than a world model under the
+WorldForge planning definition. Its policy API accepts multimodal observations such as video,
+state, and language, then returns future action chunks for a robot embodiment. That is an actor
+surface:
+
+```text
+observation + language instruction -> action chunk
+```
+
+It is not a future-state transition model:
+
+```text
+state + action -> predicted next state
+```
+
+and it is not a JEPA-style candidate scorer:
+
+```text
+observation + goal + candidate actions -> action costs
+```
+
+WorldForge therefore models GR00T as a `policy` provider. This makes it useful in the control loop
+without overstating what it can prove about future physical state:
+
+```text
+GR00T proposes actions
+  -> LeWorldModel / JEPA-WMS scores or filters candidates
+  -> WorldForge selects a plan
+  -> a host-owned controller, simulator, or predict provider executes
+  -> the host observes again
+```
+
 ### Active Inference
 
 Active inference uses structured generative models, beliefs, and expected free energy rather than
@@ -250,6 +287,11 @@ cosmos
   generation provider
   useful for synthetic video and physical-AI artifacts
 
+gr00t
+  host-owned embodied policy client adapter
+  policy provider
+  useful as an actor that proposes robot action chunks
+
 runway
   remote video generation and transfer adapter
   generation/transfer provider
@@ -272,12 +314,14 @@ flowchart TD
     WF --> Mock[mock\nreference runtime]
     WF --> LeWM[leworldmodel\nJEPA score provider]
     WF --> Cosmos[cosmos\nvideo generation platform adapter]
+    WF --> Groot[gr00t\nembodied policy adapter]
     WF --> Runway[runway\nvideo generation/transfer adapter]
     WF --> JEPA[jepa\nscaffold]
     WF --> Genie[genie\nscaffold]
 
     LeWM --> Score[score_actions -> ActionScoreResult]
     Cosmos --> Generate[generate -> VideoClip]
+    Groot --> Policy[select_actions -> ActionPolicyResult]
     Runway --> Transfer[generate/transfer -> VideoClip]
     Mock --> Predict[predict -> PredictionPayload]
 ```
@@ -315,4 +359,5 @@ Primary sources used to shape this taxonomy:
 - [OpenAI, Video generation models as world simulators](https://openai.com/index/video-generation-models-as-world-simulators/)
 - [Google DeepMind Genie 3](https://deepmind.google/models/genie/)
 - [NVIDIA Cosmos announcement](https://nvidianews.nvidia.com/news/nvidia-launches-cosmos-world-foundation-model-platform-to-accelerate-physical-ai-development)
+- [NVIDIA Isaac GR00T](https://github.com/NVIDIA/Isaac-GR00T)
 - [World Labs Marble documentation](https://docs.worldlabs.ai/)

--- a/scripts/scaffold_provider.py
+++ b/scripts/scaffold_provider.py
@@ -12,7 +12,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from textwrap import dedent
 
-CAPABILITIES = ("predict", "generate", "transfer", "reason", "embed", "score")
+CAPABILITIES = ("predict", "generate", "transfer", "reason", "embed", "score", "policy")
 DEFAULT_TAXONOMY = "unclassified provider scaffold"
 
 
@@ -146,6 +146,15 @@ def _capability_stubs(names: ProviderNames, planned_capabilities: tuple[str, ...
         )
 """
         )
+    if "policy" in planned_capabilities:
+        stubs.append(
+            """
+    def select_actions(self, *, info: JSONDict) -> ActionPolicyResult:
+        raise ProviderError(
+            f"Provider '{self.name}' select_actions() scaffold is not implemented yet."
+        )
+"""
+        )
 
     if not stubs:
         raise ValueError(f"{names.slug} scaffold requires at least one planned capability")
@@ -169,6 +178,8 @@ def _provider_source(options: ScaffoldOptions) -> str:
         model_imports.append("EmbeddingResult")
     if "score" in options.planned_capabilities:
         model_imports.extend(["ActionScoreResult", "JSONDict"])
+    if "policy" in options.planned_capabilities:
+        model_imports.extend(["ActionPolicyResult", "JSONDict"])
 
     deduped_model_imports = sorted(dict.fromkeys(model_imports))
     base_imports = ["BaseProvider", "ProviderError"]
@@ -417,6 +428,18 @@ def _test_source(options: ScaffoldOptions) -> str:
                 "",
                 '    with pytest.raises(ProviderError, match="not implemented"):',
                 "        provider.score_actions(info={}, action_candidates=[])",
+            ]
+        )
+    if "policy" in options.planned_capabilities:
+        lines.extend(
+            [
+                "",
+                "",
+                f"def test_{names.snake}_select_actions_is_not_implemented_yet() -> None:",
+                f"    provider = {names.class_name}()",
+                "",
+                '    with pytest.raises(ProviderError, match="not implemented"):',
+                "        provider.select_actions(info={})",
             ]
         )
     return "\n".join(lines).rstrip() + "\n"

--- a/src/worldforge/__init__.py
+++ b/src/worldforge/__init__.py
@@ -45,6 +45,7 @@ from worldforge.framework import (
 )
 from worldforge.models import (
     Action,
+    ActionPolicyResult,
     ActionScoreResult,
     BBox,
     DoctorReport,
@@ -79,6 +80,7 @@ except PackageNotFoundError:  # pragma: no cover - fallback for editable local i
 __all__ = [
     "__version__",
     "Action",
+    "ActionPolicyResult",
     "ActionScoreResult",
     "BBox",
     "BenchmarkInputs",

--- a/src/worldforge/framework.py
+++ b/src/worldforge/framework.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Any
 
 from worldforge.models import (
     Action,
+    ActionPolicyResult,
     ActionScoreResult,
     BBox,
     DoctorReport,
@@ -41,6 +42,7 @@ from worldforge.providers import (
     BaseProvider,
     CosmosProvider,
     GenieProvider,
+    GrootPolicyClientProvider,
     JepaProvider,
     LeWorldModelProvider,
     MockProvider,
@@ -86,6 +88,12 @@ def _normalize_candidate_action_plans(
             raise WorldForgeError(f"candidate_actions[{index}] must contain only Action instances.")
         normalized.append(actions)
     return normalized
+
+
+def _action_plans_to_score_payload(
+    candidate_action_plans: Sequence[Sequence[Action]],
+) -> list[list[JSONDict]]:
+    return [[action.to_dict() for action in candidate] for candidate in candidate_action_plans]
 
 
 def _world_file(state_dir: Path, world_id: str) -> Path:
@@ -636,6 +644,9 @@ class World:
         max_steps: int = 20,
         provider: str | None = None,
         candidate_actions: Sequence[Action | Sequence[Action]] | None = None,
+        policy_provider: str | None = None,
+        policy_info: JSONDict | None = None,
+        score_provider: str | None = None,
         score_info: JSONDict | None = None,
         score_action_candidates: object | None = None,
         execution_provider: str | None = None,
@@ -649,20 +660,45 @@ class World:
         if goal is not None and not goal.strip():
             raise WorldForgeError("goal must not be empty when provided.")
         selected_provider = _normalize_provider_name(provider, self.provider)
-        selected_provider_instance = self._provider(selected_provider)
+        uses_policy_planning = policy_info is not None or policy_provider is not None
         uses_score_planning = any(
-            item is not None for item in (candidate_actions, score_info, score_action_candidates)
+            item is not None
+            for item in (candidate_actions, score_provider, score_info, score_action_candidates)
         )
+        selected_policy_provider = policy_provider or selected_provider
+        selected_policy_provider_instance = (
+            self._provider(selected_policy_provider) if uses_policy_planning else None
+        )
+        selected_score_provider = score_provider or selected_provider
+        selected_score_provider_instance = (
+            self._provider(selected_score_provider) if uses_score_planning else None
+        )
+        if uses_policy_planning:
+            assert selected_policy_provider_instance is not None
+            if not selected_policy_provider_instance.capabilities.policy:
+                raise WorldForgeError(
+                    f"Provider '{selected_policy_provider}' does not support policy planning."
+                )
+            if policy_info is None:
+                raise WorldForgeError("Policy planning requires policy_info.")
+            if candidate_actions is not None:
+                raise WorldForgeError(
+                    "Policy planning derives candidate actions from the policy provider; do not "
+                    "pass candidate_actions."
+                )
         if uses_score_planning:
-            if not selected_provider_instance.capabilities.score:
+            assert selected_score_provider_instance is not None
+            if not selected_score_provider_instance.capabilities.score:
                 raise WorldForgeError(
-                    f"Provider '{selected_provider}' does not support score-based planning."
+                    f"Provider '{selected_score_provider}' does not support score-based planning."
                 )
-            if candidate_actions is None or score_info is None or score_action_candidates is None:
+            if not uses_policy_planning and candidate_actions is None:
                 raise WorldForgeError(
-                    "Score-based planning requires candidate_actions, score_info, "
-                    "and score_action_candidates."
+                    "Score-based planning requires candidate_actions unless policy planning "
+                    "provides candidates."
                 )
+            if score_info is None:
+                raise WorldForgeError("Score-based planning requires score_info.")
 
         resolved_goal_spec = goal_spec
         if goal_json is not None:
@@ -680,17 +716,99 @@ class World:
             actions = self._goal_actions(resolved_goal)
         actions = actions[: min(max_steps, len(actions))]
 
+        if uses_policy_planning:
+            assert policy_info is not None
+            assert selected_policy_provider_instance is not None
+            policy_result = selected_policy_provider_instance.select_actions(info=policy_info)
+            candidate_action_plans = [
+                candidate[:max_steps] for candidate in policy_result.action_candidates
+            ]
+            if not candidate_action_plans:
+                raise WorldForgeError(
+                    f"Provider '{selected_policy_provider}' returned no policy action candidates."
+                )
+            if uses_score_planning:
+                assert score_info is not None
+                assert selected_score_provider_instance is not None
+                score_payload = (
+                    score_action_candidates
+                    if score_action_candidates is not None
+                    else _action_plans_to_score_payload(candidate_action_plans)
+                )
+                score_result = selected_score_provider_instance.score_actions(
+                    info=score_info,
+                    action_candidates=score_payload,
+                )
+                if score_result.best_index >= len(candidate_action_plans):
+                    raise WorldForgeError(
+                        f"Provider '{selected_score_provider}' selected candidate index "
+                        f"{score_result.best_index}, but policy provider "
+                        f"'{selected_policy_provider}' returned only "
+                        f"{len(candidate_action_plans)} candidate action plan(s)."
+                    )
+                selected_actions = candidate_action_plans[score_result.best_index]
+                best_score = max(0.0, score_result.best_score)
+                success_probability = 1.0 / (1.0 + best_score)
+                metadata = {
+                    "planning_mode": "policy+score",
+                    "policy_provider": selected_policy_provider,
+                    "score_provider": selected_score_provider,
+                    "policy_result": policy_result.to_dict(),
+                    "score_result": score_result.to_dict(),
+                    "candidate_count": len(candidate_action_plans),
+                    "success_probability_source": "inverse_best_cost_heuristic",
+                }
+                if execution_provider is not None:
+                    metadata["execution_provider"] = execution_provider
+                return Plan(
+                    goal=resolved_goal,
+                    goal_spec=serialized_goal_spec,
+                    planner=planner,
+                    provider=selected_score_provider,
+                    actions=selected_actions,
+                    predicted_states=[],
+                    success_probability=max(0.0, min(1.0, success_probability)),
+                    metadata=metadata,
+                )
+
+            selected_actions = policy_result.actions[:max_steps]
+            metadata = {
+                "planning_mode": "policy",
+                "policy_provider": selected_policy_provider,
+                "policy_result": policy_result.to_dict(),
+                "candidate_count": len(candidate_action_plans),
+                "success_probability_source": "policy_provider_no_world_model",
+            }
+            if execution_provider is not None:
+                metadata["execution_provider"] = execution_provider
+            return Plan(
+                goal=resolved_goal,
+                goal_spec=serialized_goal_spec,
+                planner=planner,
+                provider=selected_policy_provider,
+                actions=selected_actions,
+                predicted_states=[],
+                success_probability=0.5,
+                metadata=metadata,
+            )
+
         if uses_score_planning:
             assert candidate_actions is not None
             assert score_info is not None
+            assert selected_score_provider_instance is not None
             candidate_action_plans = _normalize_candidate_action_plans(candidate_actions)
-            score_result = selected_provider_instance.score_actions(
+            score_payload = (
+                score_action_candidates
+                if score_action_candidates is not None
+                else _action_plans_to_score_payload(candidate_action_plans)
+            )
+            score_result = selected_score_provider_instance.score_actions(
                 info=score_info,
-                action_candidates=score_action_candidates,
+                action_candidates=score_payload,
             )
             if score_result.best_index >= len(candidate_action_plans):
                 raise WorldForgeError(
-                    f"Provider '{selected_provider}' selected candidate index "
+                    f"Provider '{selected_score_provider}' selected candidate index "
                     f"{score_result.best_index}, but only {len(candidate_action_plans)} "
                     "candidate action plan(s) were provided."
                 )
@@ -709,7 +827,7 @@ class World:
                 goal=resolved_goal,
                 goal_spec=serialized_goal_spec,
                 planner=planner,
-                provider=selected_provider,
+                provider=selected_score_provider,
                 actions=selected_actions,
                 predicted_states=[],
                 success_probability=max(0.0, min(1.0, success_probability)),
@@ -794,6 +912,7 @@ class WorldForge:
             CosmosProvider(event_handler=self._event_handler),
             RunwayProvider(event_handler=self._event_handler),
             LeWorldModelProvider(event_handler=self._event_handler),
+            GrootPolicyClientProvider(event_handler=self._event_handler),
             JepaProvider(event_handler=self._event_handler),
             GenieProvider(event_handler=self._event_handler),
         )
@@ -1073,6 +1192,9 @@ class WorldForge:
             info=info,
             action_candidates=action_candidates,
         )
+
+    def select_actions(self, provider: str, *, info: JSONDict) -> ActionPolicyResult:
+        return self._require_provider(provider).select_actions(info=info)
 
 
 def list_eval_suites() -> list[str]:

--- a/src/worldforge/models.py
+++ b/src/worldforge/models.py
@@ -794,6 +794,7 @@ class ProviderCapabilities:
     plan: bool = False
     transfer: bool = False
     score: bool = False
+    policy: bool = False
 
     def to_dict(self) -> JSONDict:
         return {
@@ -804,6 +805,7 @@ class ProviderCapabilities:
             "plan": self.plan,
             "transfer": self.transfer,
             "score": self.score,
+            "policy": self.policy,
         }
 
     def supports(self, capability: str) -> bool:
@@ -1440,6 +1442,88 @@ class ActionScoreResult:
             "best_score": self.best_score,
             "lower_is_better": self.lower_is_better,
             "metadata": dict(self.metadata),
+        }
+
+
+@dataclass(slots=True)
+class ActionPolicyResult:
+    """Provider-selected action chunk from an embodied policy.
+
+    Policy providers choose or propose actions from observations. They do not imply future-state
+    prediction or candidate scoring unless the provider exposes those capabilities separately.
+    ``action_candidates`` stores one or more executable candidate plans when the policy can expose
+    alternatives for downstream scoring.
+    """
+
+    provider: str
+    actions: list[Action]
+    raw_actions: JSONDict = field(default_factory=dict)
+    action_horizon: int | None = None
+    embodiment_tag: str | None = None
+    metadata: JSONDict = field(default_factory=dict)
+    action_candidates: list[list[Action]] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.provider, str) or not self.provider.strip():
+            raise WorldForgeError("ActionPolicyResult provider must be a non-empty string.")
+        if not isinstance(self.actions, list) or not self.actions:
+            raise WorldForgeError("ActionPolicyResult actions must be a non-empty list.")
+        if not all(isinstance(action, Action) for action in self.actions):
+            raise WorldForgeError("ActionPolicyResult actions must contain only Action instances.")
+        if not isinstance(self.raw_actions, dict):
+            raise WorldForgeError("ActionPolicyResult raw_actions must be a JSON object.")
+        if self.action_horizon is not None:
+            self.action_horizon = require_positive_int(
+                self.action_horizon,
+                name="ActionPolicyResult action_horizon",
+            )
+        if self.embodiment_tag is not None:
+            if not isinstance(self.embodiment_tag, str) or not self.embodiment_tag.strip():
+                raise WorldForgeError(
+                    "ActionPolicyResult embodiment_tag must be a non-empty string when provided."
+                )
+            self.embodiment_tag = self.embodiment_tag.strip()
+        if not isinstance(self.metadata, dict):
+            raise WorldForgeError("ActionPolicyResult metadata must be a JSON object.")
+        if not isinstance(self.action_candidates, list):
+            raise WorldForgeError("ActionPolicyResult action_candidates must be a list.")
+
+        normalized_candidates: list[list[Action]]
+        if self.action_candidates:
+            normalized_candidates = []
+            for index, candidate in enumerate(self.action_candidates):
+                if not isinstance(candidate, list) or not candidate:
+                    raise WorldForgeError(
+                        "ActionPolicyResult action_candidates must contain non-empty action lists."
+                    )
+                if not all(isinstance(action, Action) for action in candidate):
+                    raise WorldForgeError(
+                        f"ActionPolicyResult action_candidates[{index}] must contain only "
+                        "Action instances."
+                    )
+                normalized_candidates.append(list(candidate))
+        else:
+            normalized_candidates = [list(self.actions)]
+
+        dump_json(self.raw_actions)
+        dump_json(self.metadata)
+        self.provider = self.provider.strip()
+        self.actions = list(self.actions)
+        self.raw_actions = dict(self.raw_actions)
+        self.metadata = dict(self.metadata)
+        self.action_candidates = normalized_candidates
+
+    def to_dict(self) -> JSONDict:
+        return {
+            "provider": self.provider,
+            "actions": [action.to_dict() for action in self.actions],
+            "raw_actions": dict(self.raw_actions),
+            "action_horizon": self.action_horizon,
+            "embodiment_tag": self.embodiment_tag,
+            "metadata": dict(self.metadata),
+            "action_candidates": [
+                [action.to_dict() for action in candidate] for candidate in self.action_candidates
+            ],
         }
 
 

--- a/src/worldforge/providers/__init__.py
+++ b/src/worldforge/providers/__init__.py
@@ -9,6 +9,7 @@ from worldforge.models import (
 
 from .base import BaseProvider, PredictionPayload, ProviderError, RemoteProvider
 from .cosmos import CosmosProvider
+from .gr00t import GrootPolicyClientProvider
 from .leworldmodel import LeWorldModelProvider
 from .mock import MockProvider
 from .remote import GenieProvider, JepaProvider, StubRemoteProvider
@@ -18,6 +19,7 @@ __all__ = [
     "BaseProvider",
     "CosmosProvider",
     "GenieProvider",
+    "GrootPolicyClientProvider",
     "JepaProvider",
     "LeWorldModelProvider",
     "MockProvider",

--- a/src/worldforge/providers/base.py
+++ b/src/worldforge/providers/base.py
@@ -9,6 +9,7 @@ from time import perf_counter
 
 from worldforge.models import (
     Action,
+    ActionPolicyResult,
     ActionScoreResult,
     EmbeddingResult,
     GenerationOptions,
@@ -192,6 +193,9 @@ class BaseProvider:
 
     def score_actions(self, *, info: JSONDict, action_candidates: object) -> ActionScoreResult:
         raise ProviderError(f"Provider '{self.name}' does not implement score_actions().")
+
+    def select_actions(self, *, info: JSONDict) -> ActionPolicyResult:
+        raise ProviderError(f"Provider '{self.name}' does not implement select_actions().")
 
 
 class RemoteProvider(BaseProvider):

--- a/src/worldforge/providers/gr00t.py
+++ b/src/worldforge/providers/gr00t.py
@@ -1,0 +1,445 @@
+"""NVIDIA Isaac GR00T policy-client provider."""
+
+from __future__ import annotations
+
+import importlib
+import math
+import os
+from collections.abc import Callable, Sequence
+from time import perf_counter
+from typing import Any
+
+from worldforge.models import (
+    Action,
+    ActionPolicyResult,
+    JSONDict,
+    ProviderCapabilities,
+    ProviderEvent,
+    ProviderHealth,
+    WorldForgeError,
+    require_positive_int,
+)
+
+from .base import BaseProvider, ProviderError
+
+GROOT_POLICY_HOST_ENV_VAR = "GROOT_POLICY_HOST"
+GROOT_POLICY_PORT_ENV_VAR = "GROOT_POLICY_PORT"
+GROOT_POLICY_TIMEOUT_MS_ENV_VAR = "GROOT_POLICY_TIMEOUT_MS"
+GROOT_POLICY_API_TOKEN_ENV_VAR = "GROOT_POLICY_API_TOKEN"
+GROOT_POLICY_STRICT_ENV_VAR = "GROOT_POLICY_STRICT"
+GROOT_EMBODIMENT_TAG_ENV_VAR = "GROOT_EMBODIMENT_TAG"
+DEFAULT_GROOT_POLICY_PORT = 5555
+DEFAULT_GROOT_POLICY_TIMEOUT_MS = 15_000
+
+ActionTranslator = Callable[
+    [object, JSONDict, JSONDict],
+    Sequence[Action] | Sequence[Sequence[Action]],
+]
+
+
+def _env_value(name: str) -> str | None:
+    value = os.environ.get(name)
+    if value is None or not value.strip():
+        return None
+    return value.strip()
+
+
+def _optional_non_empty(value: str | None, *, name: str) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value.strip():
+        raise WorldForgeError(f"{name} must be a non-empty string when provided.")
+    return value.strip()
+
+
+def _optional_positive_int(value: int | str | None, *, name: str) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        if not value.strip():
+            return None
+        try:
+            value = int(value)
+        except ValueError:
+            raise WorldForgeError(f"{name} must be an integer greater than 0.") from None
+    return require_positive_int(value, name=name)
+
+
+def _optional_bool(value: bool | str | None, *, name: str) -> bool | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return value
+    if not isinstance(value, str):
+        raise WorldForgeError(f"{name} must be a boolean when provided.")
+    normalized = value.strip().lower()
+    if normalized in {"1", "true", "yes", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "off"}:
+        return False
+    raise WorldForgeError(f"{name} must be a boolean when provided.")
+
+
+def _json_compatible(value: object, *, name: str) -> object:
+    tolist = getattr(value, "tolist", None)
+    if callable(tolist):
+        return _json_compatible(tolist(), name=name)
+    if value is None or isinstance(value, str | bool):
+        return value
+    if isinstance(value, int | float):
+        number = float(value)
+        if not math.isfinite(number):
+            raise ProviderError(f"{name} must contain only finite numbers.")
+        return value
+    if isinstance(value, dict):
+        normalized: JSONDict = {}
+        for key, child in value.items():
+            if not isinstance(key, str) or not key.strip():
+                raise ProviderError(f"{name} keys must be non-empty strings.")
+            normalized[key.strip()] = _json_compatible(child, name=f"{name}.{key}")
+        return normalized
+    if isinstance(value, Sequence) and not isinstance(value, str | bytes | bytearray):
+        return [
+            _json_compatible(child, name=f"{name}[{index}]") for index, child in enumerate(value)
+        ]
+    raise ProviderError(f"{name} must be JSON-compatible.")
+
+
+def _json_object(value: object, *, name: str) -> JSONDict:
+    normalized = _json_compatible(value, name=name)
+    if not isinstance(normalized, dict):
+        raise ProviderError(f"{name} must be a JSON object.")
+    return normalized
+
+
+def _normalize_policy_action_candidates(
+    value: Sequence[Action] | Sequence[Sequence[Action]],
+) -> list[list[Action]]:
+    if not isinstance(value, Sequence) or isinstance(value, str | bytes) or not value:
+        raise ProviderError("GR00T action translator must return a non-empty action sequence.")
+    if all(isinstance(item, Action) for item in value):
+        return [list(value)]  # type: ignore[list-item]
+
+    candidates: list[list[Action]] = []
+    for index, candidate in enumerate(value):
+        if (
+            not isinstance(candidate, Sequence)
+            or isinstance(candidate, str | bytes)
+            or not candidate
+        ):
+            raise ProviderError(
+                f"GR00T action translator candidate {index} must be a non-empty action sequence."
+            )
+        actions = list(candidate)
+        if not all(isinstance(action, Action) for action in actions):
+            raise ProviderError(
+                f"GR00T action translator candidate {index} must contain only Action instances."
+            )
+        candidates.append(actions)
+    return candidates
+
+
+class GrootPolicyClientProvider(BaseProvider):
+    """Adapter for NVIDIA Isaac GR00T policy-server inference.
+
+    GR00T is modeled as an embodied policy: observations and language go in, action chunks come
+    out. It is not a future-state predictor or candidate scorer.
+    """
+
+    def __init__(
+        self,
+        name: str = "gr00t",
+        *,
+        host: str | None = None,
+        port: int | str | None = None,
+        timeout_ms: int | str | None = None,
+        api_token: str | None = None,
+        strict: bool | str | None = None,
+        embodiment_tag: str | None = None,
+        policy_client: Any | None = None,
+        action_translator: ActionTranslator | None = None,
+        event_handler: Callable[[ProviderEvent], None] | None = None,
+    ) -> None:
+        self.host = _optional_non_empty(
+            host if host is not None else _env_value(GROOT_POLICY_HOST_ENV_VAR),
+            name="GR00T policy host",
+        )
+        self.port = (
+            _optional_positive_int(
+                port if port is not None else _env_value(GROOT_POLICY_PORT_ENV_VAR),
+                name="GR00T policy port",
+            )
+            or DEFAULT_GROOT_POLICY_PORT
+        )
+        self.timeout_ms = (
+            _optional_positive_int(
+                timeout_ms
+                if timeout_ms is not None
+                else _env_value(GROOT_POLICY_TIMEOUT_MS_ENV_VAR),
+                name="GR00T policy timeout_ms",
+            )
+            or DEFAULT_GROOT_POLICY_TIMEOUT_MS
+        )
+        self.api_token = _optional_non_empty(
+            api_token if api_token is not None else _env_value(GROOT_POLICY_API_TOKEN_ENV_VAR),
+            name="GR00T policy api_token",
+        )
+        parsed_strict = _optional_bool(
+            strict if strict is not None else _env_value(GROOT_POLICY_STRICT_ENV_VAR),
+            name="GR00T policy strict",
+        )
+        self.strict = False if parsed_strict is None else parsed_strict
+        self.embodiment_tag = _optional_non_empty(
+            embodiment_tag
+            if embodiment_tag is not None
+            else _env_value(GROOT_EMBODIMENT_TAG_ENV_VAR),
+            name="GR00T embodiment_tag",
+        )
+        self._policy_client = policy_client
+        self._action_translator = action_translator
+        super().__init__(
+            name=name,
+            capabilities=ProviderCapabilities(
+                predict=False,
+                generate=False,
+                reason=False,
+                embed=False,
+                plan=False,
+                transfer=False,
+                score=False,
+                policy=True,
+            ),
+            is_local=False,
+            description=(
+                "NVIDIA Isaac GR00T policy-client adapter for selecting embodied action chunks."
+            ),
+            package="worldforge + host-supplied Isaac-GR00T runtime",
+            implementation_status="experimental",
+            deterministic=False,
+            requires_credentials=self.api_token is not None,
+            required_env_vars=[GROOT_POLICY_HOST_ENV_VAR],
+            supported_modalities=["video", "state", "language", "actions"],
+            artifact_types=["action_policy"],
+            notes=[
+                "Wraps the host-owned GR00T PolicyClient server/client API.",
+                "Does not import gr00t unless a non-injected client is used.",
+                "Requires an action_translator to map embodiment-specific raw actions to "
+                "WorldForge Action objects.",
+                "GR00T is an embodied policy provider, not a future-state world model.",
+            ],
+            default_model=self.embodiment_tag,
+            supported_models=[self.embodiment_tag] if self.embodiment_tag else [],
+            event_handler=event_handler,
+        )
+
+    def configured(self) -> bool:
+        return self._policy_client is not None or self.host is not None
+
+    def health(self) -> ProviderHealth:
+        started = perf_counter()
+        if not self.configured():
+            return ProviderHealth(
+                name=self.name,
+                healthy=False,
+                latency_ms=max(0.1, (perf_counter() - started) * 1000),
+                details=f"missing {GROOT_POLICY_HOST_ENV_VAR}",
+            )
+        if self._policy_client is None:
+            dependency_error = self._runtime_dependency_error()
+            if dependency_error is not None:
+                return ProviderHealth(
+                    name=self.name,
+                    healthy=False,
+                    latency_ms=max(0.1, (perf_counter() - started) * 1000),
+                    details=dependency_error,
+                )
+
+        try:
+            client = self._load_client()
+            ping = getattr(client, "ping", None)
+            if callable(ping) and not ping():
+                return ProviderHealth(
+                    name=self.name,
+                    healthy=False,
+                    latency_ms=max(0.1, (perf_counter() - started) * 1000),
+                    details="policy server ping failed",
+                )
+        except ProviderError as exc:
+            return ProviderHealth(
+                name=self.name,
+                healthy=False,
+                latency_ms=max(0.1, (perf_counter() - started) * 1000),
+                details=str(exc),
+            )
+
+        return ProviderHealth(
+            name=self.name,
+            healthy=True,
+            latency_ms=max(0.1, (perf_counter() - started) * 1000),
+            details=f"configured for {self.host or 'injected policy client'}:{self.port}",
+        )
+
+    def _runtime_dependency_error(self) -> str | None:
+        try:
+            policy_module = importlib.import_module("gr00t.policy.server_client")
+        except ImportError:
+            return "missing optional dependency gr00t.policy.server_client"
+        if not hasattr(policy_module, "PolicyClient"):
+            return "gr00t.policy.server_client.PolicyClient is unavailable"
+        return None
+
+    def _load_client(self) -> Any:
+        if self._policy_client is not None:
+            return self._policy_client
+        if self.host is None:
+            raise ProviderError(
+                f"Provider '{self.name}' is unavailable: missing {GROOT_POLICY_HOST_ENV_VAR}."
+            )
+        try:
+            policy_module = importlib.import_module("gr00t.policy.server_client")
+            client_type = policy_module.PolicyClient
+            self._policy_client = client_type(
+                host=self.host,
+                port=self.port,
+                timeout_ms=self.timeout_ms,
+                api_token=self.api_token,
+                strict=self.strict,
+            )
+        except Exception as exc:
+            raise ProviderError(f"Failed to create GR00T PolicyClient: {exc}") from exc
+        return self._policy_client
+
+    def _validate_info(self, info: JSONDict) -> tuple[JSONDict, JSONDict | None]:
+        if not isinstance(info, dict):
+            raise ProviderError("GR00T policy info must be a JSON object.")
+        observation = info.get("observation")
+        if not isinstance(observation, dict):
+            raise ProviderError("GR00T policy info.observation must be a JSON object.")
+        if not any(key in observation for key in ("video", "state", "language")):
+            raise ProviderError(
+                "GR00T policy observation must include at least one of video, state, or language."
+            )
+        options = info.get("options")
+        if options is not None and not isinstance(options, dict):
+            raise ProviderError("GR00T policy info.options must be a JSON object when provided.")
+        return dict(observation), dict(options) if isinstance(options, dict) else None
+
+    def _translate_actions(
+        self,
+        *,
+        raw_actions: object,
+        info: JSONDict,
+        provider_info: JSONDict,
+    ) -> list[list[Action]]:
+        if self._action_translator is None:
+            raise ProviderError(
+                "GR00T policy actions are embodiment-specific; provide action_translator to map "
+                "raw policy actions into WorldForge Action objects."
+            )
+        try:
+            translated = self._action_translator(raw_actions, info, provider_info)
+        except Exception as exc:
+            raise ProviderError(f"GR00T action translation failed: {exc}") from exc
+        return _normalize_policy_action_candidates(translated)
+
+    def _emit_policy_event(
+        self,
+        *,
+        phase: str,
+        duration_ms: float,
+        message: str = "",
+        metadata: JSONDict | None = None,
+    ) -> None:
+        self._emit_event(
+            ProviderEvent(
+                provider=self.name,
+                operation="policy",
+                phase=phase,
+                duration_ms=duration_ms,
+                message=message,
+                metadata=dict(metadata or {}),
+            )
+        )
+
+    def select_actions(self, *, info: JSONDict) -> ActionPolicyResult:
+        started = perf_counter()
+        try:
+            observation, options = self._validate_info(info)
+            client = self._load_client()
+            get_action = getattr(client, "get_action", None)
+            if not callable(get_action):
+                raise ProviderError("GR00T policy client does not expose get_action().")
+            try:
+                response = (
+                    get_action(observation, options=options)
+                    if options is not None
+                    else get_action(observation)
+                )
+            except Exception as exc:
+                raise ProviderError(f"GR00T policy inference failed: {exc}") from exc
+
+            if isinstance(response, tuple):
+                if len(response) != 2:
+                    raise ProviderError(
+                        "GR00T policy client tuple response must contain actions and info."
+                    )
+                raw_actions, raw_provider_info = response
+            else:
+                raw_actions = response
+                raw_provider_info = {}
+
+            normalized_raw_actions = _json_object(raw_actions, name="GR00T raw_actions")
+            normalized_provider_info = _json_object(
+                raw_provider_info,
+                name="GR00T provider_info",
+            )
+            candidate_plans = self._translate_actions(
+                raw_actions=raw_actions,
+                info=info,
+                provider_info=normalized_provider_info,
+            )
+            action_horizon_value = info.get("action_horizon")
+            action_horizon = (
+                _optional_positive_int(action_horizon_value, name="GR00T action_horizon")
+                if action_horizon_value is not None
+                else len(candidate_plans[0])
+            )
+            embodiment_tag = str(info.get("embodiment_tag") or self.embodiment_tag or "").strip()
+            result = ActionPolicyResult(
+                provider=self.name,
+                actions=list(candidate_plans[0]),
+                raw_actions=normalized_raw_actions,
+                action_horizon=action_horizon,
+                embodiment_tag=embodiment_tag or None,
+                metadata={
+                    "runtime": "gr00t-policy-client",
+                    "provider_info": normalized_provider_info,
+                    "candidate_count": len(candidate_plans),
+                },
+                action_candidates=candidate_plans,
+            )
+            self._emit_policy_event(
+                phase="success",
+                duration_ms=max(0.1, (perf_counter() - started) * 1000),
+                metadata={
+                    "candidate_count": len(result.action_candidates),
+                    "action_horizon": result.action_horizon,
+                    "embodiment_tag": result.embodiment_tag,
+                },
+            )
+            return result
+        except ProviderError as exc:
+            self._emit_policy_event(
+                phase="failure",
+                duration_ms=max(0.1, (perf_counter() - started) * 1000),
+                message=str(exc),
+            )
+            raise
+        except Exception as exc:
+            error = ProviderError(f"GR00T policy selection failed: {exc}")
+            self._emit_policy_event(
+                phase="failure",
+                duration_ms=max(0.1, (perf_counter() - started) * 1000),
+                message=str(error),
+            )
+            raise error from exc

--- a/src/worldforge/testing/providers.py
+++ b/src/worldforge/testing/providers.py
@@ -8,6 +8,7 @@ from typing import TypeVar
 
 from worldforge.models import (
     Action,
+    ActionPolicyResult,
     ActionScoreResult,
     BBox,
     EmbeddingResult,
@@ -48,6 +49,25 @@ def sample_contract_world_state() -> JSONDict:
         "step": 0,
         "scene": {"objects": {cube.id: cube.to_dict()}},
         "metadata": {"name": "contract-world"},
+    }
+
+
+def sample_contract_policy_info() -> JSONDict:
+    """Return a minimal embodied-policy observation payload for contract checks."""
+
+    return {
+        "observation": {
+            "video": {
+                "front": [[[[[0, 0, 0]]]]],
+            },
+            "state": {
+                "eef": [[[0.0, 0.5, 0.0]]],
+            },
+            "language": {
+                "task": [["move the object"]],
+            },
+        },
+        "action_horizon": 1,
     }
 
 
@@ -133,11 +153,25 @@ def _validate_action_scores(provider: str, result: ActionScoreResult) -> None:
     assert isinstance(result.metadata, dict)
 
 
+def _validate_action_policy(provider: str, result: ActionPolicyResult) -> None:
+    assert result.provider == provider
+    assert isinstance(result.actions, list)
+    assert result.actions
+    assert all(isinstance(action, Action) for action in result.actions)
+    assert isinstance(result.raw_actions, dict)
+    assert result.action_horizon is None or result.action_horizon >= 1
+    assert isinstance(result.metadata, dict)
+    assert isinstance(result.action_candidates, list)
+    assert result.action_candidates
+    assert all(candidate for candidate in result.action_candidates)
+
+
 def assert_provider_contract(
     provider: BaseProvider,
     *,
     world_state: JSONDict | None = None,
     action: Action | None = None,
+    policy_info: JSONDict | None = None,
     score_info: JSONDict | None = None,
     score_action_candidates: object | None = None,
 ) -> ProviderContractReport:
@@ -263,6 +297,17 @@ def assert_provider_contract(
                     if score_action_candidates is None
                     else score_action_candidates,
                 ),
+            )
+
+    if profile.capabilities.policy:
+        if can_invoke:
+            policy = provider.select_actions(info=policy_info or sample_contract_policy_info())
+            _validate_action_policy(provider.name, policy)
+            report.exercised_operations.append("policy")
+        else:
+            _expect_provider_error(
+                "policy",
+                lambda: provider.select_actions(info=policy_info or sample_contract_policy_info()),
             )
 
     return report

--- a/tests/test_gr00t_provider.py
+++ b/tests/test_gr00t_provider.py
@@ -1,0 +1,436 @@
+from __future__ import annotations
+
+import math
+import sys
+import types
+
+import pytest
+
+from worldforge import Action, ActionPolicyResult, ActionScoreResult, WorldForge, WorldForgeError
+from worldforge.models import JSONDict, ProviderCapabilities, ProviderEvent, ProviderHealth
+from worldforge.providers import (
+    BaseProvider,
+    GrootPolicyClientProvider,
+    MockProvider,
+    ProviderError,
+)
+from worldforge.testing import assert_provider_contract
+
+
+def _policy_info() -> JSONDict:
+    return {
+        "observation": {
+            "video": {
+                "front": [[[[[0, 0, 0]]]]],
+            },
+            "state": {
+                "eef": [[[0.0, 0.5, 0.0]]],
+            },
+            "language": {
+                "task": [["push the cube"]],
+            },
+        },
+        "embodiment_tag": "LIBERO_PANDA",
+        "action_horizon": 2,
+    }
+
+
+class FakeGrootClient:
+    def __init__(self, response: object, *, healthy: bool = True) -> None:
+        self.response = response
+        self.healthy = healthy
+        self.ping_calls = 0
+        self.get_action_calls: list[dict[str, object]] = []
+
+    def ping(self) -> bool:
+        self.ping_calls += 1
+        return self.healthy
+
+    def get_action(self, observation: object, options: object | None = None) -> object:
+        self.get_action_calls.append({"observation": observation, "options": options})
+        return self.response
+
+
+class FakeArray:
+    def __init__(self, value: object) -> None:
+        self.value = value
+
+    def tolist(self) -> object:
+        return self.value
+
+
+class FakeScoreProvider(BaseProvider):
+    def __init__(self, scores: list[float]) -> None:
+        self.calls: list[dict[str, object]] = []
+        self._scores = scores
+        best_index = min(range(len(scores)), key=scores.__getitem__)
+        self._result = ActionScoreResult(
+            provider="fake-score",
+            scores=scores,
+            best_index=best_index,
+            metadata={"runtime": "fake-score"},
+        )
+        super().__init__(
+            "fake-score",
+            capabilities=ProviderCapabilities(predict=False, score=True),
+            is_local=True,
+            description="Fake score provider for policy planning tests.",
+            implementation_status="test",
+            deterministic=True,
+            requires_credentials=False,
+        )
+
+    def health(self) -> ProviderHealth:
+        return ProviderHealth(name=self.name, healthy=True, latency_ms=0.1, details="configured")
+
+    def score_actions(self, *, info: JSONDict, action_candidates: object) -> ActionScoreResult:
+        self.calls.append({"info": info, "action_candidates": action_candidates})
+        return self._result
+
+
+def test_gr00t_policy_client_provider_passes_contract_and_emits_events() -> None:
+    raw_response = (
+        {
+            "arm": [[[0.1, 0.5, 0.0], [0.2, 0.5, 0.0]]],
+            "gripper": [[[0.0], [1.0]]],
+        },
+        {"latency_ms": 7.5},
+    )
+    client = FakeGrootClient(raw_response)
+    events: list[ProviderEvent] = []
+
+    def translator(_raw: object, _info: JSONDict, provider_info: JSONDict):
+        assert provider_info == {"latency_ms": 7.5}
+        return [
+            Action.move_to(0.1, 0.5, 0.0),
+            Action.move_to(0.2, 0.5, 0.0),
+        ]
+
+    provider = GrootPolicyClientProvider(
+        policy_client=client,
+        embodiment_tag="LIBERO_PANDA",
+        action_translator=translator,
+        event_handler=events.append,
+    )
+
+    report = assert_provider_contract(provider, policy_info=_policy_info())
+    result = provider.select_actions(info=_policy_info())
+
+    assert report.exercised_operations == ["policy"]
+    assert provider.profile().capabilities.policy is True
+    assert provider.profile().capabilities.predict is False
+    assert isinstance(result, ActionPolicyResult)
+    assert result.provider == "gr00t"
+    assert result.action_horizon == 2
+    assert result.embodiment_tag == "LIBERO_PANDA"
+    assert result.raw_actions["arm"] == [[[0.1, 0.5, 0.0], [0.2, 0.5, 0.0]]]
+    assert result.metadata["provider_info"] == {"latency_ms": 7.5}
+    assert client.get_action_calls[-1]["observation"] == _policy_info()["observation"]
+    assert events[-1].operation == "policy"
+    assert events[-1].phase == "success"
+
+
+def test_gr00t_policy_only_planning_uses_policy_actions(tmp_path) -> None:
+    client = FakeGrootClient(({"arm": [[[0.3, 0.5, 0.0]]]}, {}))
+    provider = GrootPolicyClientProvider(
+        policy_client=client,
+        action_translator=lambda *_args: [Action.move_to(0.3, 0.5, 0.0)],
+    )
+    forge = WorldForge(state_dir=tmp_path, auto_register_remote=False)
+    forge.register_provider(provider)
+    world = forge.create_world("robot-workcell", provider="mock")
+
+    selected = forge.select_actions("gr00t", info=_policy_info())
+    plan = world.plan(
+        goal="push the cube",
+        provider="gr00t",
+        policy_info=_policy_info(),
+        execution_provider="mock",
+    )
+    execution = world.execute_plan(plan)
+
+    assert selected.actions == [Action.move_to(0.3, 0.5, 0.0)]
+    assert plan.provider == "gr00t"
+    assert plan.actions == [Action.move_to(0.3, 0.5, 0.0)]
+    assert plan.metadata["planning_mode"] == "policy"
+    assert plan.metadata["policy_result"]["provider"] == "gr00t"
+    assert plan.success_probability == 0.5
+    assert execution.final_world().provider == "mock"
+
+
+def test_gr00t_policy_plus_score_planning_selects_scored_candidate(tmp_path) -> None:
+    candidate_plans = [
+        [Action.move_to(0.1, 0.5, 0.0)],
+        [Action.move_to(0.6, 0.5, 0.0)],
+        [Action.move_to(0.9, 0.5, 0.0)],
+    ]
+    client = FakeGrootClient(
+        (
+            {
+                "arm": [
+                    [[0.1, 0.5, 0.0]],
+                    [[0.6, 0.5, 0.0]],
+                    [[0.9, 0.5, 0.0]],
+                ]
+            },
+            {"candidate_source": "diffusion-samples"},
+        )
+    )
+    policy_provider = GrootPolicyClientProvider(
+        policy_client=client,
+        action_translator=lambda *_args: candidate_plans,
+    )
+    score_provider = FakeScoreProvider([0.9, 0.1, 0.4])
+    forge = WorldForge(state_dir=tmp_path, auto_register_remote=False)
+    forge.register_provider(policy_provider)
+    forge.register_provider(score_provider)
+    world = forge.create_world("robot-workcell", provider="mock")
+
+    plan = world.plan(
+        goal="choose the lowest world-model cost candidate",
+        provider="fake-score",
+        policy_provider="gr00t",
+        policy_info=_policy_info(),
+        score_info={"observation": [[0.0]], "goal": [[1.0]]},
+        execution_provider="mock",
+    )
+
+    assert plan.provider == "fake-score"
+    assert plan.actions == candidate_plans[1]
+    assert plan.metadata["planning_mode"] == "policy+score"
+    assert plan.metadata["policy_provider"] == "gr00t"
+    assert plan.metadata["score_provider"] == "fake-score"
+    assert plan.metadata["policy_result"]["metadata"]["candidate_count"] == 3
+    assert plan.metadata["score_result"]["best_index"] == 1
+    assert score_provider.calls[-1]["action_candidates"] == [
+        [action.to_dict() for action in candidate] for candidate in candidate_plans
+    ]
+
+
+def test_score_planning_defaults_to_serialized_action_candidates(tmp_path) -> None:
+    candidate_plans = [
+        [Action.move_to(0.1, 0.5, 0.0)],
+        [Action.move_to(0.6, 0.5, 0.0)],
+    ]
+    score_provider = FakeScoreProvider([0.7, 0.2])
+    forge = WorldForge(state_dir=tmp_path, auto_register_remote=False)
+    forge.register_provider(score_provider)
+    world = forge.create_world("robot-workcell", provider="mock")
+
+    plan = world.plan(
+        goal="choose the lowest-cost candidate",
+        provider="fake-score",
+        candidate_actions=candidate_plans,
+        score_info={"observation": [[0.0]], "goal": [[1.0]]},
+        execution_provider="mock",
+    )
+
+    assert plan.actions == candidate_plans[1]
+    assert plan.metadata["planning_mode"] == "score"
+    assert score_provider.calls[-1]["action_candidates"] == [
+        [action.to_dict() for action in candidate] for candidate in candidate_plans
+    ]
+
+
+def test_gr00t_provider_reports_unconfigured_and_failed_health(monkeypatch) -> None:
+    monkeypatch.delenv("GROOT_POLICY_HOST", raising=False)
+    missing = GrootPolicyClientProvider()
+    assert missing.configured() is False
+    assert missing.health().healthy is False
+
+    unhealthy = GrootPolicyClientProvider(
+        policy_client=FakeGrootClient(({"arm": [[[0.0, 0.0, 0.0]]]}, {}), healthy=False),
+        action_translator=lambda *_args: [Action.move_to(0.0, 0.0, 0.0)],
+    )
+    assert unhealthy.configured() is True
+    assert unhealthy.health().healthy is False
+
+
+def test_gr00t_provider_reads_env_configuration_and_reports_missing_dependency(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("GROOT_POLICY_HOST", "127.0.0.1")
+    monkeypatch.setenv("GROOT_POLICY_PORT", "7777")
+    monkeypatch.setenv("GROOT_POLICY_TIMEOUT_MS", "2000")
+    monkeypatch.setenv("GROOT_POLICY_API_TOKEN", "token")
+    monkeypatch.setenv("GROOT_POLICY_STRICT", "true")
+    monkeypatch.setenv("GROOT_EMBODIMENT_TAG", "SO100")
+
+    provider = GrootPolicyClientProvider()
+
+    assert provider.configured() is True
+    assert provider.host == "127.0.0.1"
+    assert provider.port == 7777
+    assert provider.timeout_ms == 2000
+    assert provider.api_token == "token"
+    assert provider.strict is True
+    assert provider.embodiment_tag == "SO100"
+    assert provider.health().healthy is False
+    assert "gr00t.policy.server_client" in provider.health().details
+
+
+def test_gr00t_provider_lazily_constructs_policy_client_from_import(monkeypatch) -> None:
+    created: list[dict[str, object]] = []
+
+    class ImportedPolicyClient(FakeGrootClient):
+        def __init__(self, **kwargs: object) -> None:
+            created.append(kwargs)
+            super().__init__(({"arm": FakeArray([[[0.2, 0.5, 0.0]]])}, {"ok": True}))
+
+    fake_policy_module = types.SimpleNamespace(server_client=types.SimpleNamespace())
+    fake_server_client_module = types.SimpleNamespace(PolicyClient=ImportedPolicyClient)
+    monkeypatch.setitem(sys.modules, "gr00t", types.SimpleNamespace(policy=fake_policy_module))
+    monkeypatch.setitem(sys.modules, "gr00t.policy", fake_policy_module)
+    monkeypatch.setitem(sys.modules, "gr00t.policy.server_client", fake_server_client_module)
+    provider = GrootPolicyClientProvider(
+        host="localhost",
+        port=5556,
+        timeout_ms=1234,
+        api_token="secret",
+        strict=True,
+        action_translator=lambda *_args: [Action.move_to(0.2, 0.5, 0.0)],
+    )
+
+    assert provider.health().healthy is True
+    result = provider.select_actions(info={**_policy_info(), "options": {"temperature": 0.1}})
+
+    assert created == [
+        {
+            "host": "localhost",
+            "port": 5556,
+            "timeout_ms": 1234,
+            "api_token": "secret",
+            "strict": True,
+        }
+    ]
+    assert result.raw_actions == {"arm": [[[0.2, 0.5, 0.0]]]}
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "match"),
+    [
+        ({"host": " "}, "host"),
+        ({"port": "bad"}, "port"),
+        ({"port": 0}, "port"),
+        ({"timeout_ms": 0}, "timeout_ms"),
+        ({"strict": "maybe"}, "strict"),
+        ({"strict": object()}, "strict"),
+        ({"api_token": " "}, "api_token"),
+    ],
+)
+def test_gr00t_provider_rejects_invalid_configuration(
+    kwargs: dict[str, object],
+    match: str,
+) -> None:
+    with pytest.raises(WorldForgeError, match=match):
+        GrootPolicyClientProvider(**kwargs)
+
+
+@pytest.mark.parametrize(
+    ("provider", "info", "match"),
+    [
+        (
+            GrootPolicyClientProvider(
+                policy_client=FakeGrootClient(({"arm": [[[0.0, 0.0, 0.0]]]}, {}))
+            ),
+            _policy_info(),
+            "action_translator",
+        ),
+        (
+            GrootPolicyClientProvider(
+                policy_client=FakeGrootClient(({"arm": [[[0.0, 0.0, 0.0]]]}, {})),
+                action_translator=lambda *_args: [Action.move_to(0.0, 0.0, 0.0)],
+            ),
+            {"observation": {}},
+            "at least one of video, state, or language",
+        ),
+    ],
+)
+def test_gr00t_provider_rejects_malformed_policy_inputs(
+    provider: GrootPolicyClientProvider,
+    info: JSONDict,
+    match: str,
+) -> None:
+    with pytest.raises(ProviderError, match=match):
+        provider.select_actions(info=info)
+
+
+@pytest.mark.parametrize(
+    ("response", "translator", "match"),
+    [
+        (({"arm": [[[0.0, 0.0, 0.0]]]}, {}, "extra"), lambda *_args: [Action("noop")], "tuple"),
+        ("not-a-json-object", lambda *_args: [Action("noop")], "raw_actions"),
+        (({"bad": math.nan}, {}), lambda *_args: [Action("noop")], "finite numbers"),
+        (({1: "bad-key"}, {}), lambda *_args: [Action("noop")], "keys"),
+        (({"arm": [[[0.0]]]}, "not-info"), lambda *_args: [Action("noop")], "provider_info"),
+        (({"arm": [[[0.0]]]}, {}), lambda *_args: [], "non-empty action sequence"),
+        (({"arm": [[[0.0]]]}, {}), lambda *_args: [[object()]], "Action instances"),
+    ],
+)
+def test_gr00t_provider_rejects_malformed_policy_outputs(
+    response: object,
+    translator,
+    match: str,
+) -> None:
+    provider = GrootPolicyClientProvider(
+        policy_client=FakeGrootClient(response),
+        action_translator=translator,
+    )
+
+    with pytest.raises(ProviderError, match=match):
+        provider.select_actions(info=_policy_info())
+
+
+def test_gr00t_provider_wraps_client_and_translation_failures() -> None:
+    failing_client = FakeGrootClient(({"arm": [[[0.0]]]}, {}))
+
+    def fail_get_action(_observation: object) -> object:
+        raise RuntimeError("server unavailable")
+
+    failing_client.get_action = fail_get_action  # type: ignore[method-assign]
+    provider = GrootPolicyClientProvider(
+        policy_client=failing_client,
+        action_translator=lambda *_args: [Action("noop")],
+    )
+    with pytest.raises(ProviderError, match="server unavailable"):
+        provider.select_actions(info=_policy_info())
+
+    no_get_action = GrootPolicyClientProvider(
+        policy_client=object(),
+        action_translator=lambda *_args: [Action("noop")],
+    )
+    with pytest.raises(ProviderError, match="get_action"):
+        no_get_action.select_actions(info=_policy_info())
+
+    bad_translator = GrootPolicyClientProvider(
+        policy_client=FakeGrootClient(({"arm": [[[0.0]]]}, {})),
+        action_translator=lambda *_args: (_ for _ in ()).throw(RuntimeError("bad map")),
+    )
+    with pytest.raises(ProviderError, match="bad map"):
+        bad_translator.select_actions(info=_policy_info())
+
+
+def test_policy_planning_validation_errors(tmp_path) -> None:
+    forge = WorldForge(state_dir=tmp_path, auto_register_remote=False)
+    forge.register_provider(MockProvider(name="manual-mock"))
+    world = forge.create_world("robot-workcell", provider="manual-mock")
+
+    with pytest.raises(WorldForgeError, match="does not support policy planning"):
+        world.plan(goal="move", provider="manual-mock", policy_info=_policy_info())
+
+    policy_provider = GrootPolicyClientProvider(
+        policy_client=FakeGrootClient(({"arm": [[[0.0, 0.0, 0.0]]]}, {})),
+        action_translator=lambda *_args: [Action.move_to(0.0, 0.0, 0.0)],
+    )
+    forge.register_provider(policy_provider)
+    with pytest.raises(WorldForgeError, match="Policy planning requires policy_info"):
+        world.plan(goal="move", provider="gr00t", policy_provider="gr00t")
+
+    forge.register_provider(FakeScoreProvider([0.2]))
+    with pytest.raises(WorldForgeError, match="score_info"):
+        world.plan(
+            goal="move",
+            provider="gr00t",
+            policy_info=_policy_info(),
+            score_provider="fake-score",
+        )

--- a/tests/test_helper_validations.py
+++ b/tests/test_helper_validations.py
@@ -8,6 +8,7 @@ import pytest
 
 from worldforge import (
     Action,
+    ActionPolicyResult,
     BBox,
     EmbeddingResult,
     GenerationOptions,
@@ -156,6 +157,33 @@ def test_public_models_reject_non_finite_and_incoherent_values(tmp_path) -> None
 
     with pytest.raises(WorldForgeError, match="speed"):
         Action.move_to(0.0, 0.0, 0.0, speed=0.0)
+
+    policy_result = ActionPolicyResult(
+        provider="policy",
+        actions=[Action.move_to(0.1, 0.5, 0.0)],
+        raw_actions={"arm": [[[0.1, 0.5, 0.0]]]},
+        action_horizon=1,
+        embodiment_tag="TEST",
+    )
+    assert policy_result.action_candidates == [[Action.move_to(0.1, 0.5, 0.0)]]
+    assert policy_result.to_dict()["embodiment_tag"] == "TEST"
+
+    with pytest.raises(WorldForgeError, match="actions"):
+        ActionPolicyResult(provider="policy", actions=[])
+
+    with pytest.raises(WorldForgeError, match="raw_actions"):
+        ActionPolicyResult(
+            provider="policy",
+            actions=[Action.move_to(0.1, 0.5, 0.0)],
+            raw_actions=[],  # type: ignore[arg-type]
+        )
+
+    with pytest.raises(WorldForgeError, match="action_horizon"):
+        ActionPolicyResult(
+            provider="policy",
+            actions=[Action.move_to(0.1, 0.5, 0.0)],
+            action_horizon=0,
+        )
 
     with pytest.raises(WorldForgeError, match="GenerationOptions fps"):
         GenerationOptions(fps=math.inf)

--- a/tests/test_provider_profiles.py
+++ b/tests/test_provider_profiles.py
@@ -13,6 +13,12 @@ def test_provider_profiles_and_doctor_report_include_known_scaffolds(tmp_path, m
         "LEWM_POLICY",
         "LEWORLDMODEL_CACHE_DIR",
         "LEWORLDMODEL_DEVICE",
+        "GROOT_POLICY_HOST",
+        "GROOT_POLICY_PORT",
+        "GROOT_POLICY_TIMEOUT_MS",
+        "GROOT_POLICY_API_TOKEN",
+        "GROOT_POLICY_STRICT",
+        "GROOT_EMBODIMENT_TAG",
         "JEPA_MODEL_PATH",
         "GENIE_API_KEY",
     ):
@@ -27,7 +33,9 @@ def test_provider_profiles_and_doctor_report_include_known_scaffolds(tmp_path, m
     assert registered_profiles["mock"].request_policy is None
 
     builtin_profiles = {profile.name: profile for profile in forge.builtin_provider_profiles()}
-    assert {"mock", "cosmos", "runway", "leworldmodel", "jepa", "genie"} <= set(builtin_profiles)
+    assert {"mock", "cosmos", "runway", "leworldmodel", "gr00t", "jepa", "genie"} <= set(
+        builtin_profiles
+    )
     assert builtin_profiles["cosmos"].implementation_status == "beta"
     assert builtin_profiles["cosmos"].required_env_vars == ["COSMOS_BASE_URL"]
     assert builtin_profiles["cosmos"].request_policy is not None
@@ -46,6 +54,10 @@ def test_provider_profiles_and_doctor_report_include_known_scaffolds(tmp_path, m
         "LEWORLDMODEL_POLICY",
         "LEWM_POLICY",
     ]
+    assert builtin_profiles["gr00t"].implementation_status == "experimental"
+    assert builtin_profiles["gr00t"].capabilities.policy is True
+    assert builtin_profiles["gr00t"].capabilities.predict is False
+    assert builtin_profiles["gr00t"].required_env_vars == ["GROOT_POLICY_HOST"]
 
     report = forge.doctor()
     assert isinstance(report, DoctorReport)

--- a/tests/test_provider_scaffold_script.py
+++ b/tests/test_provider_scaffold_script.py
@@ -23,6 +23,8 @@ def test_scaffold_provider_script_generates_safe_adapter_files(tmp_path: Path) -
             "score",
             "--planned-capability",
             "generate",
+            "--planned-capability",
+            "policy",
             "--remote",
             "--env-var",
             "ACME_WM_API_KEY",
@@ -48,7 +50,7 @@ def test_scaffold_provider_script_generates_safe_adapter_files(tmp_path: Path) -
     provider_source = provider_path.read_text(encoding="utf-8")
     assert "class AcmeWMProvider(BaseProvider)" in provider_source
     assert "capabilities=ProviderCapabilities(predict=False)" in provider_source
-    assert "planned_capabilities = ('score', 'generate')" in provider_source
+    assert "planned_capabilities = ('score', 'generate', 'policy')" in provider_source
     assert 'ACME_WM_ENV_VAR = "ACME_WM_API_KEY"' in provider_source
     assert "healthy=False" in provider_source
     assert "no runtime adapter implemented" in provider_source
@@ -56,11 +58,13 @@ def test_scaffold_provider_script_generates_safe_adapter_files(tmp_path: Path) -
     test_source = test_path.read_text(encoding="utf-8")
     assert "score_actions_is_not_implemented_yet" in test_source
     assert "generate_is_not_implemented_yet" in test_source
+    assert "select_actions_is_not_implemented_yet" in test_source
     assert "profile.supported_tasks == []" in test_source
 
     docs_source = docs_path.read_text(encoding="utf-8")
     assert "Taxonomy category: JEPA latent predictive world model" in docs_source
     assert "`score` implemented, advertised, and tested" in docs_source
+    assert "`policy` implemented, advertised, and tested" in docs_source
 
     py_compile.compile(str(provider_path), doraise=True)
     py_compile.compile(str(test_path), doraise=True)

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -3,11 +3,12 @@ from __future__ import annotations
 import worldforge
 import worldforge.observability as observability
 from worldforge.evaluation import EvaluationSuite
-from worldforge.providers import MockProvider
+from worldforge.providers import GrootPolicyClientProvider, MockProvider
 
 
 def test_top_level_exports_and_subpackages_import() -> None:
     assert worldforge.__version__
+    assert worldforge.ActionPolicyResult is not None
     assert worldforge.ActionScoreResult is not None
     assert worldforge.BenchmarkInputs is not None
     assert worldforge.BenchmarkReport is not None
@@ -29,6 +30,7 @@ def test_top_level_exports_and_subpackages_import() -> None:
     assert worldforge.PlanningEvaluationSuite is not None
     assert worldforge.ReasoningEvaluationSuite is not None
     assert MockProvider is not None
+    assert GrootPolicyClientProvider is not None
     assert observability.JsonLoggerSink is not None
     assert observability.InMemoryRecorderSink is not None
     assert observability.ProviderMetricsSink is not None


### PR DESCRIPTION
## Summary

Adds NVIDIA Isaac GR00T as a first-class embodied policy provider while keeping it distinct from predictive world-model providers. The new provider wraps the host-owned GR00T PolicyClient boundary, validates policy observations and raw action payloads, requires host-owned embodiment translation, and returns typed `ActionPolicyResult` objects.

The planning surface now supports policy-only and policy-plus-score workflows: GR00T can propose executable action chunks, and a score provider such as LeWorldModel or JEPA-WMS can rank candidate plans. Score planning now defaults to serialized WorldForge action candidates when no provider-native tensor payload is supplied.

Documentation was updated to place GR00T in the world-model taxonomy as an embodied VLA policy/action model, add provider authoring guidance for policy adapters, and document the new public API and architecture flow.

## Validation

- `uv run ruff check src tests examples scripts`
- `uv run ruff format --check src tests examples scripts`
- `uv run pytest --cov=src/worldforge --cov-report=term-missing --cov-fail-under=90` (`130 passed`, coverage `90.20%`)
- `git diff --check`
- `uv run python -m py_compile $(rg --files -g '*.py' src tests examples scripts)`
- `bash scripts/test_package.sh` (`130 passed` from installed wheel)

## Notes

Live GR00T policy-server smoke requires a running GR00T policy server, `GROOT_POLICY_HOST`, and a real embodiment translator supplied by the host application.