### PR TITLE
docs(specs): theworldharness M5 — polish and showcase

### DIFF
--- a/specs/theworldharness-M5-polish-showcase/plan.md
+++ b/specs/theworldharness-M5-polish-showcase/plan.md
@@ -1,0 +1,102 @@
+# Milestone M5 — Polish + showcase · Implementation Plan
+
+## Builds on
+- Roadmap §8 "M5 — Polish + showcase" — `.codex/skills/tui-development/references/roadmap.md`
+- Roadmap §1 Vision, §2 Design language, §4.1 HomeScreen, §5 Command palette, §7 Testing strategy, §10 Anti-goals, §11 Open questions — same file.
+- Skill: `.codex/skills/tui-development/SKILL.md` (snapshot testing, command palette patterns, theme rules, worker contract).
+- Persistence skill: `.codex/skills/persistence-state/SKILL.md` (sourcing recent worlds via `WorldForge.list_worlds`, no parallel state).
+- Predecessor milestones (must have landed first):
+  - M0 — Theme + chrome reset: registers `worldforge-dark` / `worldforge-light`, strips hex literals, adds `Header` clock + `Breadcrumb` + provider status pill. M5 extends the theme registration with a third variant.
+  - M1 — Screen architecture: introduces `HomeScreen`, `RunInspectorScreen`, `push_screen`, `?` help overlay, static `Ctrl+P` system commands. M5 layers the *dynamic* command provider on top.
+  - M2 — Worlds CRUD: `WorldsScreen`, `WorldEditScreen`, `ConfirmDelete`. M5 reads `WorldForge.list_worlds` for recents and palette items.
+  - M3 — Live providers: `ProvidersScreen`, capability matrix, real provider call wired through `@work`, `Esc` cancellation. M5 indexes `PROVIDER_CATALOG` plus injected providers in the palette.
+  - M4 — Eval + Benchmark: `EvalScreen`, `BenchmarkScreen`, `RunInspectorScreen`, results pinned to `.worldforge/reports/`. M5 sources recent runs from that directory.
+
+## Architecture changes
+- Add `WorldForgeCommandProvider` (new), a subclass of `textual.command.Provider`. Lives next to `TheWorldHarnessApp` in `src/worldforge/harness/tui.py` (or a co-located helper file inside `harness/` that only imports Textual when the extra is present). Indexes three sources — worlds, providers, runs — and yields fuzzy-ranked `Hit`s that dispatch existing M2/M3/M4 messages.
+- Add `RecentItems` widget (new) on `HomeScreen`, composed of two `Static` lists (recent worlds, recent runs) with row-level click and key activation. Reads through cached helpers; no direct disk access from the widget.
+- Register `worldforge-high-contrast` `Theme` (new) alongside the M0 themes. The variant overrides existing semantic tokens; it does not introduce hex literals in widget CSS.
+- Add snapshot test helpers and per-screen × per-size fixtures under `tests/test_harness_snapshots.py` (new). One `pytest.mark.parametrize` over `(screen, size)` keeps the matrix declarative and the SVG paths consistent.
+- Add `scripts/regen-harness-screenshot.sh` (new), a small wrapper around `uv run --extra harness worldforge-harness` plus a deterministic state-dir fixture, to regenerate `docs/assets/img/theworldharness-tui-screenshot-1.png`. Tracked so the next refresh is one command.
+- Extend the existing `TheWorldHarnessApp.get_system_commands` (M1) to surface the high-contrast theme switch action under a stable label. No replacement of the M1 static commands.
+
+## Module touch list
+| Path | Change | Notes |
+| --- | --- | --- |
+| `src/worldforge/harness/tui.py` | Register `worldforge-high-contrast` theme; register `WorldForgeCommandProvider`; mount `RecentItems` on `HomeScreen`; extend system commands. | Only Textual-importing module touched; preserves §3 boundary. |
+| `src/worldforge/harness/` (new helper, optional) | If `WorldForgeCommandProvider` grows beyond `tui.py` length, a co-located file (e.g., `palette.py`) may be added; it must guard its Textual import behind the extra check pattern used in `cli.py`. | Stop-and-ask if a new file is added (SKILL.md "Stop and ask"). |
+| `tests/test_harness_snapshots.py` | New parametrised snapshot tests across `(screen, size)`. | Uses `pytest-textual-snapshot`; SVGs land under `tests/snapshots/`. |
+| `tests/snapshots/` | New SVG outputs committed; reviewed in PRs. | Pinned terminal sizes, animations disabled. |
+| `tests/test_harness_tui.py` | Extend with Pilot tests for palette dynamic items, theme cycle including high-contrast, recent-items activation. | Existing flow tests remain; M5 adds new ones rather than replacing. |
+| `tests/fixtures/harness/` (new, if needed) | Deterministic fixture state (worlds, providers, reports) for the snapshot matrix and palette tests. | Tracked, deterministic; no host-specific paths. |
+| `README.md` | Update the screenshot at line 30 (file replacement); no copy changes unless the screenshot URL filename changes. | Tool-neutral, maintainer-style. |
+| `docs/assets/img/theworldharness-tui-screenshot-1.png` | Regenerated. | Deterministic; reproducible from `scripts/regen-harness-screenshot.sh`. |
+| `docs/src/theworldharness.md` | Append a short "Themes" section listing the three variants and the cycle binding; append a one-line note that `Ctrl+P` indexes worlds, providers, and recent runs. | Public behaviour change → doc update. |
+| `scripts/regen-harness-screenshot.sh` (new) | Reproducible regen for the README image. | Documented in the spec; tracked. |
+| `CHANGELOG.md` | Entry under the next version: high-contrast theme, dynamic command palette, HomeScreen recent items, snapshot matrix, screenshot refresh. | Tool-neutral copy. |
+| `.codex/skills/tui-development/references/roadmap.md` | Mark §8 M5 "done · {date}" in the closing PR. | Per roadmap §8 closing convention. |
+
+## Key technical decisions
+- **Palette item ranking — fuzzy score with a "recent" boost.** Decision: rank by Textual's built-in fuzzy matcher, with a small additive boost for items in the recent-items cache (worlds touched in the last hour, runs from the last hour). Alternatives: (a) pinned "Recent" section above dynamic items, k9s-style; (b) pure fuzzy with no recency awareness. Rationale: a boost preserves predictability for power users (recent items rise) while keeping the palette one ranked list; pinned sections fragment the list and force two layers of attention.
+- **Snapshot image format — SVG via `pytest-textual-snapshot`.** Decision: keep the test format as SVG (the library default), commit them under `tests/snapshots/`. PR diffs render as text for SVG, which is reviewable. Alternatives: PNG outputs (binary, opaque diffs) or terminal capture text (no visual fidelity). README image stays PNG to match the current `README.md` line 30 reference and avoid a Markdown renderer regression.
+- **High-contrast as a separate registered theme, not an override module.** Decision: `worldforge-high-contrast` is a third `Theme` registered next to the M0 themes, sharing the same variable names but with higher-contrast values. Alternatives: a runtime override layer or a `:contrast` modifier class. Rationale: matches the M0 registration pattern, lets the theme cycle action treat all three uniformly, and keeps Textual's contrast check applicable to the full theme rather than a partial override.
+- **Recent runs source — disk only (`.worldforge/reports/`).** Decision: the recent-runs list reads mtime-sorted JSON files under `.worldforge/reports/` written by M4. Alternatives: layer in-memory runs from the current TUI session on top. Rationale: a single source of truth keeps the palette and the HomeScreen consistent and avoids a "ghost" run that disappears on restart. Persistence skill alignment: WorldForge does not maintain a parallel run cache.
+- **Recent worlds source — `WorldForge.list_worlds`, sorted by `last_touched`.** Decision: reuse the persistence API from M2; no parallel cache. Alternatives: scan `.worldforge/worlds/` directly. Rationale: the persistence API is the contract; bypassing it would duplicate state and risk drift (CLAUDE.md priority rule #1).
+- **README image regeneration via tracked script.** Decision: commit `scripts/regen-harness-screenshot.sh`. Alternatives: document the steps in the spec body only; require a manual capture each refresh. Rationale: a script is reproducible and PR-reviewable; manual capture rotates with whoever runs it last and erodes the front-door image's honesty.
+- **Cache scanner output for the palette.** Decision: a small in-memory cache keyed by source (worlds, providers, reports) with a 500 ms TTL plus invalidation on `WorldSelected` / `ProviderSelected` / `RunCompleted` messages. Alternatives: scan on every keystroke (rejected — disk hit per keystroke); event-only invalidation with no TTL (rejected — palette can lag if a message is missed). Rationale: keeps palette latency under one frame and makes invalidation observable.
+- **Coverage at `--extra harness`.** Decision: keep the gated coverage command (`testing-validation` skill) at the existing 90% floor. Alternatives: tighten to 95% in this milestone. Rationale: snapshot tests do not lift line coverage meaningfully; the bar should rise as a separate, scoped change.
+
+## Data flow
+- Reactives on `HomeScreen`: `recent_worlds: reactive[tuple[WorldSummary, ...]] = reactive(())`, `recent_runs: reactive[tuple[Path, ...]] = reactive(())`. Recomputed in `on_mount` and on receipt of M2's `WorldSaved`-equivalent and M4's `RunCompleted` messages. Paired with `watch_recent_worlds` / `watch_recent_runs` for redraw.
+- Messages reused (no new message types unless a gap is found during implementation):
+  - `WorldSelected(world_id)` — M2; dispatched by palette world hits and recent-world rows.
+  - `ProviderSelected(provider_id)` — M3; dispatched by palette provider hits.
+  - `RunSelected(report_path)` — M4 (or its equivalent on `RunInspectorScreen`); dispatched by palette run hits and recent-run rows. If M4 names this differently, the M5 plan reuses M4's name verbatim — no rename.
+- Workers: none new. Palette queries are in-memory (cached scanner output). Recent-items refresh is a synchronous, cheap helper scheduled on `on_mount` and on the invalidating messages; if the report directory grows past a few hundred files, the helper can be promoted to `@work(thread=True, group="recent", exclusive=True)` without API change.
+- Persistence: all reads route through `WorldForge.list_worlds` (M2) and through filesystem mtime calls scoped to `.worldforge/reports/` (M4). The TUI does not hand-write JSON, hold its own cache of world or run state, or duplicate any persistence logic.
+- Theme switching: extends the M0 theme cycle action; stores the active theme in the standard Textual theme reactive. No new persistence of theme preference in M5 (out of scope; deferrable).
+
+## Theming and CSS
+- `worldforge-high-contrast` registers overrides for: `$accent`, `$panel`, `$boost`, `$surface`, `$muted`, `$success`, `$warning`, `$error`. Any new semantic tokens needed for the high-contrast pass (e.g., `$focus-ring` if the M0 themes derive it implicitly) are declared in the registration and consumed in widget CSS through the variable name only.
+- Zero hex literals introduced in widget CSS as part of M5. The hex-literal lint (recommended in the risks section) extends to the new theme registration block — colour values may appear there once, by definition.
+- Contrast verification: rely on Textual's built-in contrast check during `pytest`; supplement with one manual review at `100×30` (smallest matrix size, highest density) for the high-contrast variant.
+- Focus rings, panel borders, and status pills carry through unchanged from M0; the high-contrast theme tightens their colour values, not their CSS rules.
+
+## Testing
+- **Pilot interaction tests** (`tests/test_harness_tui.py` extensions):
+  - Open palette via `Ctrl+P`, type a partial world name from a tracked fixture, assert the first hit dispatches `WorldSelected` and the harness lands on `WorldEditScreen` with that world preselected.
+  - Open palette, type a partial provider id (e.g., `mock`), assert `ProviderSelected` dispatch and `ProvidersScreen` landing.
+  - Open palette, type a partial report filename, assert `RunSelected`-equivalent dispatch and `RunInspectorScreen` landing with that run loaded.
+  - Cycle themes through `worldforge-dark` → `worldforge-light` → `worldforge-high-contrast` → back to `worldforge-dark`; assert the active theme reactive across the cycle.
+  - HomeScreen mount: assert `recent_worlds` and `recent_runs` populate from the fixture and that activating a row dispatches the right message.
+  - Empty state: with an empty fixture state-dir, assert HomeScreen "Recent" shows the documented next-action copy from spec.md.
+- **Snapshot matrix** (`tests/test_harness_snapshots.py`, new): parametrised over `(screen, size)`:
+  - Screens: `HomeScreen`, `WorldsScreen`, `ProvidersScreen`, `EvalScreen`, `BenchmarkScreen`, `RunInspectorScreen`, `DiagnosticsScreen`.
+  - Sizes: `(100, 30)`, `(120, 40)`, `(160, 50)`.
+  - For each combination: drive Pilot to that screen with a deterministic fixture, `await pilot.pause()`, then `assert snap_compare(app, terminal_size=size)`.
+  - SVGs commit under `tests/snapshots/`. PR diffs are reviewed by the snapshot test runner.
+- **Lint rule — telemetry fence**: a small `pytest`-collected check (or a tracked `scripts/check_no_egress.py`) that greps `src/worldforge/harness/` for `httpx.post`, `requests.post`, `socket.send`, and similar egress patterns and fails if any appear. Roadmap §10 anti-goal made executable.
+- **Lint rule — hex-literal fence**: extend any existing TCSS-grep check (or add one) to reject hex literals in widget CSS. Theme registration files are exempt by path.
+- **Coverage**: `uv run --extra harness pytest --cov=src/worldforge --cov-report=term-missing --cov-fail-under=90` must stay green. The snapshot matrix may not raise coverage but must not lower it.
+- **Package contract**: `bash scripts/test_package.sh` continues to pass; new files must be picked up by hatch include rules in `pyproject.toml`. If a new tracked path is added (e.g., `tests/snapshots/`), confirm it is excluded from the wheel as appropriate.
+
+## Risks and mitigations
+- **Risk: snapshot matrix flake on CI.** Mitigation: pin terminal size for every snapshot, disable animation in test mode, await `pilot.pause()` before the assertion, fix all timing-dependent renders (e.g., a clock in the header) with a frozen value or a masked region in the snapshot.
+- **Risk: dynamic palette provider hits disk on every keystroke.** Mitigation: in-memory scanner cache with 500 ms TTL plus message-driven invalidation on `WorldSelected`, `ProviderSelected`, `RunSelected`. Pilot test asserts palette latency stays under one frame at the fixture scale.
+- **Risk: README image rotates whenever a contributor regenerates it from a different host.** Mitigation: commit `scripts/regen-harness-screenshot.sh`; document the deterministic fixture state-dir; require the screenshot to be refreshed only when the harness chrome changes (PR template note).
+- **Risk: high-contrast theme accidentally reuses dark-theme hex.** Mitigation: hex-literal lint extended to the new theme module; PR review checklist item to confirm only semantic variables are referenced from widget CSS.
+- **Risk: telemetry creep — a future contributor adds an "anonymous metrics" toggle.** Mitigation: telemetry-fence lint rule rejecting network-egress patterns under `src/worldforge/harness/`; explicit out-of-scope wording in spec.md and CHANGELOG entry.
+- **Risk: agent or tool branding leaks into a screenshot, palette item, or commit message.** Mitigation: CLAUDE.md priority rule #5 is enforced by PR review; the regeneration script uses a tracked deterministic state with neutral world / provider names.
+- **Risk: snapshot matrix grows unmaintainable as new screens land.** Mitigation: parametrise over `(screen, size)` so adding a screen is one row; document the matrix in `docs/src/theworldharness.md` so the inventory stays visible.
+- **Risk: M5 lands before one of M0–M4.** Mitigation: PR description explicitly lists the M0–M4 dependencies; CI snapshot matrix fails loudly if any expected screen does not exist; do not split M5 across earlier milestones.
+- **Risk: dynamic command provider couples to internals of `WorldForge` or `PROVIDER_CATALOG`.** Mitigation: read only through public surfaces (`WorldForge.list_worlds`, `PROVIDER_CATALOG` iteration, `Path.iterdir` on `.worldforge/reports/`). No private attribute access.
+
+## Dependencies on other milestones
+- **Required before M5 can ship**: M0, M1, M2, M3, M4. M5 is explicitly the polish pass after the functional set is complete; landing it earlier would polish surfaces that do not yet exist.
+- **Specifically depends on**:
+  - M0 theme registration scaffold (third theme slots into the same registration site).
+  - M1 `HomeScreen` and `Ctrl+P` static commands (recent items mount on the former; dynamic provider extends the latter).
+  - M2 `WorldsScreen` and `WorldForge.list_worlds` access pattern (palette + recents read worlds).
+  - M3 `ProvidersScreen` and `PROVIDER_CATALOG` plus injected-provider handling (palette indexes providers).
+  - M4 `RunInspectorScreen` and `.worldforge/reports/` JSON layout (palette + recents read runs).
+- **Blocks**: none directly. M5 is the final milestone in the current roadmap. Future work from roadmap §11 — embedded 3-D scene preview, `worldforge harness record` mode — depends on this polish baseline being landed first so that visual regressions in those features are catchable against a stable matrix.

--- a/specs/theworldharness-M5-polish-showcase/spec.md
+++ b/specs/theworldharness-M5-polish-showcase/spec.md
@@ -1,0 +1,67 @@
+# Milestone M5 — Polish + showcase
+
+## Status
+Draft · 2026-04-21
+
+## Outcome (one sentence)
+A reviewer, talk-giver, or first-time contributor can launch the harness, immediately recognise it as the credible front face of WorldForge, jump to any world, provider, or recent run via `Ctrl+P`, and capture a publication-quality screenshot of any main screen at standard terminal sizes without post-processing.
+
+## Why this milestone
+Roadmap §1 frames TheWorldHarness as the **front door of WorldForge** — a researcher should understand the project in 30 seconds, do something real in two minutes, and leave with the integration pattern in their head. After M0 lands the theme and chrome, M1 routes navigation, M2 wires worlds, M3 streams provider events, and M4 closes the eval and benchmark loop, every functional surface exists — but the surface is not yet *showcase-quality*. M5 is the polish pass that takes a working harness and makes it worth screenshotting for talks, PRs, and the README front-door image referenced from `README.md` line 30.
+
+The milestone tightens three loose ends that only become visible once the functional set is complete: (1) the design language from roadmap §2 is not fully landed until a high-contrast variant exists alongside `worldforge-dark` / `worldforge-light`; (2) the command palette from roadmap §5 is not actually a discovery surface until it indexes worlds, providers, and runs dynamically; (3) the visual contract has no regression guard until a snapshot matrix at the terminal sizes a screenshotter actually uses (`100×30`, `120×40`, `160×50`) is in CI. All three are scoped here so that future work — the open questions in roadmap §11 — has a stable, testable baseline to build on.
+
+## In scope
+- High-contrast theme variant (`worldforge-high-contrast`) registered alongside `worldforge-dark` and `worldforge-light` from M0; cyclable through the existing theme switch action; passes Textual's contrast checks.
+- Dynamic command palette `Provider` subclass (`textual.command.Provider`) yielding fuzzy-searchable items for: every world from `WorldForge.list_worlds`, every provider from `PROVIDER_CATALOG` plus injected providers, recent run JSON files under `.worldforge/reports/`. Selecting an item jumps to the right screen with the item pre-selected.
+- HomeScreen "Recent" section (roadmap §4.1): last 5 worlds touched (sorted by `last_touched` from the persistence API), last 5 runs (sorted by mtime under `.worldforge/reports/`).
+- Snapshot test matrix (roadmap §7): every main screen — `HomeScreen`, `WorldsScreen`, `ProvidersScreen`, `EvalScreen`, `BenchmarkScreen`, `RunInspectorScreen`, `DiagnosticsScreen` — captured at `100×30`, `120×40`, `160×50`. SVGs committed; `pytest-textual-snapshot` reviews diffs in PRs.
+- README screenshot refresh: regenerate `docs/assets/img/theworldharness-tui-screenshot-1.png` (referenced from `README.md` line 30) from a deterministic, reproducible harness state.
+- Polish pass on empty states (roadmap §2.4) and focus rings (roadmap §2.2) wherever the snapshot matrix surfaces a gap.
+
+## Out of scope (explicit)
+- Bespoke widget framework on top of Textual — roadmap §10 anti-goal.
+- Telemetry or any phone-home behaviour, including opt-in usage metrics — roadmap §10 anti-goal and CLAUDE.md `<forbidden>`.
+- Embedded 3-D scene preview — roadmap §11 open question, decision deferred to a follow-up milestone.
+- `worldforge harness record` mode capturing a Pilot trace plus final SVG for PR descriptions — roadmap §11 open question, considered post-M5.
+- Auto-publishing benchmark reports to the docs site — roadmap §11; the existing `.worldforge/reports/` JSON plus copyable Markdown excerpt remains the contract.
+- Adding new runtime dependencies to the `harness` extra beyond Textual — roadmap §10 anti-goal; see SKILL.md "stop and ask".
+- Functional changes to worlds, providers, eval, or benchmark surfaces — those are owned by M2–M4 and are *consumed* here, not modified.
+- Agent or tool branding in any user-visible copy or screenshot — CLAUDE.md `<priority_rules>` #5.
+
+## User stories
+1. As a talk-giver preparing slides, I run `worldforge-harness`, navigate through HomeScreen → WorldsScreen → RunInspectorScreen at `120×40`, and capture each as a screenshot, so that I can paste them into a deck without manual cropping or contrast tweaks.
+2. As a researcher with multiple saved worlds, I press `Ctrl+P`, type a fragment of a world name (e.g., `lab`), and see the matching world surfaced in the palette, so that I jump directly to its `WorldEditScreen` without scrolling a list.
+3. As a contributor reviewing a benchmark run from yesterday, I press `Ctrl+P`, type part of the report filename, and select it, so that the harness opens that run in `RunInspectorScreen` without me having to remember the path under `.worldforge/reports/`.
+4. As a contributor with reduced colour vision or a high-contrast terminal preference, I cycle to `worldforge-high-contrast`, so that every focus ring, panel border, and status pill has an explicit pass-contrast colour, rather than relying on the default dark theme's hue separation.
+5. As a maintainer reviewing a PR that touches `harness/tui.py`, I see the snapshot diff for the affected screens at all three terminal sizes in the PR check, so that any unintended visual regression — focus ring shift, padding drift, theme variable rename — is caught before merge.
+6. As a first-time visitor opening `README.md`, I see a current screenshot of the harness that matches what I get when I run `uv run --extra harness worldforge-harness`, so that the front-door image is honest about the state of the tool.
+
+## Acceptance criteria
+- [ ] Three themes registered: `worldforge-dark`, `worldforge-light`, `worldforge-high-contrast`. Each passes Textual's built-in contrast check. Theme cycle action (existing in M0) iterates through all three.
+- [ ] No new hex literals introduced in `worldforge-high-contrast`; all colour values are CSS variables (`$accent`, `$panel`, `$boost`, `$surface`, `$muted`, `$success`, `$warning`, `$error`, plus any new semantic tokens declared in the theme registration).
+- [ ] A `WorldForgeCommandProvider` subclass of `textual.command.Provider` is registered on `TheWorldHarnessApp`. Fuzzy queries return ranked items for worlds (sourced from `WorldForge.list_worlds`), providers (sourced from `PROVIDER_CATALOG` plus injected providers), and recent runs (sourced from `.worldforge/reports/` JSON files).
+- [ ] Selecting a palette item dispatches the corresponding existing message (`WorldSelected`, `ProviderSelected`, `RunCompleted`-equivalent for runs) and the harness lands on the correct screen with that item pre-selected.
+- [ ] Palette query latency stays under 1 frame (16 ms) at 100 worlds + 50 providers + 50 reports on the test fixture; cached scanner output is invalidated on the relevant message events.
+- [ ] HomeScreen "Recent" section renders two sub-lists: last 5 worlds (by `last_touched` from the persistence API) and last 5 runs (by mtime under `.worldforge/reports/`). Each row maps to a single keystroke or click that opens the item.
+- [ ] Snapshot matrix runs in CI at `100×30`, `120×40`, `160×50` for `HomeScreen`, `WorldsScreen`, `ProvidersScreen`, `EvalScreen`, `BenchmarkScreen`, `RunInspectorScreen`, `DiagnosticsScreen`. Snapshots are committed under `tests/snapshots/`; PR diffs are reviewable.
+- [ ] README screenshot is regenerated from a deterministic harness state. The exact command (or script) used to regenerate it is recorded in the spec or in a tracked script under `scripts/` so the next refresh is reproducible.
+- [ ] No new runtime dependency added to the `harness` extra in `pyproject.toml`. Coverage gate at `--extra harness` stays at or above 90%.
+- [ ] No `httpx.post`, `requests.post`, socket write, or other network egress is introduced anywhere under `src/worldforge/harness/` for telemetry or analytics purposes.
+
+## Non-functional requirements
+- Every action exposed by M5 (palette dynamic items, theme cycle, recent-item activation) is reachable from `Ctrl+P` and from a discoverable footer or screen binding — auditable via a Pilot test that walks the binding map.
+- No looping spinners, decorative fades, or animations on idle panels — roadmap §2.3.
+- Empty states for the new HomeScreen "Recent" section follow roadmap §2.4 (centred `Static`, tells the user the next action: e.g., "No recent worlds — press [b]n[/] to create one").
+- Theme contrast: each of the three themes passes Textual's contrast check; the high-contrast variant passes a stricter manual review at `100×30` (smallest matrix size) where row density is highest.
+- Snapshot tests are deterministic: terminal size pinned, animations disabled in test mode (`TheWorldHarnessApp` sets `ANIMATIONS = False` or equivalent under `app.run_test()`), `pilot.pause()` awaited before assertion. No flakes tolerated.
+- README screenshot is generated from the harness running against a tracked, deterministic state — no live provider responses, no host-specific paths visible.
+- All user-visible copy is maintainer-style and tool-neutral; no agent or tool branding anywhere in the screenshot, palette item formatting, or commit/PR text — CLAUDE.md `<priority_rules>` #5.
+- The Textual import boundary (roadmap §3, SKILL.md) is preserved: M5 introduces no Textual import outside `src/worldforge/harness/tui.py`. The command provider and any new helper classes stay co-located with the App or in a new file under `harness/` that itself only imports Textual when the extra is present.
+
+## Open questions
+- Should a palette "recent" section precede dynamic fuzzy-matched items unconditionally (k9s-style pinned recents), or be interleaved by fuzzy score? Trade-off: pinned recents are predictable but push fresh matches down; interleaved is discoverable but unpredictable across sessions.
+- Should `worldforge-high-contrast` be auto-selected by detecting terminal settings (e.g., `NO_COLOR`, accessibility env vars) on first launch, or always require explicit opt-in via the theme cycle? Default position: explicit opt-in, to keep the first-launch experience predictable; auto-detect can land in a follow-up if requested.
+- Should the README image be committed as a terminal-rendered SVG or a PNG capture? SVGs diff cleanly in PRs and scale to any width, but some Markdown renderers (older GitHub mobile clients, some embedded viewers) handle SVG inconsistently. Default position: keep PNG (matches current `README.md` line 30) but commit the regeneration script so refreshes are one command.
+- Should the snapshot matrix include a fourth size — `80×24`, the historical default — for graceful-degradation evidence? Roadmap §8 calls out only the three larger sizes; including `80×24` would surface layout overflow, but may also force layout compromises that hurt the showcase sizes.
+- Should the recent-runs source extend beyond `.worldforge/reports/` to include in-memory runs from the current TUI session that have not been pinned to disk? Default position: disk-only, to keep the source of truth single and observable.

--- a/specs/theworldharness-M5-polish-showcase/tasks.md
+++ b/specs/theworldharness-M5-polish-showcase/tasks.md
@@ -1,0 +1,66 @@
+# Milestone M5 — Polish + showcase · Tasks
+
+Each task is a single PR-sized unit. Order matters: a later task may assume an earlier one has landed in main.
+
+## T1 — Register `worldforge-high-contrast` theme
+- Files: `src/worldforge/harness/tui.py`; `tests/test_harness_tui.py`; `docs/src/theworldharness.md`.
+- Change: register a third `Theme` named `worldforge-high-contrast` next to the M0 themes. Override `$accent`, `$panel`, `$boost`, `$surface`, `$muted`, `$success`, `$warning`, `$error` with high-contrast values declared inside the theme registration only. Extend the existing M1 theme cycle action to iterate dark → light → high-contrast → dark. Document the third theme in `docs/src/theworldharness.md`.
+- Acceptance: maps to spec.md acceptance "Three themes registered… each passes Textual's contrast check" and "No new hex literals introduced in `worldforge-high-contrast` … all colour values are CSS variables".
+- Tests: extend `tests/test_harness_tui.py` with a Pilot test that cycles themes through all three and asserts the active theme reactive at each step; rely on Textual's built-in contrast check during pytest run.
+
+## T2 — Hex-literal lint and telemetry-fence guards
+- Files: `scripts/check_no_hex_in_widget_css.py` (new) or extend an existing tracked check; `scripts/check_no_egress_in_harness.py` (new); CI wiring in `.github/workflows/*.yml` *only if a gated workflow change is approved* — otherwise wire as a `pytest`-collected test.
+- Change: add executable guards that (a) reject hex literals in widget CSS under `src/worldforge/harness/` (theme registration files exempt by path), (b) reject `httpx.post`, `requests.post`, `socket.send`, and similar egress patterns under `src/worldforge/harness/`. Roadmap §10 anti-goals made executable.
+- Acceptance: maps to spec.md acceptance "No `httpx.post` … is introduced anywhere under `src/worldforge/harness/`" and the non-functional "lint rule rejecting `httpx.post`/`requests.post` from harness/".
+- Tests: each guard ships with a pair of fixtures (one passing, one failing) under `tests/fixtures/lint/` so the guard itself is tested. CI runs the guards as part of `uv run pytest`.
+- Note: if the guards must run as a workflow rather than a pytest collection, that is a `<gated>` change per CLAUDE.md and requires explicit approval.
+
+## T3 — `WorldForgeCommandProvider` (dynamic command palette)
+- Files: `src/worldforge/harness/tui.py` (or a co-located `palette.py` if size warrants — stop-and-ask per SKILL.md before adding a new file); `tests/test_harness_tui.py`; `tests/fixtures/harness/` (new fixture state-dir).
+- Change: implement a `textual.command.Provider` subclass that yields fuzzy-ranked hits for worlds (from `WorldForge.list_worlds`), providers (from `PROVIDER_CATALOG` plus injected providers), and recent runs (from `.worldforge/reports/`). Selecting a hit dispatches the existing M2/M3/M4 messages and lands on the right screen with the item preselected. Cache scanner output with a 500 ms TTL; invalidate on `WorldSelected`, `ProviderSelected`, `RunSelected`.
+- Acceptance: maps to spec.md acceptance "A `WorldForgeCommandProvider` subclass … is registered", "Selecting a palette item dispatches the corresponding existing message", and "Palette query latency stays under 1 frame".
+- Tests: Pilot tests for each of the three sources (world / provider / run): open palette via `Ctrl+P`, type a fragment from the fixture, assert the first hit dispatches the expected message and the harness lands on the correct screen with the item preselected. Latency assertion uses a fixture sized to the spec target.
+
+## T4 — HomeScreen "Recent" section and `RecentItems` widget
+- Files: `src/worldforge/harness/tui.py`; `tests/test_harness_tui.py`; `tests/fixtures/harness/`.
+- Change: add a `RecentItems` widget composed of two `Static` lists (recent worlds, recent runs) on `HomeScreen`. Sources: `WorldForge.list_worlds` sorted by `last_touched` (top 5), `.worldforge/reports/` JSON files sorted by mtime (top 5). Reactives `recent_worlds` and `recent_runs` recompute on `on_mount` and on the invalidating messages. Empty states follow roadmap §2.4.
+- Acceptance: maps to spec.md acceptance "HomeScreen 'Recent' section renders two sub-lists" and the non-functional "Empty states … follow roadmap §2.4".
+- Tests: Pilot tests for (a) populated case — assert both lists render five rows from the fixture and a row activation dispatches the right message, (b) empty case — assert the documented empty-state copy renders.
+
+## T5 — Snapshot test matrix at `100×30`, `120×40`, `160×50`
+- Files: `tests/test_harness_snapshots.py` (new); `tests/snapshots/` (new directory of committed SVGs); `tests/fixtures/harness/` extension if needed; possibly `pyproject.toml` if `pytest-textual-snapshot` is not already a dev dependency (stop-and-ask if a dependency change is needed — CLAUDE.md `<gated>`).
+- Change: add a parametrised snapshot test over `(screen, size)` covering `HomeScreen`, `WorldsScreen`, `ProvidersScreen`, `EvalScreen`, `BenchmarkScreen`, `RunInspectorScreen`, `DiagnosticsScreen` at `(100, 30)`, `(120, 40)`, `(160, 50)`. Pin terminal size, disable animations in test mode, await `pilot.pause()` before assertion.
+- Acceptance: maps to spec.md acceptance "Snapshot matrix runs in CI at `100×30`, `120×40`, `160×50` for HomeScreen, WorldsScreen, ProvidersScreen, EvalScreen, BenchmarkScreen, RunInspectorScreen" (DiagnosticsScreen also covered for completeness).
+- Tests: the snapshot tests *are* the artefact; CI executes them under `uv run --extra harness pytest`. PR diffs of `tests/snapshots/*.svg` are reviewed by maintainers.
+
+## T6 — README screenshot regeneration script
+- Files: `scripts/regen-harness-screenshot.sh` (new); `docs/assets/img/theworldharness-tui-screenshot-1.png` (regenerated); `README.md` (only if the image filename changes — otherwise unchanged).
+- Change: add a tracked, deterministic regeneration script that launches `uv run --extra harness worldforge-harness` against a fixed fixture state-dir, navigates to a chosen showcase screen, and produces the PNG referenced from `README.md` line 30. Replace the existing PNG with the new capture.
+- Acceptance: maps to spec.md acceptance "README screenshot is regenerated from a deterministic harness state. The exact command (or script) used to regenerate it is recorded".
+- Tests: smoke-only — running the script under CI is out of scope (binary capture in CI is brittle). The script's deterministic behaviour is verifiable manually; PR review confirms the image matches what `worldforge-harness` produces.
+
+## T7 — Polish pass on empty states and focus rings
+- Files: `src/worldforge/harness/tui.py`; possibly TCSS adjustments in the same file; `tests/test_harness_snapshots.py` regenerated SVGs as needed.
+- Change: walk every snapshot from T5 and fix any empty-state regression (missing centred-Static next-action copy per roadmap §2.4) and any focus-ring inconsistency (roadmap §2.2). Tighten padding or border on screens that read poorly at `100×30`. No functional changes outside polish.
+- Acceptance: maps to the spec.md user story "I can capture each as a screenshot … without manual cropping or contrast tweaks" and the non-functional "Empty states … follow roadmap §2.4".
+- Tests: snapshot diffs from T5 reviewed and committed. Pilot tests for empty states extended where copy changed.
+
+## T8 — Doc and changelog updates
+- Files: `docs/src/theworldharness.md`; `CHANGELOG.md`; `.codex/skills/tui-development/references/roadmap.md`.
+- Change: append a "Themes" subsection (three variants and the cycle binding) and a one-line note that `Ctrl+P` indexes worlds, providers, and recent runs to the harness doc. Add a CHANGELOG entry under the next release listing high-contrast theme, dynamic command palette, HomeScreen recent items, snapshot matrix, screenshot refresh — tool-neutral copy. Mark roadmap §8 M5 "done · {date}".
+- Acceptance: maps to spec.md user story "I see a current screenshot of the harness that matches what I get when I run `uv run --extra harness worldforge-harness`" (the doc points users at the matching state) and to the SKILL.md procedure step 7 ("Update `references/roadmap.md` if the change resolves a milestone").
+- Tests: docs check (`uv run python scripts/generate_provider_docs.py --check`) must stay green; coverage gate at `--extra harness` stays at or above 90%.
+
+## Definition of done
+- [ ] All tasks T1–T8 merged to main on independent PRs (or grouped where dependencies are tight, e.g., T3 + T4 share a fixture).
+- [ ] `uv run --extra harness pytest` passes locally and in CI, including the new snapshot matrix.
+- [ ] `uv run --extra harness pytest --cov=src/worldforge --cov-report=term-missing --cov-fail-under=90` stays green.
+- [ ] `uv run ruff check src tests examples scripts` and `uv run ruff format --check src tests examples scripts` are clean.
+- [ ] `bash scripts/test_package.sh` passes (no new file path missed by hatch include rules).
+- [ ] `tests/snapshots/` SVGs are reviewable in PR diffs.
+- [ ] `README.md` line 30 image renders the regenerated screenshot.
+- [ ] `docs/src/theworldharness.md` documents the three themes and the dynamic palette.
+- [ ] `CHANGELOG.md` carries a tool-neutral entry for the milestone.
+- [ ] `.codex/skills/tui-development/references/roadmap.md` §8 M5 is marked "done · {date}".
+- [ ] No new runtime dependency added to the `harness` extra; no Textual import outside `src/worldforge/harness/tui.py` (or a co-located helper that itself only imports Textual when the extra is present).
+- [ ] Telemetry-fence and hex-literal lint guards from T2 are active in CI.


### PR DESCRIPTION
Specifies and plans roadmap milestone **M5 — Polish + showcase** for TheWorldHarness, the final milestone in the current TUI roadmap.

Adds three docs under `specs/theworldharness-M5-polish-showcase/`:
- `spec.md` — outcome, in/out scope, user stories, acceptance criteria, NFRs, open questions
- `plan.md` — architecture changes, module touch list, key technical decisions, data flow, theming, testing, risks, dependencies
- `tasks.md` — ordered, PR-sized tasks with definition of done

Roadmap source: [`.codex/skills/tui-development/references/roadmap.md` §8 M5](https://github.com/AbdelStark/worldforge/blob/main/.codex/skills/tui-development/references/roadmap.md#m5--polish--showcase).

Note: the worker agent completed the docs and committed them locally but hit a transient `overloaded_error` from the Anthropic API before push. The work is intact; this PR finishes the push + PR step manually.