### PR TITLE
Refactor benchmark operation dispatch and tighten error handling

### DIFF
--- a/src/worldforge/benchmark.py
+++ b/src/worldforge/benchmark.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import csv
 import io
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from contextlib import contextmanager
 from dataclasses import dataclass, field
@@ -23,6 +23,7 @@ from worldforge.models import (
     require_positive_int,
 )
 from worldforge.observability import ProviderMetricsSink, compose_event_handlers
+from worldforge.providers.base import ProviderError
 
 
 def _sample_transfer_clip() -> VideoClip:
@@ -246,6 +247,12 @@ class ProviderBenchmarkHarness:
 
     def __init__(self, forge: WorldForge | None = None) -> None:
         self._forge = forge or WorldForge()
+        self._operation_handlers: dict[str, Callable[[str, BenchmarkInputs], None]] = {
+            "predict": self._op_predict,
+            "reason": self._op_reason,
+            "generate": self._op_generate,
+            "transfer": self._op_transfer,
+        }
 
     def supported_operations(self, provider: str) -> list[str]:
         profile = self._forge.provider_profile(provider)
@@ -275,49 +282,48 @@ class ProviderBenchmarkHarness:
         )
         return world, (cube, mug)
 
+    def _op_predict(self, provider: str, inputs: BenchmarkInputs) -> None:
+        world, _ = self._seed_world(provider)
+        world.predict(
+            inputs.prediction_action,
+            steps=inputs.prediction_steps,
+            provider=provider,
+        )
+
+    def _op_reason(self, provider: str, inputs: BenchmarkInputs) -> None:
+        world, _ = self._seed_world(provider)
+        self._forge.reason(provider, inputs.reason_query, world=world)
+
+    def _op_generate(self, provider: str, inputs: BenchmarkInputs) -> None:
+        self._forge.generate(
+            inputs.generation_prompt,
+            provider,
+            duration_seconds=inputs.generation_duration_seconds,
+        )
+
+    def _op_transfer(self, provider: str, inputs: BenchmarkInputs) -> None:
+        self._forge.transfer(
+            inputs.transfer_clip,
+            provider,
+            width=inputs.transfer_width,
+            height=inputs.transfer_height,
+            fps=inputs.transfer_fps,
+            prompt=inputs.transfer_prompt,
+        )
+
     def _invoke_operation(
         self,
         provider: str,
         operation: str,
         inputs: BenchmarkInputs,
     ) -> None:
