### PR TITLE
docs(specs): theworldharness M1 — screen architecture

### DIFF
--- a/specs/theworldharness-M1-screen-architecture/plan.md
+++ b/specs/theworldharness-M1-screen-architecture/plan.md
@@ -1,0 +1,109 @@
+# Milestone M1 — Screen architecture · Implementation Plan
+
+## Builds on
+- Roadmap §8 "M1 — Screen architecture" — `.codex/skills/tui-development/references/roadmap.md`
+- Roadmap §3 "Architecture (target)" — single `App`, many `Screen`s; `BINDINGS: ?, q, ctrl+p, ctrl+t, esc`; system commands per screen
+- Roadmap §4.1 (HomeScreen), §4.8 (RunInspectorScreen), §4.9 (Modal screens)
+- Roadmap §5 (Command palette — static system commands layer only for M1; dynamic `Provider` deferred to M5)
+- Skill: `.codex/skills/tui-development/SKILL.md` — "One App, many Screens"; `ModalScreen[T]`; messages over reach-across; bindings on screen with `show=True`; `App.get_system_commands`; worker contract
+- Predecessor milestone: M0 (registered `worldforge-dark` / `worldforge-light` `Theme`s, `Header` clock, `Breadcrumb` widget, provider status pill)
+
+## Architecture changes
+- **`HomeScreen(Screen)`** — new. Composes a 30-second intro `Static`, three `JumpCard` widgets (`n`, `p`, `e`), and an empty "Recent" placeholder area (the populated recent-items list ships with M5; M1 leaves a per §2.4 empty-state Static there).
+- **`RunInspectorScreen(Screen)`** — new. Re-homes the existing `HeroPane`, flow rail (`Select` + `FlowCard`s + Run `Button`), `TimelinePane`, `InspectorPane`, `TranscriptPane`. The `selected_flow_id` and `running` fields move from `App` to this screen.
+- **`HelpScreen(ModalScreen[None])`** — new. On mount, queries `self.app.screen` (the screen below it on the stack) and renders its `BINDINGS` as a `DataTable` with columns `key`, `action`, `description`. Dismisses on `escape` or `q`.
+- **`PlaceholderScreen(ModalScreen[None])`** — new. Used by the "Run a provider" and "Run an eval" jump cards in M1 to explain that those screens land in M3 / M4. Replaced by real `ProvidersScreen` / `EvalScreen` push targets in those milestones.
+- **`JumpCard(Static)`** — new custom widget. `can_focus=True`, posts a `JumpRequested(target: str)` `Message` on `enter`, click, or its bound letter. Border becomes `round $accent` on `:focus`.
+- **`TheWorldHarnessApp`** — modified. Slim down to: `SCREENS = {"home": HomeScreen, "run-inspector": RunInspectorScreen}`, App-level `BINDINGS` for `?`, `ctrl+p`, `ctrl+t` (theme — M0 deliverable, kept), `q`, plus chord prefixes `g h` / `g r`. Drop the App-level `r`, `1`, `2`, `3` bindings (those move to `RunInspectorScreen`). Implement `get_system_commands(self, screen)` to yield the static command list. Initial `push_screen` decision moves to `on_mount`: push `"run-inspector"` if `initial_flow_id` was set explicitly via CLI, otherwise `"home"`.
+
+## Module touch list
+| Path | Change | Notes |
+| --- | --- | --- |
+| `src/worldforge/harness/tui.py` | Refactor: extract `HomeScreen`, `RunInspectorScreen`, `HelpScreen`, `PlaceholderScreen`, `JumpCard` from the existing single-screen App. App becomes a scaffold + `SCREENS` registry + `get_system_commands`. | Textual import boundary preserved — everything stays in this file. Existing `HeroPane`, `FlowCard`, `TimelinePane`, `InspectorPane`, `TranscriptPane` move into `RunInspectorScreen.compose` unchanged. |
+| `src/worldforge/harness/cli.py` | One change: distinguish "user passed `--flow`" from "default value". Pass `initial_screen` hint into `TheWorldHarnessApp(...)`. | Keep CLI surface backwards-compatible — `--flow` semantics unchanged for users. |
+| `tests/test_harness_tui.py` | Update three existing tests to assert against `app.screen` and to push `RunInspectorScreen` (either via `--flow` constructor arg, which still pushes it, or explicitly via `app.push_screen("run-inspector")`). Add new tests per "Testing" below. | Pilot patterns extended; no new test framework dependency. |
+| `src/worldforge/harness/flows.py` | No change. | M1 is structural; `available_flows()` / `run_flow()` are reused as-is by `RunInspectorScreen`. |
+| `src/worldforge/harness/models.py` | No change. | Public `HarnessFlow` / `HarnessRun` / `HarnessStep` / `HarnessMetric` shapes are stable per skill "Stop and ask". |
+
+## Key technical decisions
+
+### Use `ModalScreen[None]` for help overlay (vs an inline collapsed pane)
+- **Decision:** `HelpScreen(ModalScreen[None])`.
+- **Alternatives considered:** A `Collapsible` pane on each screen; an `App`-level overlay `Container` toggled by `display:none`.
+- **Rationale:** The skill is explicit ("Type `ModalScreen[T]` so dismiss results are checked"). A modal is the only option that preserves screen-stack semantics, restores focus correctly on dismiss, and works uniformly from every screen. `display:none` toggling is the failure mode the roadmap §3 explicitly rejects ("New top-level views are `Screen` subclasses pushed onto the stack — never `display:none` toggling on one mega-screen").
+
+### Static system commands via `App.get_system_commands` (vs a custom `Provider`)
+- **Decision:** Implement `App.get_system_commands(self, screen)` only. No `textual.command.Provider` subclass in M1.
+- **Alternatives considered:** Build the dynamic `Provider` now, leaving its yield list as just the static items.
+- **Rationale:** Roadmap §5 splits the palette into two layers: static system commands (M1) and a dynamic `Provider` (M5). Building the `Provider` now would either hard-code the M5 surface or ship empty stubs that drift before M5 lands. `get_system_commands` is the honest M1 surface; M5 adds the `Provider` subclass without touching it.
+
+### Bindings on the screen, not on the App
+- **Decision:** Move `r`, `1`, `2`, `3` to `RunInspectorScreen.BINDINGS`. App keeps only `?`, `ctrl+p`, `ctrl+t`, `q`, plus chord prefixes.
+- **Alternatives considered:** Keep flow-selection bindings on the App so they work from Home too.
+- **Rationale:** The skill's footer-cleanliness rule ("Bindings on the screen, with `show=True` for the footer") requires this. If `1` / `2` / `3` are App-level, they appear in every screen's footer and confuse Home-screen users. The right discovery surface for "run a flow from Home" is `Ctrl+P` ("run flow leworldmodel"), which the system commands provide.
+
+### Chord bindings `g h` / `g r` for jump navigation
+- **Decision:** Use Textual chord syntax (`("g,h", "jump('home')", "Jump: Home", show=False)`).
+- **Alternatives considered:** Single-key bindings on the App (`h` for Home, `R` for Run Inspector).
+- **Rationale:** The skill cites lazygit / k9s as inspirations; both use chord-prefix navigation (`g`-prefix is the de-facto vim convention). Single keys would collide with future per-screen bindings (e.g. M2 `WorldsScreen` wants `n` for new world).
+
+### Jump cards are a custom `Static` subclass, not stock `Button`s
+- **Decision:** `JumpCard(Static)` with `can_focus=True` and a `JumpRequested(target: str)` posted message.
+- **Alternatives considered:** Three stock `Button` widgets in a `Horizontal` container.
+- **Rationale:** Roadmap §4.1 calls them "three big jump cards" — visual hierarchy that stock buttons cannot carry. Custom `Static` lets us own the border state (`:focus { border: round $accent }`) and the multi-line content (title + binding hint + one-line description). `JumpRequested` keeps the parent–child message contract per the skill's "Messages over reach-across" rule.
+
+### Placeholder modal for not-yet-built jump targets
+- **Decision:** "Run a provider" and "Run an eval" cards push a `PlaceholderScreen(ModalScreen[None])` in M1 that says "Lands in M3 / M4 — track in roadmap.md §8".
+- **Alternatives considered:** Disable those cards in M1; or omit them entirely.
+- **Rationale:** Roadmap §4.1 specifies three jump cards. Disabling two of them would tell first-time users that two thirds of the harness is broken. A placeholder modal is honest (the work is real, just not yet shipped) and creates a target for M3 / M4 to overwrite without changing Home.
+
+## Data flow
+- **Reactives:**
+  - `RunInspectorScreen.selected_flow_id: reactive[str]` — moved from `App`. Paired with `watch_selected_flow_id` to redraw the rail.
+  - `RunInspectorScreen.running: reactive[bool]` — moved from `App`. Paired with `watch_running` to toggle the Run button's `disabled` state and the hero pane's status text.
+  - `RunInspectorScreen.last_run: reactive[HarnessRun | None]` — moved from `App`.
+- **Messages:**
+  - `JumpRequested(target: str)` — posted by `JumpCard` on activation. Handled by `HomeScreen.on_jump_requested` which calls `self.app.push_screen(target)` for routable targets or `self.app.push_screen(PlaceholderScreen(...))` for M3 / M4 placeholders.
+- **Workers:**
+  - **None in M1.** M1 is structural. The existing `_run_flow` keeps its `asyncio.sleep` rhythm and stays on the screen's main task — replacing it with a real `@work(thread=True, group="provider", exclusive=True, name="<flow-id>")` worker is M3's deliverable per roadmap §8 M3 and the skill's worker contract. Any worker added now would be removed in M3 because the slideshow itself goes away then; M1 must not pre-empt that work.
+- **`push_screen_wait` usage:** Reserved for modals that return a value (e.g. M2's `ConfirmDelete[bool]`). M1 modals (`HelpScreen`, `PlaceholderScreen`) are `ModalScreen[None]` and are pushed with plain `push_screen` — `push_screen_wait` is wired into the App scaffold so M2 can use it without further plumbing.
+
+## Theming and CSS
+- All borders, backgrounds, text colors come from semantic CSS variables registered by M0: `$accent`, `$success`, `$warning`, `$error`, `$panel`, `$boost`, `$surface`, `$muted`. No hex literals.
+- `JumpCard` focus ring: `JumpCard:focus, JumpCard:focus-within { border: round $accent; }`. Idle: `border: round $panel`.
+- `HelpScreen` modal background: `background: $surface 90%`; outer container: `border: round $accent`.
+- `PlaceholderScreen` modal: same chrome as `HelpScreen` but with `border: round $warning` to signal "scaffold-not-yet-real" per roadmap §2.1.
+- `Footer` and `Header` styling stays inherited from the registered theme — no per-screen overrides.
+- The existing inline hex literals in `tui.py` (`#d8c46a`, `#8ec5a3`, `#101512`, `#171f1a`, `#d3d6cf`, `#3b423e`, `#6f7770`, `#e4dfc5`, `#9ea89f`) get replaced as part of moving each pane into its new screen — this is partly an M0 cleanup carried into M1 because the surrounding code is already being touched.
+
+## Testing
+- **Pilot tests** (extending `tests/test_harness_tui.py`):
+  - `test_initial_screen_is_home_when_no_flow_flag`: launch app with no `--flow`, assert `isinstance(app.screen, HomeScreen)`.
+  - `test_initial_screen_is_run_inspector_when_flow_flag_passed`: launch with `initial_flow_id="lerobot"` via the explicit CLI path, assert `isinstance(app.screen, RunInspectorScreen)` and `app.screen.selected_flow_id == "lerobot"`.
+  - `test_jump_to_home_from_run_inspector`: start on `RunInspectorScreen`, `await pilot.press("g", "h")`, assert `isinstance(app.screen, HomeScreen)`.
+  - `test_help_overlay_opens_and_closes`: `await pilot.press("?")`, assert `isinstance(app.screen, HelpScreen)`; `await pilot.press("escape")`, assert previous screen restored.
+  - `test_command_palette_lists_screens_and_flows`: `await pilot.press("ctrl+p")`, await pause, assert command palette contains entries for "Jump: Home", "Jump: Run Inspector", "Help", and one per flow id from `available_flows()`.
+  - `test_home_jump_card_keyboard_activation`: on `HomeScreen`, `await pilot.press("n")`, assert a `PlaceholderScreen` (or in M2+, `WorldsScreen`) is on the stack.
+  - Update existing three tests (`leworldmodel`, `lerobot`, `diagnostics`) to push `RunInspectorScreen` first — either by passing `initial_flow_id` (which now triggers the push in `on_mount`) or via `await app.push_screen("run-inspector")`.
+- **Snapshot tests** (`pytest-textual-snapshot`, pinned `terminal_size=(120, 40)` per skill):
+  - `HomeScreen` empty (no recent items).
+  - `RunInspectorScreen` mid-flow with `leworldmodel` selected.
+  - `HelpScreen` overlay over `RunInspectorScreen`.
+  - `PlaceholderScreen` overlay over `HomeScreen`.
+- **Coverage gate:** `uv run --extra harness pytest --cov=src/worldforge --cov-report=term-missing --cov-fail-under=90` must still pass. The refactor adds new code; the new code is covered by the new Pilot tests.
+
+## Risks and mitigations
+- **Risk:** Existing `tests/test_harness_tui.py` asserts `app.query_one("#inspector")` while the inspector lives on the App. After M1 it lives on `RunInspectorScreen`.
+  - **Mitigation:** Update the assertion to `app.screen.query_one("#inspector")` and push `RunInspectorScreen` first. Documented as task T6.
+- **Risk:** Command palette discoverability tanks if `show=False` is overused on screen bindings.
+  - **Mitigation:** Audit every `Binding` introduced in M1: chord prefixes (`g`) stay `show=False` because the chord targets carry the description; jump targets and `?` / `Ctrl+P` stay `show=True`. The acceptance criterion "Footer shows only the bindings of the active screen" enforces this.
+- **Risk:** The `--flow` CLI flag's "I want to run this" intent gets diluted if it now opens Home with the flow merely pre-selected.
+  - **Mitigation:** Decided in "Key technical decisions": `--flow` keeps pushing `RunInspectorScreen` directly. The CLI test in `tests/test_harness_cli.py` already asserts behaviour and must continue to pass.
+- **Risk:** Hex literal cleanup balloons the PR beyond M1's scope.
+  - **Mitigation:** Limited to the panes being touched (every pane that moves screens). Any pane that does not move stays as-is for M1 — its hex literals are M0 leftovers and get cleaned up under M0's banner if any remain.
+- **Risk:** Extracting screens reorders widget IDs in ways that break snapshot tests added by M0.
+  - **Mitigation:** Keep widget `id=` strings stable (`#hero`, `#timeline`, `#inspector`, `#transcript`, `#run-button`, `#flow-select`). Re-snapshot only the screens we are adding (Home, Help, Placeholder).
+
+## Dependencies on other milestones
+- **Required before this can ship:** M0 — registered `worldforge-dark` / `worldforge-light` themes, `Header` clock + `Breadcrumb` widget + provider status pill, semantic CSS variable surface. Without M0 the new screens would either ship more hex literals or render with the wrong chrome.
+- **Blocks:** M2 (`WorldsScreen` + `WorldEditScreen` need `push_screen` / `push_screen_wait` and the `SCREENS` registry); M3 (`ProvidersScreen` and the worker contract need the screen-local binding pattern and the `get_system_commands` hook); M4 (`EvalScreen` / `BenchmarkScreen` ditto); M5 (the dynamic command palette `Provider` extends the static `get_system_commands` list M1 ships).

--- a/specs/theworldharness-M1-screen-architecture/spec.md
+++ b/specs/theworldharness-M1-screen-architecture/spec.md
@@ -1,0 +1,65 @@
+# Milestone M1 — Screen architecture
+
+## Status
+Draft · 2026-04-21
+
+## Outcome (one sentence)
+TheWorldHarness opens on a dedicated `HomeScreen` with three jump targets, the existing flow visualisation lives behind a routed `RunInspectorScreen`, and every action is reachable from `Ctrl+P` or a `?` help overlay so users never have to guess what keys exist.
+
+## Why this milestone
+The current TUI is a single mega-screen: `TheWorldHarnessApp` mounts the hero, rail, timeline, inspector, and transcript in one `compose`, and binds `r`, `1`, `2`, `3`, `q` directly on the `App`. There is no navigation layer, no command palette, and no way to discover keys beyond the footer. Per `.codex/skills/tui-development/references/roadmap.md` §1 (Vision), the harness must read like a "keyboard-first, discoverable, polished workspace where every action is one keystroke or one `Ctrl+P` away" — that is impossible without a screen stack and a system command surface.
+
+M1's specific contribution is **navigation**, not interactivity. The slideshow nature of the existing flow runner (canned `asyncio.sleep` step animations) is a separate failure mode addressed by M3 (`.codex/skills/tui-development/SKILL.md` §"Why this skill exists" item 1). M1 is the structural prerequisite: once screens are routable and the command palette exists, M2–M5 can each add their own screen without further App-level surgery. M1 also unblocks the design language work from M0 — a `Header` breadcrumb only carries information once there is more than one screen to point at.
+
+## In scope
+- A `HomeScreen` that introduces WorldForge in roughly 30 seconds and presents three jump cards: **Create a world**, **Run a provider**, **Run an eval**, each mapped to a binding (`n`, `p`, `e`) per roadmap §4.1.
+- A `RunInspectorScreen` that owns the existing flow visualisation (`HeroPane`, flow rail, `TimelinePane`, `InspectorPane`, `TranscriptPane`) currently composed on the App.
+- A `HelpScreen` (`ModalScreen[None]`) bound to `?` that lists the active screen's bindings.
+- `App.SCREENS` registry plus `push_screen` / `push_screen_wait` usage so navigation goes through the screen stack rather than `display:none` toggling.
+- App-level `Ctrl+P` system commands surfaced via `App.get_system_commands` covering: jump to Home, jump to Run Inspector, open Help, switch each registered flow, run the selected flow, switch theme (registered in M0), and quit.
+- `g h` / `g r` chord bindings for jump-to-Home and jump-to-Run-Inspector.
+- A breadcrumb in the `Header` that reflects the active screen (`worldforge › home`, `worldforge › run-inspector › <flow-id>`).
+- Pilot tests covering screen pushes, the command palette, `?` overlay, and the `--flow` initial-screen hint.
+
+## Out of scope (explicit)
+- Worlds CRUD (`WorldsScreen`, `WorldEditScreen`, `ConfirmDelete` modal) — defer to M2.
+- Live provider workers, `Esc` cancellation, `RichLog` event streaming — defer to M3.
+- `EvalScreen`, `BenchmarkScreen`, capability-mismatch toasts — defer to M4.
+- Dynamic command palette `Provider` for worlds, providers, runs, suites — defer to M5. M1 ships only static system commands.
+- Theme registration and the semantic CSS variable migration — that is M0's deliverable; M1 consumes it but does not extend it.
+- Replacing the canned `asyncio.sleep` flow runner with real workers — M3.
+- `DiagnosticsScreen` extraction — not on the roadmap until at least M4 polish.
+
+## User stories
+1. As a researcher launching `worldforge-harness` for the first time, I land on `HomeScreen` and read a one-screen explanation of WorldForge before doing anything else, so that I do not have to hunt through the README.
+2. As a returning user, I press `Ctrl+P` and type "run flow", so that I find every flow runnable without remembering whether the binding is `1`, `2`, or `3`.
+3. As any user, I press `?` from any screen and see the bindings live on that screen, so that I never have to read source to discover keys.
+4. As a flow runner, I press `g h` from the Run Inspector, so that I jump back to Home without quitting and reopening the harness.
+5. As a CLI user, I run `worldforge-harness --flow lerobot`, so that the harness opens directly on `RunInspectorScreen` with the LeRobot flow pre-selected.
+6. As a keyboard-only user, I tab through the three Home jump cards and press `enter` on one, so that mouse and keyboard parity is real (roadmap §2.2).
+
+## Acceptance criteria
+- [ ] `App.SCREENS` registers at least `"home"` (`HomeScreen`) and `"run-inspector"` (`RunInspectorScreen`).
+- [ ] On launch with no `--flow`, the active screen is `HomeScreen` (assertable via `app.screen.__class__.__name__`).
+- [ ] On launch with `--flow <id>`, the active screen is `RunInspectorScreen` and `app.screen.selected_flow_id == <id>` for any id present in `available_flows()`.
+- [ ] Pressing `Ctrl+P` opens the command palette and the listing includes one entry per registered flow (one per `available_flows()`), one "Jump to Home", one "Jump to Run Inspector", one "Open Help", one "Quit".
+- [ ] Pressing `?` from any screen pushes a `HelpScreen` modal that lists the bindings declared on the screen below it (`show=True` and internal alike).
+- [ ] Dismissing the `HelpScreen` (`escape` or `q`) returns control to the previously active screen with no state mutation.
+- [ ] `g h` jumps to `HomeScreen` from any non-modal screen; `g r` jumps to `RunInspectorScreen`.
+- [ ] The `Header` breadcrumb text changes when the active screen changes.
+- [ ] The `Footer` shows only the bindings of the active screen, not stale App-level entries.
+- [ ] All four existing tests in `tests/test_harness_tui.py` continue to pass after being updated to push `RunInspectorScreen` first (or to assert against `app.screen` of that type).
+
+## Non-functional requirements
+- The breadcrumb in the `Header` reflects the active screen, including the current flow id when `RunInspectorScreen` is active.
+- The `Footer` shows only screen-local bindings (`show=True`); internal mechanics (`g`, `?`, chord prefixes) stay `show=False` to keep it scannable per `.codex/skills/tui-development/SKILL.md`.
+- Mouse and keyboard parity holds on every jump target: Home jump cards must be activatable by `enter`, by click, and by their letter binding (`n`, `p`, `e`).
+- The Textual import boundary is preserved: every new screen lives in `src/worldforge/harness/tui.py` (or a new sibling module that itself only imports Textual), and `flows.py`, `cli.py`, `models.py` stay Textual-free.
+- No new runtime dependency in the `harness` extra.
+- No hex literals in any new TCSS — semantic variables only (M0 contract).
+
+## Open questions
+- Should the three Home jump cards be three stock `Button` widgets or a custom `JumpCard(Static)` widget? Decided in plan.md (custom `Static` subclass with `can_focus=True`, since the roadmap §4.1 calls them "big jump cards" and stock buttons under-sell the visual hierarchy).
+- Should the help overlay show only `show=True` bindings or every binding including `show=False`? Decided in plan.md (every binding, since the whole point of the overlay is discovery — `show=False` keeps the footer clean, not the help screen).
+- Should the `--flow` CLI flag still default the user to `RunInspectorScreen`, or should it default to Home with the flow merely pre-selected? Decided in plan.md (keep current behaviour: `--flow` is an explicit "I want to run this" intent, so push `RunInspectorScreen` directly to preserve the muscle memory of every existing user).
+- Should "Run a provider" and "Run an eval" jump cards be present on Home in M1 even though `ProvidersScreen` and `EvalScreen` do not exist until M3 / M4? Yes, but those cards push a `HelpScreen`-style placeholder modal explaining the milestone they ship in. Tracked in plan.md under "Key technical decisions".

--- a/specs/theworldharness-M1-screen-architecture/tasks.md
+++ b/specs/theworldharness-M1-screen-architecture/tasks.md
@@ -1,0 +1,73 @@
+# Milestone M1 — Screen architecture · Tasks
+
+Each task is a single PR-sized unit. Order matters: a later task may assume an earlier one has landed in main. Each task should keep `uv run --extra harness pytest` green at the end.
+
+## T1 — Introduce the screen scaffold and `SCREENS` registry
+- Files: `src/worldforge/harness/tui.py`
+- Change: Add a `RunInspectorScreen(Screen)` class that wraps the existing `compose` body and the existing `_run_flow` / `_refresh_static` / `_on_flow_changed` / `_on_run_pressed` handlers, plus the `r`, `1`, `2`, `3` bindings. `TheWorldHarnessApp.compose` becomes a no-op aside from `Header` / `Footer` (handled by Screen). Register `SCREENS = {"run-inspector": RunInspectorScreen}`. In `on_mount`, `push_screen("run-inspector")`. The App still exposes `selected_flow_id` / `state_dir` / `step_delay` for the screen to read on construction. Behaviour from the user's perspective is unchanged.
+- Acceptance: maps to spec criterion "all four existing tests in `tests/test_harness_tui.py` continue to pass after being updated to push `RunInspectorScreen` first". The harness still launches into the flow visualisation with `--flow` working identically.
+- Tests: existing `test_the_world_harness_app_runs_leworldmodel_flow`, `test_the_world_harness_app_switches_to_lerobot_flow`, `test_the_world_harness_app_switches_to_diagnostics_flow` pass after asserting on `app.screen.last_run` instead of `app.last_run` (or by exposing `last_run` as a property on the App that delegates to the screen).
+
+## T2 — Add `HomeScreen` with three jump cards and `JumpCard` widget
+- Files: `src/worldforge/harness/tui.py`
+- Change: Add `JumpCard(Static)` (`can_focus=True`, posts `JumpRequested(target: str)`) and `HomeScreen(Screen)` composing a 30-second intro `Static`, three `JumpCard`s for "Create a world" (`n`), "Run a provider" (`p`), "Run an eval" (`e`), and an empty-state Static for the recent-items area. Register `"home": HomeScreen` in `SCREENS`. Default initial screen becomes `"home"` unless `--flow` was explicitly passed.
+- Acceptance: maps to "On launch with no `--flow`, the active screen is `HomeScreen`" and "On launch with `--flow <id>`, the active screen is `RunInspectorScreen`".
+- Tests: new `test_initial_screen_is_home_when_no_flow_flag` and `test_initial_screen_is_run_inspector_when_flow_flag_passed`.
+
+## T3 — `--flow` CLI semantic preserved end-to-end
+- Files: `src/worldforge/harness/cli.py`, `src/worldforge/harness/tui.py`
+- Change: Distinguish "user passed `--flow`" from default. Pass an `initial_screen: Literal["home", "run-inspector"]` argument into `TheWorldHarnessApp.__init__` derived from CLI presence. `TheWorldHarnessApp.on_mount` pushes that screen.
+- Acceptance: maps to spec criterion 3 ("On launch with `--flow <id>`, the active screen is `RunInspectorScreen`").
+- Tests: extend `tests/test_harness_cli.py` to assert the constructor receives the expected `initial_screen` value for both code paths. Pilot test: `test_initial_screen_is_run_inspector_when_flow_flag_passed`.
+
+## T4 — `HelpScreen` modal bound to `?`
+- Files: `src/worldforge/harness/tui.py`
+- Change: Add `HelpScreen(ModalScreen[None])` that on mount queries the App's previous screen and renders its `BINDINGS` as a `DataTable` (columns: `key`, `description`, `action`). App-level `BINDINGS` gets `("?", "push_screen('help')", "Help", show=True)`. Help screen dismisses on `escape` or `q`.
+- Acceptance: "Pressing `?` from any screen pushes a `HelpScreen` modal that lists the bindings declared on the screen below it" and "Dismissing the `HelpScreen` returns control to the previously active screen".
+- Tests: new `test_help_overlay_opens_and_closes`. Snapshot: `HelpScreen` overlay over `RunInspectorScreen` at `terminal_size=(120, 40)`.
+
+## T5 — Static system commands via `get_system_commands` (`Ctrl+P`)
+- Files: `src/worldforge/harness/tui.py`
+- Change: Implement `App.get_system_commands(self, screen)` that yields `("Jump: Home", "Open Home", lambda: self.push_screen("home"))`, `("Jump: Run Inspector", ...)`, `("Open Help", ...)`, one entry per flow id from `available_flows()` ("Run flow: <title>" — switches `RunInspectorScreen` to that flow, pushing the screen if not already on the stack), `("Switch theme", ...)` (delegates to M0's theme command), and `("Quit", ...)`. App-level `BINDINGS` keeps stock `("ctrl+p", "command_palette", "Commands", show=True)`.
+- Acceptance: "Pressing `Ctrl+P` opens the command palette and the listing includes one entry per registered flow … one 'Jump to Home', one 'Jump to Run Inspector', one 'Open Help', one 'Quit'."
+- Tests: new `test_command_palette_lists_screens_and_flows`. Existing tests must still pass.
+
+## T6 — Chord bindings `g h` / `g r` and footer hygiene
+- Files: `src/worldforge/harness/tui.py`
+- Change: Add chord bindings on the App: `("g,h", "switch_screen('home')", "Jump: Home", show=False)` and `("g,r", "switch_screen('run-inspector')", "Jump: Run Inspector", show=False)`. Audit every `BINDINGS` entry across the App and the two new screens to make sure `show=True` only appears on user-facing actions per the skill's footer-cleanliness rule.
+- Acceptance: "`g h` jumps to `HomeScreen` from any non-modal screen; `g r` jumps to `RunInspectorScreen`" and "The `Footer` shows only the bindings of the active screen, not stale App-level entries".
+- Tests: new `test_jump_to_home_from_run_inspector` and `test_jump_to_run_inspector_from_home`.
+
+## T7 — `PlaceholderScreen` for not-yet-built jump targets
+- Files: `src/worldforge/harness/tui.py`
+- Change: Add `PlaceholderScreen(ModalScreen[None])` that takes a `target_milestone: str` and a `next_action: str` and renders both. `HomeScreen.on_jump_requested` routes "create a world" / "run a provider" / "run an eval" to a `PlaceholderScreen` with the right milestone label until M2 / M3 / M4 overwrites them.
+- Acceptance: "Run a provider" and "Run an eval" cards do not silently fail — they push a clearly labelled placeholder modal.
+- Tests: new `test_home_jump_card_keyboard_activation` (asserts `PlaceholderScreen` on stack after `n`). Snapshot: `PlaceholderScreen` overlay over `HomeScreen`.
+
+## T8 — Breadcrumb wiring
+- Files: `src/worldforge/harness/tui.py`
+- Change: Wire each screen's `on_screen_resume` (and `on_mount`) to update the M0 `Breadcrumb` widget: `worldforge › home`, `worldforge › run-inspector › <flow-id>`, `worldforge › help`, `worldforge › placeholder`.
+- Acceptance: "The `Header` breadcrumb text changes when the active screen changes."
+- Tests: extend `test_jump_to_home_from_run_inspector` to assert the breadcrumb's text reactive after the jump.
+
+## T9 — Migrate residual hex literals on touched panes
+- Files: `src/worldforge/harness/tui.py`
+- Change: Replace inline hex literals in `HeroPane`, `FlowCard`, `TimelinePane`, `InspectorPane`, `TranscriptPane`, and the App-level `CSS` block with semantic variables registered by M0. No new tokens introduced.
+- Acceptance: spec NFR "No hex literals in any new TCSS — semantic variables only (M0 contract)."
+- Tests: relies on existing snapshot tests. New snapshots from T2 / T4 / T7 must contain no raw hex.
+
+## T10 — Roadmap update
+- Files: `.codex/skills/tui-development/references/roadmap.md`
+- Change: Mark §8 "M1 — Screen architecture" `done · 2026-MM-DD` once T1–T9 are merged. Do not edit the milestone description itself.
+- Acceptance: Per skill "Stop and ask the user — before declaring a milestone in `references/roadmap.md` 'done'".
+- Tests: docs-only; `uv run python scripts/generate_provider_docs.py --check` still passes (this file is not provider-generated).
+
+## Definition of done
+- [ ] All tasks T1–T10 merged.
+- [ ] Pilot tests in `tests/test_harness_tui.py` cover: initial screen by CLI flag, `g h` / `g r` jumps, `?` overlay open/close, `Ctrl+P` listing, jump-card keyboard activation.
+- [ ] Snapshot tests added for `HomeScreen`, `RunInspectorScreen` mid-flow, `HelpScreen` overlay, `PlaceholderScreen` overlay — all pinned at `terminal_size=(120, 40)`.
+- [ ] `uv run --extra harness pytest --cov=src/worldforge --cov-report=term-missing --cov-fail-under=90` passes.
+- [ ] `uv run ruff check src tests examples scripts` and `uv run ruff format --check src tests examples scripts` pass.
+- [ ] No new runtime dependency in the `harness` extra.
+- [ ] `flows.py`, `cli.py`, `models.py` remain Textual-free.
+- [ ] Roadmap §8 marked "done · {date}".


### PR DESCRIPTION
Specifies and plans **M1 — Screen architecture** for TheWorldHarness roadmap. Pure documentation: splits `TheWorldHarnessApp` into `HomeScreen` + a `RunInspectorScreen` that re-homes the existing flow visualisation, introduces `push_screen` / `push_screen_wait`, adds a `?` help overlay (`ModalScreen[None]`), and surfaces static system commands via `App.get_system_commands` so every action is reachable from `Ctrl+P`. Builds on M0 (theme + chrome); blocks M2–M5 by establishing the screen-stack pattern they all extend.

Roadmap milestone: [`.codex/skills/tui-development/references/roadmap.md` §8 "M1 — Screen architecture"](../blob/main/.codex/skills/tui-development/references/roadmap.md#8-milestones).

Files:
- `specs/theworldharness-M1-screen-architecture/spec.md`
- `specs/theworldharness-M1-screen-architecture/plan.md`
- `specs/theworldharness-M1-screen-architecture/tasks.md`