### PR TITLE
docs(specs): theworldharness M2 — worlds CRUD

### DIFF
--- a/specs/theworldharness-M2-worlds-crud/plan.md
+++ b/specs/theworldharness-M2-worlds-crud/plan.md
@@ -1,0 +1,137 @@
+# Milestone M2 — Worlds CRUD · Implementation Plan
+
+## Builds on
+
+- Roadmap §8 "M2 — Worlds CRUD" — `.codex/skills/tui-development/references/roadmap.md`
+- Roadmap §4.2 WorldsScreen, §4.3 WorldEditScreen, §4.9 Modal screens, §3 Architecture, §6 worker contract, §10 Anti-goals — same file
+- Skill: `.codex/skills/tui-development/SKILL.md` (Textual practices, "Stop and ask" gates)
+- Skill: `.codex/skills/persistence-state/SKILL.md` (single-writer, validate-at-boundary, never-coerce contract)
+- Predecessor milestones: M0 (theme tokens + chrome), M1 (screen stack, `push_screen` / `push_screen_wait`, modal pattern)
+- Public surface: `WorldForge.create_world`, `save_world`, `load_world`, `list_worlds`, `import_world`, `export_world`, `fork_world` in `src/worldforge/framework.py`
+
+## Architecture changes
+
+- New screen `WorldsScreen(Screen)` — table + detail pane; pushed by `g w` from `HomeScreen` and by command-palette "Worlds".
+- New screen `WorldEditScreen(Screen)` — form-style editor for a single in-memory `World`; pushed from `WorldsScreen` via `e` / `Enter` / `n` (after `NewWorld` returns) / `f` (after `fork_world`).
+- New modal `NewWorldScreen(ModalScreen[WorldSpec | None])` — name + provider + optional description fields.
+- New modal `EditObjectScreen(ModalScreen[SceneObject | None])` — kind + position + rotation + metadata fields for a single scene object.
+- New modal `ConfirmDeleteScreen(ModalScreen[bool])` — generic yes/no with caller-provided prompt copy.
+- All screens push onto the M1 screen stack; modal results are typed via `ModalScreen[T]` (per SKILL.md).
+- A small Textual-free helper module (proposed name `worlds_view.py` under `harness/`) holds presentation-pure functions used by tests: row-format for the table, summary-format for the detail pane, validation pre-check that mirrors `WorldForge` rules so error toasts can be raised before round-tripping. The module imports nothing from `textual`; SKILL.md "Stop and ask" gate "before importing Textual outside `tui.py`" is preserved.
+
+## Module touch list
+
+| Path | Change | Notes |
+| --- | --- | --- |
+| `src/worldforge/harness/tui.py` | Add `WorldsScreen`, `WorldEditScreen`, `NewWorldScreen`, `EditObjectScreen`, `ConfirmDeleteScreen`, related TCSS, and `Ctrl+P` system commands. Wire `g w` into existing screen stack from M1. | Sole Textual import site (load-bearing per SKILL.md). |
+| `src/worldforge/harness/worlds_view.py` (new) | Presentation-pure helpers (row formatting, detail summary, dirty check, id pre-validation that mirrors `_validate_storage_id`). | Textual-free; importable without the harness extra. Confirm with the user before adding (SKILL.md "Stop and ask"). |
+| `src/worldforge/harness/cli.py` | Optional: `--initial-screen worlds` flag so `worldforge-harness --initial-screen worlds` lands directly on `WorldsScreen`. | Keep Textual-free; no change to existing flow flags. |
+| `src/worldforge/harness/__init__.py` | Re-export new screen classes only if tests need them; default to keeping the harness public surface unchanged. | Stay narrow; M5 will revisit public exports for the showcase milestone. |
+| `src/worldforge/framework.py` | **Gated proposal**: add `def delete_world(self, world_id: str) -> None` that validates the id via `_validate_storage_id` and unlinks the file (no-op-friendly when absent? — see "Key technical decisions"). Requires explicit approval per `CLAUDE.md` `<gated>`. | If approval is withheld, the TUI uses an internal helper that mirrors `_validate_storage_id` and unlinks; an issue is filed for follow-up CLI parity. |
+| `src/worldforge/__init__.py` | Re-export `delete_world` only if added on `WorldForge`. | Gated alongside the framework change. |
+| `tests/test_harness_tui.py` | Add Pilot tests covering create, edit-and-save, delete (cancel + confirm), fork, filter, and rejected-id toast. | Pattern matches the existing `test_the_world_harness_app_runs_leworldmodel_flow` shape. |
+| `tests/test_harness_worlds_view.py` (new) | Unit tests for the Textual-free `worlds_view` helpers. | No Textual import — runs on the base profile. |
+| `tests/test_harness_snapshots/` (new) | `pytest-textual-snapshot` SVGs for the screens listed in spec.md acceptance criteria. | Pin `terminal_size=(120, 40)` per SKILL.md. |
+| `docs/src/playbooks.md` | Short subsection: "Manage worlds from TheWorldHarness". | Cross-link to `worldforge world` CLI parity table. |
+| `CHANGELOG.md` | "Added — TheWorldHarness M2 (Worlds CRUD)" entry on the next release. | Tool-neutral, maintainer-style. |
+| `.codex/skills/tui-development/references/roadmap.md` | Mark §8 M2 "done · YYYY-MM-DD" on landing. | Final task in tasks.md. |
+
+## Key technical decisions
+
+- **Form widget choice (`WorldEditScreen`).** Decision: stock `Input` for name, `Select` for provider (populated from `WorldForge` registered providers), `OptionList` + add/edit/remove buttons for scene objects, `Static` for the snapshot preview. Alternative considered: a single custom `Form` widget. Rejected per SKILL.md "Compose, don't subclass" — there is no new render or input model here.
+- **Snapshot preview rendering.** Decision: text-only — multi-line `Static` showing scene-object positions and a step counter; no pseudo-3-D rendering. Alternatives: ASCII iso grid (rejected per roadmap §11 "Decide after M3"); embedded image (no precedent in the codebase, would require asset pipeline).
+- **`WorldStateError` surface.** Decision: toast (`app.notify(..., severity="error")`) for boundary errors, with the message verbatim from the exception. The screen also keeps the in-memory edit buffer intact so the user can fix and retry. Alternatives: inline error under each invalid field (rejected — `WorldStateError` is structured by message, not by field; reverse-mapping would couple the TUI to the validator's wording); modal blocking dialog (rejected — too heavy for a save retry).
+- **Delete path (gated).** Preferred: add `WorldForge.delete_world(world_id: str) -> None` (validates id via `_validate_storage_id`, unlinks the file, raises `WorldStateError` on failure). This keeps the TUI as the integration reference example — every action reproducible in ~20 lines. Fallback if approval is withheld: a private `_delete_world_file(forge: WorldForge, world_id: str) -> None` helper inside `harness/tui.py` that re-validates the id with the public validator and unlinks; an issue is opened for promoting it later.
+- **Filter implementation.** Decision: client-side filter over the already-loaded `list_worlds()` result; substring match on `id` and `name`. Alternative: re-query on every keystroke (rejected — `list_worlds` reads the directory; client filter is cheaper and consistent with single-writer assumption).
+- **Worker boundary.** Decision: every call into `WorldForge.{save_world, load_world, list_worlds, import_world, export_world, fork_world, delete_world}` runs inside a `@work(thread=True, group="persistence", exclusive=True, name=...)` worker. The screen owns the worker; `Esc` calls `self.workers.cancel_group("persistence")` (SKILL.md worker contract).
+- **`refresh-on-resume` over polling.** Decision: `WorldsScreen.on_screen_resume` re-runs `list_worlds()` so returning from `WorldEditScreen` reflects new state. No filesystem watcher / polling — that would conflict with the single-writer contract.
+
+## Data flow
+
+**Reactives**
+
+- `WorldsScreen.selected_world: reactive[str | None] = reactive(None)` — drives the detail pane; paired with `watch_selected_world(self, old, new)` that loads the row-summary into the right pane.
+- `WorldsScreen.filter_query: reactive[str] = reactive("")` — paired with `watch_filter_query` that re-applies the client-side filter.
+- `WorldEditScreen.current_world: reactive[World | None] = reactive(None)` — the in-memory edit buffer.
+- `WorldEditScreen.dirty: reactive[bool] = reactive(False)` — drives the title-bar `*` marker and the `Esc`-with-confirm path.
+- `WorldEditScreen.staged_action: reactive[Action | None] = reactive(None)` — when set, triggers the preview worker.
+
+**Messages**
+
+- `WorldSelected(world_id: str)` — posted by the `DataTable` row-cursor change.
+- `WorldSaved(world_id: str)` — posted by `WorldEditScreen` after a successful `save_world` worker; `WorldsScreen` listens via `on_world_saved` to re-query.
+- `WorldDeleted(world_id: str)` — posted after a successful delete worker.
+- `WorldForked(source_id: str, fork_id: str)` — posted when `fork_world` returns; `WorldsScreen` re-queries and `WorldEditScreen` opens on `fork_id` unsaved.
+- `WorldEditDirty(dirty: bool)` — internal to `WorldEditScreen`, drives the dirty marker.
+
+**Workers**
+
+- `@work(thread=True, group="persistence", exclusive=True, name="list_worlds")` — `WorldsScreen.refresh_worlds`.
+- `@work(thread=True, group="persistence", exclusive=True, name="load_world")` — `WorldsScreen.open_selected`.
+- `@work(thread=True, group="persistence", exclusive=True, name="save_world")` — `WorldEditScreen.save_current`.
+- `@work(thread=True, group="persistence", exclusive=True, name="fork_world")` — `WorldsScreen.fork_selected`.
+- `@work(thread=True, group="persistence", exclusive=True, name="delete_world")` — `WorldsScreen.delete_selected`.
+- `@work(thread=True, group="provider", exclusive=True, name="predict_preview")` — `WorldEditScreen.refresh_preview` (only when `staged_action` is set; preview-only, never persists).
+
+All worker results post messages via `self.app.call_from_thread(self.post_message, ...)` per SKILL.md "Never mutate widgets directly from a thread worker".
+
+## Theming and CSS
+
+Semantic CSS variables only — no hex literals (SKILL.md "Don't ship inline hex colors"). Token usage:
+
+- `$accent` — selected `DataTable` row, focused panel border, active "Save" button.
+- `$panel` — idle panel borders.
+- `$success` — toast on successful save / fork / delete; the dirty marker reverts to `$success` after save.
+- `$warning` — preview caption when `staged_action` is set; the dirty `*` marker.
+- `$error` — toast on `WorldStateError`; invalid-input field outline in modals.
+- `$boost` — hover state on rows and buttons.
+- `$surface` / `$muted` — primary and secondary text inside the detail pane.
+
+Borders use `round` only (per roadmap §2.2). Hierarchy comes from borders + padding + `Rule()`, never blank-line spacers.
+
+## Testing
+
+- **Pilot tests** (`tests/test_harness_tui.py`):
+  - Full `n` → `NewWorld` modal → fill → submit → row appears round-trip.
+  - `Enter` on row → `WorldEditScreen` populated → add object → `Ctrl+S` → reopen → state preserved.
+  - `d` → `ConfirmDelete` cancel returns `False`; row still present.
+  - `d` → `ConfirmDelete` confirm returns `True`; row removed; row count decremented.
+  - `f` → fork created; new id; opened in `WorldEditScreen` with `dirty=True` until first save.
+  - `/lab` filter narrows the table.
+  - **Rejected-id path**: feed `"../escape"` to `NewWorld` → `WorldStateError` toast appears → no file is written under `state_dir` (assert via `WorldForge.list_worlds()`).
+- **Snapshot tests** (`tests/test_harness_snapshots/`) at `terminal_size=(120, 40)`:
+  - `WorldsScreen` empty (empty-state hint visible).
+  - `WorldsScreen` with 3 worlds and one selected.
+  - `WorldEditScreen` mid-edit with one staged action and the preview pane lit.
+  - `NewWorld` modal open over `WorldsScreen`.
+  - `ConfirmDelete` modal open over `WorldsScreen`.
+  - Save-error toast visible.
+- **Unit tests** (`tests/test_harness_worlds_view.py`) for the Textual-free helpers — runnable on the base profile without the `harness` extra.
+- **Coverage gate**: `uv run --extra harness pytest --cov=src/worldforge --cov-report=term-missing --cov-fail-under=90` must continue to pass; the new helpers and screens must carry tests sufficient to keep the gate green (per `CLAUDE.md` `<commands>` and `tui-development/SKILL.md` "Coverage" reference).
+
+## Risks and mitigations
+
+- **Risk**: hand-rolling JSON inside `tui.py` (e.g., to "show what's on disk") would bypass `WorldForge` validation and silently diverge from CLI behavior.
+  - **Mitigation**: every read/write goes through `WorldForge` public methods. A targeted ruff / Grep check during review rejects `json.dump` / `json.load` inside `harness/`. The detail pane reads from a loaded `World`, not from a parsed file.
+- **Risk**: blocking the Textual event loop on disk I/O (e.g., `list_worlds()` directly in `compose`).
+  - **Mitigation**: every call into `WorldForge` runs inside a `persistence`-group worker per SKILL.md worker contract; the empty state is rendered synchronously while the worker populates the table.
+- **Risk**: silent coercion of an invalid persisted payload (e.g., catching `WorldStateError` and returning a "fixed" world).
+  - **Mitigation**: `WorldStateError` is rethrown as a toast and the in-memory state is preserved unchanged. Persistence-state SKILL "Don't" — "silently coerce invalid persisted state" — covered by the rejected-id Pilot test.
+- **Risk**: introducing a public API change (`delete_world`) without approval.
+  - **Mitigation**: tasks.md splits the work so the framework change is its own gated PR; if approval is withheld, the fallback private helper path is taken and a follow-up issue is opened.
+- **Risk**: snapshot flakiness on different CIs.
+  - **Mitigation**: pin `terminal_size=(120, 40)`, await `pilot.pause()` before assertion, commit SVGs (SKILL.md "Test with Pilot and snapshots").
+- **Risk**: leaking Textual into a non-`tui.py` module.
+  - **Mitigation**: the `worlds_view.py` helper file is Textual-free by construction; a unit test imports it without the `harness` extra installed.
+- **Risk**: scope creep into M3 territory by streaming events during preview.
+  - **Mitigation**: the preview worker is single-shot — it calls `provider.predict` once and renders the resulting snapshot; no `RichLog` wiring, no event streaming, no cancel-mid-stream UX. Streaming is deferred to M3.
+
+## Dependencies on other milestones
+
+- **Required before this can ship**:
+  - M0 — semantic theme tokens (`$accent`, `$panel`, `$success`, `$warning`, `$error`, `$boost`, `$surface`, `$muted`) must be registered.
+  - M1 — screen stack (`push_screen` / `push_screen_wait`), `?` help overlay, and `Ctrl+P` system commands must exist; `WorldsScreen` and `WorldEditScreen` push onto the M1 stack rather than introducing it.
+- **Blocks**:
+  - M3 — `ProvidersScreen` will let users change a world's provider in place; that lookup wires into the same `WorldForge.list_providers` plumbing M2 introduces in `WorldEditScreen`.
+  - M4 — `EvalScreen` and `BenchmarkScreen` need a "pick a world" affordance that reads from the same listing M2 builds.
+  - M5 — `HomeScreen` "Recent worlds" list pulls from the same `WorldForge.list_worlds` cache M2 owns.

--- a/specs/theworldharness-M2-worlds-crud/spec.md
+++ b/specs/theworldharness-M2-worlds-crud/spec.md
@@ -1,0 +1,87 @@
+# Milestone M2 — Worlds CRUD
+
+## Status
+Draft · 2026-04-21
+
+## Outcome (one sentence)
+A user can create, edit, fork, save, reopen, and delete a World entirely from TheWorldHarness TUI without writing Python — and every disk write goes through the same `WorldForge` public API a library caller would use.
+
+## Why this milestone
+
+The roadmap vision (`.codex/skills/tui-development/references/roadmap.md` §1) commits to two promises that depend on this milestone landing: that a newcomer can "do something real within two minutes" (create a world), and that the harness is "the canonical, copyable example of how to use WorldForge" (anything they do in the TUI must be reproducible in ~20 lines of Python). Worlds are the first stateful object a user encounters; until M2 ships, the harness can only display canned demo flows over an empty `state_dir`.
+
+This milestone respects the persistence-state skill's contract (`.codex/skills/persistence-state/SKILL.md`): the TUI is a single-writer, never-coerce client of `WorldForge`. World IDs are validated before any path construction; payloads are validated on every load and import; `WorldStateError` is the firewall and surfaces as a toast — never silently swallowed and never "fixed" by clamping or dropping fields. The project decision recorded in `CLAUDE.md` ("keep local JSON persistence single-writer — rejected adding lock files, SQLite, or service persistence without a dedicated design") is honored: no concurrent-write coordination is introduced by this milestone.
+
+## In scope
+
+- `WorldsScreen` with `DataTable(zebra_stripes=True, cursor_type="row")` listing worlds discovered via `WorldForge.list_worlds()`. Columns: id, name, provider, step, last touched (file mtime).
+- Right-side detail pane on `WorldsScreen` showing scene-object count, current provider, history count, and the resolved `state_dir` path (per roadmap §4.2).
+- `WorldEditScreen` form with: name `Input`, provider `Select` populated from registered providers, scene-object list with add / move-up / move-down / remove, and a snapshot preview pane on the right (per roadmap §4.3).
+- `NewWorld[WorldSpec]` modal (`ModalScreen[WorldSpec | None]`) for the "create a world" path triggered by `n` from `WorldsScreen`.
+- `EditObject[SceneObject]` modal (`ModalScreen[SceneObject | None]`) for adding or editing a scene object inside `WorldEditScreen`.
+- `ConfirmDelete[bool]` modal (`ModalScreen[bool]`) used before any destructive action (delete world, drop unsaved edits when leaving `WorldEditScreen` dirty).
+- `Ctrl+S` in `WorldEditScreen` saves through `WorldForge.save_world`; `Esc` requests cancel (with `ConfirmDelete[bool]` if dirty).
+- Filter (`/`) on `WorldsScreen` narrows the table by id / name substring.
+- Fork (`f`) on `WorldsScreen` calls `WorldForge.fork_world(world_id, history_index=0, name=...)` and pushes the result into `WorldEditScreen` unsaved.
+- Live "predict next state" preview in the snapshot pane when an action is staged (calls `provider.predict` via a worker; preview-only, never persists).
+- Round-trip parity with the `worldforge world ...` CLI commands listed in `CLAUDE.md` `<commands>`: anything done in the TUI is loadable / inspectable / editable from the CLI on the same `state_dir`, and vice versa.
+- Empty state on `WorldsScreen` per roadmap §2.4 ("No worlds yet — press [b]n[/] to create one").
+- Command-palette entries (`Ctrl+P`) for: "New world", "Open world…", "Fork world…", "Delete world…" — per roadmap §5.
+
+## Out of scope (explicit)
+
+- Live provider event streaming during predict beyond the single-shot preview — full streaming UX is M3 (`ProvidersScreen` and `RichLog` wiring).
+- A 3-D scene preview — explicitly listed in roadmap §11 as "Decide after M3".
+- Multi-writer / concurrent edit coordination — explicitly forbidden by `.codex/skills/persistence-state/SKILL.md` and the `CLAUDE.md` 2026-04-20 project decision; introducing locks or SQLite needs a separate, approved design.
+- Migrations of older persisted shapes — gated per the persistence skill; if a payload fails validation it surfaces as a toast and the user must export-and-fix or discard.
+- Eval / benchmark integration on a selected world — defer to M4 (`EvalScreen`, `BenchmarkScreen`).
+- Provider capability matrix or registration UI — defer to M3 (`ProvidersScreen`).
+- Recent-worlds list on `HomeScreen` — defer to M5 (polish + showcase).
+- Renaming worlds by changing their `id` — id is the storage key and immutable; renaming is `name` only. (See "Open questions" for the fork-as-rename pattern.)
+
+## User stories
+
+1. As a researcher, I press `g w` (or click "Worlds" from `HomeScreen`), so that I land on `WorldsScreen` and see every world in my `state_dir`.
+2. As a researcher with an empty `state_dir`, I see the empty-state hint, press `n`, fill the `NewWorld` modal, and after Save I see my new world appear in the table without needing to restart.
+3. As a researcher, I press `e` on a row (or `Enter`), so that `WorldEditScreen` opens with the world's name, provider, and scene objects already populated.
+4. As a researcher in `WorldEditScreen`, I press `a` to add a scene object via the `EditObject` modal, see it appear in the list and snapshot preview, then press `Ctrl+S` to persist.
+5. As a researcher in `WorldEditScreen` with a staged action, I see the "predict next state" preview update in the snapshot pane, and that preview is *not* written to history until I commit.
+6. As a researcher, I press `d` on a row, see `ConfirmDelete` modal, press `Esc` (returns `False`) and the world is still there; I press `d` again and confirm (returns `True`) and the row disappears.
+7. As a researcher, I press `f` on a row, the world is forked (new id, history reset to a "world forked" entry per `WorldForge.fork_world`) and `WorldEditScreen` opens unsaved on the fork.
+8. As a researcher, I type `/lab` in the filter box, so that only rows whose id or name contains `lab` remain visible.
+9. As a researcher, I save a world the validator rejects (e.g. an empty name), and I see a toast carrying the `WorldStateError` message — the row in the table is unchanged and the screen does not crash.
+10. As a researcher, I open the command palette (`Ctrl+P`), type "fork", select "Fork world…", and a fuzzy-search picker over existing world ids opens.
+
+## Acceptance criteria
+
+- [ ] On mount, `WorldsScreen` populates its `DataTable` from `WorldForge.list_worlds()` and reflects a freshly saved world without app restart (re-query on `WorldSaved` / `WorldDeleted` messages).
+- [ ] `Ctrl+S` in `WorldEditScreen` invokes `WorldForge.save_world` on a worker; on `WorldStateError` the screen surfaces the message via a toast and the in-memory edit buffer is preserved (no data loss).
+- [ ] An invalid id submitted through `NewWorld` (e.g., `"../escape"`, an empty string, or a value containing path separators) raises `WorldStateError` from `WorldForge.save_world` and is rendered as a toast — *never reaches the filesystem* (matches the persistence-state procedure step 1).
+- [ ] `ConfirmDelete[bool]` returns `False` on `Esc`, on the explicit "Cancel" button, and when dismissed by clicking outside; it returns `True` only on the explicit "Delete" button or `Enter` while "Delete" is focused.
+- [ ] Delete only proceeds when `ConfirmDelete` returns `True`; the worker that removes the world file completes before the row is removed from the table.
+- [ ] A round trip — create in `NewWorld` → save → close `WorldEditScreen` → reopen via `Enter` on the row — preserves the world's `id`, `name`, `provider`, scene objects, and full history (matches the invariants asserted in `tests/test_world_lifecycle.py`).
+- [ ] Fork creates a world whose `id` differs from the source, whose history starts with a single "world forked" entry, and which is *not* yet on disk (matches `WorldForge.fork_world` semantics in `src/worldforge/framework.py:1259`).
+- [ ] All disk-touching operations (save, load, list, import, export, delete-file) run on workers in the `persistence` group; the UI never blocks on them. `Esc` while a worker is active calls `self.workers.cancel_group("persistence")`.
+- [ ] Every binding shown in the screen footer maps to a `Ctrl+P` command palette entry (mouse + keyboard parity per roadmap §5 and SKILL.md "Patterns" → "Pair every footer binding with a click target and a tooltip").
+- [ ] No widget CSS contains a hex literal; all colors come from semantic CSS variables (`$accent`, `$success`, `$error`, `$panel`, `$boost`, `$surface`, `$muted`).
+- [ ] `tests/test_harness_tui.py`-style Pilot tests cover: create round-trip, edit-and-save round-trip, delete cancel + confirm paths, rejected-id toast, fork path, filter narrowing.
+- [ ] Snapshot tests exist at `terminal_size=(120, 40)` for: `WorldsScreen` empty, `WorldsScreen` with N worlds, `WorldEditScreen` mid-edit, `NewWorld` modal, `ConfirmDelete` modal, save-error toast.
+- [ ] Coverage gate (`uv run --extra harness pytest --cov=src/worldforge --cov-report=term-missing --cov-fail-under=90`) still passes after this milestone.
+
+## Non-functional requirements
+
+- Empty states per roadmap §2.4 — never a blank panel.
+- Validation errors are toasts, not exceptions — the TUI never panics, and a `WorldStateError` from `WorldForge` is treated as expected control flow at the boundary.
+- Disk I/O on workers (`@work(thread=True, group="persistence", exclusive=True, name="<readable>")`) — UI thread never calls `save_world` / `load_world` / file unlink directly.
+- Keyboard-first: every action reachable in one keystroke or via `Ctrl+P`.
+- Footer never lies: only screen-local bindings shown; internal bindings stay `show=False`.
+- Single-writer contract preserved: the TUI assumes one `WorldForge(state_dir=...)` per process and does not introduce coordination primitives.
+- Tool-neutral copy in every visible string (per `CLAUDE.md` `<priority_rules>` item 5).
+
+## Open questions
+
+- Should `f` (fork) prompt for a new id / name immediately via a `NewWorld`-shaped modal, auto-generate (current `WorldForge.fork_world` behavior), or both via a chord (`f` auto, `F` prompt)? Default proposal: `f` auto-generates and opens `WorldEditScreen` unsaved so the user can rename before `Ctrl+S`.
+- When an action is staged but not yet committed, should the snapshot preview render the predicted next state (history step N+1) or the current state (N) with an overlay indicator? Default proposal: render N+1, with a `$warning`-tinted "preview" caption so it's unambiguous.
+- Should "delete" hard-unlink the JSON file immediately, or move it to `.worldforge/trash/<world_id>-<timestamp>.json` for one-keystroke recovery? Default proposal: hard delete with an "Undo" toast that survives 5 seconds and re-saves the in-memory state if pressed; deferred-recovery storage is out of scope unless approved.
+- Public-API question (gated, see plan.md): should this milestone introduce a `WorldForge.delete_world(world_id: str) -> None` method (currently absent — only `_world_file` helper exists), or should the TUI use a private helper inside `harness/tui.py` that mirrors the same id validation? Default proposal: add `delete_world` to the public API behind explicit approval, because the TUI is the integration reference and CLI parity (`worldforge world delete <id>`) likely wants the same surface.
+- Should `WorldsScreen` poll the `state_dir` for external changes (another process or a CLI invocation between TUI sessions added a file), or only refresh on intra-app messages and explicit `r`? Default proposal: refresh on `on_screen_resume` and on explicit `r`; no polling — polling would conflict with the single-writer contract messaging.

--- a/specs/theworldharness-M2-worlds-crud/tasks.md
+++ b/specs/theworldharness-M2-worlds-crud/tasks.md
@@ -1,0 +1,106 @@
+# Milestone M2 — Worlds CRUD · Tasks
+
+Each task is a single PR-sized unit. Order matters: a later task may assume an earlier one has landed in main. Every PR keeps the existing test gates green; no task may weaken `--cov-fail-under=90`.
+
+## T1 — Textual-free `worlds_view` helpers
+
+- Files: `src/worldforge/harness/worlds_view.py` (new), `tests/test_harness_worlds_view.py` (new).
+- Change: introduce a small Textual-free module under `src/worldforge/harness/` for presentation-pure helpers used by later tasks: `format_world_row(world: World) -> tuple[str, str, str, int, str]` (id, name, provider, step, last-touched ISO string), `format_detail_summary(world: World) -> str`, `is_dirty(original: World, edited: World) -> bool`, and `validate_id_or_reason(world_id: str) -> str | None` (mirrors `_validate_storage_id` so the TUI can render an inline error before round-tripping through `WorldForge`). Confirm with the user before adding the file (SKILL.md "Stop and ask: before introducing a new file under `src/worldforge/harness/`").
+- Acceptance: maps to spec.md acceptance "no widget CSS contains a hex literal" only indirectly; primary goal is to keep Textual import boundary intact (`from worldforge.harness.worlds_view import format_world_row` works without the `harness` extra installed).
+- Tests: `tests/test_harness_worlds_view.py` covering each helper; one test asserts the module imports without `textual` available (mock `sys.modules['textual']` to `None` and re-import).
+
+## T2 — Gated public API addition: `WorldForge.delete_world`
+
+- Files: `src/worldforge/framework.py`, `src/worldforge/__init__.py` (re-export if needed), `tests/test_world_lifecycle.py` (new tests).
+- Change: add `def delete_world(self, world_id: str) -> None` to `WorldForge` that validates `world_id` via `_validate_storage_id` (raising `WorldStateError` on rejection), unlinks the file via `_world_file(...).unlink(missing_ok=False)`, and raises `WorldStateError` on filesystem failure. **Gated** per `CLAUDE.md` `<gated>` ("persistence contract in `src/worldforge/framework.py`"); requires explicit approval before merge. If approval is withheld, this task is replaced by T2-fallback (a private `_delete_world_file` helper inside `harness/tui.py` that re-validates the id with the public validator and unlinks).
+- Acceptance: maps to spec.md "Delete only proceeds when ConfirmDelete returns True" and the open-question "delete public API". After this task, the CLI parity command `worldforge world delete <id>` becomes trivial follow-up work.
+- Tests: round-trip create → save → delete → `list_worlds()` shrinks; delete with `"../escape"` raises `WorldStateError`; delete of a non-existent id raises `WorldStateError`.
+
+## T3 — `ConfirmDelete[bool]` modal
+
+- Files: `src/worldforge/harness/tui.py`, `tests/test_harness_tui.py`.
+- Change: add `class ConfirmDeleteScreen(ModalScreen[bool])` with caller-provided prompt copy, "Cancel" and "Delete" buttons, `Esc` returning `False`, `Enter` while "Delete" is focused returning `True`. Use semantic CSS variables only.
+- Acceptance: maps to spec.md acceptance "ConfirmDelete returns False on Esc; True only on explicit confirm".
+- Tests: Pilot test that pushes the modal, presses `Esc`, asserts `False`; another that focuses "Delete", presses `Enter`, asserts `True`. Snapshot test of the modal at `terminal_size=(120, 40)`.
+
+## T4 — `NewWorld[WorldSpec]` modal
+
+- Files: `src/worldforge/harness/tui.py`, `src/worldforge/harness/worlds_view.py` (extend with a `WorldSpec` dataclass if needed), `tests/test_harness_tui.py`.
+- Change: add `class NewWorldScreen(ModalScreen[WorldSpec | None])` with `Input` for name, `Select` for provider, optional `Input` for description. On submit, return a `WorldSpec`; on `Esc` / Cancel, return `None`. Validate inputs with `worlds_view.validate_id_or_reason` before dismissing — invalid input keeps the modal open and surfaces the reason inline (`$error` outline).
+- Acceptance: maps to spec.md acceptance "An invalid id submitted through NewWorld… raises WorldStateError… never reaches the filesystem" — the modal blocks early and the screen also defends via the save worker.
+- Tests: Pilot test that submits a valid spec → modal returns `WorldSpec`; submits `"../escape"` → modal stays open with inline error; presses `Esc` → returns `None`. Snapshot test of the modal.
+
+## T5 — `WorldsScreen` (read-only first cut)
+
+- Files: `src/worldforge/harness/tui.py`, `tests/test_harness_tui.py`, `tests/test_harness_snapshots/`.
+- Change: add `class WorldsScreen(Screen)` with `DataTable(zebra_stripes=True, cursor_type="row")`, right-side detail pane, `selected_world` and `filter_query` reactives, and a `persistence`-group worker for `list_worlds`. Bindings: `n` (no-op until T7), `e` / `Enter` (no-op until T6), `d` (no-op until T8), `f` (no-op until T9), `/` filter, `r` refresh, `q` quit, `g h` home. Empty state per roadmap §2.4. Wire `g w` from the M1 `HomeScreen` to push this screen.
+- Acceptance: maps to spec.md acceptance "On mount, WorldsScreen populates its DataTable from list_worlds()" and "all colors come from semantic CSS variables".
+- Tests: Pilot test that mounts `WorldsScreen` over an empty `state_dir` and asserts the empty-state hint; another that pre-creates 3 worlds via `WorldForge.save_world` and asserts the table populates. Snapshot tests for empty and populated states at `terminal_size=(120, 40)`.
+
+## T6 — `WorldEditScreen` (read + save round-trip)
+
+- Files: `src/worldforge/harness/tui.py`, `tests/test_harness_tui.py`, `tests/test_harness_snapshots/`.
+- Change: add `class WorldEditScreen(Screen)` with `Input` for name, `Select` for provider, `OptionList` for scene objects, `Static` snapshot preview, dirty marker. Bindings: `Ctrl+S` save, `Esc` close (with `ConfirmDelete[bool]` if dirty), `a` add object (modal in T7), `Delete` remove object, `Ctrl+Up` / `Ctrl+Down` reorder. Wire `e` / `Enter` from `WorldsScreen` to push this screen with the loaded `World`. Save runs through the `save_world` worker; `WorldStateError` becomes a toast and the buffer is preserved.
+- Acceptance: maps to spec.md acceptance "Ctrl+S in WorldEditScreen calls WorldForge.save_world; a WorldStateError becomes a toast and does not corrupt state" and "load → edit → save round-trip preserves history and scene objects".
+- Tests: Pilot test that opens an existing world, edits the name, presses `Ctrl+S`, asserts the saved file matches the new name on reload (via a fresh `WorldForge.load_world`). Pilot test that simulates a `WorldStateError` (e.g., via a name-empty edit) and asserts the toast renders. Snapshot test of the screen mid-edit.
+
+## T7 — Create flow (`n` → `NewWorld` → `WorldEditScreen` unsaved)
+
+- Files: `src/worldforge/harness/tui.py`, `tests/test_harness_tui.py`.
+- Change: wire `n` on `WorldsScreen` to `push_screen_wait(NewWorldScreen())`; on a returned `WorldSpec`, build a fresh `World` via `WorldForge.create_world(name, provider=provider, description=description)` and push `WorldEditScreen` unsaved (`dirty=True`). Add `EditObjectScreen(ModalScreen[SceneObject | None])` for `a` inside `WorldEditScreen` so the user can populate scene objects before first save.
+- Acceptance: maps to user story 2 ("As a researcher with an empty state_dir, I see the empty-state hint, press `n`, fill the modal, and after Save I see my new world appear").
+- Tests: Pilot test that walks `n` → fill modal → `Ctrl+S` → return to `WorldsScreen` → row visible in table. Snapshot test of the chained modal-over-edit-over-table state.
+
+## T8 — Delete flow (`d` → `ConfirmDelete` → `delete_world` worker)
+
+- Files: `src/worldforge/harness/tui.py`, `tests/test_harness_tui.py`, `tests/test_harness_snapshots/`.
+- Change: wire `d` on `WorldsScreen` to `push_screen_wait(ConfirmDeleteScreen(prompt=...))`; on `True`, run the `delete_world` worker (T2 if approved; otherwise the fallback private helper). On worker success, post `WorldDeleted(world_id)`; the table re-queries via `on_world_deleted`. On `WorldStateError`, toast and leave the row alone.
+- Acceptance: maps to spec.md acceptance "Delete only proceeds when ConfirmDelete returns True; the worker that removes the world file completes before the row is removed from the table".
+- Tests: Pilot test for cancel path (row count unchanged) and confirm path (row count decremented; file gone). Snapshot test of the modal over the table.
+
+## T9 — Fork flow (`f` → `fork_world` → `WorldEditScreen` unsaved)
+
+- Files: `src/worldforge/harness/tui.py`, `tests/test_harness_tui.py`.
+- Change: wire `f` on `WorldsScreen` to a `fork_world` worker that calls `WorldForge.fork_world(world_id, history_index=0)`. On success, post `WorldForked(source_id, fork_id)` and push `WorldEditScreen` on the fork with `dirty=True`. The fork is *not* on disk until the user presses `Ctrl+S`.
+- Acceptance: maps to spec.md acceptance "Fork creates a world whose id differs from the source, whose history starts with a single 'world forked' entry, and which is not yet on disk".
+- Tests: Pilot test that forks an existing world, asserts `WorldEditScreen` opens with `dirty=True`, and asserts `WorldForge.list_worlds()` does not yet include the fork id; after `Ctrl+S`, the fork id is present.
+
+## T10 — Live "predict next state" preview
+
+- Files: `src/worldforge/harness/tui.py`, `tests/test_harness_tui.py`.
+- Change: add a `provider`-group worker `refresh_preview` on `WorldEditScreen` triggered by `staged_action` reactive changes. Worker calls `provider.predict(...)` once and renders the predicted snapshot into the right-pane `Static` with a `$warning`-tinted "preview" caption. Cancellation on `Esc` calls `self.workers.cancel_group("provider")` per SKILL.md worker contract. No `RichLog` wiring; no streaming; no persistence side effects (M3 owns streaming).
+- Acceptance: maps to spec.md user story 5 ("see the 'predict next state' preview update… preview is not written to history until I commit").
+- Tests: Pilot test that stages an action against the `mock` provider, awaits the preview worker, and asserts the caption + the preview text differs from the pre-staging snapshot. Asserts `WorldForge.load_world(world_id).history` length is unchanged after preview.
+
+## T11 — Filter (`/`) on `WorldsScreen`
+
+- Files: `src/worldforge/harness/tui.py`, `tests/test_harness_tui.py`.
+- Change: add an `Input` triggered by `/` that drives the `filter_query` reactive; client-side substring match on `id` and `name` over the already-loaded list. `Esc` clears the filter and returns focus to the table.
+- Acceptance: maps to spec.md user story 8.
+- Tests: Pilot test that types `lab` and asserts only matching rows remain visible.
+
+## T12 — Command-palette entries
+
+- Files: `src/worldforge/harness/tui.py`, `tests/test_harness_tui.py`.
+- Change: extend `App.get_system_commands` with: "New world" (push `NewWorldScreen` then route on success), "Open world…" (fuzzy picker over `list_worlds()`), "Fork world…" (fuzzy picker → fork worker), "Delete world…" (fuzzy picker → `ConfirmDelete`). All entries also surface as footer bindings on `WorldsScreen` (mouse + keyboard parity).
+- Acceptance: maps to spec.md acceptance "Every binding shown in the screen footer maps to a Ctrl+P command palette entry" and roadmap §5 ("If a feature exists but isn't in the palette, it doesn't exist for new users").
+- Tests: Pilot test that opens the palette, types "fork", selects the entry, and asserts the fork picker opens.
+
+## T13 — Docs, changelog, roadmap update
+
+- Files: `docs/src/playbooks.md`, `CHANGELOG.md`, `.codex/skills/tui-development/references/roadmap.md`.
+- Change: add a "Manage worlds from TheWorldHarness" subsection in `playbooks.md` cross-linking the `worldforge world` CLI parity table; add a `CHANGELOG.md` entry under "Added" for the next release; mark roadmap §8 M2 "done · YYYY-MM-DD".
+- Acceptance: maps to roadmap §8 milestone-completion contract ("Each milestone ends with a runnable harness, a Pilot test for the new flow, snapshot tests for the new screens, and a roadmap update marking the milestone 'done' with the date").
+- Tests: `uv run python scripts/generate_provider_docs.py --check` (no drift); `uv run --extra harness pytest --cov=src/worldforge --cov-report=term-missing --cov-fail-under=90` (gate green).
+
+## Definition of done
+
+- [ ] All tasks T1–T13 merged on `main`.
+- [ ] Pilot tests for create / edit-and-save / delete-cancel / delete-confirm / fork / filter / rejected-id / preview present in `tests/test_harness_tui.py`.
+- [ ] Snapshot tests for the screens listed in spec.md acceptance criteria committed under `tests/test_harness_snapshots/` and reviewed in their landing PRs.
+- [ ] Coverage gate (`uv run --extra harness pytest --cov=src/worldforge --cov-report=term-missing --cov-fail-under=90`) green.
+- [ ] Provider docs check (`uv run python scripts/generate_provider_docs.py --check`) green.
+- [ ] No hex literals in widget CSS introduced by this milestone.
+- [ ] Textual import boundary preserved: only `src/worldforge/harness/tui.py` imports `textual`.
+- [ ] `.codex/skills/tui-development/references/roadmap.md` §8 marked "done · YYYY-MM-DD".
+- [ ] `CHANGELOG.md` entry added under the next unreleased section.


### PR DESCRIPTION
Specify TheWorldHarness milestone **M2 — Worlds CRUD** using the spec / plan / tasks pattern. Pure documentation; no source or test changes.

The spec covers `WorldsScreen`, `WorldEditScreen`, the `NewWorld[WorldSpec]` / `EditObject[SceneObject]` / `ConfirmDelete[bool]` modals, fork, filter, a single-shot "predict next state" preview, and full keyboard + `Ctrl+P` command-palette parity. Every persistence operation routes through the public `WorldForge` API (`create_world`, `save_world`, `load_world`, `list_worlds`, `import_world`, `export_world`, `fork_world`), and `WorldStateError` is the toast surface — the single-writer, never-coerce persistence contract is preserved. The plan flags a gated public-API addition (`WorldForge.delete_world`) since no such method exists today and the harness is the integration reference example. Tasks split the milestone into 13 PR-sized units that keep the Textual import boundary intact and the >=90% coverage gate green.

Roadmap milestone anchor: [`.codex/skills/tui-development/references/roadmap.md` §8 "M2 — Worlds CRUD"](../blob/main/.codex/skills/tui-development/references/roadmap.md#m2--worlds-crud)