### PR TITLE
[codex] Add GR00T live smoke script

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,6 +139,9 @@ rm -f "$tmp_req"
 - `scripts/smoke_leworldmodel.py` is an optional real-checkpoint smoke. Run it from an isolated
   Python 3.10 environment with the upstream GitHub `stable-worldmodel[train,env]` runtime; do not
   add those dependencies to WorldForge's base package.
+- `scripts/smoke_gr00t_policy.py` is an optional live PolicyClient smoke. It may launch
+  `gr00t/eval/run_gr00t_server.py` from a host-owned Isaac-GR00T checkout, but it still requires
+  the host to provide real observations and an embodiment-specific action translator.
 - `JEPA_WMS_MODEL_PATH`, `JEPA_WMS_MODEL_NAME`, and `JEPA_WMS_DEVICE` are documented by the
   `jepa-wms` candidate only. They do not make `JEPAWMSProvider` available through `WorldForge`;
   direct tests must inject `runtime=` or use `JEPAWMSProvider.from_torch_hub(...)`.

--- a/README.md
+++ b/README.md
@@ -226,6 +226,11 @@ Use `scripts/smoke_leworldmodel.py` from an isolated environment with the upstre
 `stable-worldmodel[train,env]` runtime to download the public `quentinll/lewm-pusht` weights,
 prepare the object checkpoint, and run a real `score_actions(...)` smoke.
 
+GR00T is a host-owned live policy integration. Run `scripts/smoke_gr00t_policy.py` from an
+environment that can import Isaac-GR00T and reach a policy server. The script can launch
+`gr00t/eval/run_gr00t_server.py` from a local Isaac-GR00T checkout with `--start-server`, but the
+host must supply real policy observations and an embodiment-specific action translator.
+
 ## Development
 
 Primary commands:

--- a/docs/src/operations.md
+++ b/docs/src/operations.md
@@ -94,6 +94,11 @@ include those IDs in surrounding application logs.
 - To smoke-test a real LeWorldModel checkpoint, install the upstream
   `stable-worldmodel[train,env]` runtime in an isolated environment and run
   `python scripts/smoke_leworldmodel.py --stablewm-home /path/to/stablewm-home`.
+- To smoke-test a real GR00T policy server, install or check out NVIDIA Isaac-GR00T, prepare a
+  host-specific observation factory and action translator, then run
+  `python scripts/smoke_gr00t_policy.py --gr00t-root /path/to/Isaac-GR00T --start-server ...`.
+  The script can also connect to an existing server with `GROOT_POLICY_HOST` and
+  `--policy-info-json` or `--observation-module`.
 
 ## Release Checklist
 

--- a/docs/src/providers/README.md
+++ b/docs/src/providers/README.md
@@ -177,3 +177,6 @@ GR00T:
   `language`.
 - A host-supplied `action_translator` maps GR00T's embodiment-specific raw actions to WorldForge
   `Action` objects.
+- `scripts/smoke_gr00t_policy.py` can connect to an existing policy server or launch
+  `gr00t/eval/run_gr00t_server.py` from a local Isaac-GR00T checkout for a live PolicyClient
+  smoke.

--- a/docs/src/providers/gr00t.md
+++ b/docs/src/providers/gr00t.md
@@ -170,6 +170,39 @@ the score provider. If the scorer needs native tensors or latents, pass
 `score_action_candidates=...`; WorldForge only requires that the number of policy candidates and
 native score candidates describe the same candidate set.
 
+## Live Smoke
+
+Use `scripts/smoke_gr00t_policy.py` for a real PolicyClient smoke. The script can either connect
+to a server that is already running or launch the upstream GR00T server from an Isaac-GR00T
+checkout.
+
+Connect to an existing server:
+
+```bash
+GROOT_POLICY_HOST=127.0.0.1 \
+GROOT_POLICY_PORT=5555 \
+uv run python scripts/smoke_gr00t_policy.py \
+  --policy-info-json /path/to/policy_info.json \
+  --translator /path/to/translator.py:translate_actions
+```
+
+Launch the upstream server first, then run the smoke:
+
+```bash
+uv run python scripts/smoke_gr00t_policy.py \
+  --start-server \
+  --gr00t-root /path/to/Isaac-GR00T \
+  --model-path nvidia/GR00T-N1.6-3B \
+  --embodiment-tag GR1 \
+  --policy-info-json /path/to/policy_info.json \
+  --translator /path/to/translator.py:translate_actions
+```
+
+The translator callable receives `(raw_actions, info, provider_info)` and must return either a
+single WorldForge action chunk or multiple candidate chunks. Use `--observation-module
+module_or_file:function` when observations need NumPy arrays or host-side preprocessing that JSON
+cannot represent cleanly.
+
 ## Failure Modes
 
 - Missing `GROOT_POLICY_HOST` leaves the auto-registered provider unavailable.

