### PR TITLE
docs(specs): theworldharness M4 — eval and benchmark

### DIFF
--- a/specs/theworldharness-M4-eval-benchmark/plan.md
+++ b/specs/theworldharness-M4-eval-benchmark/plan.md
@@ -1,0 +1,142 @@
+# Milestone M4 — Eval + Benchmark · Implementation Plan
+
+## Builds on
+- Roadmap §8 "M4 — Eval + Benchmark" — [`../../.codex/skills/tui-development/references/roadmap.md`](../../.codex/skills/tui-development/references/roadmap.md)
+- Skill: [`../../.codex/skills/tui-development/SKILL.md`](../../.codex/skills/tui-development/SKILL.md) — worker idiom, `RichLog` streaming, toast pattern, semantic CSS variables, snapshot tests pinned to `terminal_size=(120, 40)`.
+- Skill: [`../../.codex/skills/evaluation-benchmarking/SKILL.md`](../../.codex/skills/evaluation-benchmarking/SKILL.md) — capability-mismatch must stay a hard `WorldForgeError`; every cited number must be traceable to a preserved JSON; renderers have one source of truth.
+- Predecessor milestones: M0 (theme + chrome reset — `$success` / `$error` / `$accent` already registered), M1 (screen stack + `RunInspectorScreen` exists and accepts a `HarnessRun`), M3 (worker idiom proven against `mock` predict + `Esc` cancellation). M2 (Worlds CRUD) is *optional but useful*: if `WorldsScreen` is live, eval can default to the currently-selected world; otherwise it falls back to a per-suite scratch world (which is what `EvaluationSuite._build_world` already constructs).
+- Source modules consumed (read-only by M4): `src/worldforge/evaluation/suites.py` (`EvaluationSuite`, `EvaluationReport`, `EvaluationResult`, `ProviderSummary`); `src/worldforge/benchmark.py` (`ProviderBenchmarkHarness`, `BENCHMARKABLE_OPERATIONS`, the benchmark report and gate types); `src/worldforge/cli.py` `_cmd_eval` / `_cmd_benchmark` for parity reference.
+
+## Architecture changes
+- **New `EvalScreen`** (`Screen[None]`) — two-column form on the left (suite picker, provider multi-select, "Run" button), worker-output `RichLog` and verdict banner on the right. Composes a shared `ExportPane` widget for JSON / Markdown / CSV preview switching.
+- **New `BenchmarkScreen`** (`Screen[None]`) — provider × operation × iterations × concurrency × format form on the left, `ProgressBar` + rolling-stats panel + per-iteration `RichLog` on the right, shared `ExportPane` reused.
+- **New `ExportPane` widget** — composes a `Tabs("json", "markdown", "csv")` over a `Static` (or `RichLog` for long output). Reactive `report_format`. Pure presentation; no I/O. Reused on `RunInspectorScreen`.
+- **New report-persistence helper** in `harness/tui.py` (or a Textual-free helper next to `harness/flows.py`) — `_write_report(forge: WorldForge, kind: str, report_artifacts: dict[str, str]) -> Path` that creates `.worldforge/reports/` on first use, names the file `<kind>-<iso8601>-<run-id>.json`, writes `artifacts["json"]`, and returns the resolved path. Lives off the `WorldForge` state-dir convention so the path follows `--state-dir`.
+- **`RunInspectorScreen` extension** — accept either a benchmark or an evaluation `HarnessRun`; mount `ExportPane` so format switches reflow without rerunning.
+- **No new files outside `src/worldforge/harness/`.** Textual-free helpers (the report path resolver, the artifact dict builder) sit in `harness/flows.py`; Textual screens stay inside `harness/tui.py` per the import boundary.
+- **`.worldforge/reports/`** is a new convention; created lazily on first run; documented in `docs/src/playbooks.md` and called out in M4-completion changelog entry.
+
+## Module touch list
+| Path | Change | Notes |
+| --- | --- | --- |
+| `src/worldforge/harness/tui.py` | Add `EvalScreen`, `BenchmarkScreen`, `ExportPane` widget; extend `RunInspectorScreen`; register new screens with the `App` and add palette entries via `get_system_commands` plus a new `command.Provider` for "Run eval suite …" / "Run benchmark …" dynamic items. | Textual-only file; existing import boundary preserved. |
+| `src/worldforge/harness/flows.py` | Add Textual-free helpers: `eval_run_artifacts(forge, suite_id, providers, world=None)`, `benchmark_run_artifacts(forge, providers, operations, iterations, concurrency)`, and `write_report(forge, kind, artifacts) -> Path`. These wrap the existing `EvaluationSuite` / `ProviderBenchmarkHarness` calls so the screens never reach into provider state directly and the same helpers are unit-testable without Textual. | Keeps the wire-up Pilot-testable and CLI-parity-checkable. |
+| `src/worldforge/harness/models.py` | Extend `HarnessRun` (or add a discriminated `kind: Literal["flow","eval","benchmark"]`) so `RunInspectorScreen` can render either; add `report_path: Path \| None`. | Needs explicit approval before merging — it touches the public flow surface listed in the TUI skill's "Stop and ask the user" list. Discuss before T2. |
+| `src/worldforge/harness/cli.py` | Add `--flow eval` / `--flow benchmark` shortcuts so `worldforge-harness --flow eval` lands directly on `EvalScreen`. | Pure wiring; no new dependencies. |
+| `tests/test_harness_tui.py` | Add Pilot tests: capability-mismatch toast, eval happy path, benchmark live progress, format-tab switching, `Esc` cancellation. | Use the slow-mock helper from M3. |
+| `tests/test_harness_flows.py` | Unit tests for the new flows-helpers (`eval_run_artifacts`, `benchmark_run_artifacts`, `write_report`) — Textual-free. | Confirms CLI / TUI parity by comparing artifact bytes to `EvaluationReport.to_json()` directly. |
+| `tests/snapshots/` | Six new `.svg` snapshots per the spec's snapshot list. | Pinned to `terminal_size=(120, 40)`. |
+| `docs/src/playbooks.md` | New section: "Where TheWorldHarness writes preserved reports" — documents the `.worldforge/reports/` convention and the `<kind>-<timestamp>-<run-id>.json` filename shape. | Required because public behavior changed. |
+| `docs/src/architecture.md` and `docs/src/evaluation.md` / `docs/src/benchmarking.md` | One-paragraph cross-link from each topic to "also reachable from TheWorldHarness". | Keeps the docs honest about the integration reference claim. |
+| `CHANGELOG.md` | Entry under Unreleased: "TheWorldHarness M4 — Eval + Benchmark screens; reports preserved under `.worldforge/reports/`." | Maintainer-style copy, no tool branding. |
+
+## Key technical decisions
+
+### D1 — Shared renderer, not a parallel TUI renderer
+- **Decision:** the TUI imports `EvaluationReport.artifacts()` and the benchmark report's equivalent and renders the resulting strings directly in `ExportPane` and `_write_report`.
+- **Alternatives considered:** (a) building a TUI-tailored renderer with rich markup; (b) generating a slimmer "preview" JSON in the TUI and a full JSON for export.
+- **Rationale:** the evaluation-benchmarking skill's first failure mode is *misclaimed scope*. The cheapest defense against TUI-vs-CLI drift is a single rendering path: if the user sees a number on screen, it came from the same `to_json()` / `to_markdown()` / `to_csv()` that the CLI tests already cover. Renderer regression tests in `tests/test_evaluation_and_planning.py` and `tests/test_benchmark.py` then automatically protect the TUI surface too.
+
+### D2 — Capability mismatch is a toast, not a modal
+- **Decision:** raise `WorldForgeError` from the worker → catch in `on_worker_state_changed` → render a `$error`-coloured toast with the verbatim message and a one-key ("p") action that pushes `ProvidersScreen` with the offending provider pre-selected.
+- **Alternatives considered:** (a) a blocking modal that demands acknowledgement; (b) silently disabling the provider from the picker; (c) catching and converting to a generic `"Run failed"` line in the log.
+- **Rationale:** option (a) is heavier than the moment deserves and breaks keyboard flow. Option (b) hides the capability model — exactly the failure mode the skill warns against. Option (c) is the most dangerous: it silently turns the suite contract harness into a no-op (skill's "Stop and ask the user": "before catching a `WorldForgeError` from a suite"). A toast is loud enough to teach, light enough not to derail.
+
+### D3 — Reports preserved under `.worldforge/reports/`
+- **Decision:** mirror the existing `.worldforge/worlds/` convention. Files are named `<kind>-<iso8601-utc>-<run-id>.json` (e.g., `eval-planning-2026-04-21T140332Z-7c9f.json`, `benchmark-2026-04-21T141001Z-3a08.json`).
+- **Alternatives considered:** (a) writing to `os.tmpdir`; (b) writing only on user request.
+- **Rationale:** the skill mandates that any externally cited number be traceable to a preserved file. Auto-write removes the "I forgot to save and now I quoted it in a PR" failure mode. Following the worlds-dir convention keeps the state-dir override (`--state-dir`) consistent across screens.
+
+### D4 — One worker group per screen, `Esc` is the universal cancel
+- **Decision:** `EvalScreen` uses `group="eval"`; `BenchmarkScreen` uses `group="benchmark"`. Both `Esc`-bind to `self.workers.cancel_group(<group>)`.
+- **Alternatives considered:** (a) one `group="long-work"` shared across both; (b) per-suite group names.
+- **Rationale:** (a) means popping into `RunInspectorScreen` while a benchmark runs would let `Esc` accidentally cancel an unrelated eval. (b) is over-engineered. One group per screen matches roadmap §6 exactly.
+
+### D5 — Multi-provider eval and benchmark are first-class
+- **Decision:** the form's provider input is a multi-select; `EvaluationSuite.run_report(providers=...)` and `ProviderBenchmarkHarness.run(...)` already accept sequences and produce per-provider summary rows.
+- **Alternatives considered:** single-provider only in M4; defer multi-provider to M5.
+- **Rationale:** the CLI accepts repeated `--provider` flags today; if the TUI doesn't, it isn't the integration reference. Cost is one widget, not new model code.
+
+## Data flow
+
+**Reactives (per screen):**
+- `selected_suite: reactive[str | None] = reactive(None)` (`EvalScreen`)
+- `selected_providers: reactive[tuple[str, ...]] = reactive(())` (both)
+- `selected_operations: reactive[tuple[str, ...]] = reactive(("predict",))` (`BenchmarkScreen`)
+- `iterations: reactive[int] = reactive(5)` (`BenchmarkScreen`, validated `>= 1`)
+- `concurrency: reactive[int] = reactive(1)` (`BenchmarkScreen`, validated `>= 1`)
+- `report_format: reactive[Literal["json","markdown","csv"]] = reactive("markdown")` (`ExportPane` on both screens, mirrored to `RunInspectorScreen`)
+- `current_run: reactive[HarnessRun | None] = reactive(None)`
+
+Pair each with `watch_<name>` to redraw the affected pane only.
+
+**Messages:**
+- `EvalStarted(suite_id: str, providers: tuple[str, ...])`
+- `EvalSampleReceived(scenario: str, provider: str, score: float, passed: bool)`
+- `EvalCompleted(run: HarnessRun)`
+- `BenchmarkStarted(provider: str, operation: str, iterations: int)`
+- `BenchmarkSampleReceived(sample: BenchmarkSample)` — emitted from worker via `call_from_thread(self.post_message, ...)`
+- `BenchmarkCompleted(run: HarnessRun)`
+- `ReportExported(path: Path, kind: str)`
+- `CapabilityMismatch(error: WorldForgeError, provider: str, missing: tuple[str, ...])`
+
+**Workers:**
+```python
+@work(thread=True, group="eval", exclusive=True, name=f"eval.{suite_id}")
+def _run_eval(self, suite_id: str, providers: tuple[str, ...]) -> None:
+    log = self.query_one(RichLog)
+    try:
+        artifacts, report = eval_run_artifacts(self.forge, suite_id, providers)
+    except WorldForgeError as exc:
+        # NOT swallowed — re-posted as a typed message and surfaced as a toast.
+        self.app.call_from_thread(self.post_message, CapabilityMismatch(exc, ..., ...))
+        return
+    path = write_report(self.forge, f"eval-{suite_id}", artifacts)
+    self.app.call_from_thread(self.post_message, EvalCompleted(...))
+    self.app.call_from_thread(self.post_message, ReportExported(path, "eval"))
+```
+
+`BenchmarkScreen` mirrors this with `group="benchmark"`. Per-iteration progress is forwarded by passing a small `on_sample` callback into the helper, which the worker invokes via `call_from_thread` so the `RichLog` and `ProgressBar` update without thread-mutating widgets directly.
+
+**Screen lifecycle:**
+- On screen pop: workers are auto-cancelled (Textual default for screen-bound workers); `Esc` is the same code path.
+- `RunCompleted` posts cause `app.push_screen(RunInspectorScreen(run))` so the inspector screen is the destination, not an inline panel.
+
+## Theming and CSS
+- All new TCSS uses semantic variables only:
+  - Pass verdict banner: `background: $success 20%; color: $success;`
+  - Fail verdict banner / capability-mismatch toast: `background: $error 20%; color: $error;`
+  - Selected format tab in `ExportPane`: `border-bottom: thick $accent;`
+  - Cancelled-state badge: `color: $warning;`
+  - Progress bar: rely on Textual stock `ProgressBar` styling; do not override colours.
+- `:focus-within` on the form pane gets `border: round $accent`; idle panes stay `border: round $panel`.
+- No hex literals. Light-theme contrast verified by snapshot tests in both themes.
+
+## Testing
+- **Pilot tests** (`tests/test_harness_tui.py`):
+  - `test_eval_screen_capability_mismatch_surfaces_worldforge_error`: pick `generation` × `leworldmodel` (mock-registered for the test); assert the rendered toast contains the exact `WorldForgeError` message and that the worker did not silently complete.
+  - `test_eval_screen_planning_against_mock_writes_report`: pick `planning` × `mock`; assert (a) `RunInspectorScreen` becomes active, (b) the file at `ReportExported.path` exists, (c) `json.loads(path.read_text())` round-trips to the same `EvaluationReport.to_dict()` produced by calling `EvaluationSuite.from_builtin("planning").run_report("mock", forge=forge).to_dict()` directly.
+  - `test_benchmark_screen_streams_progress`: pick `mock` × `predict` × 5 iterations using the slow-mock helper from M3; assert the `RichLog` receives at least 5 `BenchmarkSampleReceived` lines and the `ProgressBar.percentage` reaches 100.
+  - `test_format_tab_switch_does_not_rerun`: after a successful eval, switch `report_format` from markdown to csv to json; assert no new worker is spawned and the preview pane updates synchronously.
+  - `test_esc_cancels_active_benchmark_and_writes_partial_report`: start a long benchmark, press `Esc`, assert `current_run.status == "cancelled"` and the JSON at `ReportExported.path` is well-formed.
+- **Unit tests** (`tests/test_harness_flows.py`):
+  - `test_write_report_uses_state_dir`: verify the path is `forge.state_dir / "reports" / "<kind>-..."` and the directory is created on first use.
+  - `test_eval_run_artifacts_matches_cli_renderer`: assert `artifacts["json"] == EvaluationReport.to_json()` byte-for-byte for a known fixture.
+- **Snapshot tests** (six SVGs, all pinned to `terminal_size=(120, 40)` per skill rule, both themes):
+  - `EvalScreen` idle, `EvalScreen` mid-run, `EvalScreen` verdict-pass, `EvalScreen` verdict-fail, `BenchmarkScreen` live metrics, `RunInspectorScreen` JSON-export preview.
+- **Coverage gate**: `uv run --extra harness pytest --cov=src/worldforge --cov-report=term-missing --cov-fail-under=90` must stay green. The new helpers are exercised by both Pilot and unit tests, so coverage should rise, not drop.
+- **CLI parity check**: a single test compares `EvaluationReport.to_json()` produced via the TUI helper to the one produced via `_cmd_eval`; if they ever drift, the test fails before reviewers do.
+
+## Risks and mitigations
+- **R1 — Renderer divergence between CLI and TUI.** The CLI's report is the canonical citation source; if the TUI renders something subtly different, screenshots in PRs would no longer match the JSON. *Mitigation:* D1 (shared renderer) plus the byte-level parity test in `tests/test_harness_flows.py`. Any future change to `EvaluationReport.to_*` regenerates both surfaces by construction.
+- **R2 — Capability mismatch silently caught in a bare `except`.** The single most damaging regression; turns the contract harness into a no-op. *Mitigation:* the only `except WorldForgeError` clause in `harness/tui.py` is the one that re-posts `CapabilityMismatch`; a small Pilot test asserts the message reaches the toast verbatim. A grep guard in CI (`! grep -RnE "except (Exception|BaseException|WorldForgeError)" src/worldforge/harness/tui.py | grep -v CapabilityMismatch`) is cheap to add and worth it; defer that to T7 if maintainers agree.
+- **R3 — Unpreserved benchmark numbers in screenshots.** A user takes a screenshot of `BenchmarkScreen` with live numbers that were never persisted. *Mitigation:* the screen never displays a *final* "save report" affordance — the JSON is written *first*, and the path-toast is what tells the user the run completed. The screenshot policy lives in M5; M4 just makes preservation automatic.
+- **R4 — Slow-mock or noisy CI causes flaky benchmark snapshots.** *Mitigation:* snapshot tests use a frozen-clock fixture for any visible latency numbers; the live `RichLog` is asserted by message count, not by visible content.
+- **R5 — `HarnessRun` model change is breaking.** Touches public surface listed in the TUI skill's "Stop and ask the user". *Mitigation:* T2 is gated; raise the discriminated-kind change as a separate review before merging the screens that depend on it.
+- **R6 — `.worldforge/reports/` collides with a user-managed directory.** Unlikely (matches the existing `.worldforge/worlds/` convention) but possible. *Mitigation:* document the path in `docs/src/playbooks.md`; never delete files under it; use UTC ISO8601 + run-id so collisions require the same millisecond *and* the same 4-hex run-id.
+
+## Dependencies on other milestones
+- **Required before this can ship:** M0 (theme + chrome reset — semantic variables registered), M1 (screen stack and `RunInspectorScreen` accept a `HarnessRun`), M3 (worker idiom proven; `Esc` cancellation pattern reusable; slow-mock test helper available).
+- **Optional but useful:** M2 (Worlds CRUD) — when present, `EvalScreen` can default to the currently-selected world for suites that accept one (`run_with_world`). When absent, falls back to the per-suite scratch world built by `EvaluationSuite._build_world`.
+- **This milestone blocks:** M5 (recent-runs list on `HomeScreen` and the dynamic command palette provider for "Recent runs" depend on `.worldforge/reports/` existing); M5 README screenshot refresh (the new screens are the reason for the refresh).
+- **Cross-milestone non-dependency:** the `optional-runtime-smokes` skill is *not* a prerequisite. M4 explicitly does not run live LeWorldModel / GR00T / LeRobot — those are surfaced as registered providers with their own capability advertisements; if their env vars are absent, they simply do not appear in the picker.

--- a/specs/theworldharness-M4-eval-benchmark/spec.md
+++ b/specs/theworldharness-M4-eval-benchmark/spec.md
@@ -1,0 +1,62 @@
+# Milestone M4 — Eval + Benchmark
+
+## Status
+Draft · 2026-04-21
+
+## Outcome (one sentence)
+A user of TheWorldHarness can run any built-in evaluation suite or benchmark against any registered provider from the TUI, watch honest live progress, and land the result in `RunInspectorScreen` with JSON / Markdown / CSV export that matches the `worldforge` CLI byte-for-byte.
+
+## Why this milestone
+TheWorldHarness is the front face of WorldForge and, per the roadmap vision ([`../../.codex/skills/tui-development/references/roadmap.md`](../../.codex/skills/tui-development/references/roadmap.md) §1), its job is to leave a user with the integration pattern in their head. Until M4, the harness only exercises provider `predict` events (from M3). Evaluation suites and the benchmark harness are two of the most visible public surfaces of WorldForge, and they are where users will look to answer "what can this provider actually do" and "how fast is it". If those paths are only reachable through the CLI, the TUI is by definition incomplete as an integration reference.
+
+M4 closes that gap under the claim-hygiene discipline the evaluation-benchmarking skill codifies ([`../../.codex/skills/evaluation-benchmarking/SKILL.md`](../../.codex/skills/evaluation-benchmarking/SKILL.md)): suites measure adapter behavior (not realism), benchmarks measure latency / retries / throughput (not quality), every externally cited number must be preserved to disk, and capability mismatches are a hard `WorldForgeError` that the TUI must never silently swallow. The M4 screens must surface — not sand off — those invariants.
+
+## In scope
+- `EvalScreen`: pick a built-in suite (`generation`, `physics`, `planning`, `reasoning`, `transfer`) × one or more providers that advertise the suite's required capabilities; mismatch is a hard toast pointing the user at `ProvidersScreen` (cross-reference M3 capability matrix).
+- `BenchmarkScreen`: pick a provider × one or more operations (from `BENCHMARKABLE_OPERATIONS`) × iterations × format; a live `ProgressBar` with rolling median and p95 latency pulled from the run-so-far.
+- Runs land in `RunInspectorScreen` (from M1) as a `HarnessRun` whose metrics pane reflects `EvaluationReport` / `BenchmarkReport` fields; JSON / Markdown / CSV preview pane switches format *in place* without rerunning.
+- Export is unified: both screens write a JSON report to `.worldforge/reports/<suite-or-benchmark>-<timestamp>-<run-id>.json`, the Markdown and CSV variants are regeneratable from the JSON, and a success toast prints the absolute path so the file backing any cited number is discoverable.
+- Both workflows are reachable from the command palette (Ctrl+P) as `"Run eval suite …"` and `"Run benchmark …"` — feature exists iff it is palette-searchable per roadmap §5.
+- Cancellation: `Esc` cancels the active worker; the partial run is still visible in `RunInspectorScreen` with a "Cancelled" status.
+
+## Out of scope (explicit)
+- Live optional-runtime evals / benchmarks against CUDA / TensorRT / real checkpoints — those belong to `optional-runtime-smokes` and stay host-owned.
+- Multi-run comparison views (side-by-side diffing of two benchmark reports, or tracking a "last-good" baseline) — listed under Open questions; not required to call M4 done.
+- Auto-publishing reports to the docs site — explicit non-goal per roadmap §11.
+- Benchmark budget gate configuration from the TUI (the CLI `--budget-file` path is the source of truth) — may be layered on later; the TUI shows gate outcomes if a budget file is selected, but editing is out of scope.
+- Custom / user-defined suites beyond the five built-ins — defer until there is a registered discovery hook on `EvaluationSuite`.
+
+## User stories
+1. As a researcher evaluating a new deterministic provider, I press `e` on `HomeScreen`, pick the `planning` suite and `mock`, and within a few seconds I see a pass verdict, per-scenario metrics, and a preserved JSON report path — so that I can cite "5/5 scenarios passed" in a PR with a file behind it.
+2. As a researcher comparing adapter latency, I open `BenchmarkScreen`, pick `mock` × `predict` × 20 iterations, and watch the rolling median / p95 update live as iterations complete — so that I can spot variance before the run finishes and export the JSON at the end.
+3. As a newcomer, I try to run the `generation` suite against `leworldmodel`, and I get a hard, high-contrast error toast explaining that `leworldmodel` does not advertise `generate`, plus a one-key action to jump to `ProvidersScreen` — so that the capability model teaches me instead of hiding.
+4. As a reviewer reading a PR, I receive a run ID plus a path under `.worldforge/reports/` — so that I can `jq` / `diff` / re-render the exact numbers without rerunning anything.
+
+## Acceptance criteria
+- [ ] `EvalScreen` launches the selected suite through `EvaluationSuite.run_report(providers=..., forge=...)` inside a `@work(thread=True, group="eval", exclusive=True)` worker; the UI never blocks.
+- [ ] `BenchmarkScreen` launches through `ProviderBenchmarkHarness(forge=forge).run(...)` inside a `@work(thread=True, group="benchmark", exclusive=True)` worker; iteration samples stream to a `RichLog` via `call_from_thread`.
+- [ ] Capability mismatch raises `WorldForgeError` from the worker. The screen's exception handler catches it *only* to render a `$error`-colored toast and post a `CapabilityMismatch` message; the error is **not** swallowed, not converted to a generic log line, and not allowed to leave the worker silently.
+- [ ] The toast copy names the missing capability and the provider, and offers a one-key ("p") jump to `ProvidersScreen` with the offending provider pre-selected.
+- [ ] Every completed run writes a JSON report to `.worldforge/reports/<kind>-<timestamp>-<run-id>.json`, where `<kind>` is `eval-<suite-id>` or `benchmark`. The Markdown and CSV outputs shown in the preview pane come from the same `EvaluationReport.artifacts()` / benchmark report rendering path the CLI uses — one source of truth, not a parallel TUI renderer.
+- [ ] After a successful run, a `$success` toast shows `"Report saved: <absolute path>"` and includes a "copy path" binding.
+- [ ] `RunInspectorScreen` can show both eval and benchmark results; switching `report_format` between `json` / `markdown` / `csv` reflows the preview pane without rerunning the suite.
+- [ ] `Esc` during a run cancels the worker via `self.workers.cancel_group("eval"|"benchmark")`; the partial run surface is labelled `"Cancelled"` in the transcript and still writes whatever JSON was already assembled (empty-results JSON is acceptable and documented).
+- [ ] Both screens expose their primary action via (a) a screen binding shown in the footer, (b) a command palette entry, and (c) a click target on the form — mouse + keyboard parity per roadmap §5.
+- [ ] A Pilot test drives a capability-mismatch attempt and asserts the toast contains the `WorldForgeError` message text verbatim (proof that nothing is swallowed).
+- [ ] A Pilot test runs `planning` × `mock` end-to-end and asserts (i) `RunInspectorScreen` is active after success, (ii) the saved JSON path exists on disk, (iii) loading that JSON round-trips to the same `EvaluationReport.to_dict()` shape.
+- [ ] Snapshot tests cover: `EvalScreen` idle, `EvalScreen` mid-run, `EvalScreen` verdict-pass, `EvalScreen` verdict-fail, `BenchmarkScreen` live metrics, `RunInspectorScreen` with a JSON export preview — each pinned at `terminal_size=(120, 40)`.
+- [ ] Coverage gate (`uv run --extra harness pytest --cov=src/worldforge --cov-report=term-missing --cov-fail-under=90`) passes with the new screens and tests.
+
+## Non-functional requirements
+- **Honest progress.** `ProgressBar(total=None)` until the total iteration count is known (known at start for benchmark, known at start for eval = `len(scenarios) * len(providers)`), then switch to a determinate bar. No looping spinners when the worker is idle or cancelled.
+- **One renderer.** The JSON / Markdown / CSV produced by the TUI is byte-identical to the CLI's — shared code path (`EvaluationReport.to_json` / `.to_markdown` / `.to_csv`, and the matching benchmark report methods). The TUI may pretty-print its own preview pane, but the *saved* artifact and the *copied* artifact must go through the canonical renderer.
+- **Theming parity.** `EvalScreen` and `BenchmarkScreen` render correctly on `worldforge-dark` and `worldforge-light`. No hex literals anywhere in the new TCSS — semantic variables only (`$success` for pass, `$error` for fail and for capability-mismatch toasts, `$accent` for the selected format tab, `$warning` for cancelled state).
+- **No event-loop block.** A slow-mock provider (e.g., 50 ms per call × 100 iterations) must not freeze the UI; the benchmark progress bar must update between iterations.
+- **Empty-state legibility.** Before any suite / provider is chosen, the screen shows a centred `Static` with the next action: `"No suite selected — press [b]s[/] to pick one"` / `"No provider selected — press [b]p[/]"`.
+
+## Open questions
+- Should benchmark preset configurations (a named tuple of `{provider, operation, iterations, concurrency, format}`) be user-savable to `.worldforge/benchmark-presets.json` and exposed as dynamic palette entries? Needed for M5 polish; not required to call M4 done.
+- Should eval verdicts pin a "last good" baseline so regressions surface in the TUI verdict banner? Would require a `.worldforge/reports/index.json` convention; defer until after M4 ships.
+- Should `RunInspectorScreen` gain a small diff view when the user opens two consecutive benchmark reports? Potentially M5.
+- Should the TUI allow pointing `--budget-file` at an existing JSON to display benchmark gate violations inline, or is that strictly a CLI concern? Lean toward read-only display in M5.
+- When a cancellation produces an empty `EvaluationReport`, should the JSON be written at all, or only a `.cancelled` marker? Current spec writes the empty report for traceability; revisit if noisy.

--- a/specs/theworldharness-M4-eval-benchmark/tasks.md
+++ b/specs/theworldharness-M4-eval-benchmark/tasks.md
@@ -1,0 +1,55 @@
+# Milestone M4 — Eval + Benchmark · Tasks
+
+Each task is a single PR-sized unit. Order matters: a later task may assume an earlier one has landed in main.
+
+## T1 — Textual-free flow helpers + report persistence
+- Files: `src/worldforge/harness/flows.py`, `tests/test_harness_flows.py`.
+- Change: introduce three Textual-free helpers — `eval_run_artifacts(forge, suite_id, providers, world=None) -> tuple[dict[str, str], EvaluationReport]`, `benchmark_run_artifacts(forge, providers, operations, iterations, concurrency, on_sample=None)`, and `write_report(forge, kind, artifacts) -> Path`. The first two thin-wrap `EvaluationSuite.from_builtin(...).run_report(...)` and `ProviderBenchmarkHarness(forge=forge).run(...)` and return both the JSON / Markdown / CSV artifact dict and the underlying report object. `write_report` resolves `forge.state_dir / "reports"`, creates it on first use, and writes `<kind>-<iso8601-utc>-<run-id>.json` containing `artifacts["json"]`. None of these helpers may import Textual.
+- Acceptance: maps to spec acceptance criteria 5 (artifact bytes match canonical renderer) and 7 (`Esc` cancellation can still write whatever JSON was assembled). Capability mismatch surfaces as `WorldForgeError` raised from these helpers without being caught (acceptance criterion 3).
+- Tests: `test_eval_run_artifacts_matches_cli_renderer` (byte-equality with `EvaluationReport.to_json()`); `test_benchmark_run_artifacts_invokes_on_sample` (callback called once per iteration); `test_write_report_creates_reports_dir_and_returns_resolved_path`; `test_write_report_filename_contains_kind_timestamp_and_run_id`; `test_capability_mismatch_propagates_as_worldforge_error`.
+
+## T2 — Extend `HarnessRun` to discriminate eval / benchmark / flow kinds
+- Files: `src/worldforge/harness/models.py`, `tests/test_harness_flows.py`.
+- Change: add `kind: Literal["flow", "eval", "benchmark"]` (default `"flow"` for backward compatibility) and `report_path: Path | None = None` to `HarnessRun`. Add minimal typed view-helpers (`is_eval_run` / `is_benchmark_run`) so `RunInspectorScreen` can branch without `isinstance` gymnastics. **Gated change** — public surface listed in the TUI skill's "Stop and ask the user"; surface for review *before* T3 lands.
+- Acceptance: existing tests for `HarnessRun` round-tripping continue to pass with the default `kind="flow"`; new fields participate in `to_dict` / `from_dict`.
+- Tests: extend the existing `HarnessRun` round-trip tests with one case per `kind` value and a case with a `report_path`. No Textual imports.
+
+## T3 — `EvalScreen` (form, worker, verdict, export)
+- Files: `src/worldforge/harness/tui.py`, `tests/test_harness_tui.py`, `tests/snapshots/eval_screen_idle.svg`, `tests/snapshots/eval_screen_mid_run.svg`, `tests/snapshots/eval_screen_verdict_pass.svg`, `tests/snapshots/eval_screen_verdict_fail.svg`.
+- Change: add `EvalScreen(Screen[None])` with reactives (`selected_suite`, `selected_providers`, `report_format`), a left-side form (`Select` for suite, `SelectionList` for providers, `Button("Run", id="run")`), a right-side `RichLog` + verdict banner + `ExportPane` (split out as a small `Widget` so `BenchmarkScreen` and `RunInspectorScreen` reuse it). The `Run` action launches the worker described in plan §Data flow under `group="eval"`. Capability mismatch is caught only in the worker boundary handler and re-posted as `CapabilityMismatch`. Successful completion writes the report via T1's `write_report`, posts `EvalCompleted` and `ReportExported`, and pushes `RunInspectorScreen(run)`. Add a `BINDINGS = [("escape", "cancel_eval", "Cancel"), ("r", "run", "Run"), ...]` and an entry in `App.get_system_commands` plus a dynamic command provider for each built-in suite name.
+- Acceptance: spec criteria 1 (worker), 3 (capability error not swallowed), 4 (toast points at `ProvidersScreen`), 5 (canonical renderer for export), 6 (success toast with absolute path), 8 (`Esc` cancels via `cancel_group("eval")`), 9 (mouse + keyboard parity), 10 (Pilot test for capability mismatch), 11 (Pilot test for happy-path report on disk).
+- Tests: `test_eval_screen_capability_mismatch_surfaces_worldforge_error`, `test_eval_screen_planning_against_mock_writes_report`, `test_format_tab_switch_does_not_rerun`, plus the four `EvalScreen` snapshots pinned at `terminal_size=(120, 40)` in both `worldforge-dark` and `worldforge-light`.
+
+## T4 — `BenchmarkScreen` (live progress, rolling p95, export)
+- Files: `src/worldforge/harness/tui.py`, `tests/test_harness_tui.py`, `tests/snapshots/benchmark_screen_live.svg`.
+- Change: add `BenchmarkScreen(Screen[None])` with reactives for provider / operation / iterations / concurrency / format, a left-side form, and a right-side panel containing `ProgressBar(total=None)` until the iteration count is known and a small "rolling stats" `Static` showing the running median + p95 latency from samples received so far. Worker uses `group="benchmark"`, posts `BenchmarkSampleReceived` per iteration via `call_from_thread`, and on completion writes the report and pushes `RunInspectorScreen`. Reuse the `ExportPane` from T3.
+- Acceptance: spec criteria 2 (worker), 5 (renderer parity), 6 (success toast with path), 7 (`RunInspectorScreen` reflows formats without rerun), 8 (`Esc` cancellation), 9 (palette + binding + click parity), 12 (snapshot at `terminal_size=(120, 40)`).
+- Tests: `test_benchmark_screen_streams_progress` (asserts ≥ N `BenchmarkSampleReceived` messages and `ProgressBar.percentage == 100`); `test_esc_cancels_active_benchmark_and_writes_partial_report`; `test_benchmark_run_renders_same_json_as_cli` (byte-equality with `_cmd_benchmark` JSON output for a fixed seed/iteration count); the `benchmark_screen_live.svg` snapshot.
+
+## T5 — `RunInspectorScreen` extension + `ExportPane` reuse
+- Files: `src/worldforge/harness/tui.py`, `tests/test_harness_tui.py`, `tests/snapshots/run_inspector_json_export.svg`.
+- Change: extend `RunInspectorScreen` to accept a `HarnessRun` whose `kind` is `"eval"` or `"benchmark"`, mount the same `ExportPane` from T3, and render a `report_path` line linking to the preserved JSON. Format-tab switching is reactive only — no worker spawn — and reflows the preview pane.
+- Acceptance: spec criteria 7 (in-place format reflow without rerun), 9 (mouse + keyboard parity), 12 (snapshot).
+- Tests: `test_run_inspector_renders_eval_run_metrics`, `test_run_inspector_renders_benchmark_run_metrics`, `test_run_inspector_format_switch_does_not_rerun`, plus the `run_inspector_json_export.svg` snapshot.
+
+## T6 — Wrapper CLI shortcuts and palette discovery
+- Files: `src/worldforge/harness/cli.py`, `tests/test_harness_cli.py`.
+- Change: extend the wrapper's `--flow` choices with `eval` and `benchmark`. When passed, the harness boots straight onto the corresponding screen instead of `HomeScreen`. Add the dynamic `command.Provider` registration so `Ctrl+P` exposes "Run eval suite: planning", "Run benchmark: mock × predict", etc.
+- Acceptance: spec criterion 9 (palette parity); roadmap §5 ("if a feature exists but isn't in the palette, it doesn't exist for new users").
+- Tests: `test_wrapper_cli_flow_eval_lands_on_eval_screen`, `test_wrapper_cli_flow_benchmark_lands_on_benchmark_screen`, plus a Pilot test that opens the palette and asserts the eval / benchmark items are present and selectable.
+
+## T7 — Docs, changelog, and (optional) CI grep guard
+- Files: `docs/src/playbooks.md`, `docs/src/evaluation.md`, `docs/src/benchmarking.md`, `docs/src/architecture.md`, `CHANGELOG.md`, optionally `.github/workflows/ci.yml`.
+- Change: add the "Where TheWorldHarness writes preserved reports" section to `playbooks.md` documenting the `.worldforge/reports/<kind>-<timestamp>-<run-id>.json` convention. Add a one-paragraph cross-link from `evaluation.md` and `benchmarking.md` to "also reachable from TheWorldHarness", and a single line under `architecture.md`'s harness section. Add a Changelog entry under `## Unreleased` in maintainer-style copy. Optional: add a CI grep guard rejecting any `except WorldForgeError` in `src/worldforge/harness/tui.py` that does not lead to a `CapabilityMismatch` post (mitigation R2). The CI workflow change is **gated**; do not land it without explicit approval per `<gated>` rules.
+- Acceptance: spec criteria 5 (renderer parity, surfaced in docs as "shared with the `worldforge` CLI"); roadmap "every milestone updates the spec / docs / changelog".
+- Tests: `tests/test_docs.py` should already verify referenced files exist; if not, add a check that the new playbook section path is present. Keep `uv run python scripts/generate_provider_docs.py --check` clean (this milestone changes no provider docs).
+
+## Definition of done
+- [ ] All tasks T1–T7 merged
+- [ ] Pilot tests for capability-mismatch, eval happy path, benchmark live progress, format-tab no-rerun, and `Esc` cancellation are green in CI
+- [ ] Six new snapshot SVGs committed and reviewed in PRs (both `worldforge-dark` and `worldforge-light` where the spec calls for theming parity)
+- [ ] Coverage gate `uv run --extra harness pytest --cov=src/worldforge --cov-report=term-missing --cov-fail-under=90` passes
+- [ ] Package contract `bash scripts/test_package.sh` passes (no new files outside the `src/worldforge` tree are required at runtime)
+- [ ] `.worldforge/reports/` convention documented in `docs/src/playbooks.md`
+- [ ] CHANGELOG entry under `## Unreleased`
+- [ ] Roadmap §8 marked `done · YYYY-MM-DD` in `.codex/skills/tui-development/references/roadmap.md`


### PR DESCRIPTION
Specifies and plans TheWorldHarness milestone **M4 — Eval + Benchmark** under `specs/theworldharness-M4-eval-benchmark/` (spec / plan / tasks). Pure documentation — no code changes.

The milestone introduces `EvalScreen` and `BenchmarkScreen`, lands their results in `RunInspectorScreen` with shared JSON / Markdown / CSV export, and treats capability mismatch as a hard `WorldForgeError` surfaced as a toast (never silently swallowed). Every cited number is preserved to `.worldforge/reports/<kind>-<timestamp>-<run-id>.json` so reviewers can trace it back to disk. Renderers are shared with the `worldforge` CLI to prevent TUI / CLI drift.

Roadmap milestone anchor: [`.codex/skills/tui-development/references/roadmap.md` §8 — M4 — Eval + Benchmark](../blob/main/.codex/skills/tui-development/references/roadmap.md#m4--eval--benchmark).

## Test plan
- [ ] Reviewers confirm spec acceptance criteria match the roadmap intent for M4 and the claim-hygiene discipline from `evaluation-benchmarking/SKILL.md`.
- [ ] `uv run pytest` stays green (no code changes; verified locally — 269 passed, 3 skipped).
- [ ] Open questions in `spec.md` are triaged before implementation tasks (T1–T7) start.