### PR TITLE
chore: add .env.example, unshadow it in .gitignore, and align Makefile with CI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,105 @@
+# WorldForge environment configuration template.
+#
+# Copy this file to `.env` and fill in the values for the providers you plan to
+# use. WorldForge only auto-registers optional providers when their required
+# environment variables are present, so leaving a block blank simply disables
+# that provider.
+#
+# Never commit a real `.env`. Credentials belong to the host environment.
+
+# -----------------------------------------------------------------------------
+# Cosmos (NVIDIA Cosmos NIM) -- generate
+# -----------------------------------------------------------------------------
+# Required to auto-register: base URL of a reachable Cosmos deployment.
+# Example: http://localhost:8000 or https://your-cosmos.example.com
+COSMOS_BASE_URL=
+
+# Optional bearer token sent as `Authorization: Bearer ...` when set.
+NVIDIA_API_KEY=
+
+# -----------------------------------------------------------------------------
+# Runway (image-to-video / video-to-video) -- generate, transfer
+# -----------------------------------------------------------------------------
+# Required to auto-register: preferred name is RUNWAYML_API_SECRET.
+# RUNWAY_API_SECRET is accepted as a legacy alias.
+RUNWAYML_API_SECRET=
+# RUNWAY_API_SECRET=
+
+# Optional: override the default Runway base URL.
+# RUNWAYML_BASE_URL=
+
+# -----------------------------------------------------------------------------
+# LeWorldModel (JEPA cost model via stable_worldmodel) -- score
+# -----------------------------------------------------------------------------
+# Required to auto-register: checkpoint run name relative to $STABLEWM_HOME
+# (upstream default: ~/.stable-wm). Example: pusht/lewm
+# LEWM_POLICY is accepted as a legacy alias.
+LEWORLDMODEL_POLICY=
+# LEWM_POLICY=
+
+# Optional: override the checkpoint cache directory.
+# LEWORLDMODEL_CACHE_DIR=
+
+# Optional: torch device string, e.g. cpu, cuda, cuda:0.
+# LEWORLDMODEL_DEVICE=
+
+# -----------------------------------------------------------------------------
+# GR00T (NVIDIA Isaac GR00T PolicyClient) -- policy
+# -----------------------------------------------------------------------------
+# Required to auto-register: reachable host running the GR00T policy server.
+GROOT_POLICY_HOST=
+
+# Optional: port (default 5555).
+# GROOT_POLICY_PORT=5555
+
+# Optional: request timeout in milliseconds (default 15000).
+# GROOT_POLICY_TIMEOUT_MS=15000
+
+# Optional: bearer token sent to the policy server when set.
+# GROOT_POLICY_API_TOKEN=
+
+# Optional: 1/true enables strict mode on the PolicyClient.
+# GROOT_POLICY_STRICT=
+
+# Optional: embodiment tag attached to policy requests.
+# GROOT_EMBODIMENT_TAG=
+
+# -----------------------------------------------------------------------------
+# LeRobot (Hugging Face LeRobot pretrained policies) -- policy
+# -----------------------------------------------------------------------------
+# Required to auto-register: Hugging Face repo id or local checkpoint directory.
+# Example: lerobot/act_aloha_sim_transfer_cube_human
+# LEROBOT_POLICY is accepted as a legacy alias.
+LEROBOT_POLICY_PATH=
+# LEROBOT_POLICY=
+
+# Optional: policy class hint. Must be one of:
+# act, diffusion, pi0, pi0fast, sac, smolvla, tdmpc, vqbet
+# LEROBOT_POLICY_TYPE=
+
+# Optional: torch device string.
+# LEROBOT_DEVICE=
+
+# Optional: checkpoint cache directory.
+# LEROBOT_CACHE_DIR=
+
+# Optional: embodiment tag attached to policy requests.
+# LEROBOT_EMBODIMENT_TAG=
+
+# -----------------------------------------------------------------------------
+# JEPA-WMS candidate (facebookresearch/jepa-wms torch-hub scaffold)
+# -----------------------------------------------------------------------------
+# These variables are documented by the `jepa-wms` provider candidate only and
+# do NOT make JEPAWMSProvider available through WorldForge auto-registration.
+# Direct tests must inject `runtime=` or use JEPAWMSProvider.from_torch_hub(...).
+# JEPA_WMS_MODEL_PATH=
+# JEPA_WMS_MODEL_NAME=
+# JEPA_WMS_DEVICE=
+
+# -----------------------------------------------------------------------------
+# Scaffold providers (deterministic mock-backed stubs for future adapters)
+# -----------------------------------------------------------------------------
+# Setting these only enables the credential-gated stub paths; they do not
+# provide real JEPA or Genie behavior. Treat them as reservations, not runtimes.
+# JEPA_MODEL_PATH=
+# GENIE_API_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Environment and secrets
 .env
 .env.*
