### PR TITLE
Pin legacy provider env aliases with regression tests

### DIFF
--- a/tests/test_provider_catalog.py
+++ b/tests/test_provider_catalog.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import pytest
+
+from worldforge import WorldForge
 from worldforge.providers.catalog import PROVIDER_CATALOG, create_known_providers
 
 
@@ -30,3 +33,58 @@ def test_provider_catalog_instantiates_known_provider_profiles() -> None:
     assert profiles["lerobot"].capabilities.policy is True
     assert profiles["jepa"].implementation_status == "scaffold"
     assert profiles["genie"].implementation_status == "scaffold"
+
+
+# Pairs of (canonical_env_var, legacy_alias) that provider auto-registration must continue
+# to honour. The legacy aliases are documented in CHANGELOG.md; clearing both names and
+# setting only the legacy one proves the fallback path is wired end-to-end.
+LEGACY_ENV_ALIAS_CASES = (
+    pytest.param(
+        "leworldmodel",
+        ("LEWORLDMODEL_POLICY", "LEWM_POLICY"),
+        "cube/lewm",
+        ("score",),
+        id="leworldmodel-LEWM_POLICY",
+    ),
+    pytest.param(
+        "runway",
+        ("RUNWAYML_API_SECRET", "RUNWAY_API_SECRET"),
+        "runway-legacy-secret",
+        ("generate", "transfer"),
+        id="runway-RUNWAY_API_SECRET",
+    ),
+    pytest.param(
+        "lerobot",
+        ("LEROBOT_POLICY_PATH", "LEROBOT_POLICY"),
+        "lerobot/act_aloha_sim_transfer_cube_human",
+        ("policy",),
+        id="lerobot-LEROBOT_POLICY",
+    ),
+)
+
+
+@pytest.mark.parametrize(
+    ("provider_name", "env_names", "legacy_value", "expected_capabilities"),
+    LEGACY_ENV_ALIAS_CASES,
+)
+def test_legacy_env_alias_triggers_provider_registration(
+    tmp_path,
+    monkeypatch,
+    provider_name: str,
+    env_names: tuple[str, str],
+    legacy_value: str,
+    expected_capabilities: tuple[str, ...],
+) -> None:
+    canonical, legacy = env_names
+    monkeypatch.delenv(canonical, raising=False)
+    monkeypatch.delenv(legacy, raising=False)
+    monkeypatch.setenv(legacy, legacy_value)
+
+    forge = WorldForge(state_dir=tmp_path)
+
+    assert provider_name in forge.providers()
+    capabilities = forge.provider_profile(provider_name).capabilities
+    for capability in expected_capabilities:
+        assert capabilities.supports(capability), (
+            f"{provider_name} registered via {legacy} should advertise {capability}"
+        )


### PR DESCRIPTION
## Summary

- Add a parametrized regression test in `tests/test_provider_catalog.py` that pins the three documented legacy provider environment variable aliases.
- Covers `LEWM_POLICY`, `RUNWAY_API_SECRET`, and `LEROBOT_POLICY`, clearing both the canonical and legacy names before setting only the legacy one.
- Each case asserts the provider registers via `WorldForge` and advertises its documented capability surface.

## Test plan

- [x] `uv run pytest tests/test_provider_catalog.py`
- [x] `uv run pytest`
- [x] `uv run ruff check src tests examples scripts`
- [x] `uv run ruff format --check src tests examples scripts`
- [x] `uv run python scripts/generate_provider_docs.py --check`
- [x] `uv run worldforge doctor`
- [x] `bash scripts/test_package.sh`