### PR TITLE
docs(specs): theworldharness M3 — live providers

### DIFF
--- a/specs/theworldharness-M3-live-providers/plan.md
+++ b/specs/theworldharness-M3-live-providers/plan.md
@@ -1,0 +1,207 @@
+# Milestone M3 — Live providers · Implementation Plan
+
+## Builds on
+- Roadmap §8 "M3 — Live providers" — `.codex/skills/tui-development/references/roadmap.md`
+- Roadmap §4.4 "ProvidersScreen" — capability matrix shape and bindings
+- Roadmap §6 "Long-running work — the worker contract" — the canonical worker idiom this milestone instantiates
+- Skill: `.codex/skills/tui-development/SKILL.md` — Fast start, "SOTA Textual practices", "Don't" list (no event-loop blocking, no thread-direct widget mutation)
+- Skill: `.codex/skills/provider-adapter-development/SKILL.md` + `references/capability-matrix.md` — capability truthfulness, the eight capability names, `assert_provider_contract`
+- Capability and event contracts in code:
+  - `src/worldforge/models.py` — `CAPABILITY_NAMES`, `ProviderCapabilities`, `ProviderEvent` (phases `retry` / `success` / `failure`)
+  - `src/worldforge/providers/base.py` — `BaseProvider`, `ProviderError`, `event_handler` ctor arg
+  - `src/worldforge/providers/catalog.py` — `PROVIDER_CATALOG`, `create_known_providers`
+  - `src/worldforge/providers/mock.py` — `MockProvider.predict` (the one real call wired in M3)
+  - `src/worldforge/framework.py` — `WorldForge.create_world`, `World.predict`, `register_provider`, `list_providers`
+- Predecessor milestones:
+  - **Required:** M0 (themes registered, semantic CSS variables, Header status pill reactive), M1 (screen stack with `push_screen` / `push_screen_wait`, `Ctrl+P` system commands, `?` help overlay).
+  - **Optional but useful:** M2 (Worlds CRUD). If M2 has landed, M3 reads `selected_world` from the App reactive. If not, M3 falls back to `WorldForge.create_world("scratch")`. The fallback is deterministic and tested.
+
+## Architecture changes
+- New `Screen` subclass: `ProvidersScreen` (in `src/worldforge/harness/tui.py`).
+- New `ModalScreen[ProviderHandle]` subclass: `RegisterProviderModal` (same file).
+- New widget composition inside `ProvidersScreen`:
+  - `DataTable(zebra_stripes=True, cursor_type="row")` for the capability matrix (rows = providers, columns = capabilities).
+  - `Static` detail pane on the right (health + env-var requirements + last-call summary).
+  - `RichLog(highlight=True, markup=True, max_lines=5000)` event stream below.
+  - `ProgressBar` (indeterminate while a provider call is in flight).
+- New typed messages (defined inside `tui.py`):
+  - `class ProviderEventReceived(Message): event: ProviderEvent`
+  - `class RunRequested(Message): provider: str; capability: str`
+  - `class RunCompleted(Message): provider: str; latency_ms: float`
+  - `class RunCancelled(Message): provider: str`
+- New reactives on `ProvidersScreen`:
+  - `current_row_provider: reactive[str | None]` — the highlighted row.
+  - `running_operation: reactive[Literal["idle", "running", "cancelled", "error", "done"]]`.
+  - `last_call_summary: reactive[dict[str, dict[str, Any]]]` — keyed by provider name, holds `{phase, latency_ms, retries}` for the most recent call.
+- The App's `current_provider` reactive (introduced in M0) stays the cross-screen source of truth; `ProvidersScreen` writes it on `Enter`.
+- A small adapter, `_QueueingEventHandler`, is a `Callable[[ProviderEvent], None]` that pushes events into a thread-safe `queue.Queue`. It is passed to `WorldForge(event_handler=queueing_handler)` at App startup so every registered provider inherits it (per `WorldForge.register_provider`'s "inherits the global handler if the provider does not declare one" contract). The worker drains the queue and uses `call_from_thread` to mutate the UI. Re-attaching a handler to an already-registered provider is not a public surface and is intentionally not used.
+
+## Module touch list
+| Path | Change | Notes |
+| --- | --- | --- |
+| `src/worldforge/harness/tui.py` | Add `ProvidersScreen`, `RegisterProviderModal`, `ProviderEventReceived` / `RunRequested` / `RunCompleted` / `RunCancelled` message classes, the `provider` worker, the `_QueueingEventHandler` helper. Add a Ctrl+P system command "Open providers". Add binding to push `ProvidersScreen`. | The only Textual-touching file. Keep `flows.py`, `cli.py`, `models.py` unchanged so the base package's installability stays intact. |
+| `tests/test_harness_tui.py` | Add Pilot tests: open `ProvidersScreen`, assert row count = `len(WorldForge().list_providers())`, assert column count = `len(CAPABILITY_NAMES)`; press Enter → `current_provider` updates; press `p` → events appear in `RichLog`; press `Esc` mid-run → `running_operation == "cancelled"`. | Use a slow-mock fixture that yields events with controllable cadence so cancellation is observable without wall-clock flake. |
+| `tests/test_harness_tui_snapshots.py` (new file or extend existing) | Snapshot tests at `terminal_size=(120, 40)`: `ProvidersScreen` idle, mid-run with populated `RichLog`, cancelled, `worldforge-light` variant of idle. | Commit SVGs; review diffs in PR. |
+| `tests/conftest.py` | Add `slow_mock_provider` fixture (a `MockProvider` subclass whose `predict` sleeps 50 ms × N between simulated event emissions; emits via `event_handler`). | Private fixture by default; promote to `worldforge.testing` only if a second consumer appears (open question in spec). |
+| `.codex/skills/tui-development/references/roadmap.md` | After merge: mark §8 M3 "done · YYYY-MM-DD". Honest spec rule (`<context_lifecycle>`). | Roadmap-only edit; not part of the implementation tasks below — added by the closing PR. |
+
+No changes to `pyproject.toml`, `uv.lock`, `src/worldforge/__init__.py`, `src/worldforge/models.py`, `src/worldforge/framework.py`, `src/worldforge/providers/*`, or `.github/workflows/*`. M3 is purely a TUI surfacing layer over the existing provider contract.
+
+## Key technical decisions
+
+### D1 — Where the `current_provider` reactive lives
+- **Decision:** on `TheWorldHarnessApp`, not on `ProvidersScreen`.
+- **Alternatives:** screen-local reactive read by other screens via `self.app.query_one(ProvidersScreen).current_provider`.
+- **Rationale:** the status pill in the Header (M0) and future `EvalScreen` / `BenchmarkScreen` (M4) all need this value. Reaching across the screen stack to query it would be the "reach across the DOM" anti-pattern called out in SKILL.md "Don't". App-level reactive is the right scope.
+
+### D2 — Capability cell glyphs
+- **Decision:** `●` real, `○` scaffold, blank for "not advertised".
+- **Alternatives:** letters (`R` / `S` / blank), Unicode shapes (`■` / `□`), color-only (no glyph).
+- **Rationale:** matches roadmap §4.4 verbatim. Glyph plus semantic color (`$success` / `$warning` / `$muted`) is dual-coded so a colorblind reader still parses it, satisfying the "honest UX" theme of the milestone.
+
+### D3 — Event streaming channel: `post_message` vs `call_from_thread(log.write, ...)`
+- **Decision:** `self.app.call_from_thread(self.post_message, ProviderEventReceived(event))` — i.e., post a typed message and let the screen's `on_provider_event_received` handler write to the `RichLog`.
+- **Alternatives:** the SKILL.md fast-start example uses `call_from_thread(log.write, format_event(event))` directly; that is shorter but skips the typed message hop.
+- **Rationale:** the typed message is the same channel that updates `last_call_summary`, the status pill, and the `running_operation` reactive. Funneling everything through one `Message` keeps state transitions atomic in the event loop and makes Pilot tests assert against `running_operation` rather than against parsed `RichLog` text. Slightly more code; much better testability.
+
+### D4 — Cancellation surface: `Esc` key vs visible "Cancel" button
+- **Decision:** both. `Esc` is the binding (footer entry, `show=True`); a clickable "Cancel" target sits next to the `ProgressBar` for mouse parity (SKILL.md "Pair every footer binding with a click target").
+- **Alternatives:** keyboard-only (faster to ship, fails the parity rule).
+- **Rationale:** mouse + keyboard parity is a hard rule in the skill. Without the visible target, `ProvidersScreen` would silently fail the parity audit at M5.
+
+### D5 — Worker → provider event seam
+- **Decision:** the App constructs `WorldForge(event_handler=self._queueing_handler)` at startup, so every always-registered and auto-registered provider inherits the handler at registration time (per `WorldForge.register_provider`'s documented inheritance behavior). The worker drains the shared `queue.Queue` inline after the synchronous `predict` call returns — and, for the slow-mock test, between simulated event emissions.
+- **Alternatives:** mutate `provider.event_handler` post-registration (no public API; relies on attribute access); patch `MockProvider` to be async; add a streaming method to `BaseProvider`.
+- **Rationale:** changing the provider base class or `WorldForge` registration semantics is gated (`<gated>`) and out of scope for M3. Using `WorldForge`'s existing `event_handler` constructor arg is the smallest seam that keeps the provider contract untouched while still letting the worker stream events. M4's longer-running providers (e.g., HTTP `cosmos.generate`) will already emit events progressively, so the same drain pattern works without refactor.
+
+### D6 — Throwaway world fallback
+- **Decision:** if `selected_world` is `None`, call `WorldForge.create_world("scratch")` and use it for the predict; the empty state of `ProvidersScreen` documents this.
+- **Alternatives:** require M2 first; refuse to run; prompt the user with a modal.
+- **Rationale:** M3 must not block on M2 — the milestone outcome ("the harness stops being a slideshow") is the bar. The scratch world is a real `World` that hits the real `WorldForge` API, which is the reference example M3 owes downstream callers.
+
+### D7 — RichLog formatting
+- **Decision:** `f"[dim]{ts}[/] [{phase_color}]{event.phase:^9}[/] {event.provider}.{event.operation} ({event.duration_ms or 0:.1f}ms)"` where `phase_color` maps `success → $success`, `failure → $error`, `retry → $warning`. Markup only — no f-strings interpolating raw `event.message` or `event.metadata` (those go to the metrics pane to keep the log scannable).
+- **Alternatives:** dump `event.to_dict()` as JSON per line; use plain text.
+- **Rationale:** `RichLog(markup=True)` lets us dual-code phase via color and the right-aligned text glyph. JSON dump is unscannable; plain text loses the phase-at-a-glance. Critically: nothing here interpolates secrets; `event.metadata` rendering happens elsewhere through the same sanitisation contract the provider already enforces.
+
+## Data flow
+
+### Reactives
+- `App.current_provider: reactive[str]` (introduced in M0; `ProvidersScreen` writes on `Enter`).
+- `ProvidersScreen.current_row_provider: reactive[str | None]`.
+- `ProvidersScreen.running_operation: reactive[Literal["idle", "running", "cancelled", "error", "done"]] = reactive("idle")`.
+- `ProvidersScreen.last_call_summary: reactive[dict[str, dict[str, Any]]]` — watch redraws the detail pane.
+
+### Messages
+- `ProviderEventReceived(event: ProviderEvent)` — child → screen, on every drained event.
+- `RunRequested(provider: str, capability: str)` — emitted on key `p`, listened by the screen which spawns the worker.
+- `RunCompleted(provider: str, latency_ms: float)` — worker → screen on success. `Prediction` does not expose an `id`; the latency is what the detail pane needs.
+- `RunCancelled(provider: str)` — worker → screen when `is_cancelled` returns True.
+
+### Worker contract (the heart of M3)
+```python
+@work(thread=True, group="provider", exclusive=True, name="provider.predict")
+def _run_predict(self, provider_name: str) -> None:
+    worker = get_current_worker()
+    # The App constructed `WorldForge(event_handler=self._queueing_handler)` at startup,
+    # so every registered provider already drains into `self._event_queue`.
+    forge = self.app.forge
+    world = self._current_or_scratch_world(forge)
+
+    try:
+        # mock.predict is synchronous and emits the success event before returning;
+        # remote providers (M4+) emit retry / success / failure progressively, so the
+        # drain loop already handles streaming providers without further refactor.
+        prediction = world.predict(Action(kind="noop"), steps=1, provider=provider_name)
+    except ProviderError as exc:
+        self.app.call_from_thread(
+            self.post_message,
+            ProviderEventReceived(_failure_event(provider_name, exc)),
+        )
+        return
+
+    while not self._event_queue.empty():
+        if worker.is_cancelled:
+            self.app.call_from_thread(self.post_message, RunCancelled(provider_name))
+            return
+        event = self._event_queue.get_nowait()
+        self.app.call_from_thread(self.post_message, ProviderEventReceived(event))
+
+    self.app.call_from_thread(
+        self.post_message,
+        RunCompleted(provider=provider_name, latency_ms=prediction.latency_ms),
+    )
+```
+
+`Esc` binding:
+```python
+def action_cancel_run(self) -> None:
+    if self.running_operation == "running":
+        self.workers.cancel_group("provider")  # the worker checks is_cancelled
+```
+
+The worker contract above maps 1:1 to roadmap §6 and SKILL.md "Long-running work uses workers." It is the only worker shape this milestone introduces; M4 reuses it.
+
+## Theming and CSS
+
+All TCSS for `ProvidersScreen` references semantic variables only — zero hex literals (this milestone exists partly to demonstrate the practice).
+
+| Element | Variable |
+| --- | --- |
+| Capability cell, "real" dot | `$success` |
+| Capability cell, "scaffold" dot | `$warning` |
+| Capability cell, "not advertised" | `$muted` |
+| Selected row gutter | `$accent` |
+| Active pane border | `border: round $accent` (per roadmap §2.2) |
+| Idle pane border | `border: round $panel` |
+| RichLog "failure" line | `$error` |
+| RichLog "retry" line | `$warning` |
+| Default text | `$surface` |
+| Hint / secondary text | `$muted` |
+
+A snapshot test of `worldforge-light` confirms the matrix and `RichLog` remain readable on a light terminal — that is the M0 → M3 regression bar (failure mode #3 in SKILL.md "Why this skill exists").
+
+## Testing
+
+### Pilot interaction tests (`tests/test_harness_tui.py`)
+- `test_providers_screen_rows_match_registered_providers` — open `ProvidersScreen`, assert `DataTable.row_count == len(WorldForge().list_providers())`.
+- `test_providers_screen_columns_match_capability_names` — assert `DataTable.column_count == len(CAPABILITY_NAMES)`.
+- `test_capability_cells_reflect_provider_capabilities` — register a fixture provider with `ProviderCapabilities(predict=True, generate=False)`; assert the rendered cells dual-code "●" + `$success` for predict and blank + `$muted` for generate.
+- `test_enter_sets_current_provider` — focus row "mock"; `pilot.press("enter")`; assert `app.current_provider == "mock"` and the Header status pill text contains "mock".
+- `test_p_runs_real_mock_predict_and_streams_events` — `pilot.press("p")`; await `pilot.pause()`; assert at least one `ProviderEvent` with `phase == "success"` was rendered into the `RichLog`.
+- `test_esc_cancels_running_predict` — using the `slow_mock_provider` fixture; press `p`; press `esc` mid-run; assert `running_operation == "cancelled"` within one frame; assert a `RunCancelled` message was posted.
+- `test_event_loop_remains_responsive_during_run` — using the slow-mock; press `p`; press `ctrl+t` (theme switch); assert the theme actually changed mid-run (the App's `theme` reactive flipped).
+- `test_register_provider_modal_appends_row` — press `r`; dismiss modal with a constructed handle; assert the matrix row count increased by one and the new row appears.
+- `test_no_blocking_io_in_compose_or_on_mount` — Pilot test that opening `ProvidersScreen` does not hit any `WorldForge` heavy method on the main task (use a recorder around `world.predict` and assert it is not called from `compose` / `on_mount`).
+
+### Snapshot tests (`tests/test_harness_tui_snapshots.py`)
+- `test_providers_screen_idle_dark_snapshot` — `terminal_size=(120, 40)`, default theme.
+- `test_providers_screen_idle_light_snapshot` — same, `worldforge-light`.
+- `test_providers_screen_mid_run_snapshot` — drive `pilot.press("p")` then `pilot.pause()` for a fixed simulated tick count from the slow-mock; capture.
+- `test_providers_screen_cancelled_snapshot` — drive run, press `esc`, capture.
+
+All snapshots use `terminal_size=(120, 40)` per SKILL.md "Snapshot test default screens at `terminal_size=(120, 40)`."
+
+### Coverage gate
+- `uv run --extra harness pytest --cov=src/worldforge --cov-report=term-missing --cov-fail-under=90` must still pass. The new code is in `tui.py` (covered by Pilot tests) and the test fixtures themselves; no decrease in baseline expected.
+
+### Truthfulness regression test
+- `test_capability_matrix_is_not_hand_coded` — a static test that grep / AST-walks `tui.py` for any literal capability dict (e.g., `{"mock": {"predict": True, ...}}`) and fails if found. The matrix must derive from `provider.capabilities` at render time only.
+
+## Risks and mitigations
+- **Risk:** worker thread mutates a widget directly (e.g., `log.write(...)` from inside the worker body). **Mitigation:** all worker-to-UI hops go through `self.app.call_from_thread(self.post_message, ...)`; reviewer rule + a code comment at the top of the worker function. The Pilot test `test_event_loop_remains_responsive_during_run` would surface a stall in CI.
+- **Risk:** capability matrix drifts from `ProviderCapabilities` (someone edits `tui.py` to "fix a wrong cell"). **Mitigation:** the matrix is derived at render time from `provider.capabilities` only; `test_capability_matrix_is_not_hand_coded` plus `test_capability_cells_reflect_provider_capabilities` catch a hand-coded override. Capability flag drift is caught upstream by `assert_provider_contract` in `tests/test_provider_contracts.py`, which is the right layer per `<priority_rules>` #1.
+- **Risk:** secrets or signed URLs leak into the `RichLog`. **Mitigation:** the TUI never interpolates `event.message` / `event.metadata` into the log line; the line is built from `phase`, `provider`, `operation`, `duration_ms` only. The provider's own sanitisation contract (per `<code_conventions>`) handles its event payloads.
+- **Risk:** the throwaway "scratch" world from the M3 fallback litters `.worldforge/worlds/`. **Mitigation:** `WorldForge.create_world` returns a `World` in memory and only persists when the host calls `save_world(...)` — M3's predict path never calls `save_world`, so no JSON is written. The state dir is still created at `WorldForge.__init__` time but stays empty for the scratch flow. If/when M2 lands, the scratch fallback is replaced by `selected_world`.
+- **Risk:** `Esc` swallows the user's intent to back out of the screen rather than cancel the run. **Mitigation:** `Esc` cancels the worker only when `running_operation == "running"`; otherwise it routes to the screen's normal pop. Documented in the footer entry and the `?` help overlay.
+- **Risk:** the M0 / M1 dependencies are not yet merged when this lands. **Mitigation:** the spec marks them required; if M0/M1 PRs are still open, M3 sits behind them in the merge queue. M2 is optional and the scratch-world fallback covers its absence.
+
+## Dependencies on other milestones
+- **Required before this can ship:**
+  - **M0** — semantic CSS variables, `Theme` registrations, Header status pill reactive (`current_provider`).
+  - **M1** — screen stack, `push_screen` / `push_screen_wait`, `Ctrl+P` system commands (so "Open providers" can register), `?` help overlay.
+- **Optional but improves UX:**
+  - **M2** — Worlds CRUD; `selected_world` becomes the predict target. Without M2, the scratch-world fallback is used.
+- **This milestone blocks:**
+  - **M4** — `EvalScreen` and `BenchmarkScreen` reuse the same worker contract, the same `ProviderEventReceived` message class, and the same `RichLog` styling. M3 is the reference implementation.
+  - **M5** — the dynamic command palette `Provider` for "every provider as a fuzzy item" depends on `ProvidersScreen` existing as the jump target.

--- a/specs/theworldharness-M3-live-providers/spec.md
+++ b/specs/theworldharness-M3-live-providers/spec.md
@@ -1,0 +1,93 @@
+# Milestone M3 — Live providers
+
+## Status
+Draft · 2026-04-21
+
+## Outcome (one sentence)
+A user can pick a registered provider from `ProvidersScreen`, trigger a real `mock.predict` call against a real `World`, watch `ProviderEvent`s stream into a `RichLog` in real time, and cancel the in-flight call with `Esc` — with the cancellation observable in the UI rather than silently dropped.
+
+## Why this milestone
+TheWorldHarness today plays canned `asyncio.sleep` step animations: every "flow" is a slideshow that never crosses a real provider boundary. The roadmap §1 vision is the opposite — within two minutes a newcomer should "do something real": call a provider, watch live events, see a verdict. The first failure mode catalogued in `.codex/skills/tui-development/SKILL.md` "Why this skill exists" §1 names this directly: "Treating the harness as a slideshow." M3 is the milestone that retires it.
+
+It also fixes the second failure mode from the same SKILL section — "Blocking the Textual event loop." The harness has not had to enforce the worker contract because nothing it did was actually long-running. Wiring `mock.predict` (and only `mock.predict`) through `@work(thread=True, group="provider", exclusive=True)` with `call_from_thread` UI mutation establishes the canonical pattern that M4 (Eval / Benchmark) and beyond reuse without further design work.
+
+The choice of `mock` for the first real call is deliberate and aligned with `<priority_rules>` #2 in `CLAUDE.md`: it is the only always-registered provider, requires no credentials, no network, and no optional runtime — so M3 can ship in the `harness` extra without dragging torch / CUDA / robot SDKs into base dependencies.
+
+## In scope
+- `ProvidersScreen` (new `Screen` subclass under `src/worldforge/harness/tui.py`) with a capability matrix.
+  - Rows: every provider returned by `WorldForge.list_providers()` (covers `PROVIDER_CATALOG` entries that auto-registered + any host-injected provider). For status / env-var detail, the screen also calls `WorldForge.provider_profile(name)` per row — `ProviderInfo` carries `capabilities` but not `implementation_status`, which lives on `ProviderProfile`.
+  - Columns: the eight capabilities from `worldforge.models.CAPABILITY_NAMES` in this fixed order: `predict`, `generate`, `reason`, `embed`, `plan`, `transfer`, `score`, `policy` (matches `references/capability-matrix.md`).
+  - Cell semantics, sourced **only** from `info.capabilities` (per row) and `profile.implementation_status`:
+    - `●` real — `profile.implementation_status` is `"stable"` (or any non-scaffold status) and the capability flag is `True`.
+    - `○` scaffold — `profile.implementation_status == "scaffold"` and the capability flag is `True`.
+    - blank — capability flag is `False` (not advertised).
+  - Currently-selected provider (the App's `current_provider` reactive, introduced in M0) is highlighted in the row gutter.
+- Detail pane on the selected provider, sourced from `WorldForge.provider_profile(name)` and `WorldForge.provider_health(name)`:
+  - `health()` output (status, latency_ms, details).
+  - Required env vars (names only — see "Non-functional requirements" on masking).
+  - Last call latency, last call retry count, last call phase (drawn from the most recent `ProviderEvent` for this provider, kept in a per-provider in-memory ring of size 1).
+- Bindings (Screen-local, `show=True`):
+  - `enter` — set the highlighted provider as the App `current_provider`.
+  - `r` — open the `RegisterProvider[ProviderHandle]` modal (see Modal screens in roadmap §4.9). The modal returns a constructed provider; the screen calls `WorldForge.register_provider(...)` and refreshes its rows.
+  - `p` — run `mock.predict` against the current world (the only real call wired in M3).
+  - `esc` — cancel via `self.workers.cancel_group("provider")`.
+- One real `mock.predict` call wired through `@work(thread=True, group="provider", exclusive=True, name="provider.predict")`:
+  - The worker iterates the provider's `ProviderEvent` stream (the provider's `event_handler` posts events to a thread-safe queue the worker drains).
+  - For each event, the worker calls `self.app.call_from_thread(self.post_message, ProviderEventReceived(event))`. The `ProvidersScreen` handles the message and writes to a `RichLog(highlight=True, markup=True, max_lines=5000)`.
+  - On success, the worker posts `ProviderEventReceived` with phase `success` and a final `RunCompleted(provider, latency_ms)`.
+  - On `ProviderError`, the worker posts a `ProviderEventReceived` with phase `failure`.
+- The world used for the predict:
+  - If a world is selected (M2 has landed and `selected_world` is set), use it.
+  - Otherwise, the screen creates a throwaway world via `WorldForge.create_world("scratch")` and uses it for the run. The fallback is documented in the empty state.
+- Cancellation:
+  - Pressing `Esc` calls `self.workers.cancel_group("provider")`.
+  - The worker checks `get_current_worker().is_cancelled` between drained events and returns early.
+  - The status pill on the Header (introduced in M0) flips from `running` to `cancelled`; a toast notes "Cancelled".
+- Empty states (per roadmap §2.4):
+  - No providers registered: `"No providers registered — set the env vars in .env.example or run with --provider mock"`.
+  - No prior call: `"No run captured — press [b]p[/] to run mock.predict"`.
+
+## Out of scope (explicit)
+- Real `generate`, `transfer`, `reason`, `embed`, `plan` calls. They are deferred to M4 (Eval / Benchmark) which exercises providers through the suites rather than ad-hoc bindings on `ProvidersScreen`.
+- Real `score` / `policy` calls against live LeWorldModel / GR00T / LeRobot. Those touch optional runtimes (torch, CUDA, robot SDKs) and belong to the optional-runtime-smokes skill / future milestones — `<priority_rules>` #2 forbids dragging them into base or `harness` deps.
+- Dynamic command palette provider for providers (every provider as a fuzzy-searchable Ctrl+P entry). That is roadmap §5 layer 2 and is explicitly assigned to M5.
+- Persisting `current_provider` across sessions. Listed under "Open questions".
+- Registering providers from environment that were not auto-registered at startup (the `r` modal handles direct construction; env-driven re-scan is deferred).
+- A 3-D scene preview during the predict (roadmap §11 open question, decided "after M3" — i.e., not in M3).
+- Telemetry / phone-home of any kind (anti-goal §10).
+
+## User stories
+1. As a researcher who just opened the harness, I open `ProvidersScreen` from the command palette, so that I can see at a glance which of my configured providers advertise `predict` and which do not.
+2. As a researcher comparing capability claims, I focus a provider row, so that the right pane shows `health()`, env-var names, and the last call's latency / retry count.
+3. As a researcher, I press Enter on `mock`, so that it becomes the current provider — the Header status pill updates to `mock · predict`.
+4. As a researcher, I press `p`, so that a real `mock.predict` runs against the current (or scratch) world; events stream into the RichLog in order, with timestamps.
+5. As a researcher, I press `Esc` while events are streaming, so that the worker cancels promptly, the RichLog records the cancellation, and the status pill reflects `cancelled`.
+6. As a host integrating a custom provider, I press `r`, so that a modal lets me register an injected provider; the matrix refreshes to include the new row immediately.
+7. As a user on a light terminal, I switch to `worldforge-light` (Ctrl+T), so that the matrix dots and the focus ring remain readable — neither hex literals nor a dark-only assumption breaks the read.
+
+## Acceptance criteria
+- [ ] `ProvidersScreen` renders one row per `WorldForge.list_providers()` entry; row count equals the registered provider count exactly (no hand-coded fallback list in `tui.py`).
+- [ ] Capability cells are derived from `provider.capabilities` and `provider.implementation_status` only; a Pilot test asserts that flipping a capability flag on a fixture provider changes the rendered cell.
+- [ ] A capability flag set `True` on a provider whose method raises `ProviderError` (a contract drift) is caught by `assert_provider_contract` in the test suite, never by the UI rendering. The UI trusts the flag.
+- [ ] Pressing `p` with `mock` as `current_provider` triggers a real `mock.predict` call in a worker; at least one `ProviderEvent` with phase `success` is rendered in the `RichLog`, in order, with a timestamp prefix.
+- [ ] The Textual event loop is never blocked: a Pilot test using a deliberate slow-mock (a `MockProvider` subclass whose `predict` sleeps in 50 ms slices between events) keeps the UI responsive — `pilot.press("ctrl+t")` to switch theme during the run still applies within one frame.
+- [ ] Pressing `Esc` while a run is in flight cancels the worker within one animation frame; the status pill transitions `running → cancelled`; the `RichLog` records a `cancelled` line; a Pilot test asserts `running_operation == "cancelled"`.
+- [ ] Cancellation is observable: a worker that returns due to `is_cancelled` posts a `RunCancelled` message; the screen's `running_operation` reactive reflects it. Silent drops fail the test.
+- [ ] Pressing `r` opens `RegisterProvider[ProviderHandle]`; on dismiss with a non-`None` handle, the screen calls `WorldForge.register_provider(...)` and the matrix shows the new row without a screen pop / repush.
+- [ ] No hex literals are added to the screen's TCSS; capability cell colors come from `$success` (real), `$warning` (scaffold), `$muted` (not advertised), focus ring from `$accent`. A snapshot test at `terminal_size=(120, 40)` exists for: idle, mid-run (with `RichLog` populated), and cancelled states.
+- [ ] No new runtime dependency is added beyond Textual; `pyproject.toml` `[project.optional-dependencies].harness` is unchanged.
+- [ ] Textual is still imported only from `src/worldforge/harness/tui.py`; `flows.py`, `cli.py`, `models.py` remain Textual-free.
+
+## Non-functional requirements
+- **Honest progress.** The `ProgressBar` for the run starts indeterminate (`total=None`) and only becomes determinate if a total step count is known up front. `mock.predict` finishes in one shot, so the bar advances from indeterminate to "done" — no fake "progress" frames.
+- **No secret leakage in event log.** `ProviderEvent` is already sanitised by the provider (per `<code_conventions>`: "must not leak credentials or signed URLs"). The TUI must not append unsanitised payloads on top of what the provider emits — the `RichLog` line is constructed from `event.to_dict()` fields only.
+- **Light/dark parity.** Capability cells, dots, focus ring, and the RichLog markup must read on both `worldforge-dark` and `worldforge-light` (a snapshot of each).
+- **Mouse + keyboard parity.** Every binding (`enter`, `r`, `p`, `esc`) has a footer entry (`show=True`) and a clickable target (the cell or pane it triggers). No keyboard-only or mouse-only paths.
+- **Capability-truthfulness contract.** No string capability is ever introduced by the UI; `ProvidersScreen` references only names from `worldforge.models.CAPABILITY_NAMES`. A Pilot test asserts the column count equals `len(CAPABILITY_NAMES)`.
+- **Worker hygiene.** The only mutation paths from inside the `provider` worker group are `self.app.call_from_thread(...)` and `self.app.call_from_thread(self.post_message, ...)`. A grep-based test (or a comment + reviewer rule) keeps direct widget mutation out of the worker body.
+
+## Open questions
+- Should the App `current_provider` selection persist across sessions? If so, the persistence layer is already single-writer JSON (per `<project_decisions>` 2026-04-20) — a small `harness.json` next to `.worldforge/worlds/` would be the lightest fit, but it adds a new tracked file shape. Decide before the M3 PR opens.
+- Should env-var requirements display a masked-presence check (`COSMOS_BASE_URL: set`, `RUNWAYML_API_SECRET: missing`) or names only? Names-only is safer (matches `worldforge doctor`'s sanitised behavior); masked-presence is more useful but requires reading `os.environ` from the TUI process — confirm with the user before adding.
+- Should the `r` modal offer a templated "register a mock variant under a different name" path, or only generic injected-provider registration? The former is convenient for testing; the latter matches `WorldForge.register_provider`'s public surface.
+- The slow-mock used for the cancellation test — does it live as a `worldforge.testing` helper (public surface, useful for downstream tests of the same shape) or as a private fixture under `tests/`? Default position: private fixture in M3, promote to `worldforge.testing` only if a second consumer appears.

--- a/specs/theworldharness-M3-live-providers/tasks.md
+++ b/specs/theworldharness-M3-live-providers/tasks.md
@@ -1,0 +1,106 @@
+# Milestone M3 — Live providers · Tasks
+
+Each task is a single PR-sized unit. Order matters: a later task assumes the previous tasks' code is in place. All tasks land on `src/worldforge/harness/tui.py` and `tests/` only — Textual's import boundary is preserved.
+
+## T1 — Add `ProvidersScreen` skeleton with capability matrix (read-only)
+- Files: `src/worldforge/harness/tui.py`, `tests/test_harness_tui.py`
+- Change: introduce `ProvidersScreen(Screen)` rendering a `DataTable` (rows = `WorldForge.list_providers()`, columns = `worldforge.models.CAPABILITY_NAMES`) plus an empty detail pane. Cells derive from `provider.capabilities` and `provider.implementation_status` only. Register the screen via the M1 screen stack and add a `Ctrl+P` system command "Open providers". TCSS uses semantic variables only (`$success` / `$warning` / `$muted` / `$accent` / `$panel`).
+- Acceptance:
+  - Acceptance criteria 1, 2, 9 from `spec.md`.
+  - `ProvidersScreen` reachable from the command palette and from a top-level binding.
+  - Empty state rendered when `WorldForge.list_providers()` is empty.
+- Tests:
+  - `test_providers_screen_rows_match_registered_providers`
+  - `test_providers_screen_columns_match_capability_names`
+  - `test_capability_cells_reflect_provider_capabilities`
+  - `test_capability_matrix_is_not_hand_coded`
+
+## T2 — Wire selection: `current_row_provider` reactive + `Enter` sets `App.current_provider`
+- Files: `src/worldforge/harness/tui.py`, `tests/test_harness_tui.py`
+- Change: add `current_row_provider: reactive[str | None]` on `ProvidersScreen` watching `DataTable` cursor; bind `Enter` to set `self.app.current_provider` to the highlighted provider. The Header status pill (introduced in M0) updates via its existing `watch_current_provider`.
+- Acceptance:
+  - User story 3 from `spec.md`.
+  - Footer shows the `Enter` binding (`show=True`).
+- Tests:
+  - `test_enter_sets_current_provider`
+
+## T3 — Detail pane: `health()`, env-var names, last-call summary
+- Files: `src/worldforge/harness/tui.py`, `tests/test_harness_tui.py`
+- Change: render the detail pane on `watch_current_row_provider`. Source: `WorldForge.provider_profile(name)` for env-var names + `implementation_status`, `WorldForge.provider_health(name)` for status / latency, `last_call_summary` reactive for the most recent call's `phase` / `latency_ms` / `retries`. Env-var values are **not** read from `os.environ` (open question in spec; defaulting to names-only for safety).
+- Acceptance:
+  - User story 2 from `spec.md`.
+  - No call to `os.environ` from the detail pane.
+- Tests:
+  - `test_detail_pane_renders_health_and_env_vars`
+  - `test_detail_pane_shows_last_call_summary_after_run` (depends on T5)
+
+## T4 — Worker plumbing: messages, reactives, `_QueueingEventHandler`, `RichLog`
+- Files: `src/worldforge/harness/tui.py`, `tests/test_harness_tui.py`
+- Change: add the typed `Message` classes (`ProviderEventReceived`, `RunRequested`, `RunCompleted`, `RunCancelled`), the `running_operation` reactive, the `_QueueingEventHandler` adapter (pushes `ProviderEvent` into a `queue.Queue`), and the `RichLog(highlight=True, markup=True, max_lines=5000)` widget. Add the screen handler `on_provider_event_received` that formats the line per decision D7 in `plan.md`.
+- Acceptance:
+  - All scaffolding for T5 in place; no functional behavior yet beyond rendering posted messages.
+- Tests:
+  - `test_provider_event_received_writes_to_rich_log` (post a fabricated `ProviderEvent` directly; assert one line appears, with phase color via markup).
+  - `test_rich_log_does_not_render_event_metadata` (truthfulness — fabricated event with metadata, assert log line does not contain the metadata text).
+
+## T5 — Real `mock.predict` worker + `p` binding + scratch-world fallback
+- Files: `src/worldforge/harness/tui.py`, `tests/test_harness_tui.py`, `tests/conftest.py`
+- Change: add the `_run_predict` worker per `plan.md` "Worker contract" — `@work(thread=True, group="provider", exclusive=True, name="provider.predict")`. Bind `p` to post `RunRequested(provider=app.current_provider, capability="predict")`; the screen handler spawns the worker. World source: `selected_world` if set (M2), else `WorldForge.create_world("scratch")` in-memory. Add `slow_mock_provider` fixture in `conftest.py`.
+- Acceptance:
+  - Acceptance criteria 4, 5, 8 from `spec.md`.
+  - User stories 4, 7 from `spec.md`.
+- Tests:
+  - `test_p_runs_real_mock_predict_and_streams_events`
+  - `test_event_loop_remains_responsive_during_run`
+  - `test_no_blocking_io_in_compose_or_on_mount`
+
+## T6 — Cancellation: `Esc` binding, `is_cancelled` check, observable status transition
+- Files: `src/worldforge/harness/tui.py`, `tests/test_harness_tui.py`
+- Change: add `action_cancel_run` bound to `Esc` calling `self.workers.cancel_group("provider")` only when `running_operation == "running"`. The worker checks `get_current_worker().is_cancelled` between drained events; on cancel it posts `RunCancelled(provider)` and the screen flips `running_operation` to `"cancelled"`. Add the visible "Cancel" click target next to the `ProgressBar` (mouse + keyboard parity).
+- Acceptance:
+  - Acceptance criteria 6, 7 from `spec.md`.
+  - User story 5 from `spec.md`.
+  - `Esc` falls through to normal screen-pop when `running_operation != "running"`.
+- Tests:
+  - `test_esc_cancels_running_predict`
+  - `test_esc_pops_screen_when_idle`
+
+## T7 — `RegisterProvider[ProviderHandle]` modal + `r` binding
+- Files: `src/worldforge/harness/tui.py`, `tests/test_harness_tui.py`
+- Change: add `RegisterProviderModal(ModalScreen[ProviderHandle | None])` with a name + class form. On dismiss with a non-`None` handle, the screen calls `WorldForge.register_provider(...)` and refreshes the matrix in place (no screen pop / repush). Bind `r` to `push_screen_wait(RegisterProviderModal())` from inside a worker (per SKILL.md troubleshooting).
+- Acceptance:
+  - Acceptance criterion 8 from `spec.md`.
+  - User story 6 from `spec.md`.
+- Tests:
+  - `test_register_provider_modal_appends_row`
+
+## T8 — Snapshot tests at `terminal_size=(120, 40)`
+- Files: `tests/test_harness_tui_snapshots.py`
+- Change: add four snapshots — `idle_dark`, `idle_light`, `mid_run`, `cancelled`. All use `terminal_size=(120, 40)` and a deterministic seed via the `slow_mock_provider` fixture; mid-run uses `pilot.pause()` after a fixed simulated tick count to remove timing flake.
+- Acceptance:
+  - Acceptance criterion 9 from `spec.md` (snapshots exist for the three states + the light variant).
+- Tests:
+  - `test_providers_screen_idle_dark_snapshot`
+  - `test_providers_screen_idle_light_snapshot`
+  - `test_providers_screen_mid_run_snapshot`
+  - `test_providers_screen_cancelled_snapshot`
+
+## T9 — Roadmap honesty + AGENTS / CLAUDE notes (closing PR)
+- Files: `.codex/skills/tui-development/references/roadmap.md`, `CHANGELOG.md`
+- Change: mark roadmap §8 "M3 — Live providers" as `done · YYYY-MM-DD`. Add a CHANGELOG entry under "Unreleased": `feat(harness): live mock.predict from ProvidersScreen with cancellable worker and event streaming`.
+- Acceptance:
+  - Roadmap is honest per `<context_lifecycle>`.
+  - CHANGELOG mentions only the public, user-visible change (no agent / tool branding per `<priority_rules>` #5).
+- Tests:
+  - none new; the full local gate from `CLAUDE.md <commands>` runs green.
+
+## Definition of done
+- [ ] Tasks T1–T9 merged.
+- [ ] Pilot tests in `tests/test_harness_tui.py` pass under `uv run --extra harness pytest`.
+- [ ] Snapshot SVGs committed and reviewed in the PR diff.
+- [ ] Coverage gate passes: `uv run --extra harness pytest --cov=src/worldforge --cov-report=term-missing --cov-fail-under=90`.
+- [ ] Package contract passes: `bash scripts/test_package.sh` (no leak of Textual into base imports).
+- [ ] Provider docs check passes unchanged (no provider catalog change in M3).
+- [ ] Roadmap §8 marked "done · YYYY-MM-DD".
+- [ ] No new entries in `[project.optional-dependencies].harness` beyond Textual.
+- [ ] Branch / commit / PR text remains maintainer-style, tool-neutral (no agent / tool branding).


### PR DESCRIPTION
Spec, implementation plan, and task breakdown for TheWorldHarness roadmap milestone **M3 — Live providers**: the milestone that retires the harness's canned `asyncio.sleep` demo flows by introducing a `ProvidersScreen` with a capability matrix sourced from `ProviderCapabilities`, wiring a single real `mock.predict` call through `@work(thread=True, group="provider", exclusive=True)` with `ProviderEvent`s streaming into a `RichLog` via `call_from_thread`, and making `Esc` an observable cancellation rather than a silent drop. Pure documentation; no source changes.

Roadmap reference: [`.codex/skills/tui-development/references/roadmap.md` §8 — M3 — Live providers](../blob/main/.codex/skills/tui-development/references/roadmap.md#m3--live-providers)

Files:
- `specs/theworldharness-M3-live-providers/spec.md` — outcome, scope, user stories, acceptance criteria, open questions
- `specs/theworldharness-M3-live-providers/plan.md` — architecture, module touch list, technical decisions, worker contract, theming, testing strategy, dependencies
- `specs/theworldharness-M3-live-providers/tasks.md` — nine PR-sized tasks (T1 read-only matrix → T9 closing roadmap update) with per-task acceptance and tests

## Test plan
- [ ] Verify spec / plan / tasks templates match the coordinator's prescribed structure
- [ ] Verify capability cell semantics match `references/capability-matrix.md`
- [ ] Verify worker contract matches roadmap §6 and SKILL.md "Long-running work uses workers"
- [ ] Verify no source / dependency changes (`git diff main -- src pyproject.toml uv.lock` is empty)
- [ ] Verify cross-milestone dependencies (M0, M1 required; M2 optional; M4, M5 blocked) are stated in `plan.md`