+!.env.example
 *.pem
 *.key
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -167,6 +167,11 @@ rm -f "$tmp_req"
   `jepa-wms` candidate only. They do not make `JEPAWMSProvider` available through `WorldForge`;
   direct tests must inject `runtime=` or use `JEPAWMSProvider.from_torch_hub(...)`.
 - `RUNWAYML_API_SECRET` is preferred, but `RUNWAY_API_SECRET` remains supported as a legacy alias.
+- `.env.example` is tracked via an explicit `!.env.example` rule in `.gitignore` (the general
+  `.env.*` pattern would otherwise exclude it). Keep both the template and the exception in sync
+  when adding new provider environment variables.
+- `make lint` and `make format` run against `src tests examples scripts` to match CI and the
+  commands documented in `README.md`. Do not drop `scripts` from either target.
 
 ## Current State
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ releases may still include breaking changes when the public API needs to tighten
 
 ### Added
 
+- Added `.env.example` documenting every provider environment variable recognized by
+  WorldForge (`COSMOS_BASE_URL`, `NVIDIA_API_KEY`, `RUNWAYML_API_SECRET` and the legacy
+  `RUNWAY_API_SECRET` alias, `RUNWAYML_BASE_URL`, `LEWORLDMODEL_POLICY` and the legacy
+  `LEWM_POLICY` alias, `LEWORLDMODEL_CACHE_DIR`, `LEWORLDMODEL_DEVICE`, the full
+  `GROOT_POLICY_*` and `GROOT_EMBODIMENT_TAG` set, the full `LEROBOT_*` set including the
+  legacy `LEROBOT_POLICY` alias, the `JEPA_WMS_*` candidate variables, and the scaffold
+  `JEPA_MODEL_PATH` and `GENIE_API_KEY`). Each variable is annotated with whether it is
+  required for auto-registration or strictly optional, closing the gap between the README's
+  `cp .env.example .env` onboarding step and the repository contents.
+
+### Fixed
+
+- Tracked `.env.example` in the repository by adding an explicit `!.env.example` exception
+  to `.gitignore`; the general `.env.*` glob was silently excluding the onboarding template.
+- Aligned `make lint` and `make format` with CI, `README.md`, and `AGENTS.md` by adding
+  `scripts/` to the `ruff check` and `ruff format` invocations and to the `clean` sweep.
+  The previous Makefile skipped scripts, so local `make lint` could pass while CI failed on
+  changes under `scripts/`.
+
 - Added `lerobot` as a first-class optional policy provider for Hugging Face LeRobot
   pretrained policies (ACT, Diffusion, TDMPC, VQBet, Pi0, Pi0Fast, SAC, SmolVLA). The
   adapter lazily imports `lerobot.policies.pretrained.PreTrainedPolicy`, supports injectable

--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,11 @@ sync:
 	$(UV) sync --group dev
 
 format:
-	$(UV) run ruff format src tests examples
+	$(UV) run ruff format src tests examples scripts
 
 lint:
-	$(UV) run ruff check src tests examples
-	$(UV) run ruff format --check src tests examples
+	$(UV) run ruff check src tests examples scripts
+	$(UV) run ruff format --check src tests examples scripts
 
 test:
 	$(UV) run pytest
@@ -31,4 +31,4 @@ check: lint test test-package
 
 clean:
 	rm -rf build dist .pytest_cache .ruff_cache .worldforge .coverage
-	find src tests examples -name '__pycache__' -type d -prune -exec rm -rf {} +
+	find src tests examples scripts -name '__pycache__' -type d -prune -exec rm -rf {} +


### PR DESCRIPTION
The README instructs new contributors to `cp .env.example .env`, but the file
was missing and `.env.*` in `.gitignore` silently blocked it from ever being
tracked. Added an annotated template covering every provider env var WorldForge
reads (Cosmos, Runway, LeWorldModel, GR00T, LeRobot, JEPA-WMS candidate, and
the credential-gated scaffold stubs), noting which are required for
auto-registration and which are optional.

Also aligned `make lint`/`make format`/`make clean` with CI, `README.md`, and
`AGENTS.md` by including `scripts/` in the ruff invocations and cleanup sweep.
Previously `make lint` could pass locally while CI failed on the same diff.

https://claude.ai/code/session_01GddZu1eTqhpZ6FSc2RsjjH