### PR TITLE
Harmonize provider contract tests via shared helper

### DIFF
--- a/tests/test_gr00t_provider.py
+++ b/tests/test_gr00t_provider.py
@@ -88,6 +88,30 @@ class FakeScoreProvider(BaseProvider):
         return self._result
 
 
+def test_gr00t_provider_contract() -> None:
+    client = FakeGrootClient(({"arm": [[[0.1, 0.5, 0.0]]]}, {}))
+    provider = GrootPolicyClientProvider(
+        policy_client=client,
+        embodiment_tag="LIBERO_PANDA",
+        action_translator=lambda *_args: [Action.move_to(0.1, 0.5, 0.0)],
+    )
+
+    report = assert_provider_contract(provider, policy_info=_policy_info())
+
+    assert report.configured is True
+    assert report.exercised_operations == ["policy"]
+    assert set(provider.profile().capabilities.enabled_names()) == {"policy"}
+
+
+def test_gr00t_provider_contract_unconfigured(monkeypatch) -> None:
+    monkeypatch.delenv("GROOT_POLICY_HOST", raising=False)
+
+    report = assert_provider_contract(GrootPolicyClientProvider())
+
+    assert report.configured is False
+    assert report.exercised_operations == []
+
+
 def test_gr00t_policy_client_provider_passes_contract_and_emits_events() -> None:
     raw_response = (
         {

--- a/tests/test_lerobot_provider.py
+++ b/tests/test_lerobot_provider.py
@@ -109,6 +109,30 @@ class FakeScoreProvider(BaseProvider):
         return self._result
 
 
+def test_lerobot_provider_contract() -> None:
+    provider = LeRobotPolicyProvider(
+        policy=FakeLeRobotPolicy(response=FakeTensor([[0.1, 0.5, 0.0]])),
+        embodiment_tag="aloha",
+        action_translator=lambda *_args: [Action.move_to(0.1, 0.5, 0.0)],
+    )
+
+    report = assert_provider_contract(provider, policy_info=_policy_info())
+
+    assert report.configured is True
+    assert report.exercised_operations == ["policy"]
+    assert set(provider.profile().capabilities.enabled_names()) == {"policy"}
+
+
+def test_lerobot_provider_contract_unconfigured(monkeypatch) -> None:
+    monkeypatch.delenv("LEROBOT_POLICY_PATH", raising=False)
+    monkeypatch.delenv("LEROBOT_POLICY", raising=False)
+
+    report = assert_provider_contract(LeRobotPolicyProvider())
+
+    assert report.configured is False
+    assert report.exercised_operations == []
+
+
 def test_lerobot_policy_provider_passes_contract_and_emits_events() -> None:
     response = FakeTensor([[0.1, 0.5, 0.0]])
     policy = FakeLeRobotPolicy(response)

--- a/tests/test_leworldmodel_provider.py
+++ b/tests/test_leworldmodel_provider.py
@@ -8,6 +8,7 @@ import pytest
 
 from worldforge import Action, ActionScoreResult, WorldForge, WorldForgeError
 from worldforge.providers import LeWorldModelProvider, ProviderError
+from worldforge.testing import assert_provider_contract
 
 FIXTURE_DIR = Path(__file__).parent / "fixtures" / "providers"
 
@@ -295,6 +296,35 @@ def test_leworldmodel_provider_rejects_malformed_payload_fixtures(
             info=payload["info"],
             action_candidates=payload["action_candidates"],
         )
+
+
+def test_leworldmodel_provider_contract() -> None:
+    payload = _fixture("leworldmodel_score_request.json")
+    provider = LeWorldModelProvider(
+        policy="pusht/lewm",
+        model_loader=lambda _policy, _cache_dir: FakeLeWorldModel([0.7, 0.15, 0.4]),
+        tensor_module=FakeTorch(),
+    )
+
+    report = assert_provider_contract(
+        provider,
+        score_info=payload["info"],
+        score_action_candidates=payload["action_candidates"],
+    )
+
+    assert report.configured is True
+    assert report.exercised_operations == ["score"]
+    assert set(provider.profile().capabilities.enabled_names()) == {"score"}
+
+
+def test_leworldmodel_provider_contract_unconfigured(monkeypatch) -> None:
+    monkeypatch.delenv("LEWORLDMODEL_POLICY", raising=False)
+    monkeypatch.delenv("LEWM_POLICY", raising=False)
+
+    report = assert_provider_contract(LeWorldModelProvider(tensor_module=FakeTorch()))
+
+    assert report.configured is False
+    assert report.exercised_operations == []
 
 
 def test_leworldmodel_provider_rejects_malformed_score_output_fixture() -> None:

--- a/tests/test_remote_video_providers.py
+++ b/tests/test_remote_video_providers.py
@@ -9,12 +9,104 @@ import pytest
 from worldforge import GenerationOptions, ProviderEvent, ProviderRequestPolicy, VideoClip
 from worldforge.models import WorldForgeError
 from worldforge.providers import CosmosProvider, ProviderError, RunwayProvider
+from worldforge.testing import assert_provider_contract
 
 _FIXTURE_DIR = Path(__file__).parent / "fixtures" / "providers"
 
 
 def _fixture(name: str) -> dict[str, object]:
     return json.loads((_FIXTURE_DIR / name).read_text(encoding="utf-8"))
+
+
+def test_cosmos_provider_contract() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "GET" and request.url.path == "/v1/health/ready":
+            return httpx.Response(200, json=_fixture("cosmos_health_ready.json"))
+        if request.method == "POST" and request.url.path == "/v1/infer":
+            return httpx.Response(200, json=_fixture("cosmos_generate_success.json"))
+        raise AssertionError(f"Unexpected request: {request.method} {request.url}")
+
+    provider = CosmosProvider(
+        base_url="http://cosmos.test",
+        transport=httpx.MockTransport(handler),
+    )
+
+    report = assert_provider_contract(provider)
+
+    assert report.configured is True
+    assert report.exercised_operations == ["generate"]
+    assert set(provider.profile().capabilities.enabled_names()) == {"generate"}
+
+
+def test_cosmos_provider_contract_unconfigured(monkeypatch) -> None:
+    monkeypatch.delenv("COSMOS_BASE_URL", raising=False)
+
+    report = assert_provider_contract(CosmosProvider())
+
+    assert report.configured is False
+    assert report.exercised_operations == []
+
+
+def test_runway_provider_contract(monkeypatch) -> None:
+    monkeypatch.setenv("RUNWAYML_API_SECRET", "runway-test-key")
+    generated_bytes = b"runway-generated"
+    transferred_bytes = b"runway-transferred"
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "GET" and request.url.path == "/v1/organization":
+            return httpx.Response(200, json={"id": "org_test"})
+        if request.method == "POST" and request.url.path == "/v1/image_to_video":
+            return httpx.Response(200, json={"id": "task_generate"})
+        if request.method == "POST" and request.url.path == "/v1/video_to_video":
+            return httpx.Response(200, json={"id": "task_transfer"})
+        if request.method == "GET" and request.url.path == "/v1/tasks/task_generate":
+            return httpx.Response(
+                200,
+                json={
+                    "id": "task_generate",
+                    "createdAt": "2026-04-07T00:00:00Z",
+                    "status": "SUCCEEDED",
+                    "output": ["https://downloads.example.com/generated.mp4"],
+                },
+            )
+        if request.method == "GET" and request.url.path == "/v1/tasks/task_transfer":
+            return httpx.Response(
+                200,
+                json={
+                    "id": "task_transfer",
+                    "createdAt": "2026-04-07T00:00:00Z",
+                    "status": "SUCCEEDED",
+                    "output": ["https://downloads.example.com/transferred.mp4"],
+                },
+            )
+        if request.method == "GET" and request.url.host == "downloads.example.com":
+            if request.url.path.endswith("generated.mp4"):
+                return httpx.Response(200, content=generated_bytes)
+            if request.url.path.endswith("transferred.mp4"):
+                return httpx.Response(200, content=transferred_bytes)
+        raise AssertionError(f"Unexpected request: {request.method} {request.url}")
+
+    provider = RunwayProvider(
+        transport=httpx.MockTransport(handler),
+        poll_interval_seconds=0.0,
+        max_polls=1,
+    )
+
+    report = assert_provider_contract(provider)
+
+    assert report.configured is True
+    assert set(report.exercised_operations) == {"generate", "transfer"}
+    assert set(provider.profile().capabilities.enabled_names()) == {"generate", "transfer"}
+
+
+def test_runway_provider_contract_unconfigured(monkeypatch) -> None:
+    monkeypatch.delenv("RUNWAYML_API_SECRET", raising=False)
+    monkeypatch.delenv("RUNWAY_API_SECRET", raising=False)
+
+    report = assert_provider_contract(RunwayProvider())
+
+    assert report.configured is False
+    assert report.exercised_operations == []
 
 
 def test_cosmos_provider_health_and_generate() -> None:


### PR DESCRIPTION
## Summary
- Adds dedicated top-level contract assertions in `tests/test_leworldmodel_provider.py`, `tests/test_gr00t_provider.py`, `tests/test_lerobot_provider.py`, and `tests/test_remote_video_providers.py` that exercise the existing `worldforge.testing.assert_provider_contract` helper alongside the existing custom coverage.
- Each per-provider test file now has a configured and an unconfigured contract check that verifies the capability set advertised by the provider matches the operations the helper was able to exercise.
- Purely additive: no existing tests were modified, renamed, or removed, and no source files changed.

## Test plan
- [x] `uv run pytest tests/test_leworldmodel_provider.py tests/test_gr00t_provider.py tests/test_lerobot_provider.py tests/test_remote_video_providers.py`
- [x] `uv lock --check`
- [x] `uv run ruff check src tests examples scripts`
- [x] `uv run ruff format --check src tests examples scripts`
- [x] `uv run python scripts/generate_provider_docs.py --check`
- [x] `uv run pytest`
- [x] `uv run worldforge doctor`
- [x] `bash scripts/test_package.sh`