### PR TITLE
docs(specs): theworldharness M0 — theme and chrome reset

### DIFF
--- a/specs/theworldharness-M0-theme-chrome/plan.md
+++ b/specs/theworldharness-M0-theme-chrome/plan.md
@@ -1,0 +1,109 @@
+# Milestone M0 — Theme + chrome reset · Implementation Plan
+
+## Builds on
+- Roadmap §8 "M0 — Theme + chrome reset (foundation)" — `../../.codex/skills/tui-development/references/roadmap.md`
+- Roadmap §2 "Design language" (especially §2.1 color tokens, §2.2 typography and chrome) — same file.
+- Skill: `../../.codex/skills/tui-development/SKILL.md` (Why this skill exists §3 "Theme drift", SOTA Textual practices, worker contract, Stop-and-ask points).
+- Predecessor milestones: none (M0 is the foundation).
+
+## Architecture changes
+- `TheWorldHarnessApp` (in `src/worldforge/harness/tui.py`) gains:
+  - Two registered `Theme` objects: `worldforge-dark` (default) and `worldforge-light`. Registered in `on_mount` via `self.register_theme(...)`; `self.theme = "worldforge-dark"` set immediately after.
+  - A new reactive `current_provider: reactive[str] = reactive("mock · predict")` (string form for M0; M3+ may upgrade to a typed pair). Paired with `watch_current_provider(self, old, new)` that re-renders the status pill.
+  - A new internal `Ctrl+T` binding `("ctrl+t", "toggle_theme", "Theme", show=False)` and matching `action_toggle_theme(self)` that flips between the two registered theme names.
+- A new `Breadcrumb(Static)` widget defined in the same `tui.py` module. It exposes a `path: reactive[tuple[str, ...]]` and renders `worldforge › <segment>` from the tuple. For M0 the tuple is `("worldforge", flow.short_title)`; M1+ will deepen it.
+- A new `ProviderStatusPill(Static)` widget defined in the same `tui.py` module. It reads `provider · capability` from a single string reactive on the App and renders inside the header region.
+- Existing `HeroPane`, `FlowCard`, `TimelinePane`, `InspectorPane`, `TranscriptPane` are modified to replace every hex literal in their `Panel(border_style=...)` and `Text(style=...)` calls with semantic-token strings (Textual's CSS variables resolve at render via `$accent`, etc., when used in TCSS; for Rich-side `style=` strings, the values resolve through `App.get_css_variables()` which Textual exposes through theme registration).
+- The `CSS` class-level TCSS block in `TheWorldHarnessApp` is rewritten to use `$panel`, `$surface`, `$muted`, `$boost`, `$accent` only — no hex.
+- No new files are added. No existing files are deleted. No exports change. The Textual import boundary stays at `tui.py` only (SKILL.md §"Module boundary").
+
+## Module touch list
+| Path | Change | Notes |
+| --- | --- | --- |
+| `src/worldforge/harness/tui.py` | Modified | Register two themes; add `Breadcrumb` and `ProviderStatusPill` widgets; add `current_provider` reactive + `watch_current_provider`; add `Ctrl+T` binding + `action_toggle_theme`; replace every hex literal in TCSS and inline `style=`/`border_style=` with semantic tokens; mount the new widgets in `compose()`. |
+| `tests/test_harness_tui.py` | Modified | Add Pilot test for theme cycle (`pilot.press("ctrl+t")` → assert `app.theme`); add Pilot assertion that the breadcrumb and status pill are queryable after mount and after a flow switch. |
+| `tests/test_harness_tui_snapshots.py` (new, optional) | Added | Snapshot tests via `pytest-textual-snapshot` for the home view in both themes at `terminal_size=(130, 42)`. Gated on whether `pytest-textual-snapshot` is approved as a dev dep — see "Open questions" in `spec.md`. |
+| `src/worldforge/harness/flows.py` | Untouched | Flow models do not change. |
+| `src/worldforge/harness/cli.py` | Untouched | CLI entry point does not change. |
+| `src/worldforge/harness/models.py` | Untouched | No public model changes. |
+| `pyproject.toml` | Possibly modified (gated) | If snapshots land in M0, add `pytest-textual-snapshot` to the dev group. Requires explicit approval (CLAUDE.md `<gated>`). |
+
+## Key technical decisions
+
+### Decision 1: Register `Theme` objects, do not ship raw TCSS color blocks
+- **Decision**: Use `App.register_theme(Theme(...))` and toggle via `App.theme = "..."`.
+- **Alternatives**: (a) Ship a single TCSS variable block at the App level; rely on Textual's built-in `dark` boolean to flip palettes. (b) Define two TCSS files and swap them at runtime.
+- **Rationale**: Registered themes are Textual's first-class abstraction for the dark/light/high-contrast triad (roadmap §2.1, §3). They give `Ctrl+T` a one-line implementation, they survive the M5 high-contrast addition without refactor, and they keep all token definitions in Python next to the App definition (one source of truth). The `dark` boolean approach is being phased out in modern Textual; the dual-TCSS approach duplicates token names.
+
+### Decision 2: Keep widgets in `tui.py`; do not split into `widgets.py` yet
+- **Decision**: The new `Breadcrumb` and `ProviderStatusPill` widgets live in `tui.py`.
+- **Alternatives**: Create `src/worldforge/harness/widgets.py`.
+- **Rationale**: SKILL.md §"Module boundary" makes the Textual import boundary load-bearing for the base package's installability (`httpx`-only profile). Adding a `widgets.py` that imports Textual would either break that boundary or require a second gate. Two small classes do not justify the boundary churn for M0; M1's screen split is the right moment to revisit module organisation.
+
+### Decision 3: Provider status pill is a string for M0, not a typed pair
+- **Decision**: `current_provider: reactive[str]` carrying a pre-formatted `"mock · predict"` string.
+- **Alternatives**: Introduce `class ProviderHandle(provider: str, capability: str)` and reactive over that.
+- **Rationale**: A typed pair belongs in the public flow model (see `models.py`), and SKILL.md §"Stop and ask the user" requires explicit approval before reshaping `HarnessFlow` / `HarnessRun` / `HarnessStep` / `HarnessMetric`. M0 must not block on that. M3 ("Live providers") is the natural moment to promote the string into a typed pair, when real provider events start flowing.
+
+### Decision 4: Replace inline Rich `style="#abc123"` with semantic tokens by routing through `self.get_css_variables()`
+- **Decision**: For Rich renderables that today take literal `style="#d8c46a"`, replace with the resolved value of `$accent` etc. read at render time from the active theme.
+- **Alternatives**: Move every renderable to a TCSS-styled `Static` with no inline Rich style.
+- **Rationale**: A full TCSS rewrite of the Rich tables/panels is M1's scope (the screen split is when those panels become real widgets). For M0 the constraint is only "no hex literals"; resolving tokens at render time satisfies it without rewriting the rendering code.
+
+### Decision 5: `Ctrl+T` is a hidden binding, not a visible one
+- **Decision**: `("ctrl+t", "toggle_theme", "Theme", show=False)`.
+- **Rationale**: Roadmap §2.2 says "the footer never lies" and "internal bindings stay `show=False`". Theme toggling is a meta-action, not a flow action. M1 will surface it through the `Ctrl+P` palette where it belongs.
+
+## Data flow
+- **Reactives**:
+  - `selected_flow_id: str` — already exists as a plain attribute (`tui.py:226`); upgrade to `reactive[str]` so changes trigger `watch_selected_flow_id` which updates the breadcrumb path and the `current_provider` string. This change is internal; no public API change.
+  - `current_provider: reactive[str] = reactive("mock · predict")` — new. `watch_current_provider(self, old, new)` re-renders the `ProviderStatusPill`.
+- **Messages**: None new in M0. The single-screen App still reaches into its own children via `query_one`. Cross-widget message passing arrives in M1 with the screen split.
+- **Workers**: None new in M0. The existing `_run_flow` loop is left as-is (it uses `asyncio.sleep`, which is M3's problem — see roadmap §8 "M3 — Live providers"). The worker contract from SKILL.md §"Long-running work uses workers" is honored by *not adding* any new long-running call here; we keep the playback shape we already have, just reskinned.
+- **Cancel paths**: Not applicable for M0 (no workers added). M3 wires `Esc` → `self.workers.cancel_group("provider")`.
+- **Theme switch**: `action_toggle_theme(self)` runs on the main thread; reads `self.theme`, flips it, returns. Textual handles re-render automatically. No `call_from_thread` needed.
+
+## Theming and CSS
+- **Semantic tokens used (all eight from roadmap §2.1)**: `$accent`, `$success`, `$warning`, `$error`, `$panel`, `$boost`, `$surface`, `$muted`.
+- **Mapping from current hex usage to tokens** (informational; final values defined inside the registered `Theme` objects):
+  - `#d8c46a` (running / selected accent) → `$warning` for the running state, `$accent` for the selected state.
+  - `#8ec5a3` (success / ready / provider tag) → `$success`.
+  - `#d3d6cf` (default body text) → `$surface`.
+  - `#3b423e` (idle border) → `$panel`.
+  - `#6f7770` (pending step text) → `$muted`.
+  - `#101512` (screen background) → `$surface` (background derives from the theme's `background` field, set in the registered `Theme`).
+  - `#171f1a` (header / footer background) → `$panel` for chrome backgrounds.
+  - `#e4dfc5` (header text) and `#9ea89f` (footer text) → `$surface` and `$muted` respectively.
+- **Light/dark parity check method**:
+  1. Snapshot the home view at `terminal_size=(130, 42)` in `worldforge-dark` and `worldforge-light`. Visually diff in PR.
+  2. Pilot test that programmatically flips themes and asserts both renders complete without exception.
+  3. Manual contrast check: every token used as a foreground must have sufficient contrast against the token used as its background in both themes. Both themes ship through Textual's contrast checks (roadmap §2.1) — relying on Textual's own validators is the simplest enforcement for M0.
+- **Hex-literal lint**: a CI-friendly check is `grep -E '#[0-9a-fA-F]{3,8}' src/worldforge/harness/tui.py` returning empty. (Promoting this to a real lint rule is M5 polish; for M0 the human-eye review plus the test gating is sufficient.)
+
+## Testing
+- **Pilot tests** (modify `tests/test_harness_tui.py`):
+  - `test_theme_toggle_cycles_between_registered_themes`: mount, assert `app.theme == "worldforge-dark"`, press `ctrl+t`, assert `app.theme == "worldforge-light"`, press `ctrl+t` again, assert back to `worldforge-dark`.
+  - `test_breadcrumb_reflects_selected_flow`: mount, query `Breadcrumb`, assert path tuple includes `"worldforge"` and the initial flow's `short_title`; press `2` to switch flow, assert breadcrumb path updates.
+  - `test_status_pill_reflects_selected_flow_provider`: mount, query `ProviderStatusPill`, assert it renders the initial flow's `provider · capability`; press `2`, assert it updates.
+  - Existing `test_the_world_harness_app_runs_*_flow` tests pass unchanged (regression coverage that the chrome reset did not break the playback loop).
+- **Snapshot tests** (new file, gated on `pytest-textual-snapshot` approval):
+  - `test_home_view_dark_snapshot`: `assert snap_compare(app, terminal_size=(130, 42))` with `app.theme = "worldforge-dark"`.
+  - `test_home_view_light_snapshot`: same with `"worldforge-light"`.
+  - `await pilot.pause()` before assertion to defeat animation timing flake (SKILL.md troubleshooting row).
+- **Coverage gate**: must not drop below 90 percent with `--extra harness` (CLAUDE.md `<commands>` "Coverage gate"). The new widgets and reactive watchers each get at least one Pilot exercise above; that should keep coverage at parity.
+
+## Risks and mitigations
+- **Risk**: Resolving Rich `style=` strings against the active theme at render time may behave differently across Textual minor versions.
+  - **Mitigation**: Pin the `harness` extra to the existing range (`textual>=8.2,<9` per `pyproject.toml:55-57`); add a Pilot assertion that both themes render a representative panel without raising.
+- **Risk**: The status pill says `mock · predict` but a flow's actual provider/capability does not match the M0 string we hard-derive.
+  - **Mitigation**: Derive the pill string from the flow's existing `provider` field (`tui.py:59`) plus a small `_capability_for_flow(flow_id)` helper local to `tui.py` that returns `"score"` / `"policy"` / `"diagnostics"` for the three known flows. Document in code that this helper is M0-temporary and will be replaced when `HarnessFlow` grows a typed capability field (deferred per Decision 3).
+- **Risk**: Snapshot tests flake across CI runners.
+  - **Mitigation**: Pin `terminal_size=(130, 42)`; call `await pilot.pause()` before snapshotting; commit SVGs and review diffs in PRs (SKILL.md §"Test with `Pilot` and snapshots").
+- **Risk**: Adding `pytest-textual-snapshot` requires a gated dependency change.
+  - **Mitigation**: If approval is not granted before M0 ships, downgrade snapshot acceptance to Pilot-only assertions (see `spec.md` "Open questions") and file a follow-up issue tagged for M5 visual-test landing.
+- **Risk**: A semantic token chosen for one purpose in `worldforge-dark` is illegible in `worldforge-light` (e.g. a near-white `$boost`).
+  - **Mitigation**: Each theme defines its own value for every token; no token is "shared" across themes. PR review checks visual snapshots in both themes before merge.
+
+## Dependencies on other milestones
+- **Required before this can ship**: none. M0 is the foundation.
+- **Blocks**: M1 (the screen architecture split inherits the registered themes — every new `Screen` reads the same tokens), M2 (`WorldsScreen` and `WorldEditScreen` rely on `$accent` / `$panel` for focus rings), M3 (`ProvidersScreen` capability-matrix cells use `$success` / `$warning` / `$muted` for `●` / `○` / blank), M4 (Eval and Benchmark verdict colors), M5 (the high-contrast theme variant slots into the same registered-theme machinery).

--- a/specs/theworldharness-M0-theme-chrome/spec.md
+++ b/specs/theworldharness-M0-theme-chrome/spec.md
@@ -1,0 +1,65 @@
+# Milestone M0 — Theme + chrome reset
+
+## Status
+Draft · 2026-04-21
+
+## Outcome (one sentence)
+A user opening `worldforge-harness` in either a dark or a light terminal sees the same single-screen flow surface they have today, but rendered through registered `worldforge-dark` / `worldforge-light` themes with a clock, breadcrumb, and provider-status pill in the header — so the harness reads as a polished workspace instead of a hard-coded dark demo.
+
+## Why this milestone
+The current TUI in `src/worldforge/harness/tui.py` hard-codes hex literals — `#101512`, `#171f1a`, `#9ea89f` in the `CSS` block (see `tui.py:154-215`), and `#d8c46a`, `#8ec5a3`, `#d3d6cf`, `#3b423e`, `#6f7770` inside Rich `Text(style=...)` and `Panel(border_style=...)` calls scattered through `HeroPane`, `FlowCard`, `TimelinePane`, `InspectorPane`, and `TranscriptPane` (see `tui.py:30, 40-44, 53-91, 116-128, 137-139`). This bakes a dark-terminal assumption into the front face of the project; on a light terminal, foreground tokens collide with the user's background and the harness instantly stops looking like a credible workspace. Roadmap §1 names the harness as "the front door of WorldForge" and demands a 30-second first-impression that reads as polished — and SKILL.md "Why this skill exists" §3 ("Theme drift") calls this exact failure mode out: hard-coded hex breaks light terminals and ships an unwanted opinion about background color.
+
+M0 is the foundation milestone. It does not add features. It retires hex literals in favor of semantic CSS variables (`$accent`, `$success`, `$warning`, `$error`, `$panel`, `$boost`, `$surface`, `$muted` — see roadmap §2.1), registers `worldforge-dark` and `worldforge-light` `Theme` objects on the `App`, and adds the chrome (header clock, breadcrumb, provider-status pill) that every subsequent milestone (M1–M5) builds on. Without M0, every later screen would either re-introduce hex drift or have to be rewritten the day a light terminal user shows up.
+
+## In scope
+- Register two Textual `Theme` objects on `TheWorldHarnessApp`: `worldforge-dark` (default) and `worldforge-light`. Both bind the eight semantic tokens listed in roadmap §2.1.
+- Replace every hex literal currently in `src/worldforge/harness/tui.py` — both in the `CSS` TCSS block and in the inline `style="..."` / `border_style="..."` arguments inside the Rich renderables — with semantic variables (`$accent`, `$success`, `$warning`, `$error`, `$panel`, `$boost`, `$surface`, `$muted`).
+- Add `Header(show_clock=True)` (the clock argument is already present at `tui.py:233`; verify it survives the rewrite).
+- Add a custom `Breadcrumb` widget that renders the current location as `worldforge › <flow>` for M0 (single-screen app; later milestones will deepen the trail). The widget lives in `tui.py` and uses semantic tokens only.
+- Add a provider status pill widget in the header right region showing `<provider> · <capability>` for the currently selected flow's provider/capability tag (e.g. `mock · predict`). Reads from a new `current_provider: reactive[str]` on the App.
+- Add a `Ctrl+T` binding (`show=False`) that switches between the two registered themes via `App.theme = "..."` so the light/dark parity can be exercised by the user and by Pilot tests without restart.
+- Snapshot tests for the harness in both themes at the existing pinned terminal size (`130, 42`, matching `tests/test_harness_tui.py:19`).
+
+## Out of scope (explicit)
+- New screens. The harness stays a single-screen App for M0; the `HomeScreen` / `WorldsScreen` / `RunInspectorScreen` split is M1's job (roadmap §8 "M1 — Screen architecture").
+- Command palette / `Ctrl+P` system commands — those land in M1 (roadmap §8).
+- The high-contrast theme (`worldforge-high-contrast`). Roadmap §2.1 explicitly defers it until "the layout stabilises" (i.e. after M1+); M5 picks it up (roadmap §8 "M5 — Polish + showcase").
+- The dynamic command provider for worlds / providers / runs — M5.
+- Replacing the slideshow `asyncio.sleep` step animation with real worker-driven streaming — M3 ("M3 — Live providers"). M0 keeps the existing flow loop intact; only the colors and chrome change.
+- Any change to `src/worldforge/harness/flows.py`, `cli.py`, or `models.py`. The Textual import boundary stays strict (SKILL.md §"Module boundary").
+- New runtime dependencies. Textual is already in the `harness` extra (`pyproject.toml:55-57`); `pytest-textual-snapshot` for the snapshot tests is the only addition discussed, and is gated to the dev/harness test environment — see `plan.md` "Dependencies on other milestones" and the open questions below.
+
+## User stories
+1. As a researcher opening `worldforge-harness` for the first time on a light-themed terminal, I see a harness whose foreground text, borders, and status pills are legible against my background, so I can read what the project does within 30 seconds without recoloring my terminal.
+2. As a researcher who already runs everything in a dark terminal, I see the same harness I had before — same flows, same keystrokes, same layout — but with a header clock, a `worldforge › <flow>` breadcrumb, and a `<provider> · <capability>` status pill in the header right, so I always know which flow is "armed" without scanning the cards.
+3. As a contributor extending the harness in M1+, I can add a new screen and write its TCSS using semantic tokens (`$accent`, `$panel`, …) without re-deriving a color palette, so theme drift cannot re-enter through new code.
+4. As a maintainer reviewing a harness PR, I can `grep -E '#[0-9a-fA-F]{3,8}' src/worldforge/harness/tui.py` and get zero hits, so the "no hex literals" rule (SKILL.md §"Don't") is mechanically enforceable.
+5. As a user toggling between dark and light terminals during a demo, I press `Ctrl+T` and the harness switches `worldforge-dark` ↔ `worldforge-light` in place, so I can show both without restarting.
+
+## Acceptance criteria
+- [ ] `grep -E '#[0-9a-fA-F]{3,8}' src/worldforge/harness/tui.py` returns no matches (no hex literal remains anywhere — TCSS block, Rich `style=`, Rich `border_style=`).
+- [ ] `TheWorldHarnessApp` registers exactly two themes named `worldforge-dark` and `worldforge-light` via `App.register_theme(...)`, and `App.theme` defaults to `worldforge-dark`.
+- [ ] Both themes define values for every semantic token listed in roadmap §2.1: `$accent`, `$success`, `$warning`, `$error`, `$panel`, `$boost`, `$surface`, `$muted`.
+- [ ] The header renders `Header(show_clock=True)` and contains, in addition to the title/subtitle, a visible `Breadcrumb` reading `worldforge › <flow short_title>` and a status pill reading `<provider> · <capability>` derived from the selected flow.
+- [ ] A `Ctrl+T` binding cycles `App.theme` between `worldforge-dark` and `worldforge-light`; it is declared `show=False` so it does not crowd the footer (roadmap §2.2).
+- [ ] All existing footer bindings (`r`, `1`, `2`, `3`, `q`) remain visible in the footer with their existing labels.
+- [ ] All existing Pilot tests in `tests/test_harness_tui.py` still pass without modification (the run-flow → assert reactive contract is preserved end-to-end).
+- [ ] New Pilot test exercises the `Ctrl+T` theme switch and asserts `app.theme` changes.
+- [ ] New snapshot tests cover the home view in both themes at `terminal_size=(130, 42)` (the size already pinned in `tests/test_harness_tui.py:19`).
+- [ ] Coverage gate `uv run --extra harness pytest --cov=src/worldforge --cov-report=term-missing --cov-fail-under=90` still passes.
+- [ ] `uv run ruff check src tests examples scripts` and `uv run ruff format --check src tests examples scripts` are clean.
+
+## Non-functional requirements
+- **Light/dark parity.** Every widget that is legible in `worldforge-dark` must be legible in `worldforge-light`. No widget may rely on a token whose computed value is undefined in one of the two themes.
+- **Footer never lies.** Bindings shown in the footer must match the bindings that actually fire. Internal-only bindings (theme cycle) stay `show=False` (SKILL.md §"Bindings on the screen, with `show=True` for the footer").
+- **Breadcrumb is load-bearing.** It must update when the selected flow changes; it must never render stale state.
+- **Status pill never lies.** When the selected flow uses the `mock` provider, the pill says `mock · <capability>` — not the previous flow's provider. It updates on flow change before the next user interaction.
+- **No event-loop blocking.** The theme switch and breadcrumb update happen on the main thread (no worker needed for M0); they must not introduce sync I/O or `time.sleep` (SKILL.md §"Don't").
+- **Module boundary preserved.** Textual remains imported only from `src/worldforge/harness/tui.py`. The `Breadcrumb` widget lives in `tui.py`.
+- **Snapshot determinism.** Snapshots pin `terminal_size=(130, 42)` and call `await pilot.pause()` before assertion (SKILL.md §"Snapshot tests flake" troubleshooting row).
+
+## Open questions
+- **Does `pytest-textual-snapshot` need to be added to the `dev` group, or can it stay an opt-in dev-only install?** The snapshot test approach in roadmap §7 and SKILL.md §"Test with `Pilot` and snapshots" assumes it is available. Adding it touches `pyproject.toml`, which is gated (CLAUDE.md `<gated>`). If approval is not granted, M0's snapshot acceptance criterion downgrades to Pilot-only assertions on `app.theme` and on the presence of the breadcrumb / status-pill widgets, with a follow-up to land snapshots once the dependency is approved.
+- **Where does the provider-status pill source its `provider · capability` string from for flows whose `HarnessFlow` does not yet carry an explicit capability tag?** For M0 we read `flow.provider` (already exists, see `tui.py:59`) and derive a capability label per flow id (`leworldmodel → score`, `lerobot → policy`, `diagnostics → diagnostics`). If `HarnessFlow` should grow a `capability: str` field, that is a public-models change and belongs to its own milestone — defer.
+- **Does the `Breadcrumb` widget belong in `tui.py` or in a new `src/worldforge/harness/widgets.py`?** The Textual import boundary forces `tui.py` for M0; a `widgets.py` would either need to be Textual-importing (which breaks the boundary) or stay empty until M1+. Default: keep it in `tui.py` and revisit during M1's screen split.
+- **Should `worldforge-light` be auto-selected when the terminal reports a light background (Textual exposes this via `App.dark`)?** Roadmap §2.1 only mandates that both themes ship; auto-detect is a UX nicety. Default for M0: ship both, default to `worldforge-dark`, expose `Ctrl+T`. Auto-detect is a candidate for M5.

--- a/specs/theworldharness-M0-theme-chrome/tasks.md
+++ b/specs/theworldharness-M0-theme-chrome/tasks.md
@@ -1,0 +1,53 @@
+# Milestone M0 — Theme + chrome reset · Tasks
+
+Each task is a single PR-sized unit. Order matters: a later task may assume an earlier one has landed in main.
+
+## T1 — Register `worldforge-dark` and `worldforge-light` themes
+- Files: `src/worldforge/harness/tui.py`
+- Change: Define two `Theme` objects (or `Theme`-equivalent dataclass per Textual 8.x API) covering all eight semantic tokens from roadmap §2.1 (`$accent`, `$success`, `$warning`, `$error`, `$panel`, `$boost`, `$surface`, `$muted`) plus the implicit `background` / `foreground` fields the renderer needs. Register both in `on_mount` via `self.register_theme(...)`. Set `self.theme = "worldforge-dark"` immediately after registration so the default is unchanged from the user's perspective.
+- Acceptance: maps to spec.md AC "registers exactly two themes named `worldforge-dark` and `worldforge-light`" and "defaults to `worldforge-dark`".
+- Tests: extend `tests/test_harness_tui.py` with `test_themes_registered` — mount, assert both names appear in `app.available_themes` (or whatever the public Textual API exposes for registered themes), assert `app.theme == "worldforge-dark"`.
+
+## T2 — Strip every hex literal from TCSS and Rich style strings
+- Files: `src/worldforge/harness/tui.py`
+- Change: Rewrite the class-level `CSS` block (currently `tui.py:154-215`) to use only `$panel` / `$surface` / `$muted` / `$boost` / `$accent`. Replace every `style="#..."` / `border_style="#..."` inside `HeroPane`, `FlowCard`, `TimelinePane`, `InspectorPane`, `TranscriptPane` with semantic-token references (e.g. via `self.app.get_css_variables()` resolved at render time, or by switching to `Static` with TCSS class names). Keep widget structure and behavior identical; only colors change.
+- Acceptance: maps to spec.md AC `grep -E '#[0-9a-fA-F]{3,8}' src/worldforge/harness/tui.py returns no matches`.
+- Tests: existing `test_the_world_harness_app_runs_leworldmodel_flow` / `..._lerobot_flow` / `..._diagnostics_flow` continue to pass unmodified; add a tiny CI-friendly assertion in a unit test that scans the file's text for the `#` color pattern as a safety net.
+
+## T3 — Add `Ctrl+T` theme cycle binding
+- Files: `src/worldforge/harness/tui.py`, `tests/test_harness_tui.py`
+- Change: Add `("ctrl+t", "toggle_theme", "Theme", show=False)` to `BINDINGS`. Implement `action_toggle_theme(self)` that flips between `worldforge-dark` and `worldforge-light` by setting `self.theme`.
+- Acceptance: maps to spec.md AC "`Ctrl+T` binding cycles `App.theme` between `worldforge-dark` and `worldforge-light`; declared `show=False`".
+- Tests: new `test_theme_toggle_cycles_between_registered_themes` — mount, assert dark, press `ctrl+t`, assert light, press `ctrl+t`, assert dark.
+
+## T4 — Add `Breadcrumb` widget and mount it in the header region
+- Files: `src/worldforge/harness/tui.py`, `tests/test_harness_tui.py`
+- Change: Define `class Breadcrumb(Static)` with `path: reactive[tuple[str, ...]] = reactive((), layout=True)` and a `watch_path` that re-renders the joined `worldforge › <segment> › ...` string using `$muted` for the separator and `$surface` for the segments. Promote `selected_flow_id` to a reactive on the App; wire `watch_selected_flow_id` to update the breadcrumb's `path` to `("worldforge", flow.short_title)`. Mount the widget inside (or immediately under) `Header(...)` in `compose()`.
+- Acceptance: maps to spec.md AC "header contains a visible `Breadcrumb` reading `worldforge › <flow short_title>`".
+- Tests: new `test_breadcrumb_reflects_selected_flow` — mount, query `Breadcrumb`, assert path tuple matches initial flow; press `2`, assert path updates.
+
+## T5 — Add `ProviderStatusPill` widget driven by `current_provider` reactive
+- Files: `src/worldforge/harness/tui.py`, `tests/test_harness_tui.py`
+- Change: Define `class ProviderStatusPill(Static)` rendering `<provider> · <capability>` styled with `$boost` background and `$surface` foreground. Add `current_provider: reactive[str] = reactive("mock · predict")` on the App with a `watch_current_provider` that re-renders the pill. Add a tiny private `_capability_for_flow(flow_id) -> str` helper returning `"score"` / `"policy"` / `"diagnostics"` for the three current flow ids; document it as M0-temporary (will be replaced when `HarnessFlow` grows a typed capability field — see spec.md "Open questions"). Update `current_provider` in `watch_selected_flow_id` (T4) so flow change updates both breadcrumb and pill.
+- Acceptance: maps to spec.md AC "status pill reading `<provider> · <capability>` derived from the selected flow" and NFR "Status pill never lies".
+- Tests: new `test_status_pill_reflects_selected_flow_provider` — mount, query `ProviderStatusPill`, assert initial `mock · score`; press `2` (lerobot), assert update.
+
+## T6 — Snapshot tests for both themes (gated)
+- Files: `tests/test_harness_tui_snapshots.py` (new), possibly `pyproject.toml` (gated dependency add)
+- Change: If `pytest-textual-snapshot` is approved as a dev-group dependency, add it to the dev group and create a new test module that calls `snap_compare(app, terminal_size=(130, 42))` once with `app.theme = "worldforge-dark"` and once with `"worldforge-light"`. Each test calls `await pilot.pause()` before snapshotting (SKILL.md troubleshooting). Commit the resulting SVGs.
+- Acceptance: maps to spec.md AC "new snapshot tests cover the home view in both themes at `terminal_size=(130, 42)`".
+- Tests: the snapshot tests *are* the deliverable. If the dependency add is rejected, this task downgrades to a no-op and the AC drops to Pilot-only theme assertions (already covered by T3).
+
+## T7 — Verify gates and update agent context
+- Files: any docs / CHANGELOG entries that public-behavior changes warrant; `.codex/skills/tui-development/references/roadmap.md` §8 marker.
+- Change: Run the local gate sequence from `CLAUDE.md` `<commands>` "Full local gate" — lint, format check, provider docs check, tests, coverage gate (`--extra harness`), package contract. After all merge, update roadmap §8 "M0 — Theme + chrome reset (foundation)" with `done · <date>`. Add a CHANGELOG entry describing the chrome reset under "Unreleased / Harness".
+- Acceptance: maps to spec.md AC "Coverage gate ... still passes" and "ruff check / format check are clean", and the Definition of Done below.
+- Tests: gate scripts themselves (no new test code in this task).
+
+## Definition of done
+- [ ] All tasks merged
+- [ ] Pilot + snapshot tests in CI (snapshot tests landed iff T6's dependency add was approved; otherwise filed as a follow-up for M5)
+- [ ] Roadmap §8 marked "done · {date}"
+- [ ] `grep -E '#[0-9a-fA-F]{3,8}' src/worldforge/harness/tui.py` returns no matches
+- [ ] `uv run --extra harness pytest --cov=src/worldforge --cov-report=term-missing --cov-fail-under=90` passes
+- [ ] CHANGELOG updated under the "Unreleased" / Harness section


### PR DESCRIPTION
This PR lands the spec / plan / tasks documents for **TheWorldHarness M0 — Theme + chrome reset (foundation)**, the first milestone in the TUI roadmap. M0 retires the hard-coded hex literals in `src/worldforge/harness/tui.py`, registers `worldforge-dark` and `worldforge-light` `Theme` objects on the App, and adds the chrome (header clock, `Breadcrumb` widget, provider status pill) that every later milestone (M1–M5) builds on. No code changes here — only the documentation that scopes the work.

Roadmap anchor: [`.codex/skills/tui-development/references/roadmap.md` §8 "M0 — Theme + chrome reset (foundation)"](../blob/main/.codex/skills/tui-development/references/roadmap.md#8-milestones).

## Files
- `specs/theworldharness-M0-theme-chrome/spec.md` — outcome, in/out of scope, user stories, acceptance criteria, NFRs, open questions.
- `specs/theworldharness-M0-theme-chrome/plan.md` — architecture changes, module touch list, key decisions, data flow, theming, testing, risks, dependencies on other milestones.
- `specs/theworldharness-M0-theme-chrome/tasks.md` — seven PR-sized tasks (T1 register themes → T7 verify gates) with mapped acceptance criteria.

## Test plan
- [ ] Reviewers confirm the eight semantic tokens listed in roadmap §2.1 are covered (`$accent`, `$success`, `$warning`, `$error`, `$panel`, `$boost`, `$surface`, `$muted`).
- [ ] Reviewers confirm the open questions (snapshot dependency add, capability-pill source, widget module location, light-terminal auto-detect) are resolved or explicitly deferred before T1 starts.
- [ ] `uv run pytest` was run on this branch and passes (269 passed, 3 skipped) — pure-docs change, no behavior touched.