--- a/scripts/smoke_gr00t_policy.py
+++ b/scripts/smoke_gr00t_policy.py
@@ -1,0 +1,353 @@
+#!/usr/bin/env python
+"""Run a live NVIDIA Isaac GR00T policy smoke through WorldForge."""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+import time
+from collections.abc import Callable
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+from worldforge.models import JSONDict
+from worldforge.providers import GrootPolicyClientProvider
+
+DEFAULT_MODEL_PATH = "nvidia/GR00T-N1.6-3B"
+DEFAULT_EMBODIMENT_TAG = "GR1"
+DEFAULT_HOST = "127.0.0.1"
+DEFAULT_PORT = 5555
+DEFAULT_TIMEOUT_MS = 15_000
+DEFAULT_STARTUP_TIMEOUT_SECONDS = 300.0
+
+
+def _env_int(name: str, default: int) -> int:
+    raw = os.environ.get(name)
+    if raw is None or not raw.strip():
+        return default
+    try:
+        value = int(raw)
+    except ValueError as exc:
+        raise SystemExit(f"{name} must be an integer.") from exc
+    if value <= 0:
+        raise SystemExit(f"{name} must be greater than 0.")
+    return value
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    raw = os.environ.get(name)
+    if raw is None or not raw.strip():
+        return default
+    normalized = raw.strip().lower()
+    if normalized in {"1", "true", "yes", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "off"}:
+        return False
+    raise SystemExit(f"{name} must be a boolean.")
+
+
+def _load_json_file(path: Path, *, name: str) -> JSONDict:
+    try:
+        payload = json.loads(path.expanduser().read_text())
+    except FileNotFoundError as exc:
+        raise SystemExit(f"{name} file does not exist: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"{name} file is not valid JSON: {path}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise SystemExit(f"{name} must decode to a JSON object.")
+    return payload
+
+
+def _module_from_path(path: Path) -> ModuleType:
+    resolved = path.expanduser().resolve()
+    if not resolved.exists():
+        raise SystemExit(f"Python module file does not exist: {path}")
+    module_spec = importlib.util.spec_from_file_location(resolved.stem, resolved)
+    if module_spec is None or module_spec.loader is None:
+        raise SystemExit(f"Could not load Python module from: {path}")
+    module = importlib.util.module_from_spec(module_spec)
+    module_spec.loader.exec_module(module)
+    return module
+
+
+def _load_callable(spec: str, *, name: str) -> Callable[..., Any]:
+    if ":" not in spec:
+        raise SystemExit(f"{name} must be formatted as module_or_file:function.")
+    module_ref, function_name = spec.rsplit(":", 1)
+    if not module_ref.strip() or not function_name.strip():
+        raise SystemExit(f"{name} must be formatted as module_or_file:function.")
+
+    candidate_path = Path(module_ref)
+    if candidate_path.exists() or module_ref.endswith(".py") or "/" in module_ref:
+        module = _module_from_path(candidate_path)
+    else:
+        try:
+            module = importlib.import_module(module_ref)
+        except ImportError as exc:
+            raise SystemExit(f"Could not import {name} module '{module_ref}': {exc}") from exc
+
+    try:
+        loaded = getattr(module, function_name)
+    except AttributeError as exc:
+        raise SystemExit(f"{name} function '{function_name}' was not found.") from exc
+    if not callable(loaded):
+        raise SystemExit(f"{name} target '{function_name}' is not callable.")
+    return loaded
+
+
+def _load_policy_info(args: argparse.Namespace) -> JSONDict:
+    if args.policy_info_json is not None:
+        info = _load_json_file(args.policy_info_json, name="policy-info")
+    elif args.observation_json is not None:
+        info = {
+            "observation": _load_json_file(args.observation_json, name="observation"),
+        }
+    elif args.observation_module is not None:
+        factory = _load_callable(args.observation_module, name="observation factory")
+        try:
+            produced = factory()
+        except Exception as exc:
+            raise SystemExit(f"Observation factory failed: {exc}") from exc
+        if not isinstance(produced, dict):
+            raise SystemExit("Observation factory must return a dictionary.")
+        info = dict(produced) if "observation" in produced else {"observation": dict(produced)}
+    else:
+        raise SystemExit(
+            "Live policy smoke requires --policy-info-json, --observation-json, "
+            "or --observation-module."
+        )
+
+    if args.options_json is not None:
+        info["options"] = _load_json_file(args.options_json, name="options")
+    if args.embodiment_tag is not None:
+        info.setdefault("embodiment_tag", args.embodiment_tag)
+    if args.action_horizon is not None:
+        info["action_horizon"] = args.action_horizon
+    return info
+
+
+def _server_module_available() -> bool:
+    try:
+        return importlib.util.find_spec("gr00t.eval.run_gr00t_server") is not None
+    except ModuleNotFoundError:
+        return False
+
+
+def _server_command(args: argparse.Namespace) -> tuple[list[str], Path | None]:
+    command_prefix: list[str]
+    cwd: Path | None = None
+    if args.gr00t_root is not None:
+        root = args.gr00t_root.expanduser().resolve()
+        server_script = root / "gr00t" / "eval" / "run_gr00t_server.py"
+        if not server_script.exists():
+            raise SystemExit(
+                "--gr00t-root must point at an Isaac-GR00T checkout containing "
+                "gr00t/eval/run_gr00t_server.py."
+            )
+        if str(root) not in sys.path:
+            sys.path.insert(0, str(root))
+        command_prefix = ["uv", "run", "python", "gr00t/eval/run_gr00t_server.py"]
+        cwd = root
+    elif _server_module_available():
+        command_prefix = [sys.executable, "-m", "gr00t.eval.run_gr00t_server"]
+    else:
+        raise SystemExit(
+            "Cannot start GR00T policy server: provide --gr00t-root pointing to an "
+            "Isaac-GR00T checkout, or run this script in an environment where "
+            "gr00t.eval.run_gr00t_server is importable."
+        )
+
+    model_path = args.model_path or DEFAULT_MODEL_PATH
+    embodiment_tag = args.embodiment_tag or DEFAULT_EMBODIMENT_TAG
+    command = [
+        *command_prefix,
+        "--embodiment-tag",
+        embodiment_tag,
+        "--host",
+        args.server_host,
+        "--port",
+        str(args.port),
+    ]
+    if args.dataset_path is not None:
+        command.extend(["--dataset-path", args.dataset_path])
+    else:
+        command.extend(["--model-path", model_path])
+    if args.device is not None:
+        command.extend(["--device", args.device])
+    command.extend(args.server_arg or [])
+    return command, cwd
+
+
+def _start_server(args: argparse.Namespace) -> subprocess.Popen[bytes] | None:
+    if not args.start_server:
+        return None
+    command, cwd = _server_command(args)
+    print("Starting GR00T policy server:", " ".join(command), file=sys.stderr)
+    return subprocess.Popen(command, cwd=str(cwd) if cwd is not None else None)
+
+
+def _wait_for_health(
+    provider: GrootPolicyClientProvider,
+    *,
+    process: subprocess.Popen[bytes] | None,
+    timeout_seconds: float,
+) -> JSONDict:
+    deadline = time.monotonic() + timeout_seconds
+    last_health = provider.health()
+    while time.monotonic() < deadline:
+        if process is not None and process.poll() is not None:
+            raise SystemExit(f"GR00T policy server exited early with code {process.returncode}.")
+        last_health = provider.health()
+        if last_health.healthy:
+            return last_health.to_dict()
+        time.sleep(2.0)
+    raise SystemExit(
+        "GR00T policy server did not become healthy before timeout. "
+        f"Last health details: {last_health.details}"
+    )
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--host", default=os.environ.get("GROOT_POLICY_HOST", DEFAULT_HOST))
+    parser.add_argument("--port", type=int, default=_env_int("GROOT_POLICY_PORT", DEFAULT_PORT))
+    parser.add_argument(
+        "--timeout-ms",
+        type=int,
+        default=_env_int("GROOT_POLICY_TIMEOUT_MS", DEFAULT_TIMEOUT_MS),
+    )
+    parser.add_argument("--api-token", default=os.environ.get("GROOT_POLICY_API_TOKEN"))
+    parser.add_argument(
+        "--strict",
+        action=argparse.BooleanOptionalAction,
+        default=_env_bool("GROOT_POLICY_STRICT", False),
+    )
+    parser.add_argument("--embodiment-tag", default=os.environ.get("GROOT_EMBODIMENT_TAG"))
+    parser.add_argument("--action-horizon", type=int, default=None)
+    parser.add_argument("--health-only", action="store_true")
+
+    input_group = parser.add_mutually_exclusive_group()
+    input_group.add_argument(
+        "--policy-info-json",
+        type=Path,
+        help="JSON file containing the full WorldForge policy_info object.",
+    )
+    input_group.add_argument(
+        "--observation-json",
+        type=Path,
+        help="JSON file containing only the GR00T observation object.",
+    )
+    input_group.add_argument(
+        "--observation-module",
+        help=(
+            "Python factory formatted as module_or_file:function. Returns observation or "
+            "policy_info."
+        ),
+    )
+    parser.add_argument(
+        "--translator",
+        help=(
+            "Python action translator formatted as module_or_file:function. The callable receives "
+            "(raw_actions, info, provider_info) and returns WorldForge Action objects."
+        ),
+    )
+    parser.add_argument(
+        "--options-json", type=Path, help="Optional JSON file passed as info.options."
+    )
+
+    parser.add_argument("--start-server", action="store_true")
+    parser.add_argument(
+        "--gr00t-root",
+        type=Path,
+        default=Path(os.environ["GROOT_REPO"]) if os.environ.get("GROOT_REPO") else None,
+        help="Isaac-GR00T checkout used to launch gr00t/eval/run_gr00t_server.py.",
+    )
+    parser.add_argument("--model-path", default=os.environ.get("GROOT_MODEL_PATH"))
+    parser.add_argument("--dataset-path", default=os.environ.get("GROOT_DATASET_PATH"))
+    parser.add_argument("--device", default=os.environ.get("GROOT_POLICY_DEVICE", "cuda:0"))
+    parser.add_argument(
+        "--server-host",
+        default=os.environ.get("GROOT_POLICY_BIND_HOST", DEFAULT_HOST),
+        help="Bind host passed to the launched GR00T server.",
+    )
+    parser.add_argument(
+        "--startup-timeout-seconds",
+        type=float,
+        default=DEFAULT_STARTUP_TIMEOUT_SECONDS,
+    )
+    parser.add_argument(
+        "--server-arg",
+        action="append",
+        default=[],
+        help="Extra argument forwarded to run_gr00t_server.py. Repeat as needed.",
+    )
+    parser.add_argument("--leave-server-running", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    if args.gr00t_root is not None:
+        root = args.gr00t_root.expanduser().resolve()
+        if str(root) not in sys.path:
+            sys.path.insert(0, str(root))
+    if args.timeout_ms <= 0:
+        raise SystemExit("--timeout-ms must be greater than 0.")
+    if args.port <= 0:
+        raise SystemExit("--port must be greater than 0.")
+    if args.action_horizon is not None and args.action_horizon <= 0:
+        raise SystemExit("--action-horizon must be greater than 0.")
+    if not args.health_only and args.translator is None:
+        raise SystemExit("--translator is required unless --health-only is set.")
+
+    translator = (
+        None if args.translator is None else _load_callable(args.translator, name="translator")
+    )
+    provider = GrootPolicyClientProvider(
+        host=args.host,
+        port=args.port,
+        timeout_ms=args.timeout_ms,
+        api_token=args.api_token,
+        strict=args.strict,
+        embodiment_tag=args.embodiment_tag,
+        action_translator=translator,
+    )
+
+    process = _start_server(args)
+    try:
+        if process is not None:
+            health_payload = _wait_for_health(
+                provider,
+                process=process,
+                timeout_seconds=args.startup_timeout_seconds,
+            )
+        else:
+            health = provider.health()
+            health_payload = health.to_dict()
+            if not health.healthy:
+                raise SystemExit(f"GR00T provider is not healthy: {health.details}")
+
+        output: JSONDict = {"health": health_payload}
+        if not args.health_only:
+            result = provider.select_actions(info=_load_policy_info(args))
+            output["result"] = result.to_dict()
+        print(json.dumps(output, indent=2, sort_keys=True))
+        return 0
+    finally:
+        if process is not None and not args.leave_server_running and process.poll() is None:
+            process.terminate()
+            try:
+                process.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.wait()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_gr00t_smoke_script.py
+++ b/tests/test_gr00t_smoke_script.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+
+def _load_script() -> ModuleType:
+    script_path = Path(__file__).resolve().parents[1] / "scripts" / "smoke_gr00t_policy.py"
+    spec = importlib.util.spec_from_file_location("smoke_gr00t_policy", script_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _args(**overrides: object) -> argparse.Namespace:
+    defaults = {
+        "policy_info_json": None,
+        "observation_json": None,
+        "observation_module": None,
+        "options_json": None,
+        "embodiment_tag": None,
+        "action_horizon": None,
+        "gr00t_root": None,
+        "model_path": None,
+        "dataset_path": None,
+        "host": "127.0.0.1",
+        "port": 5555,
+        "device": "cuda:0",
+        "server_host": "127.0.0.1",
+        "server_arg": [],
+    }
+    defaults.update(overrides)
+    return argparse.Namespace(**defaults)
+
+
+def test_smoke_script_loads_file_callables(tmp_path: Path) -> None:
+    module_path = tmp_path / "translator.py"
+    module_path.write_text(
+        "def translate(raw_actions, info, provider_info):\n"
+        "    return (raw_actions, info, provider_info)\n"
+    )
+    script = _load_script()
+
+    loaded = script._load_callable(f"{module_path}:translate", name="translator")
+
+    assert loaded({"arm": []}, {"observation": {}}, {}) == (
+        {"arm": []},
+        {"observation": {}},
+        {},
+    )
+
+
+def test_smoke_script_builds_policy_info_from_json_files(tmp_path: Path) -> None:
+    policy_path = tmp_path / "policy.json"
+    options_path = tmp_path / "options.json"
+    policy_path.write_text(
+        json.dumps(
+            {
+                "observation": {
+                    "language": {"task": [["pick up the cube"]]},
+                }
+            }
+        )
+    )
+    options_path.write_text(json.dumps({"episode_index": 2}))
+    script = _load_script()
+
+    info = script._load_policy_info(
+        _args(
+            policy_info_json=policy_path,
+            options_json=options_path,
+            embodiment_tag="GR1",
+            action_horizon=8,
+        )
+    )
+
+    assert info == {
+        "observation": {"language": {"task": [["pick up the cube"]]}},
+        "options": {"episode_index": 2},
+        "embodiment_tag": "GR1",
+        "action_horizon": 8,
+    }
+
+
+def test_smoke_script_builds_policy_info_from_observation_factory(tmp_path: Path) -> None:
+    module_path = tmp_path / "observation.py"
+    module_path.write_text(
+        "def build():\n    return {'language': {'task': [['open the drawer']]}}\n"
+    )
+    script = _load_script()
+
+    info = script._load_policy_info(_args(observation_module=f"{module_path}:build"))
+
+    assert info == {
+        "observation": {
+            "language": {"task": [["open the drawer"]]},
+        }
+    }
+
+
+def test_smoke_script_rejects_missing_server_checkout(tmp_path: Path) -> None:
+    script = _load_script()
+
+    with pytest.raises(SystemExit, match="Isaac-GR00T checkout"):
+        script._server_command(_args(gr00t_root=tmp_path))


### PR DESCRIPTION
## Summary

Adds `scripts/smoke_gr00t_policy.py`, a live NVIDIA Isaac GR00T PolicyClient smoke that can either connect to an already running policy server or launch `gr00t/eval/run_gr00t_server.py` from a host-owned Isaac-GR00T checkout.

The script supports full `policy_info` JSON, observation-only JSON, or a Python observation factory for NumPy/tensor-style host preprocessing. It requires a translator callable for real action selection because GR00T raw actions are embodiment-specific and WorldForge should not guess robot semantics.

Docs now point operators to the new smoke path from the GR00T provider page, operations guide, README, and agent context.

## Validation

- `uv run ruff check src tests examples scripts`
- `uv run ruff format --check src tests examples scripts`
- `uv run pytest tests/test_gr00t_smoke_script.py tests/test_gr00t_provider.py` (`29 passed`)
- `uv run pytest --cov=src/worldforge --cov-report=term-missing --cov-fail-under=90` (`134 passed`, coverage `90.20%`)
- `git diff --check`
- `uv run python -m py_compile $(rg --files -g '*.py' src tests examples scripts)`
- `bash scripts/test_package.sh` (`134 passed` from installed wheel)

## Live Smoke Attempt

- `uv run python scripts/smoke_gr00t_policy.py --health-only` failed as expected on this host with `missing optional dependency gr00t.policy.server_client`.
- `uv run python scripts/smoke_gr00t_policy.py --start-server --health-only --model-path nvidia/GR00T-N1.6-3B --embodiment-tag GR1` failed as expected on this host because no Isaac-GR00T checkout or importable `gr00t.eval.run_gr00t_server` module is available.

This confirms the script produces actionable preflight failures without pretending a live GR00T runtime is present.