### PR TITLE
Add LeRobot policy provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ releases may still include breaking changes when the public API needs to tighten
 
 ### Added
 
+- Added `lerobot` as a first-class optional policy provider for Hugging Face LeRobot
+  pretrained policies (ACT, Diffusion, TDMPC, VQBet, Pi0, Pi0Fast, SAC, SmolVLA). The
+  adapter lazily imports `lerobot.policies.pretrained.PreTrainedPolicy`, supports injectable
+  policies and policy loaders for offline testing, validates observation payloads, preserves
+  raw policy tensors, and requires a host-owned action translator before returning executable
+  WorldForge actions. Ships with policy-only and policy+score planning support,
+  auto-registration when `LEROBOT_POLICY_PATH` (or `LEROBOT_POLICY`) is set, contract tests,
+  a full end-to-end demo at `examples/lerobot_e2e_demo.py`, and a real-checkpoint live smoke
+  script at `scripts/smoke_lerobot_policy.py`.
 - Added `leworldmodel` as a first-class optional provider for LeWorldModel JEPA cost models,
   including the `score` capability, `ActionScoreResult`, `WorldForge.score_actions(...)`, typed
   input validation, score-output validation, provider profile metadata, and fixture-driven tests.

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Module responsibilities:
 | `src/worldforge/models.py` | Typed domain models, serialization helpers, and framework-level validation errors |
 | `src/worldforge/framework.py` | `WorldForge`, `World`, persistence, planning, prediction, comparison, and diagnostics |
 | `src/worldforge/observability.py` | Composable `ProviderEvent` sinks for JSON logging, in-memory recording, and metrics aggregation |
-| `src/worldforge/providers/` | Provider primitives plus `mock`, `cosmos`, `runway`, `leworldmodel`, `gr00t`, `jepa`, and `genie` adapters |
+| `src/worldforge/providers/` | Provider primitives plus `mock`, `cosmos`, `runway`, `leworldmodel`, `gr00t`, `lerobot`, `jepa`, and `genie` adapters |
 | `src/worldforge/evaluation/` | Built-in evaluation suites and report rendering |
 | `src/worldforge/testing/` | Reusable provider contract assertions for adapter packages |
 | `tests/` | Framework, CLI, packaging, and adapter regression coverage |