-        if operation == "predict":
-            world, _ = self._seed_world(provider)
-            world.predict(
-                inputs.prediction_action,
-                steps=inputs.prediction_steps,
-                provider=provider,
+        handler = self._operation_handlers.get(operation)
+        if handler is None:
+            raise WorldForgeError(
+                f"Unknown benchmark operation '{operation}'. "
+                f"Known operations: {', '.join(self.benchmarkable_operations)}."
             )
-            return
-
-        if operation == "reason":
-            world, _ = self._seed_world(provider)
-            self._forge.reason(provider, inputs.reason_query, world=world)
-            return
-
-        if operation == "generate":
-            self._forge.generate(
-                inputs.generation_prompt,
-                provider,
-                duration_seconds=inputs.generation_duration_seconds,
-            )
-            return
-
-        if operation == "transfer":
-            self._forge.transfer(
-                inputs.transfer_clip,
-                provider,
-                width=inputs.transfer_width,
-                height=inputs.transfer_height,
-                fps=inputs.transfer_fps,
-                prompt=inputs.transfer_prompt,
-            )
-            return
-
-        raise WorldForgeError(
-            f"Unknown benchmark operation '{operation}'. "
-            f"Known operations: {', '.join(self.benchmarkable_operations)}."
-        )
+        handler(provider, inputs)
 
     def _sample_once(
         self,
@@ -328,7 +334,7 @@ class ProviderBenchmarkHarness:
         started = perf_counter()
         try:
             self._invoke_operation(provider, operation, inputs)
-        except Exception as exc:
+        except (ProviderError, WorldForgeError, TimeoutError) as exc:
             return _BenchmarkSample(
                 latency_ms=max(0.1, (perf_counter() - started) * 1000),
                 error=str(exc),

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -6,7 +6,9 @@ import httpx
 import pytest
 
 from worldforge import ProviderBenchmarkHarness, ProviderRequestPolicy, WorldForge, WorldForgeError
+from worldforge.benchmark import BenchmarkInputs
 from worldforge.providers import CosmosProvider, RunwayProvider
+from worldforge.providers.base import ProviderError
 
 
 def test_provider_benchmark_harness_reports_mock_operations(tmp_path) -> None:
@@ -104,3 +106,44 @@ def test_provider_benchmark_harness_rejects_unsupported_operations(tmp_path) -> 
 
     with pytest.raises(WorldForgeError, match="unsupported operations: transfer"):
         harness.run("cosmos", operations=["transfer"], iterations=1)
+
+
+def test_provider_benchmark_harness_rejects_unknown_invoke_operation(tmp_path) -> None:
+    forge = WorldForge(state_dir=tmp_path)
+    harness = ProviderBenchmarkHarness(forge=forge)
+
+    with pytest.raises(WorldForgeError, match="Unknown benchmark operation"):
+        harness._invoke_operation("mock", "not-a-real-op", BenchmarkInputs())
+
+
+def test_provider_benchmark_harness_records_provider_error_samples(tmp_path) -> None:
+    forge = WorldForge(state_dir=tmp_path)
+    harness = ProviderBenchmarkHarness(forge=forge)
+
+    def _boom(provider: str, inputs: BenchmarkInputs) -> None:
+        raise ProviderError("simulated provider outage")
+
+    # Swap the predict handler so the narrowed except branch fires without an outbound call.
+    harness._operation_handlers["predict"] = _boom
+
+    report = harness.run("mock", operations=["predict"], iterations=2, concurrency=1)
+    result = report.results[0]
+    assert result.success_count == 0
+    assert result.error_count == 2
+    assert all("simulated provider outage" in message for message in result.errors)
+
+
+def test_provider_benchmark_harness_propagates_unexpected_exceptions(tmp_path) -> None:
+    forge = WorldForge(state_dir=tmp_path)
+    harness = ProviderBenchmarkHarness(forge=forge)
+
+    class _UnexpectedError(Exception):
+        pass
+
+    def _boom(provider: str, inputs: BenchmarkInputs) -> None:
+        raise _UnexpectedError("this must propagate")
+
+    harness._operation_handlers["predict"] = _boom
+
+    with pytest.raises(_UnexpectedError, match="this must propagate"):
+        harness.run("mock", operations=["predict"], iterations=1, concurrency=1)


### PR DESCRIPTION
## Summary
- Replace the per-operation if/elif ladder in `ProviderBenchmarkHarness._invoke_operation` with a dispatch table keyed by operation name, built once at construction time.
- Narrow the catch-all `except Exception` in `_sample_once` to `(ProviderError, WorldForgeError, TimeoutError)` so programming errors and other unexpected exceptions surface rather than being silently recorded as benchmark samples.
- Add regression tests covering the dispatch error branch, the recorded-error path for provider failures, and propagation of unexpected exceptions.

Public surface (`ProviderBenchmarkHarness`, `run_benchmark`, benchmark dataclasses, exports) is unchanged. `sum(...) / len(...) if ... else None` aggregations are left intact because `worldforge.models.average` returns `0.0` on empty input, which would change the `average_latency_ms` return shape from `None` to `0.0`.

## Test plan
- [x] `uv run pytest tests/test_benchmark.py`
- [x] `uv run pytest` (233 passed, 3 skipped)
- [x] `uv run ruff check src tests examples scripts`
- [x] `uv run ruff format --check src tests examples scripts`
- [x] `uv lock --check`
- [x] `uv run python scripts/generate_provider_docs.py --check`
- [x] `uv run worldforge doctor`
- [x] `bash scripts/test_package.sh`
- [x] Benchmark module coverage: 94% (up from baseline)