@@ -210,6 +210,7 @@ More detail lives in [docs/src/world-model-taxonomy.md](./docs/src/world-model-t
 | `runway` | beta | auto-registers when `RUNWAYML_API_SECRET` or `RUNWAY_API_SECRET` is set | real HTTP adapter for Runway image-to-video and video-to-video APIs |
 | `leworldmodel` | beta | auto-registers when `LEWORLDMODEL_POLICY` or `LEWM_POLICY` is set | real optional adapter for LeWorldModel JEPA cost models via `stable_worldmodel.policy.AutoCostModel`; scores action candidates with lower cost as better |
 | `gr00t` | experimental | auto-registers when `GROOT_POLICY_HOST` is set | host-owned NVIDIA Isaac GR00T PolicyClient adapter for embodied action selection; exposes `policy`, not predictive world-model capabilities |
+| `lerobot` | beta | auto-registers when `LEROBOT_POLICY_PATH` or `LEROBOT_POLICY` is set | host-owned Hugging Face LeRobot `PreTrainedPolicy` adapter for embodied action selection (ACT, Diffusion, TDMPC, VQBet, Pi0, SmolVLA, ...); exposes `policy` |
 | `jepa` | scaffold | auto-registers when `JEPA_MODEL_PATH` is set | credential-gated stub backed by deterministic mock behavior |
 | `genie` | scaffold | auto-registers when `GENIE_API_KEY` is set | credential-gated stub backed by deterministic mock behavior |
 
@@ -270,6 +271,55 @@ The demo's `predicted_states` list is empty by design: a score provider ranks ca
 it does not mutate the world or emit generated video/world-state rollouts. Execution remains a
 separate provider step.
 
+LeRobot is a host-owned live policy integration. Install
+[`lerobot`](https://github.com/huggingface/lerobot) in the host environment and set
+`LEROBOT_POLICY_PATH` (or `LEROBOT_POLICY`) to a Hugging Face repo id or local checkpoint
+directory, for example `lerobot/act_aloha_sim_transfer_cube_human`. LeRobot is an
+action-policy provider: observations (state, camera images, task language) go in, raw robot
+action tensors come out. WorldForge cannot infer what those tensors mean for a given robot, so
+a host-supplied `action_translator` maps them into WorldForge `Action` objects. The adapter
+lazily imports `lerobot.policies.pretrained.PreTrainedPolicy` only when a non-injected policy
+is loaded, so a clean WorldForge install does not pull in LeRobot, PyTorch, or robot runtime
+dependencies.
+
+For a checkout-safe end-to-end walkthrough that does not need `lerobot` or checkpoints, run
+`uv run python examples/lerobot_e2e_demo.py`. It wires the real `LeRobotPolicyProvider` to a
+deterministic fake policy, then demonstrates provider registration, candidate action
+proposal, score-based candidate selection, mock execution, JSON persistence, and reload
+through the real WorldForge policy+score planning pipeline. Use
+`scripts/smoke_lerobot_policy.py` for the real-checkpoint path.
+
+Concretely, the demo:
+
+1. Registers the real `LeRobotPolicyProvider` next to the local `mock` execution provider and
+   a tiny deterministic distance-to-goal score provider.
+2. Creates a small world with one `blue_cube` and an `object_at` goal.
+3. Calls `WorldForge.select_actions("lerobot", info=...)` to get three candidate two-step
+   action chunks from the injected policy through the host-supplied translator.
+4. Calls `World.plan(..., policy_provider="lerobot", score_provider=..., policy_info=...)`,
+   which ranks the policy's candidates by distance to the goal and picks the best one.
+5. Executes the selected WorldForge actions through `execution_provider="mock"`, saves the
+   final world, reloads it from disk, and reports the final cube position.
+
+```bash
+uv run python examples/lerobot_e2e_demo.py
+```
+
+Real-checkpoint path:
+
+```bash
+uv venv --python=3.10 .venv-lerobot
+source .venv-lerobot/bin/activate
+uv pip install -e .
+uv pip install "lerobot[aloha]"
+
+python scripts/smoke_lerobot_policy.py \
+  --policy-path lerobot/act_aloha_sim_transfer_cube_human \
+  --observation-module /path/to/obs.py:build_observation \
+  --translator /path/to/translator.py:translate_actions \
+  --device cpu
+```
+
 GR00T is a host-owned live policy integration. Run `scripts/smoke_gr00t_policy.py` from an
 environment that can import Isaac-GR00T and reach a policy server. The script can launch
 `gr00t/eval/run_gr00t_server.py` from a local Isaac-GR00T checkout with `--start-server`, but the
@@ -326,6 +376,10 @@ See [AGENTS.md](./AGENTS.md) for repository context used by AI-assisted and firs
 - `gr00t` is a real optional policy-client adapter, but live execution requires a host-owned
   Isaac-GR00T runtime, reachable policy server, compatible NVIDIA CUDA/TensorRT environment when
   launching the upstream server, real observations, and an embodiment-specific action translator.
+- `lerobot` is a real optional policy-client adapter, but live execution requires `lerobot`
+  and its robot or simulation dependencies installed in the host environment, a Hugging Face
+  repo id or local checkpoint path, real observations, and an embodiment-specific action
+  translator. The adapter never drives hardware; it only evaluates the policy.
 - Remote provider health checks depend on live credentials and network reachability even though they now use typed timeout and retry policy.
 - Provider observability includes local JSON logging and in-memory metrics sinks, but host applications still own production logging, metrics export, trace IDs, dashboards, and alerts.
 - World persistence is local JSON state, not a concurrent multi-writer store or service.

--- a/docs/src/providers/README.md
+++ b/docs/src/providers/README.md
@@ -14,6 +14,7 @@ definition, [Architecture](../architecture.md) for the end-to-end provider injec
 | `runway` | beta | register when `RUNWAYML_API_SECRET` or `RUNWAY_API_SECRET` is set | real HTTP adapter for Runway image-to-video and video-to-video APIs |
 | `leworldmodel` | beta | register when `LEWORLDMODEL_POLICY` or `LEWM_POLICY` is set | real optional adapter for LeWorldModel JEPA cost models through `stable_worldmodel.policy.AutoCostModel` |
 | [`gr00t`](./gr00t.md) | experimental | register when `GROOT_POLICY_HOST` is set | host-owned NVIDIA Isaac GR00T PolicyClient adapter for embodied action selection |
+| [`lerobot`](./lerobot.md) | beta | register when `LEROBOT_POLICY_PATH` or `LEROBOT_POLICY` is set | host-owned Hugging Face LeRobot `PreTrainedPolicy` adapter for embodied action selection |
 | `jepa` | scaffold | register when `JEPA_MODEL_PATH` is set | credential-gated stub backed by deterministic mock behavior |
 | `genie` | scaffold | register when `GENIE_API_KEY` is set | credential-gated stub backed by deterministic mock behavior |
 
@@ -100,8 +101,8 @@ WorldForge action candidates for scoring by default; hosts can pass provider-nat
 
 `policy` providers return `ActionPolicyResult` from `select_actions(...)`. The result preserves raw
 provider actions, selected WorldForge actions, candidate action chunks, embodiment metadata, and
-provider-native info. `gr00t` uses this surface because Isaac GR00T is an embodied VLA policy, not
-a future-state predictor.
+provider-native info. `gr00t` and `lerobot` both use this surface because Isaac GR00T and Hugging
+Face LeRobot are embodied action policies, not future-state predictors.
 
 LeWorldModel is the architectural reference provider for score-based planning. It is first class
 because it matches the JEPA planning contract WorldForge is designed to support: observations,
@@ -119,6 +120,9 @@ instead of pretending it can generate video, reason over text, or mutate world s
   action-candidate payloads before invoking the cost model.
 - `gr00t` validates policy observations, preserves raw policy actions, and requires a host-owned
   action translator before returning executable WorldForge actions.
+- `lerobot` validates policy observations, preserves raw policy actions, lazily loads
+  `lerobot.policies.pretrained.PreTrainedPolicy`, and requires a host-owned action translator
+  before returning executable WorldForge actions.
 - Health checks, polling, and downloads retry with backoff by default. Create-style POST requests remain single-attempt unless a caller passes a custom policy.
 - `WorldForge(event_handler=...)` and provider constructor `event_handler=` arguments accept a `ProviderEvent` callback for host-side logging and metrics.
 - `worldforge.observability.compose_event_handlers(...)` lets host apps attach multiple sinks without writing a custom dispatcher.
@@ -191,3 +195,24 @@ GR00T:
   smoke.
 - The latest local live-smoke attempt could not run upstream Isaac-GR00T on macOS arm64 because
   CUDA/TensorRT packages such as `tensorrt-cu13-libs` require a compatible NVIDIA/Linux runtime.
+
+LeRobot:
+
+- `LEROBOT_POLICY_PATH` (alias `LEROBOT_POLICY`) is the Hugging Face repo id or local checkpoint
+  directory for a LeRobot `PreTrainedPolicy`.
+- `LEROBOT_POLICY_TYPE` optionally pins a specific policy class such as `act`, `diffusion`,
+  `tdmpc`, `vqbet`, `pi0`, `pi0fast`, `sac`, or `smolvla`.
+- `LEROBOT_DEVICE`, `LEROBOT_CACHE_DIR`, and `LEROBOT_EMBODIMENT_TAG` are optional.
+- The adapter lazily imports `lerobot.policies.pretrained.PreTrainedPolicy` only when a
+  non-injected policy is loaded.
+- `info["observation"]` must be a non-empty JSON object; keys follow LeRobot's naming
+  conventions (`observation.state`, `observation.images.<camera>`, `task`, ...).
+- `info["mode"]` picks between `select_action` (single-step) and `predict_chunk` (full action
+  chunk, only available when the policy implements `predict_action_chunk`).
+- A host-supplied `action_translator` maps LeRobot's embodiment-specific raw action tensors to
+  WorldForge `Action` objects, optionally as multiple candidate chunks.
+- `examples/lerobot_e2e_demo.py` runs a checkout-safe end-to-end demo of the real provider
+  with an injected deterministic policy.
+- `scripts/smoke_lerobot_policy.py` loads a real LeRobot checkpoint via `PreTrainedPolicy`
+  and runs a live policy smoke; it requires `lerobot` and any robot-specific dependencies in
+  the host environment.

--- a/docs/src/providers/lerobot.md
+++ b/docs/src/providers/lerobot.md
@@ -1,0 +1,247 @@
+# LeRobot Provider
+
+Status: beta host-owned policy-client adapter
+
+Taxonomy category: embodied policy / imitation + RL action model
+
+This adapter wraps Hugging Face [LeRobot](https://github.com/huggingface/lerobot)'s pretrained
+policy interface. LeRobot is modeled as an actor: it accepts multimodal observations
+(state, cameras, language) and returns robot action tensors. It is not modeled as a
+predictive world model, video generator, or candidate scorer.
+
+```text
+observation (+ language instruction) -> action tensor
+```
+
+WorldForge keeps the boundary explicit:
+
+```text
+LeRobot PreTrainedPolicy
+  -> raw embodiment-specific action tensors
+  -> host-supplied action_translator
+  -> ActionPolicyResult
+  -> World.plan(... planning_mode="policy")
+```
+
+For actor plus world-model planning:
+
+```text
+LeRobot proposes candidate action chunks
+  -> LeWorldModel / JEPA-WMS / another score provider ranks candidates
+  -> World.plan(... planning_mode="policy+score")
+  -> execution_provider runs the chosen WorldForge actions
+```
+
+## Configuration
+
+- `LEROBOT_POLICY_PATH` (alias `LEROBOT_POLICY`): required for auto-registration. Hugging Face
+  repo id (e.g. `lerobot/act_aloha_sim_transfer_cube_human`) or local checkpoint directory.
+- `LEROBOT_POLICY_TYPE`: optional. One of `act`, `diffusion`, `tdmpc`, `vqbet`, `pi0`,
+  `pi0fast`, `sac`, `smolvla`. Skipped policy-type auto-detection goes through
+  `PreTrainedPolicy.from_pretrained`, which reads the checkpoint metadata itself.
+- `LEROBOT_DEVICE`: optional. Device string passed to `policy.to(...)` after loading
+  (e.g. `cpu`, `cuda`, `cuda:0`, `mps`).
+- `LEROBOT_CACHE_DIR`: optional. Hugging Face cache directory override.
+- `LEROBOT_EMBODIMENT_TAG`: optional. Metadata string stored on the returned
+  `ActionPolicyResult`.
+
+The adapter does not add `lerobot`, PyTorch, NumPy, or robot runtime dependencies to
+WorldForge's base install. Those dependencies remain host-owned and are only imported when
+a non-injected policy is loaded.
+
+## Policy Runtime Contract
+
+Direct construction with a fake or host-owned policy:
+
+```python
+from worldforge.providers import LeRobotPolicyProvider
+
+provider = LeRobotPolicyProvider(
+    policy=policy,
+    embodiment_tag="aloha",
+    action_translator=translate_actions,
+)
+```
+
+The injected or lazily loaded policy must expose:
+
+```python
+policy.select_action(observation) -> action_tensor              # required
+policy.predict_action_chunk(observation) -> action_chunk_tensor # optional
+policy.reset()                                                  # optional
+```
+
+If no policy is injected, WorldForge lazily imports:
+
+```python
+from lerobot.policies.pretrained import PreTrainedPolicy
+policy = PreTrainedPolicy.from_pretrained(LEROBOT_POLICY_PATH, cache_dir=...)
+```
+
+When `LEROBOT_POLICY_TYPE` is set, the adapter imports the specific policy class (for example
+`lerobot.policies.act.modeling_act.ACTPolicy`) and calls `from_pretrained` on that class
+instead. Both lookup paths are lazy: `lerobot` is only imported when a real policy needs to
+load.
+
+After loading, the adapter calls `policy.to(device)`, `policy.eval()`, `policy.requires_grad_(False)`,
+and `policy.reset()` when those methods exist.
+
+## Input Shape
+
+`select_actions(...)` expects:
+
+```python
+provider.select_actions(
+    info={
+        "observation": {
+            "observation.state": state_tensor_or_array,
+            "observation.images.top": image_tensor_or_array,
+            "task": "pick up the red cube",
+        },
+        "embodiment_tag": "aloha",
+        "action_horizon": 16,
+        "options": {},
+        "mode": "select_action",   # or "predict_chunk"
+    }
+)
+```
+
+- `info["observation"]` must be a non-empty JSON object. Keys follow LeRobot's naming convention
+  (e.g. `observation.state`, `observation.images.<camera>`, `task`). Arrays may be tensor-like
+  objects with `tolist()`; the adapter normalizes raw provider output into JSON-compatible
+  metadata.
+- `info["options"]` is optional, must be a JSON object when provided, and is passed through to
+  the translator via `info`.
+- `info["mode"]` selects between `select_action` (one step) and `predict_chunk` (full action
+  chunk). `predict_chunk` only works when the policy implements `predict_action_chunk`.
+
+## Action Translation
+
+LeRobot actions are embodiment-specific: a 7-DoF arm, a bimanual 14-DoF setup, a
+gripper-plus-mobile-base, or something else entirely. WorldForge cannot safely infer what a
+joint command means for a host robot. The provider therefore requires a host-supplied
+`action_translator` before it can return executable WorldForge `Action` objects:
+
+```python
+from worldforge import Action
+
+def translate_actions(raw_actions, info, provider_info):
+    tensor = raw_actions.tolist() if hasattr(raw_actions, "tolist") else raw_actions
+    return [
+        Action.move_to(float(x), float(y), float(z))
+        for (x, y, z) in tensor[0]
+    ]
+```
+
+The translator may return a single action chunk:
+
+```python
+[Action.move_to(...), Action.move_to(...)]
+```
+
+or multiple candidate chunks:
+
+```python
+[
+    [Action.move_to(0.1, 0.5, 0.0)],
+    [Action.move_to(0.4, 0.5, 0.0)],
+]
+```
+
+Multiple candidates are useful when pairing LeRobot with a score provider (policy+score
+planning).
+
+## Planning
+
+Policy-only planning:
+
+```python
+plan = world.plan(
+    goal="pick up the red cube",
+    provider="lerobot",
+    policy_info=policy_info,
+    execution_provider="mock",
+)
+```
+
+Policy plus score planning:
+
+```python
+plan = world.plan(
+    goal="choose the lowest-cost policy candidate",
+    policy_provider="lerobot",
+    score_provider="leworldmodel",
+    policy_info=policy_info,
+    score_info=lewm_info,
+    execution_provider="mock",
+)
+```
+
+WorldForge serializes policy candidates into `Action.to_dict()` payloads by default before
+calling the score provider. If the scorer needs native tensors or latents, pass
+`score_action_candidates=...`; WorldForge only requires that the number of policy candidates
+and native score candidates describe the same candidate set.
+
+## Checkout-Safe Demo
+
+`examples/lerobot_e2e_demo.py` runs the real `LeRobotPolicyProvider` with an injected
+deterministic policy. It exercises `select_actions`, `World.plan(policy+score)`,
+`execute_plan`, JSON persistence, and reload without needing `lerobot`, torch, or checkpoint
+downloads:
+
+```bash
+uv run python examples/lerobot_e2e_demo.py
+```
+
+## Live Smoke
+
+Use `scripts/smoke_lerobot_policy.py` for a real `PreTrainedPolicy` smoke. It loads the
+checkpoint in the host environment, so `lerobot` and the robot's dependencies must already be
+installed.
+
+```bash
+uv venv --python=3.10 .venv-lerobot
+source .venv-lerobot/bin/activate
+uv pip install -e .
+uv pip install "lerobot[aloha]"
+
+python scripts/smoke_lerobot_policy.py \
+  --policy-path lerobot/act_aloha_sim_transfer_cube_human \
+  --observation-module /path/to/obs.py:build_observation \
+  --translator /path/to/translator.py:translate_actions \
+  --device cpu
+```
+
+`--policy-info-json` accepts a complete `policy_info` JSON payload. `--observation-json`
+accepts an observation-only payload. `--observation-module module_or_file:function` is the
+right escape hatch when observations need NumPy arrays, PyTorch tensors, or host-side
+preprocessing that JSON cannot represent cleanly.
+
+The translator callable receives `(raw_actions, info, provider_info)` and must return either
+a single WorldForge action chunk or multiple candidate chunks. `--health-only` reports
+provider health without running inference and is useful during environment setup.
+
+## Failure Modes
+
+- Missing `LEROBOT_POLICY_PATH` leaves the auto-registered provider unavailable.
+- Missing `lerobot` (or `lerobot.policies.pretrained.PreTrainedPolicy`) is reported by
+  `health()`.
+- Missing `action_translator` fails with `ProviderError`.
+- Malformed `info.observation` (not a non-empty JSON object, non-string keys, options not a
+  dict, unknown `mode`) fails before invoking the policy.
+- Non-JSON-compatible raw actions or provider info fail before returning
+  `ActionPolicyResult`.
+- Failed policy inference is wrapped in `ProviderError`.
+- Requesting `mode="predict_chunk"` against a policy that does not implement
+  `predict_action_chunk` fails explicitly instead of returning stale single-step output.
+
+## Tests
+
+- `tests/test_lerobot_provider.py` covers fake-policy contract checks, event emission,
+  malformed inputs, missing translator, unconfigured health, env configuration, lazy import
+  of `PreTrainedPolicy`, select/predict_chunk modes, `reset()` delegation, auto-registration,
+  and policy+score planning.
+- `tests/test_lerobot_e2e_demo.py` runs the full end-to-end demo and asserts the planning,
+  execution, persistence, reload, and event-emission output.
+- `tests/test_lerobot_smoke_script.py` covers the smoke script's JSON-file and factory input
+  loaders, callable resolution, and input validation. It does not require `lerobot` or a GPU.

--- a/examples/lerobot_e2e_demo.py
+++ b/examples/lerobot_e2e_demo.py
@@ -1,0 +1,348 @@
+"""End-to-end LeRobot provider-surface policy+score-planning demo.
+
+This demo uses the real :class:`LeRobotPolicyProvider` with an injected tiny fake
+policy. It runs in a clean WorldForge checkout without downloading LeRobot
+checkpoints, torch, or HF weights. It exercises the same provider, policy
+planning, score planning, execution, and persistence path that a real
+Hugging Face LeRobot checkpoint would use, but it does not load upstream
+LeRobot neural weights.
+
+What the demo does:
+
+1. Registers the real :class:`LeRobotPolicyProvider` alongside the local ``mock``
+   execution provider and a tiny deterministic score provider.
+2. Creates a small world with one ``blue_cube`` and an ``object_at`` goal.
+3. Asks the LeRobot provider to propose three candidate two-step action chunks
+   via ``select_actions(...)``.
+4. Ranks those candidates by distance-to-goal through the score provider's
+   ``score_actions(...)`` surface, selecting the best one via
+   ``World.plan(..., planning_mode="policy+score")``.
+5. Executes the selected WorldForge actions through ``execution_provider="mock"``,
+   saves the final world, reloads it from disk, and reports the final cube
+   position.
+
+The point of this demo is to show a clean, well-documented integration between
+LeRobot policies and WorldForge planning without pretending we ran upstream
+neural inference. Use ``scripts/smoke_lerobot_policy.py`` for the real-checkpoint
+smoke path.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from worldforge import (
+    Action,
+    ActionScoreResult,
+    BBox,
+    Position,
+    SceneObject,
+    StructuredGoal,
+    WorldForge,
+)
+from worldforge.models import (
+    JSONDict,
+    ProviderCapabilities,
+    ProviderEvent,
+    ProviderHealth,
+)
+from worldforge.providers import BaseProvider, LeRobotPolicyProvider
+
+
+class DemoTensor:
+    """Minimal tensor-like object accepted by :class:`LeRobotPolicyProvider`."""
+
+    def __init__(self, value: object) -> None:
+        self.value = value
+
+    def tolist(self) -> object:
+        return self.value
+
+
+class DemoLeRobotPolicy:
+    """Small deterministic policy emulating LeRobot's ``PreTrainedPolicy`` surface.
+
+    Returns three candidate two-step action chunks. Each chunk moves the cube from
+    the starting position to a different final position. The score provider ranks
+    them by Euclidean distance to the goal.
+    """
+
+    def __init__(self, candidates: list[list[list[float]]]) -> None:
+        self._candidates = candidates
+        self.reset_calls = 0
+        self.select_calls = 0
+        self.requires_grad_disabled = False
+        self.eval_called = False
+
+    def eval(self) -> DemoLeRobotPolicy:
+        self.eval_called = True
+        return self
+
+    def requires_grad_(self, enabled: bool) -> None:
+        self.requires_grad_disabled = not enabled
+
+    def reset(self) -> None:
+        self.reset_calls += 1
+
+    def select_action(self, _observation: object) -> object:
+        self.select_calls += 1
+        return DemoTensor(self._candidates)
+
+
+class DemoDistanceScoreProvider(BaseProvider):
+    """Tiny score provider used by the demo.
+
+    Ranks candidate action chunks by the distance from the chunk's final waypoint
+    to a goal position carried in ``info["goal"]``. Scores are costs: lower is
+    better.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(
+            name="demo-distance-score",
+            capabilities=ProviderCapabilities(predict=False, score=True),
+            is_local=True,
+            description="Deterministic distance-to-goal score provider for the LeRobot E2E demo.",
+            implementation_status="test",
+            deterministic=True,
+            requires_credentials=False,
+        )
+
+    def health(self) -> ProviderHealth:
+        return ProviderHealth(name=self.name, healthy=True, latency_ms=0.1, details="configured")
+
+    def score_actions(self, *, info: JSONDict, action_candidates: object) -> ActionScoreResult:
+        goal = info["goal"]
+        if not isinstance(goal, list) or len(goal) != 3:
+            raise ValueError("demo score info.goal must be a [x, y, z] list.")
+        if not isinstance(action_candidates, list) or not action_candidates:
+            raise ValueError("demo score provider requires a non-empty action candidate list.")
+        scores: list[float] = []
+        for candidate in action_candidates:
+            if not isinstance(candidate, list) or not candidate:
+                raise ValueError("demo score provider requires non-empty candidate chunks.")
+            final = candidate[-1]["parameters"]["target"]
+            scores.append(
+                round(
+                    math.dist(
+                        [float(final["x"]), float(final["y"]), float(final["z"])],
+                        [float(goal[0]), float(goal[1]), float(goal[2])],
+                    ),
+                    4,
+                )
+            )
+        best_index = min(range(len(scores)), key=scores.__getitem__)
+        return ActionScoreResult(
+            provider=self.name,
+            scores=scores,
+            best_index=best_index,
+            lower_is_better=True,
+            metadata={"score_type": "distance_to_goal", "candidate_count": len(scores)},
+        )
+
+
+def _policy_info(embodiment_tag: str, task: str) -> JSONDict:
+    return {
+        "observation": {
+            "observation.state": [[0.0, 0.5, 0.0]],
+            "observation.images.top": [[[[0, 0, 0]]]],
+            "task": task,
+        },
+        "embodiment_tag": embodiment_tag,
+        "action_horizon": 2,
+    }
+
+
+def _make_candidate_tensors() -> list[list[list[float]]]:
+    return [
+        [[0.20, 0.50, 0.00], [0.35, 0.50, 0.00]],
+        [[0.30, 0.50, 0.00], [0.55, 0.50, 0.00]],
+        [[0.70, 0.50, 0.00], [0.95, 0.50, 0.00]],
+    ]
+
+
+def _make_candidate_plans(cube_id: str) -> list[list[Action]]:
+    return [
+        [
+            Action.move_to(0.20, 0.50, 0.00, object_id=cube_id),
+            Action.move_to(0.35, 0.50, 0.00, object_id=cube_id),
+        ],
+        [
+            Action.move_to(0.30, 0.50, 0.00, object_id=cube_id),
+            Action.move_to(0.55, 0.50, 0.00, object_id=cube_id),
+        ],
+        [
+            Action.move_to(0.70, 0.50, 0.00, object_id=cube_id),
+            Action.move_to(0.95, 0.50, 0.00, object_id=cube_id),
+        ],
+    ]
+
+
+def _build_translator(cube_id: str) -> Any:
+    def translator(
+        _raw: object,
+        _info: JSONDict,
+        _provider_info: JSONDict,
+    ) -> list[list[Action]]:
+        return _make_candidate_plans(cube_id)
+
+    return translator
+
+
+def run_demo(*, state_dir: Path | None = None, emit: bool = True) -> JSONDict:
+    """Run the full LeRobot E2E demo and return a JSON-serializable summary."""
+
+    resolved_state_dir = state_dir or Path(tempfile.mkdtemp(prefix="worldforge-lerobot-demo-"))
+    events: list[ProviderEvent] = []
+
+    forge = WorldForge(state_dir=resolved_state_dir, auto_register_remote=False)
+    world = forge.create_world("lerobot-policy-plus-score-demo", provider="mock")
+    cube = world.add_object(
+        SceneObject(
+            "blue_cube",
+            Position(0.0, 0.5, 0.0),
+            BBox(Position(-0.05, 0.45, -0.05), Position(0.05, 0.55, 0.05)),
+        )
+    )
+    goal_position = Position(0.55, 0.50, 0.00)
+    goal = StructuredGoal.object_at(
+        object_id=cube.id,
+        object_name=cube.name,
+        position=goal_position,
+        tolerance=0.05,
+    )
+
+    policy = DemoLeRobotPolicy(_make_candidate_tensors())
+
+    def loader(
+        _policy_path: str,
+        _policy_type: str | None,
+        _device: str | None,
+        _cache_dir: str | None,
+    ) -> DemoLeRobotPolicy:
+        return policy
+
+    provider = LeRobotPolicyProvider(
+        policy_path="demo/lerobot-aloha-fake",
+        policy_type="act",
+        embodiment_tag="aloha",
+        device="cpu",
+        policy_loader=loader,
+        action_translator=_build_translator(cube.id),
+        event_handler=events.append,
+    )
+    score_provider = DemoDistanceScoreProvider()
+    forge.register_provider(provider)
+    forge.register_provider(score_provider)
+
+    policy_info = _policy_info("aloha", "move the blue cube near the goal")
+    score_info: JSONDict = {"goal": [goal_position.x, goal_position.y, goal_position.z]}
+
+    policy_result = forge.select_actions("lerobot", info=policy_info)
+    plan = world.plan(
+        goal_spec=goal,
+        provider="demo-distance-score",
+        policy_provider="lerobot",
+        policy_info=policy_info,
+        score_info=score_info,
+        execution_provider="mock",
+        planner="lerobot-demo-mpc",
+    )
+    execution = world.execute_plan(plan)
+    final_world = execution.final_world()
+    saved_world_id = forge.save_world(final_world)
+    reloaded_world = forge.load_world(saved_world_id)
+    final_cube = reloaded_world.get_object_by_id(cube.id)
+    if final_cube is None:
+        raise RuntimeError("demo cube was not present after execution")
+
+    summary: JSONDict = {
+        "demo_kind": "lerobot_provider_surface",
+        "runtime_mode": "injected_deterministic_policy",
+        "uses_real_upstream_checkpoint": False,
+        "uses_lerobot_provider": True,
+        "uses_worldforge_policy_plus_score_planning": True,
+        "state_dir": str(resolved_state_dir),
+        "providers": forge.providers(),
+        "lerobot_health": forge.provider_health("lerobot").to_dict(),
+        "goal": goal.to_dict(),
+        "policy_candidate_count": len(policy_result.action_candidates),
+        "selected_candidate_index": plan.metadata["score_result"]["best_index"],
+        "candidate_costs": plan.metadata["score_result"]["scores"],
+        "selected_actions": [action.to_dict() for action in plan.actions],
+        "plan": plan.to_dict(),
+        "final_cube_position": final_cube.position.to_dict(),
+        "saved_world_id": saved_world_id,
+        "saved_worlds": forge.list_worlds(),
+        "event_phases": [event.phase for event in events],
+        "policy_reset_calls": policy.reset_calls,
+        "policy_eval_called": policy.eval_called,
+        "policy_requires_grad_disabled": policy.requires_grad_disabled,
+        "policy_select_calls": policy.select_calls,
+    }
+    if emit:
+        _print_summary(summary)
+    return summary
+
+
+def _print_summary(summary: JSONDict) -> None:
+    print("WorldForge LeRobot E2E demo")
+    print("=" * 29)
+    print("Runtime mode: injected deterministic LeRobot-shaped policy")
+    print("Uses real LeRobotPolicyProvider: yes")
+    print("Uses upstream LeRobot checkpoint inference: no")
+    print("Planning path: WorldForge select_actions -> World.plan(policy+score) -> execute_plan")
+    print(f"State directory: {summary['state_dir']}")
+    print(f"Registered providers: {', '.join(summary['providers'])}")
+    print(f"LeRobot health: {summary['lerobot_health']['details']}")
+    print()
+    print("Candidate costs, lower is better:")
+    for index, score in enumerate(summary["candidate_costs"]):
+        marker = " <- selected" if index == summary["selected_candidate_index"] else ""
+        print(f"  candidate {index}: {score}{marker}")
+    print()
+    print("Selected actions:")
+    for action in summary["selected_actions"]:
+        target = action["parameters"]["target"]
+        print(f"  {action['type']} -> ({target['x']:.2f}, {target['y']:.2f}, {target['z']:.2f})")
+    final = summary["final_cube_position"]
+    print()
+    print(f"Final cube position: ({final['x']:.2f}, {final['y']:.2f}, {final['z']:.2f})")
+    print(f"Saved world id: {summary['saved_world_id']}")
+    print(f"Provider event phases: {', '.join(summary['event_phases'])}")
+    print()
+    print("JSON summary:")
+    print(json.dumps(summary, indent=2, sort_keys=True))
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--state-dir",
+        type=Path,
+        default=None,
+        help="Directory for persisted demo worlds. Defaults to a temporary directory.",
+    )
+    parser.add_argument(
+        "--json-only",
+        action="store_true",
+        help="Print only the final JSON summary.",
+    )
+    return parser
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    summary = run_demo(state_dir=args.state_dir, emit=not args.json_only)
+    if args.json_only:
+        print(json.dumps(summary, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/smoke_lerobot_policy.py
+++ b/scripts/smoke_lerobot_policy.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python
+"""Run a live Hugging Face LeRobot policy smoke through WorldForge.
+
+This is the real-checkpoint counterpart to ``examples/lerobot_e2e_demo.py``. It
+loads a LeRobot pretrained policy (``PreTrainedPolicy.from_pretrained``), calls
+:class:`LeRobotPolicyProvider.select_actions` with host-supplied observations,
+and invokes a host-supplied action translator to map embodiment-specific output
+back into WorldForge actions.
+
+The script does not own the LeRobot runtime. Install ``lerobot`` and any robot
+or dataset dependencies in the host environment before running:
+
+.. code-block:: bash
+
+   uv venv --python=3.10 .venv-lerobot
+   source .venv-lerobot/bin/activate
+   uv pip install -e .
+   uv pip install "lerobot[aloha]"
+
+Then provide a policy path, an observation source, and a translator:
+
+.. code-block:: bash
+
+   python scripts/smoke_lerobot_policy.py \
+     --policy-path lerobot/act_aloha_sim_transfer_cube_human \
+     --observation-module /path/to/obs.py:build_observation \
+     --translator /path/to/translator.py:translate_actions \
+     --device cpu
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import importlib.util
+import json
+import os
+from collections.abc import Callable
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+from worldforge.models import JSONDict
+from worldforge.providers import LeRobotPolicyProvider
+
+DEFAULT_DEVICE = "cpu"
+DEFAULT_MODE = "select_action"
+
+
+def _env_value(name: str) -> str | None:
+    raw = os.environ.get(name)
+    if raw is None or not raw.strip():
+        return None
+    return raw.strip()
+
+
+def _load_json_file(path: Path, *, name: str) -> JSONDict:
+    try:
+        payload = json.loads(path.expanduser().read_text())
+    except FileNotFoundError as exc:
+        raise SystemExit(f"{name} file does not exist: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"{name} file is not valid JSON: {path}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise SystemExit(f"{name} must decode to a JSON object.")
+    return payload
+
+
+def _module_from_path(path: Path) -> ModuleType:
+    resolved = path.expanduser().resolve()
+    if not resolved.exists():
+        raise SystemExit(f"Python module file does not exist: {path}")
+    module_spec = importlib.util.spec_from_file_location(resolved.stem, resolved)
+    if module_spec is None or module_spec.loader is None:
+        raise SystemExit(f"Could not load Python module from: {path}")
+    module = importlib.util.module_from_spec(module_spec)
+    module_spec.loader.exec_module(module)
+    return module
+
+
+def _load_callable(spec: str, *, name: str) -> Callable[..., Any]:
+    if ":" not in spec:
+        raise SystemExit(f"{name} must be formatted as module_or_file:function.")
+    module_ref, function_name = spec.rsplit(":", 1)
+    if not module_ref.strip() or not function_name.strip():
+        raise SystemExit(f"{name} must be formatted as module_or_file:function.")
+
+    candidate_path = Path(module_ref)
+    if candidate_path.exists() or module_ref.endswith(".py") or "/" in module_ref:
+        module = _module_from_path(candidate_path)
+    else:
+        try:
+            module = importlib.import_module(module_ref)
+        except ImportError as exc:
+            raise SystemExit(f"Could not import {name} module '{module_ref}': {exc}") from exc
+
+    try:
+        loaded = getattr(module, function_name)
+    except AttributeError as exc:
+        raise SystemExit(f"{name} function '{function_name}' was not found.") from exc
+    if not callable(loaded):
+        raise SystemExit(f"{name} target '{function_name}' is not callable.")
+    return loaded
+
+
+def _load_policy_info(args: argparse.Namespace) -> JSONDict:
+    if args.policy_info_json is not None:
+        info = _load_json_file(args.policy_info_json, name="policy-info")
+    elif args.observation_json is not None:
+        info = {"observation": _load_json_file(args.observation_json, name="observation")}
+    elif args.observation_module is not None:
+        factory = _load_callable(args.observation_module, name="observation factory")
+        try:
+            produced = factory()
+        except Exception as exc:
+            raise SystemExit(f"Observation factory failed: {exc}") from exc
+        if not isinstance(produced, dict):
+            raise SystemExit("Observation factory must return a dictionary.")
+        info = dict(produced) if "observation" in produced else {"observation": dict(produced)}
+    else:
+        raise SystemExit(
+            "Live policy smoke requires --policy-info-json, --observation-json, "
+            "or --observation-module."
+        )
+
+    if args.options_json is not None:
+        info["options"] = _load_json_file(args.options_json, name="options")
+    if args.embodiment_tag is not None:
+        info.setdefault("embodiment_tag", args.embodiment_tag)
+    if args.action_horizon is not None:
+        info["action_horizon"] = args.action_horizon
+    if args.mode is not None:
+        info["mode"] = args.mode
+    return info
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--policy-path",
+        default=_env_value("LEROBOT_POLICY_PATH") or _env_value("LEROBOT_POLICY"),
+        help="Hugging Face repo id or local directory of a LeRobot checkpoint.",
+    )
+    parser.add_argument(
+        "--policy-type",
+        default=_env_value("LEROBOT_POLICY_TYPE"),
+        help="Optional LeRobot policy type (act, diffusion, tdmpc, vqbet, pi0, smolvla, ...).",
+    )
+    parser.add_argument(
+        "--device",
+        default=_env_value("LEROBOT_DEVICE") or DEFAULT_DEVICE,
+        help="Device string passed to policy.to(...) after loading.",
+    )
+    parser.add_argument(
+        "--cache-dir",
+        default=_env_value("LEROBOT_CACHE_DIR"),
+        help="Optional Hugging Face cache directory override.",
+    )
+    parser.add_argument(
+        "--embodiment-tag",
+        default=_env_value("LEROBOT_EMBODIMENT_TAG"),
+        help="Optional embodiment tag stored in the ActionPolicyResult.",
+    )
+    parser.add_argument(
+        "--action-horizon",
+        type=int,
+        default=None,
+        help="Optional explicit action horizon. Defaults to the translator's chunk length.",
+    )
+    parser.add_argument(
+        "--mode",
+        choices=["select_action", "predict_chunk"],
+        default=DEFAULT_MODE,
+        help=(
+            "Inference mode: 'select_action' for one step or 'predict_chunk' for a full "
+            "predicted action chunk (only when the policy implements it)."
+        ),
+    )
+    parser.add_argument("--health-only", action="store_true")
+
+    input_group = parser.add_mutually_exclusive_group()
+    input_group.add_argument(
+        "--policy-info-json",
+        type=Path,
+        help="JSON file containing the full WorldForge policy_info object.",
+    )
+    input_group.add_argument(
+        "--observation-json",
+        type=Path,
+        help="JSON file containing only the LeRobot observation dictionary.",
+    )
+    input_group.add_argument(
+        "--observation-module",
+        help=(
+            "Python factory formatted as module_or_file:function. Returns an observation dict "
+            "or a full policy_info object."
+        ),
+    )
+    parser.add_argument(
+        "--translator",
+        help=(
+            "Python action translator formatted as module_or_file:function. The callable "
+            "receives (raw_actions, info, provider_info) and returns WorldForge Action "
+            "objects, optionally as candidate chunks."
+        ),
+    )
+    parser.add_argument(
+        "--options-json",
+        type=Path,
+        help="Optional JSON file merged into info.options.",
+    )
+    return parser
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    if not args.policy_path:
+        raise SystemExit("Live LeRobot smoke requires --policy-path or LEROBOT_POLICY_PATH.")
+    if args.action_horizon is not None and args.action_horizon <= 0:
+        raise SystemExit("--action-horizon must be greater than 0.")
+    if not args.health_only and args.translator is None:
+        raise SystemExit("--translator is required unless --health-only is set.")
+
+    translator = (
+        None if args.translator is None else _load_callable(args.translator, name="translator")
+    )
+    provider = LeRobotPolicyProvider(
+        policy_path=args.policy_path,
+        policy_type=args.policy_type,
+        device=args.device,
+        cache_dir=args.cache_dir,
+        embodiment_tag=args.embodiment_tag,
+        action_translator=translator,
+    )
+    health = provider.health()
+    if not health.healthy:
+        raise SystemExit(f"LeRobot provider is not healthy: {health.details}")
+
+    output: JSONDict = {"health": health.to_dict()}
+    if not args.health_only:
+        result = provider.select_actions(info=_load_policy_info(args))
+        output["result"] = result.to_dict()
+    print(json.dumps(output, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/worldforge/framework.py
+++ b/src/worldforge/framework.py
@@ -44,6 +44,7 @@ from worldforge.providers import (
     GenieProvider,
     GrootPolicyClientProvider,
     JepaProvider,
+    LeRobotPolicyProvider,
     LeWorldModelProvider,
     MockProvider,
     ProviderError,
@@ -913,6 +914,7 @@ class WorldForge:
             RunwayProvider(event_handler=self._event_handler),
             LeWorldModelProvider(event_handler=self._event_handler),
             GrootPolicyClientProvider(event_handler=self._event_handler),
+            LeRobotPolicyProvider(event_handler=self._event_handler),
             JepaProvider(event_handler=self._event_handler),
             GenieProvider(event_handler=self._event_handler),
         )

--- a/src/worldforge/providers/__init__.py
+++ b/src/worldforge/providers/__init__.py
@@ -10,6 +10,7 @@ from worldforge.models import (
 from .base import BaseProvider, PredictionPayload, ProviderError, RemoteProvider
 from .cosmos import CosmosProvider
 from .gr00t import GrootPolicyClientProvider
+from .lerobot import LeRobotPolicyProvider
 from .leworldmodel import LeWorldModelProvider
 from .mock import MockProvider
 from .remote import GenieProvider, JepaProvider, StubRemoteProvider
@@ -21,6 +22,7 @@ __all__ = [
     "GenieProvider",
     "GrootPolicyClientProvider",
     "JepaProvider",
+    "LeRobotPolicyProvider",
     "LeWorldModelProvider",
     "MockProvider",
     "PredictionPayload",

--- a/src/worldforge/providers/lerobot.py
+++ b/src/worldforge/providers/lerobot.py
@@ -1,0 +1,558 @@
+"""Hugging Face LeRobot policy provider adapter.
+
+LeRobot ships pretrained robot policies (``ACT``, ``Diffusion``, ``TDMPC``, ``VQBet``,
+``Pi0``, ``SmolVLA``, ...) that subclass :class:`lerobot.policies.pretrained.PreTrainedPolicy`.
+Every policy exposes the same inference surface:
+
+* ``policy.reset()`` resets any internal action-chunk or stepper state.
+* ``policy.select_action(observation)`` returns a single-step action tensor.
+* ``policy.predict_action_chunk(observation)`` (optional) returns an action chunk.
+
+WorldForge models LeRobot as an embodied :class:`policy` provider, not a predictive world
+model. Observations and optional language go in, raw robot action tensors come out, and a
+host-supplied :data:`ActionTranslator` turns the embodiment-specific tensor into executable
+WorldForge :class:`Action` objects. The provider never touches real hardware; it only
+evaluates the policy.
+"""
+
+from __future__ import annotations
+
+import importlib
+import math
+import os
+from collections.abc import Callable, Sequence
+from contextlib import nullcontext
+from time import perf_counter
+from typing import Any
+
+from worldforge.models import (
+    Action,
+    ActionPolicyResult,
+    JSONDict,
+    ProviderCapabilities,
+    ProviderEvent,
+    ProviderHealth,
+    WorldForgeError,
+    require_positive_int,
+)
+
+from .base import BaseProvider, ProviderError
+
+LEROBOT_POLICY_PATH_ENV_VAR = "LEROBOT_POLICY_PATH"
+LEROBOT_POLICY_PATH_ENV_ALIASES = (LEROBOT_POLICY_PATH_ENV_VAR, "LEROBOT_POLICY")
+LEROBOT_POLICY_TYPE_ENV_VAR = "LEROBOT_POLICY_TYPE"
+LEROBOT_DEVICE_ENV_VAR = "LEROBOT_DEVICE"
+LEROBOT_CACHE_DIR_ENV_VAR = "LEROBOT_CACHE_DIR"
+LEROBOT_EMBODIMENT_TAG_ENV_VAR = "LEROBOT_EMBODIMENT_TAG"
+
+SUPPORTED_POLICY_TYPES: tuple[str, ...] = (
+    "act",
+    "diffusion",
+    "pi0",
+    "pi0fast",
+    "sac",
+    "smolvla",
+    "tdmpc",
+    "vqbet",
+)
+
+PolicyLoader = Callable[[str, str | None, str | None, str | None], Any]
+ActionTranslator = Callable[
+    [object, JSONDict, JSONDict],
+    Sequence[Action] | Sequence[Sequence[Action]],
+]
+
+
+def _first_env_value(names: Sequence[str]) -> str | None:
+    for name in names:
+        value = os.environ.get(name)
+        if value is not None and value.strip():
+            return value.strip()
+    return None
+
+
+def _optional_non_empty(value: str | None, *, name: str) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value.strip():
+        raise WorldForgeError(f"{name} must be a non-empty string when provided.")
+    return value.strip()
+
+
+def _optional_policy_type(value: str | None, *, name: str) -> str | None:
+    normalized = _optional_non_empty(value, name=name)
+    if normalized is None:
+        return None
+    lowered = normalized.lower()
+    if lowered not in SUPPORTED_POLICY_TYPES:
+        supported = ", ".join(SUPPORTED_POLICY_TYPES)
+        raise WorldForgeError(f"{name} must be one of: {supported}. Got '{normalized}'.")
+    return lowered
+
+
+def _json_compatible(value: object, *, name: str) -> object:
+    tolist = getattr(value, "tolist", None)
+    if callable(tolist):
+        return _json_compatible(tolist(), name=name)
+    if value is None or isinstance(value, str | bool):
+        return value
+    if isinstance(value, int | float):
+        number = float(value)
+        if not math.isfinite(number):
+            raise ProviderError(f"{name} must contain only finite numbers.")
+        return value
+    if isinstance(value, dict):
+        normalized: JSONDict = {}
+        for key, child in value.items():
+            if not isinstance(key, str) or not key.strip():
+                raise ProviderError(f"{name} keys must be non-empty strings.")
+            normalized[key.strip()] = _json_compatible(child, name=f"{name}.{key}")
+        return normalized
+    if isinstance(value, Sequence) and not isinstance(value, str | bytes | bytearray):
+        return [
+            _json_compatible(child, name=f"{name}[{index}]") for index, child in enumerate(value)
+        ]
+    raise ProviderError(f"{name} must be JSON-compatible.")
+
+
+def _json_object(value: object, *, name: str) -> JSONDict:
+    normalized = _json_compatible(value, name=name)
+    if not isinstance(normalized, dict):
+        raise ProviderError(f"{name} must be a JSON object.")
+    return normalized
+
+
+def _normalize_policy_action_candidates(
+    value: Sequence[Action] | Sequence[Sequence[Action]],
+) -> list[list[Action]]:
+    if not isinstance(value, Sequence) or isinstance(value, str | bytes) or not value:
+        raise ProviderError("LeRobot action translator must return a non-empty action sequence.")
+    if all(isinstance(item, Action) for item in value):
+        return [list(value)]  # type: ignore[list-item]
+
+    candidates: list[list[Action]] = []
+    for index, candidate in enumerate(value):
+        if (
+            not isinstance(candidate, Sequence)
+            or isinstance(candidate, str | bytes)
+            or not candidate
+        ):
+            raise ProviderError(
+                f"LeRobot action translator candidate {index} must be a non-empty action sequence."
+            )
+        actions = list(candidate)
+        if not all(isinstance(action, Action) for action in actions):
+            raise ProviderError(
+                f"LeRobot action translator candidate {index} must contain only Action instances."
+            )
+        candidates.append(actions)
+    return candidates
+
+
+class LeRobotPolicyProvider(BaseProvider):
+    """Adapter for Hugging Face LeRobot pretrained policies.
+
+    LeRobot is modeled as an embodied policy: observations (and optional language instructions)
+    go in, action tensors come out. The adapter keeps the LeRobot runtime optional by loading
+    policies lazily through ``PreTrainedPolicy.from_pretrained`` or a host-supplied
+    ``policy_loader``.
+    """
+
+    def __init__(
+        self,
+        name: str = "lerobot",
+        *,
+        policy_path: str | None = None,
+        policy_type: str | None = None,
+        device: str | None = None,
+        cache_dir: str | None = None,
+        embodiment_tag: str | None = None,
+        policy: Any | None = None,
+        policy_loader: PolicyLoader | None = None,
+        action_translator: ActionTranslator | None = None,
+        event_handler: Callable[[ProviderEvent], None] | None = None,
+    ) -> None:
+        self.policy_path = _optional_non_empty(
+            policy_path
+            if policy_path is not None
+            else _first_env_value(LEROBOT_POLICY_PATH_ENV_ALIASES),
+            name="LeRobot policy_path",
+        )
+        self.policy_type = _optional_policy_type(
+            policy_type if policy_type is not None else os.environ.get(LEROBOT_POLICY_TYPE_ENV_VAR),
+            name="LeRobot policy_type",
+        )
+        self.device = _optional_non_empty(
+            device if device is not None else os.environ.get(LEROBOT_DEVICE_ENV_VAR),
+            name="LeRobot device",
+        )
+        self.cache_dir = _optional_non_empty(
+            cache_dir if cache_dir is not None else os.environ.get(LEROBOT_CACHE_DIR_ENV_VAR),
+            name="LeRobot cache_dir",
+        )
+        self.embodiment_tag = _optional_non_empty(
+            embodiment_tag
+            if embodiment_tag is not None
+            else os.environ.get(LEROBOT_EMBODIMENT_TAG_ENV_VAR),
+            name="LeRobot embodiment_tag",
+        )
+        self._policy = policy
+        self._policy_loader = policy_loader
+        self._action_translator = action_translator
+
+        supported_models = [self.policy_path] if self.policy_path else []
+        super().__init__(
+            name=name,
+            capabilities=ProviderCapabilities(
+                predict=False,
+                generate=False,
+                reason=False,
+                embed=False,
+                plan=False,
+                transfer=False,
+                score=False,
+                policy=True,
+            ),
+            is_local=True,
+            description=(
+                "Hugging Face LeRobot pretrained-policy adapter for embodied action selection."
+            ),
+            package="worldforge + lerobot",
+            implementation_status="beta",
+            deterministic=False,
+            requires_credentials=False,
+            required_env_vars=list(LEROBOT_POLICY_PATH_ENV_ALIASES),
+            supported_modalities=["state", "images", "language", "actions"],
+            artifact_types=["action_policy"],
+            notes=[
+                "Loads policies with lerobot.policies.PreTrainedPolicy.from_pretrained.",
+                "Supports ACT, Diffusion, TDMPC, VQBet, Pi0, Pi0Fast, SAC, SmolVLA policies.",
+                "Set LEROBOT_POLICY_PATH to a Hugging Face repo id or local checkpoint directory.",
+                "Requires a host-supplied action_translator to map raw policy tensors to "
+                "WorldForge Action objects; LeRobot policies are embodiment-specific.",
+                "LeRobot is an action-policy provider, not a predictive world model.",
+            ],
+            default_model=self.policy_path,
+            supported_models=supported_models,
+            event_handler=event_handler,
+        )
+
+    def configured(self) -> bool:
+        return self._policy is not None or self.policy_path is not None
+
+    def health(self) -> ProviderHealth:
+        started = perf_counter()
+        if not self.configured():
+            return ProviderHealth(
+                name=self.name,
+                healthy=False,
+                latency_ms=max(0.1, (perf_counter() - started) * 1000),
+                details=(f"missing {LEROBOT_POLICY_PATH_ENV_VAR} (or injected policy)"),
+            )
+        if self._policy is None:
+            dependency_error = self._runtime_dependency_error()
+            if dependency_error is not None:
+                return ProviderHealth(
+                    name=self.name,
+                    healthy=False,
+                    latency_ms=max(0.1, (perf_counter() - started) * 1000),
+                    details=dependency_error,
+                )
+        detail_source = "injected policy"
+        if self._policy is None:
+            detail_source = self.policy_path or detail_source
+        return ProviderHealth(
+            name=self.name,
+            healthy=True,
+            latency_ms=max(0.1, (perf_counter() - started) * 1000),
+            details=f"configured for {detail_source}",
+        )
+
+    def _runtime_dependency_error(self) -> str | None:
+        if self._policy_loader is not None:
+            return None
+        try:
+            importlib.import_module("lerobot")
+        except ImportError:
+            return "missing optional dependency lerobot"
+        try:
+            pretrained_module = importlib.import_module("lerobot.policies.pretrained")
+        except ImportError:
+            try:
+                pretrained_module = importlib.import_module("lerobot.common.policies.pretrained")
+            except ImportError:
+                return "lerobot.policies.pretrained is unavailable"
+        if not hasattr(pretrained_module, "PreTrainedPolicy"):
+            return "lerobot.policies.pretrained.PreTrainedPolicy is unavailable"
+        return None
+
+    def _load_policy(self) -> Any:
+        if self._policy is not None:
+            return self._policy
+        if self.policy_path is None:
+            raise ProviderError(
+                f"Provider '{self.name}' is unavailable: set {LEROBOT_POLICY_PATH_ENV_VAR}."
+            )
+        try:
+            if self._policy_loader is not None:
+                loaded = self._policy_loader(
+                    self.policy_path,
+                    self.policy_type,
+                    self.device,
+                    self.cache_dir,
+                )
+            else:
+                loaded = self._load_policy_from_lerobot()
+        except ProviderError:
+            raise
+        except Exception as exc:
+            raise ProviderError(
+                f"Failed to load LeRobot policy '{self.policy_path}': {exc}"
+            ) from exc
+        if self.device is not None and hasattr(loaded, "to"):
+            loaded = loaded.to(self.device)
+        if hasattr(loaded, "eval"):
+            loaded = loaded.eval()
+        if hasattr(loaded, "requires_grad_"):
+            loaded.requires_grad_(False)
+        if hasattr(loaded, "reset"):
+            loaded.reset()
+        self._policy = loaded
+        return loaded
+
+    def _load_policy_from_lerobot(self) -> Any:
+        assert self.policy_path is not None
+        kwargs: dict[str, Any] = {}
+        if self.cache_dir is not None:
+            kwargs["cache_dir"] = self.cache_dir
+        if self.policy_type is not None:
+            policy_class = self._import_policy_class(self.policy_type)
+            return policy_class.from_pretrained(self.policy_path, **kwargs)
+        try:
+            pretrained_module = importlib.import_module("lerobot.policies.pretrained")
+        except ImportError:
+            pretrained_module = importlib.import_module("lerobot.common.policies.pretrained")
+        base_class = pretrained_module.PreTrainedPolicy
+        return base_class.from_pretrained(self.policy_path, **kwargs)
+
+    def _import_policy_class(self, policy_type: str) -> Any:
+        class_suffix = {
+            "act": ("act", "ACTPolicy"),
+            "diffusion": ("diffusion", "DiffusionPolicy"),
+            "pi0": ("pi0", "PI0Policy"),
+            "pi0fast": ("pi0fast", "PI0FASTPolicy"),
+            "sac": ("sac", "SACPolicy"),
+            "smolvla": ("smolvla", "SmolVLAPolicy"),
+            "tdmpc": ("tdmpc", "TDMPCPolicy"),
+            "vqbet": ("vqbet", "VQBeTPolicy"),
+        }[policy_type]
+        submodule, class_name = class_suffix
+        candidates = (
+            f"lerobot.policies.{submodule}.modeling_{submodule}",
+            f"lerobot.policies.{submodule}",
+            f"lerobot.common.policies.{submodule}.modeling_{submodule}",
+            f"lerobot.common.policies.{submodule}",
+        )
+        last_error: Exception | None = None
+        for module_name in candidates:
+            try:
+                module = importlib.import_module(module_name)
+            except ImportError as exc:
+                last_error = exc
+                continue
+            policy_class = getattr(module, class_name, None)
+            if policy_class is not None:
+                return policy_class
+        raise ProviderError(
+            f"Could not import LeRobot policy class '{class_name}' for type "
+            f"'{policy_type}': {last_error}"
+        )
+
+    def _validate_info(self, info: JSONDict) -> tuple[JSONDict, JSONDict | None, str]:
+        if not isinstance(info, dict):
+            raise ProviderError("LeRobot policy info must be a JSON object.")
+        observation = info.get("observation")
+        if not isinstance(observation, dict) or not observation:
+            raise ProviderError("LeRobot policy info.observation must be a non-empty JSON object.")
+        for key in observation:
+            if not isinstance(key, str) or not key.strip():
+                raise ProviderError("LeRobot policy observation keys must be non-empty strings.")
+        options = info.get("options")
+        if options is not None and not isinstance(options, dict):
+            raise ProviderError("LeRobot policy info.options must be a JSON object when provided.")
+        mode = info.get("mode", "select_action")
+        if not isinstance(mode, str) or mode.strip() not in {"select_action", "predict_chunk"}:
+            raise ProviderError(
+                "LeRobot policy info.mode must be 'select_action' or 'predict_chunk'."
+            )
+        return dict(observation), dict(options) if isinstance(options, dict) else None, mode.strip()
+
+    def _translate_actions(
+        self,
+        *,
+        raw_actions: object,
+        info: JSONDict,
+        provider_info: JSONDict,
+    ) -> list[list[Action]]:
+        if self._action_translator is None:
+            raise ProviderError(
+                "LeRobot policy actions are embodiment-specific; provide action_translator to "
+                "map raw policy actions into WorldForge Action objects."
+            )
+        try:
+            translated = self._action_translator(raw_actions, info, provider_info)
+        except Exception as exc:
+            raise ProviderError(f"LeRobot action translation failed: {exc}") from exc
+        return _normalize_policy_action_candidates(translated)
+
+    def _emit_policy_event(
+        self,
+        *,
+        phase: str,
+        duration_ms: float,
+        message: str = "",
+        metadata: JSONDict | None = None,
+    ) -> None:
+        self._emit_event(
+            ProviderEvent(
+                provider=self.name,
+                operation="policy",
+                phase=phase,
+                duration_ms=duration_ms,
+                message=message,
+                metadata=dict(metadata or {}),
+            )
+        )
+
+    def _no_grad_context(self) -> Any:
+        try:
+            torch = importlib.import_module("torch")
+        except ImportError:
+            return nullcontext()
+        no_grad = getattr(torch, "no_grad", None)
+        if callable(no_grad):
+            return no_grad()
+        return nullcontext()
+
+    def _invoke_policy(self, policy: Any, observation: JSONDict, mode: str) -> object:
+        if mode == "predict_chunk":
+            predictor = getattr(policy, "predict_action_chunk", None)
+            if not callable(predictor):
+                raise ProviderError(
+                    "LeRobot policy does not implement predict_action_chunk(); use "
+                    "mode='select_action' instead."
+                )
+            with self._no_grad_context():
+                return predictor(observation)
+        selector = getattr(policy, "select_action", None)
+        if not callable(selector):
+            raise ProviderError("LeRobot policy does not implement select_action().")
+        with self._no_grad_context():
+            return selector(observation)
+
+    def reset(self) -> None:
+        """Reset the underlying policy's internal action-chunk/stepper state, when available."""
+
+        if self._policy is None:
+            return
+        reset = getattr(self._policy, "reset", None)
+        if callable(reset):
+            reset()
+
+    def select_actions(self, *, info: JSONDict) -> ActionPolicyResult:
+        started = perf_counter()
+        try:
+            observation, options, mode = self._validate_info(info)
+            policy = self._load_policy()
+            try:
+                raw = self._invoke_policy(policy, observation, mode)
+            except ProviderError:
+                raise
+            except Exception as exc:
+                raise ProviderError(f"LeRobot policy inference failed: {exc}") from exc
+
+            if isinstance(raw, tuple):
+                if len(raw) != 2:
+                    raise ProviderError(
+                        "LeRobot policy tuple response must contain (actions, info)."
+                    )
+                raw_actions, raw_provider_info = raw
+            else:
+                raw_actions = raw
+                raw_provider_info = {}
+
+            normalized_raw_actions = _json_object(
+                {"actions": raw_actions},
+                name="LeRobot raw_actions",
+            )
+            normalized_provider_info = _json_object(
+                raw_provider_info,
+                name="LeRobot provider_info",
+            )
+            candidate_plans = self._translate_actions(
+                raw_actions=raw_actions,
+                info=info,
+                provider_info=normalized_provider_info,
+            )
+            action_horizon_value = info.get("action_horizon")
+            if action_horizon_value is None:
+                action_horizon = len(candidate_plans[0])
+            elif isinstance(action_horizon_value, bool) or not isinstance(
+                action_horizon_value, int
+            ):
+                raise ProviderError(
+                    "LeRobot info.action_horizon must be an integer greater than 0."
+                )
+            else:
+                action_horizon = require_positive_int(
+                    action_horizon_value,
+                    name="LeRobot action_horizon",
+                )
+            embodiment_tag = str(info.get("embodiment_tag") or self.embodiment_tag or "").strip()
+            result = ActionPolicyResult(
+                provider=self.name,
+                actions=list(candidate_plans[0]),
+                raw_actions=normalized_raw_actions,
+                action_horizon=action_horizon,
+                embodiment_tag=embodiment_tag or None,
+                metadata={
+                    "runtime": "lerobot",
+                    "policy_path": self.policy_path,
+                    "policy_type": self.policy_type,
+                    "device": self.device,
+                    "mode": mode,
+                    "provider_info": normalized_provider_info,
+                    "candidate_count": len(candidate_plans),
+                },
+                action_candidates=candidate_plans,
+            )
+            self._emit_policy_event(
+                phase="success",
+                duration_ms=max(0.1, (perf_counter() - started) * 1000),
+                metadata={
+                    "policy_path": self.policy_path,
+                    "policy_type": self.policy_type,
+                    "candidate_count": len(result.action_candidates),
+                    "action_horizon": result.action_horizon,
+                    "embodiment_tag": result.embodiment_tag,
+                    "mode": mode,
+                },
+            )
+            return result
+        except ProviderError as exc:
+            self._emit_policy_event(
+                phase="failure",
+                duration_ms=max(0.1, (perf_counter() - started) * 1000),
+                message=str(exc),
+                metadata={"policy_path": self.policy_path, "policy_type": self.policy_type},
+            )
+            raise
+        except Exception as exc:
+            error = ProviderError(f"LeRobot policy selection failed: {exc}")
+            self._emit_policy_event(
+                phase="failure",
+                duration_ms=max(0.1, (perf_counter() - started) * 1000),
+                message=str(error),
+                metadata={"policy_path": self.policy_path, "policy_type": self.policy_type},
+            )
+            raise error from exc

--- a/tests/test_lerobot_e2e_demo.py
+++ b/tests/test_lerobot_e2e_demo.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+
+def _load_demo() -> ModuleType:
+    script_path = Path(__file__).resolve().parents[1] / "examples" / "lerobot_e2e_demo.py"
+    spec = importlib.util.spec_from_file_location("lerobot_e2e_demo", script_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_lerobot_e2e_demo_runs_full_policy_plus_score_flow(tmp_path: Path) -> None:
+    demo = _load_demo()
+
+    summary = demo.run_demo(state_dir=tmp_path, emit=False)
+
+    assert summary["demo_kind"] == "lerobot_provider_surface"
+    assert summary["runtime_mode"] == "injected_deterministic_policy"
+    assert summary["uses_real_upstream_checkpoint"] is False
+    assert summary["uses_lerobot_provider"] is True
+    assert summary["uses_worldforge_policy_plus_score_planning"] is True
+    assert summary["providers"] == ["demo-distance-score", "lerobot", "mock"]
+    assert summary["lerobot_health"]["healthy"] is True
+    assert summary["policy_candidate_count"] == 3
+    assert summary["candidate_costs"] == [0.2, 0.0, 0.4]
+    assert summary["selected_candidate_index"] == 1
+    assert summary["plan"]["metadata"]["planning_mode"] == "policy+score"
+    assert summary["plan"]["metadata"]["policy_provider"] == "lerobot"
+    assert summary["plan"]["metadata"]["score_provider"] == "demo-distance-score"
+    assert summary["plan"]["metadata"]["policy_result"]["provider"] == "lerobot"
+    assert summary["final_cube_position"] == {"x": 0.55, "y": 0.5, "z": 0.0}
+    assert summary["saved_world_id"] in summary["saved_worlds"]
+    assert summary["event_phases"] == ["success", "success"]
+    assert summary["policy_eval_called"] is True
+    assert summary["policy_requires_grad_disabled"] is True
+    assert summary["policy_reset_calls"] == 1
+    assert summary["policy_select_calls"] == 2

--- a/tests/test_lerobot_provider.py
+++ b/tests/test_lerobot_provider.py
@@ -1,0 +1,662 @@
+from __future__ import annotations
+
+import importlib
+import math
+import sys
+import types
+
+import pytest
+
+from worldforge import Action, ActionPolicyResult, ActionScoreResult, WorldForge, WorldForgeError
+from worldforge.models import JSONDict, ProviderCapabilities, ProviderEvent, ProviderHealth
+from worldforge.providers import (
+    BaseProvider,
+    LeRobotPolicyProvider,
+    MockProvider,
+    ProviderError,
+)
+from worldforge.testing import assert_provider_contract
+
+
+def _policy_info() -> JSONDict:
+    return {
+        "observation": {
+            "observation.state": [[0.0, 0.5, 0.0]],
+            "observation.images.top": [[[[0, 0, 0]]]],
+            "task": "pick up the red cube",
+        },
+        "embodiment_tag": "aloha",
+        "action_horizon": 2,
+    }
+
+
+class FakeTensor:
+    def __init__(self, value: object) -> None:
+        self.value = value
+
+    def tolist(self) -> object:
+        return self.value
+
+
+class FakeLeRobotPolicy:
+    """Mimics the lerobot.policies.pretrained.PreTrainedPolicy surface."""
+
+    def __init__(
+        self,
+        response: object,
+        *,
+        chunk_response: object | None = None,
+        device: str | None = None,
+    ) -> None:
+        self.response = response
+        self.chunk_response = chunk_response
+        self.device = device
+        self.reset_calls = 0
+        self.select_action_calls: list[object] = []
+        self.predict_action_chunk_calls: list[object] = []
+        self.requires_grad_disabled = False
+        self.eval_called = False
+
+    def to(self, device: str) -> FakeLeRobotPolicy:
+        self.device = device
+        return self
+
+    def eval(self) -> FakeLeRobotPolicy:
+        self.eval_called = True
+        return self
+
+    def requires_grad_(self, enabled: bool) -> None:
+        self.requires_grad_disabled = not enabled
+
+    def reset(self) -> None:
+        self.reset_calls += 1
+
+    def select_action(self, observation: object) -> object:
+        self.select_action_calls.append(observation)
+        return self.response
+
+    def predict_action_chunk(self, observation: object) -> object:
+        self.predict_action_chunk_calls.append(observation)
+        return self.chunk_response
+
+
+class FakeScoreProvider(BaseProvider):
+    def __init__(self, scores: list[float]) -> None:
+        self.calls: list[dict[str, object]] = []
+        self._scores = scores
+        best_index = min(range(len(scores)), key=scores.__getitem__)
+        self._result = ActionScoreResult(
+            provider="fake-score",
+            scores=scores,
+            best_index=best_index,
+            metadata={"runtime": "fake-score"},
+        )
+        super().__init__(
+            "fake-score",
+            capabilities=ProviderCapabilities(predict=False, score=True),
+            is_local=True,
+            description="Fake score provider for LeRobot policy+score planning tests.",
+            implementation_status="test",
+            deterministic=True,
+            requires_credentials=False,
+        )
+
+    def health(self) -> ProviderHealth:
+        return ProviderHealth(name=self.name, healthy=True, latency_ms=0.1, details="configured")
+
+    def score_actions(self, *, info: JSONDict, action_candidates: object) -> ActionScoreResult:
+        self.calls.append({"info": info, "action_candidates": action_candidates})
+        return self._result
+
+
+def test_lerobot_policy_provider_passes_contract_and_emits_events() -> None:
+    response = FakeTensor([[0.1, 0.5, 0.0]])
+    policy = FakeLeRobotPolicy(response)
+    events: list[ProviderEvent] = []
+
+    def translator(raw: object, _info: JSONDict, provider_info: JSONDict):
+        assert provider_info == {}
+        return [Action.move_to(0.1, 0.5, 0.0)]
+
+    provider = LeRobotPolicyProvider(
+        policy=policy,
+        embodiment_tag="aloha",
+        action_translator=translator,
+        event_handler=events.append,
+    )
+
+    report = assert_provider_contract(provider, policy_info=_policy_info())
+    result = provider.select_actions(info=_policy_info())
+
+    assert report.exercised_operations == ["policy"]
+    assert provider.profile().capabilities.policy is True
+    assert provider.profile().capabilities.predict is False
+    assert provider.profile().is_local is True
+    assert isinstance(result, ActionPolicyResult)
+    assert result.provider == "lerobot"
+    assert result.action_horizon == 2
+    assert result.embodiment_tag == "aloha"
+    assert result.raw_actions == {"actions": [[0.1, 0.5, 0.0]]}
+    assert result.metadata["runtime"] == "lerobot"
+    assert result.metadata["mode"] == "select_action"
+    assert policy.select_action_calls[-1] == _policy_info()["observation"]
+    assert events[-1].operation == "policy"
+    assert events[-1].phase == "success"
+
+
+def test_lerobot_provider_supports_predict_action_chunk_mode() -> None:
+    chunk = FakeTensor([[[0.0, 0.5, 0.0], [0.1, 0.5, 0.0]]])
+    policy = FakeLeRobotPolicy(
+        response=FakeTensor([[0.0, 0.0, 0.0]]),
+        chunk_response=chunk,
+    )
+    provider = LeRobotPolicyProvider(
+        policy=policy,
+        action_translator=lambda *_args: [
+            [Action.move_to(0.0, 0.5, 0.0), Action.move_to(0.1, 0.5, 0.0)],
+        ],
+    )
+    info = {**_policy_info(), "mode": "predict_chunk"}
+
+    result = provider.select_actions(info=info)
+
+    assert result.metadata["mode"] == "predict_chunk"
+    assert policy.predict_action_chunk_calls
+    assert not policy.select_action_calls
+    assert len(result.actions) == 2
+
+
+def test_lerobot_provider_rejects_chunk_mode_when_unsupported() -> None:
+    policy = FakeLeRobotPolicy(response=FakeTensor([[0.0]]))
+    policy.predict_action_chunk = None  # type: ignore[method-assign]
+    provider = LeRobotPolicyProvider(
+        policy=policy,
+        action_translator=lambda *_args: [Action.move_to(0.0, 0.0, 0.0)],
+    )
+
+    with pytest.raises(ProviderError, match="predict_action_chunk"):
+        provider.select_actions(info={**_policy_info(), "mode": "predict_chunk"})
+
+
+def test_lerobot_policy_only_planning_uses_policy_actions(tmp_path) -> None:
+    policy = FakeLeRobotPolicy(response=FakeTensor([[0.3, 0.5, 0.0]]))
+    provider = LeRobotPolicyProvider(
+        policy=policy,
+        action_translator=lambda *_args: [Action.move_to(0.3, 0.5, 0.0)],
+    )
+    forge = WorldForge(state_dir=tmp_path, auto_register_remote=False)
+    forge.register_provider(provider)
+    world = forge.create_world("robot-workcell", provider="mock")
+
+    selected = forge.select_actions("lerobot", info=_policy_info())
+    plan = world.plan(
+        goal="push the cube",
+        provider="lerobot",
+        policy_info=_policy_info(),
+        execution_provider="mock",
+    )
+    execution = world.execute_plan(plan)
+
+    assert selected.actions == [Action.move_to(0.3, 0.5, 0.0)]
+    assert plan.provider == "lerobot"
+    assert plan.actions == [Action.move_to(0.3, 0.5, 0.0)]
+    assert plan.metadata["planning_mode"] == "policy"
+    assert plan.metadata["policy_result"]["provider"] == "lerobot"
+    assert plan.success_probability == 0.5
+    assert execution.final_world().provider == "mock"
+
+
+def test_lerobot_policy_plus_score_planning_selects_scored_candidate(tmp_path) -> None:
+    candidate_plans = [
+        [Action.move_to(0.1, 0.5, 0.0)],
+        [Action.move_to(0.6, 0.5, 0.0)],
+        [Action.move_to(0.9, 0.5, 0.0)],
+    ]
+    policy = FakeLeRobotPolicy(response=FakeTensor([[0.0, 0.5, 0.0]]))
+    policy_provider = LeRobotPolicyProvider(
+        policy=policy,
+        action_translator=lambda *_args: candidate_plans,
+    )
+    score_provider = FakeScoreProvider([0.7, 0.2, 0.9])
+    forge = WorldForge(state_dir=tmp_path, auto_register_remote=False)
+    forge.register_provider(policy_provider)
+    forge.register_provider(score_provider)
+    world = forge.create_world("robot-workcell", provider="mock")
+
+    plan = world.plan(
+        goal="pick lowest-cost candidate",
+        provider="fake-score",
+        policy_provider="lerobot",
+        policy_info=_policy_info(),
+        score_info={"observation": [[0.0]], "goal": [[1.0]]},
+        execution_provider="mock",
+    )
+
+    assert plan.provider == "fake-score"
+    assert plan.actions == candidate_plans[1]
+    assert plan.metadata["planning_mode"] == "policy+score"
+    assert plan.metadata["policy_provider"] == "lerobot"
+    assert plan.metadata["score_provider"] == "fake-score"
+    assert plan.metadata["policy_result"]["metadata"]["candidate_count"] == 3
+    assert plan.metadata["score_result"]["best_index"] == 1
+
+
+def test_lerobot_provider_reports_unconfigured_and_missing_dependency(monkeypatch) -> None:
+    monkeypatch.delenv("LEROBOT_POLICY_PATH", raising=False)
+    monkeypatch.delenv("LEROBOT_POLICY", raising=False)
+    missing = LeRobotPolicyProvider()
+    assert missing.configured() is False
+    assert missing.health().healthy is False
+    assert "LEROBOT_POLICY_PATH" in missing.health().details
+
+    real_import = importlib.import_module
+
+    def no_lerobot(name: str, *args: object, **kwargs: object):
+        if name == "lerobot" or name.startswith("lerobot."):
+            raise ImportError("no lerobot")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(importlib, "import_module", no_lerobot)
+    monkeypatch.setenv("LEROBOT_POLICY_PATH", "lerobot/act_aloha_sim_transfer_cube_human")
+    unhealthy = LeRobotPolicyProvider()
+    assert unhealthy.configured() is True
+    assert unhealthy.health().healthy is False
+    assert "lerobot" in unhealthy.health().details
+
+
+def test_lerobot_provider_reads_env_configuration(monkeypatch) -> None:
+    monkeypatch.setenv("LEROBOT_POLICY_PATH", "lerobot/diffusion_pusht")
+    monkeypatch.setenv("LEROBOT_POLICY_TYPE", "diffusion")
+    monkeypatch.setenv("LEROBOT_DEVICE", "cpu")
+    monkeypatch.setenv("LEROBOT_CACHE_DIR", "/tmp/lerobot-cache")
+    monkeypatch.setenv("LEROBOT_EMBODIMENT_TAG", "pusht")
+
+    provider = LeRobotPolicyProvider()
+
+    assert provider.policy_path == "lerobot/diffusion_pusht"
+    assert provider.policy_type == "diffusion"
+    assert provider.device == "cpu"
+    assert provider.cache_dir == "/tmp/lerobot-cache"
+    assert provider.embodiment_tag == "pusht"
+    assert provider.profile().default_model == "lerobot/diffusion_pusht"
+    assert provider.configured() is True
+
+
+def test_lerobot_provider_lazily_loads_via_loader_and_applies_device() -> None:
+    created: list[dict[str, object]] = []
+
+    def loader(
+        policy_path: str,
+        policy_type: str | None,
+        device: str | None,
+        cache_dir: str | None,
+    ) -> FakeLeRobotPolicy:
+        created.append(
+            {
+                "policy_path": policy_path,
+                "policy_type": policy_type,
+                "device": device,
+                "cache_dir": cache_dir,
+            }
+        )
+        return FakeLeRobotPolicy(response=FakeTensor([[0.42, 0.5, 0.0]]))
+
+    provider = LeRobotPolicyProvider(
+        policy_path="lerobot/act_aloha_sim_transfer_cube_human",
+        policy_type="act",
+        device="cpu",
+        cache_dir="/tmp/cache",
+        policy_loader=loader,
+        action_translator=lambda *_args: [Action.move_to(0.42, 0.5, 0.0)],
+    )
+
+    assert provider.health().healthy is True
+    result = provider.select_actions(info=_policy_info())
+
+    assert created == [
+        {
+            "policy_path": "lerobot/act_aloha_sim_transfer_cube_human",
+            "policy_type": "act",
+            "device": "cpu",
+            "cache_dir": "/tmp/cache",
+        }
+    ]
+    assert result.actions == [Action.move_to(0.42, 0.5, 0.0)]
+
+
+def test_lerobot_provider_lazily_imports_pretrained_policy(monkeypatch) -> None:
+    loads: list[dict[str, object]] = []
+
+    class FakePretrainedPolicy:
+        @classmethod
+        def from_pretrained(cls, path: str, **kwargs: object) -> FakeLeRobotPolicy:
+            loads.append({"path": path, "kwargs": kwargs})
+            return FakeLeRobotPolicy(response=FakeTensor([[0.2, 0.5, 0.0]]))
+
+    pretrained_module = types.SimpleNamespace(PreTrainedPolicy=FakePretrainedPolicy)
+    policies_module = types.SimpleNamespace(pretrained=pretrained_module)
+    lerobot_module = types.SimpleNamespace(policies=policies_module)
+    monkeypatch.setitem(sys.modules, "lerobot", lerobot_module)
+    monkeypatch.setitem(sys.modules, "lerobot.policies", policies_module)
+    monkeypatch.setitem(sys.modules, "lerobot.policies.pretrained", pretrained_module)
+
+    provider = LeRobotPolicyProvider(
+        policy_path="lerobot/act_aloha_sim_transfer_cube_human",
+        cache_dir="/tmp/cache",
+        action_translator=lambda *_args: [Action.move_to(0.2, 0.5, 0.0)],
+    )
+
+    assert provider.health().healthy is True
+    result = provider.select_actions(info=_policy_info())
+
+    assert loads == [
+        {
+            "path": "lerobot/act_aloha_sim_transfer_cube_human",
+            "kwargs": {"cache_dir": "/tmp/cache"},
+        }
+    ]
+    assert result.actions == [Action.move_to(0.2, 0.5, 0.0)]
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "match"),
+    [
+        ({"policy_path": " "}, "policy_path"),
+        ({"policy_type": "notapolicy"}, "policy_type"),
+        ({"device": " "}, "device"),
+        ({"cache_dir": " "}, "cache_dir"),
+        ({"embodiment_tag": " "}, "embodiment_tag"),
+    ],
+)
+def test_lerobot_provider_rejects_invalid_configuration(
+    kwargs: dict[str, object],
+    match: str,
+) -> None:
+    with pytest.raises(WorldForgeError, match=match):
+        LeRobotPolicyProvider(**kwargs)
+
+
+@pytest.mark.parametrize(
+    ("info", "match"),
+    [
+        ({}, "observation"),
+        ({"observation": "not-a-dict"}, "observation"),
+        ({"observation": {}}, "observation"),
+        ({"observation": {"observation.state": [[0.0]]}, "options": "bad"}, "options"),
+        ({"observation": {"observation.state": [[0.0]]}, "mode": "rollout"}, "mode"),
+        (
+            {"observation": {"observation.state": [[0.0]]}, "action_horizon": 0},
+            "action_horizon",
+        ),
+        (
+            {"observation": {"observation.state": [[0.0]]}, "action_horizon": "two"},
+            "action_horizon",
+        ),
+    ],
+)
+def test_lerobot_provider_rejects_malformed_info(
+    info: JSONDict,
+    match: str,
+) -> None:
+    provider = LeRobotPolicyProvider(
+        policy=FakeLeRobotPolicy(response=FakeTensor([[0.0]])),
+        action_translator=lambda *_args: [Action.move_to(0.0, 0.0, 0.0)],
+    )
+
+    with pytest.raises(ProviderError, match=match):
+        provider.select_actions(info=info)
+
+
+@pytest.mark.parametrize(
+    ("response", "translator", "match"),
+    [
+        (
+            (FakeTensor([[0.0]]), {}, "extra"),
+            lambda *_args: [Action.move_to(0.0, 0.0, 0.0)],
+            "tuple",
+        ),
+        (
+            FakeTensor([[math.nan]]),
+            lambda *_args: [Action.move_to(0.0, 0.0, 0.0)],
+            "finite numbers",
+        ),
+        (
+            (FakeTensor([[0.0]]), "not-info"),
+            lambda *_args: [Action.move_to(0.0, 0.0, 0.0)],
+            "provider_info",
+        ),
+        (
+            FakeTensor([[0.0]]),
+            lambda *_args: [],
+            "non-empty action sequence",
+        ),
+        (
+            FakeTensor([[0.0]]),
+            lambda *_args: [[object()]],
+            "Action instances",
+        ),
+    ],
+)
+def test_lerobot_provider_rejects_malformed_outputs(
+    response: object,
+    translator,
+    match: str,
+) -> None:
+    provider = LeRobotPolicyProvider(
+        policy=FakeLeRobotPolicy(response=response),
+        action_translator=translator,
+    )
+
+    with pytest.raises(ProviderError, match=match):
+        provider.select_actions(info=_policy_info())
+
+
+def test_lerobot_provider_wraps_policy_and_translator_failures() -> None:
+    failing_policy = FakeLeRobotPolicy(response=FakeTensor([[0.0]]))
+
+    def fail_select(_observation: object) -> object:
+        raise RuntimeError("gpu unavailable")
+
+    failing_policy.select_action = fail_select  # type: ignore[method-assign]
+    provider = LeRobotPolicyProvider(
+        policy=failing_policy,
+        action_translator=lambda *_args: [Action("noop")],
+    )
+    with pytest.raises(ProviderError, match="gpu unavailable"):
+        provider.select_actions(info=_policy_info())
+
+    no_select = LeRobotPolicyProvider(
+        policy=object(),
+        action_translator=lambda *_args: [Action("noop")],
+    )
+    with pytest.raises(ProviderError, match="select_action"):
+        no_select.select_actions(info=_policy_info())
+
+    bad_translator = LeRobotPolicyProvider(
+        policy=FakeLeRobotPolicy(response=FakeTensor([[0.0]])),
+        action_translator=lambda *_args: (_ for _ in ()).throw(RuntimeError("bad map")),
+    )
+    with pytest.raises(ProviderError, match="bad map"):
+        bad_translator.select_actions(info=_policy_info())
+
+
+def test_lerobot_provider_missing_translator_raises() -> None:
+    provider = LeRobotPolicyProvider(
+        policy=FakeLeRobotPolicy(response=FakeTensor([[0.0]])),
+    )
+    with pytest.raises(ProviderError, match="action_translator"):
+        provider.select_actions(info=_policy_info())
+
+
+def test_lerobot_provider_reset_delegates_when_policy_loaded() -> None:
+    policy = FakeLeRobotPolicy(response=FakeTensor([[0.0]]))
+    provider = LeRobotPolicyProvider(
+        policy=policy,
+        action_translator=lambda *_args: [Action.move_to(0.0, 0.0, 0.0)],
+    )
+    provider.reset()
+    assert policy.reset_calls == 1
+
+
+def test_lerobot_provider_reset_is_noop_when_policy_not_loaded() -> None:
+    provider = LeRobotPolicyProvider(policy_path="lerobot/act_aloha_sim_transfer_cube_human")
+    provider.reset()  # should not raise
+
+
+def test_lerobot_auto_registers_when_policy_path_env_set(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("LEROBOT_POLICY_PATH", "lerobot/act_aloha_sim_transfer_cube_human")
+    forge = WorldForge(state_dir=tmp_path)
+    assert "lerobot" in forge.providers()
+
+
+def test_lerobot_not_auto_registered_without_policy_path_env(monkeypatch, tmp_path) -> None:
+    monkeypatch.delenv("LEROBOT_POLICY_PATH", raising=False)
+    monkeypatch.delenv("LEROBOT_POLICY", raising=False)
+    forge = WorldForge(state_dir=tmp_path)
+    assert "lerobot" not in forge.providers()
+
+
+def test_lerobot_provider_lazily_imports_specific_policy_class(monkeypatch) -> None:
+    loads: list[dict[str, object]] = []
+
+    class FakeACTPolicy:
+        @classmethod
+        def from_pretrained(cls, path: str, **kwargs: object) -> FakeLeRobotPolicy:
+            loads.append({"path": path, "kwargs": kwargs, "class": cls.__name__})
+            return FakeLeRobotPolicy(response=FakeTensor([[0.3, 0.5, 0.0]]))
+
+    act_module = types.SimpleNamespace(ACTPolicy=FakeACTPolicy)
+    policies_module = types.SimpleNamespace(act=types.SimpleNamespace(modeling_act=act_module))
+    lerobot_module = types.SimpleNamespace(policies=policies_module)
+    monkeypatch.setitem(sys.modules, "lerobot", lerobot_module)
+    monkeypatch.setitem(sys.modules, "lerobot.policies", policies_module)
+    monkeypatch.setitem(sys.modules, "lerobot.policies.act", policies_module.act)
+    monkeypatch.setitem(sys.modules, "lerobot.policies.act.modeling_act", act_module)
+
+    provider = LeRobotPolicyProvider(
+        policy_path="lerobot/act_aloha_sim_transfer_cube_human",
+        policy_type="act",
+        action_translator=lambda *_args: [Action.move_to(0.3, 0.5, 0.0)],
+    )
+    result = provider.select_actions(info=_policy_info())
+
+    assert loads == [
+        {
+            "path": "lerobot/act_aloha_sim_transfer_cube_human",
+            "kwargs": {},
+            "class": "FakeACTPolicy",
+        }
+    ]
+    assert result.actions == [Action.move_to(0.3, 0.5, 0.0)]
+
+
+def test_lerobot_provider_falls_back_to_common_path_for_policy_class(monkeypatch) -> None:
+    class FakeDiffusionPolicy:
+        @classmethod
+        def from_pretrained(cls, path: str, **_kwargs: object) -> FakeLeRobotPolicy:
+            return FakeLeRobotPolicy(response=FakeTensor([[0.1]]))
+
+    diffusion_modeling = types.SimpleNamespace(DiffusionPolicy=FakeDiffusionPolicy)
+    monkeypatch.setitem(
+        sys.modules,
+        "lerobot.common.policies.diffusion.modeling_diffusion",
+        diffusion_modeling,
+    )
+
+    real_import = importlib.import_module
+
+    def selective_import(name: str, *args: object, **kwargs: object):
+        if name in {
+            "lerobot.policies.diffusion.modeling_diffusion",
+            "lerobot.policies.diffusion",
+            "lerobot.common.policies.diffusion",
+        }:
+            raise ImportError(f"simulated missing module {name}")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(importlib, "import_module", selective_import)
+
+    provider = LeRobotPolicyProvider(
+        policy_path="lerobot/diffusion_pusht",
+        policy_type="diffusion",
+        action_translator=lambda *_args: [Action.move_to(0.1, 0.0, 0.0)],
+    )
+    result = provider.select_actions(info=_policy_info())
+
+    assert result.actions == [Action.move_to(0.1, 0.0, 0.0)]
+
+
+def test_lerobot_provider_raises_when_no_policy_class_resolves(monkeypatch) -> None:
+    real_import = importlib.import_module
+
+    def no_policy_module(name: str, *args: object, **kwargs: object):
+        if name.startswith("lerobot.policies.vqbet") or name.startswith(
+            "lerobot.common.policies.vqbet"
+        ):
+            raise ImportError("simulated missing vqbet module")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(importlib, "import_module", no_policy_module)
+
+    provider = LeRobotPolicyProvider(
+        policy_path="lerobot/vqbet_pusht",
+        policy_type="vqbet",
+        action_translator=lambda *_args: [Action.move_to(0.0, 0.0, 0.0)],
+    )
+    with pytest.raises(ProviderError, match="VQBeTPolicy"):
+        provider.select_actions(info=_policy_info())
+
+
+def test_lerobot_provider_load_errors_wrapped(monkeypatch) -> None:
+    def broken_loader(*_args: object) -> FakeLeRobotPolicy:
+        raise RuntimeError("checkpoint corrupt")
+
+    provider = LeRobotPolicyProvider(
+        policy_path="lerobot/act_aloha_sim_transfer_cube_human",
+        policy_loader=broken_loader,
+        action_translator=lambda *_args: [Action.move_to(0.0, 0.0, 0.0)],
+    )
+    with pytest.raises(ProviderError, match="Failed to load LeRobot policy"):
+        provider.select_actions(info=_policy_info())
+
+
+def test_lerobot_provider_load_without_policy_path_raises() -> None:
+    provider = LeRobotPolicyProvider(
+        policy_loader=lambda *_args: FakeLeRobotPolicy(response=FakeTensor([[0.0]])),
+        action_translator=lambda *_args: [Action.move_to(0.0, 0.0, 0.0)],
+    )
+    with pytest.raises(ProviderError, match="LEROBOT_POLICY_PATH"):
+        provider.select_actions(info=_policy_info())
+
+
+def test_lerobot_provider_no_grad_fallback_without_torch(monkeypatch) -> None:
+    real_import = importlib.import_module
+
+    def no_torch(name: str, *args: object, **kwargs: object):
+        if name == "torch":
+            raise ImportError("no torch")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(importlib, "import_module", no_torch)
+    policy = FakeLeRobotPolicy(response=FakeTensor([[0.2, 0.5, 0.0]]))
+    provider = LeRobotPolicyProvider(
+        policy=policy,
+        action_translator=lambda *_args: [Action.move_to(0.2, 0.5, 0.0)],
+    )
+    result = provider.select_actions(info=_policy_info())
+
+    assert result.actions == [Action.move_to(0.2, 0.5, 0.0)]
+
+
+def test_policy_planning_validation_errors_for_lerobot(tmp_path) -> None:
+    forge = WorldForge(state_dir=tmp_path, auto_register_remote=False)
+    forge.register_provider(MockProvider(name="manual-mock"))
+    world = forge.create_world("robot-workcell", provider="manual-mock")
+
+    policy_provider = LeRobotPolicyProvider(
+        policy=FakeLeRobotPolicy(response=FakeTensor([[0.0, 0.0, 0.0]])),
+        action_translator=lambda *_args: [Action.move_to(0.0, 0.0, 0.0)],
+    )
+    forge.register_provider(policy_provider)
+    with pytest.raises(WorldForgeError, match="Policy planning requires policy_info"):
+        world.plan(goal="move", provider="lerobot", policy_provider="lerobot")

--- a/tests/test_lerobot_smoke_script.py
+++ b/tests/test_lerobot_smoke_script.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+
+def _load_script() -> ModuleType:
+    script_path = Path(__file__).resolve().parents[1] / "scripts" / "smoke_lerobot_policy.py"
+    spec = importlib.util.spec_from_file_location("smoke_lerobot_policy", script_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _args(**overrides: object) -> argparse.Namespace:
+    defaults: dict[str, object] = {
+        "policy_info_json": None,
+        "observation_json": None,
+        "observation_module": None,
+        "options_json": None,
+        "embodiment_tag": None,
+        "action_horizon": None,
+        "mode": "select_action",
+        "policy_path": "lerobot/act_aloha_sim_transfer_cube_human",
+        "policy_type": None,
+        "device": "cpu",
+        "cache_dir": None,
+        "translator": None,
+        "health_only": False,
+    }
+    defaults.update(overrides)
+    return argparse.Namespace(**defaults)
+
+
+def test_smoke_script_loads_file_callables(tmp_path: Path) -> None:
+    module_path = tmp_path / "translator.py"
+    module_path.write_text(
+        "def translate(raw_actions, info, provider_info):\n"
+        "    return (raw_actions, info, provider_info)\n"
+    )
+    script = _load_script()
+
+    loaded = script._load_callable(f"{module_path}:translate", name="translator")
+
+    assert loaded({"actions": []}, {"observation": {}}, {}) == (
+        {"actions": []},
+        {"observation": {}},
+        {},
+    )
+
+
+def test_smoke_script_builds_policy_info_from_json_files(tmp_path: Path) -> None:
+    policy_path = tmp_path / "policy.json"
+    options_path = tmp_path / "options.json"
+    policy_path.write_text(
+        json.dumps(
+            {
+                "observation": {
+                    "observation.state": [[0.0, 0.5, 0.0]],
+                    "task": "pick up the cube",
+                }
+            }
+        )
+    )
+    options_path.write_text(json.dumps({"temperature": 0.1}))
+    script = _load_script()
+
+    info = script._load_policy_info(
+        _args(
+            policy_info_json=policy_path,
+            options_json=options_path,
+            embodiment_tag="aloha",
+            action_horizon=8,
+            mode="predict_chunk",
+        )
+    )
+
+    assert info == {
+        "observation": {
+            "observation.state": [[0.0, 0.5, 0.0]],
+            "task": "pick up the cube",
+        },
+        "options": {"temperature": 0.1},
+        "embodiment_tag": "aloha",
+        "action_horizon": 8,
+        "mode": "predict_chunk",
+    }
+
+
+def test_smoke_script_builds_policy_info_from_observation_factory(tmp_path: Path) -> None:
+    module_path = tmp_path / "observation.py"
+    module_path.write_text(
+        "def build():\n"
+        "    return {\n"
+        "        'observation.state': [[0.0, 0.5, 0.0]],\n"
+        "        'task': 'open the drawer',\n"
+        "    }\n"
+    )
+    script = _load_script()
+
+    info = script._load_policy_info(_args(observation_module=f"{module_path}:build"))
+
+    assert info == {
+        "observation": {
+            "observation.state": [[0.0, 0.5, 0.0]],
+            "task": "open the drawer",
+        },
+        "mode": "select_action",
+    }
+
+
+def test_smoke_script_rejects_missing_policy_info(tmp_path: Path) -> None:
+    script = _load_script()
+
+    with pytest.raises(SystemExit, match="Live policy smoke requires"):
+        script._load_policy_info(_args())
+
+
+def test_smoke_script_rejects_non_json_object_policy_info(tmp_path: Path) -> None:
+    policy_path = tmp_path / "policy.json"
+    policy_path.write_text(json.dumps([1, 2, 3]))
+    script = _load_script()
+
+    with pytest.raises(SystemExit, match="must decode to a JSON object"):
+        script._load_policy_info(_args(policy_info_json=policy_path))
+
+
+def test_smoke_script_rejects_nonexistent_module_file(tmp_path: Path) -> None:
+    script = _load_script()
+
+    with pytest.raises(SystemExit, match="does not exist"):
+        script._load_callable(f"{tmp_path}/does_not_exist.py:translate", name="translator")
+
+
+def test_smoke_script_rejects_invalid_callable_spec() -> None:
+    script = _load_script()
+
+    with pytest.raises(SystemExit, match="module_or_file:function"):
+        script._load_callable("no-colon-here", name="translator")


### PR DESCRIPTION
Integrate Hugging Face LeRobot as a first-class optional policy provider.
The adapter wraps `PreTrainedPolicy.from_pretrained` and exposes LeRobot's
action-selection surface (ACT, Diffusion, TDMPC, VQBet, Pi0, Pi0Fast, SAC,
SmolVLA) through WorldForge's existing `policy` capability, preserving the
clean separation between embodied actor policies and predictive world
models.

Key design choices:

- Lazy import: `lerobot` is only imported when a non-injected policy is
  loaded, so WorldForge's base install stays dependency-free.
- Injectable policy and policy_loader hooks make the adapter fully testable
  without downloading upstream checkpoints.
- Host-supplied `action_translator` maps embodiment-specific raw tensors to
  WorldForge `Action` objects, mirroring the GR00T contract.
- Validates observations, modes, horizons, and raw outputs; every failure
  flows through `ProviderError` with context.
- Auto-registers when `LEROBOT_POLICY_PATH` (or `LEROBOT_POLICY`) is set.

Ships with:

- 39 unit tests covering contract, events, env config, lazy import,
  select_action/predict_chunk modes, translator failures, and registration.
- Checkout-safe end-to-end demo at `examples/lerobot_e2e_demo.py` that
  exercises provider registration, candidate action proposal,
  policy+score planning, mock execution, persistence, and reload.
- Real-checkpoint live smoke script at `scripts/smoke_lerobot_policy.py`
  with JSON/observation-factory input loading.
- Provider docs, README integration, provider-matrix update, and CHANGELOG
  entry.

All 184 tests pass, coverage stays above 90%, and the wheel-install
validation script also passes.

https://claude.ai/code/session_01PSb8RBX61rvX416DNbfBMK