### PR TITLE
feat(harness): M0 theme and chrome reset (TheWorldHarness)

### DIFF
--- a/.codex/skills/tui-development/references/roadmap.md
+++ b/.codex/skills/tui-development/references/roadmap.md
@@ -268,7 +268,7 @@ the milestone "done" with the date.
 
 | Milestone | Spec | Plan | Tasks | Implementation status |
 | --- | --- | --- | --- | --- |
-| M0 — Theme + chrome reset | [spec](../../../../specs/theworldharness-M0-theme-chrome/spec.md) | [plan](../../../../specs/theworldharness-M0-theme-chrome/plan.md) | [tasks](../../../../specs/theworldharness-M0-theme-chrome/tasks.md) | not started |
+| M0 — Theme + chrome reset | [spec](../../../../specs/theworldharness-M0-theme-chrome/spec.md) | [plan](../../../../specs/theworldharness-M0-theme-chrome/plan.md) | [tasks](../../../../specs/theworldharness-M0-theme-chrome/tasks.md) | done · 2026-04-21 |
 | M1 — Screen architecture | [spec](../../../../specs/theworldharness-M1-screen-architecture/spec.md) | [plan](../../../../specs/theworldharness-M1-screen-architecture/plan.md) | [tasks](../../../../specs/theworldharness-M1-screen-architecture/tasks.md) | not started |
 | M2 — Worlds CRUD | [spec](../../../../specs/theworldharness-M2-worlds-crud/spec.md) | [plan](../../../../specs/theworldharness-M2-worlds-crud/plan.md) | [tasks](../../../../specs/theworldharness-M2-worlds-crud/tasks.md) | not started |
 | M3 — Live providers | [spec](../../../../specs/theworldharness-M3-live-providers/spec.md) | [plan](../../../../specs/theworldharness-M3-live-providers/plan.md) | [tasks](../../../../specs/theworldharness-M3-live-providers/tasks.md) | not started |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ releases may still include breaking changes when the public API needs to tighten
 
 ## Unreleased
 
+### Harness
+
+- Reskinned TheWorldHarness with registered `worldforge-dark` and `worldforge-light` themes,
+  retiring the hard-coded hex literals in `src/worldforge/harness/tui.py` in favour of semantic
+  tokens (`$accent`, `$success`, `$warning`, `$error`, `$panel`, `$boost`, `$surface`, plus the
+  custom `$muted` variable) so the harness reads as a polished workspace on light terminals.
+- Added a header chrome strip with a `worldforge > <flow>` breadcrumb and a
+  `<provider> . <capability>` status pill that update reactively when the selected flow changes.
+- Added a hidden `Ctrl+T` binding that cycles between the two registered themes without
+  restarting the harness.
+
 ### Added
 
 - Added the `worldforge world` CLI command group for local JSON persistence workflows, including

--- a/src/worldforge/harness/theme.py
+++ b/src/worldforge/harness/theme.py
@@ -1,0 +1,61 @@
+"""Color palette for TheWorldHarness themes.
+
+This module defines the raw color tokens used by ``worldforge-dark`` and
+``worldforge-light``. It is deliberately Textual-free so the harness extra
+boundary stays intact (only ``tui.py`` is allowed to import Textual). The
+``tui`` module reads these mappings to construct ``textual.theme.Theme``
+instances at runtime.
+
+Keys mirror the semantic tokens documented in roadmap section 2.1 plus the
+``foreground`` / ``background`` fields the renderer requires to derive shades.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+# Palette values were lifted from the original tui.py hex literals (greenish
+# black / cream amber / sage green family) and balanced for both dark and
+# light terminals. Each theme defines every token used at runtime; nothing is
+# shared across themes by design.
+WORLDFORGE_DARK_PALETTE: Final[dict[str, str]] = {
+    "primary": "#8ec5a3",
+    "secondary": "#6f9c84",
+    "accent": "#d8c46a",
+    "warning": "#d8c46a",
+    "error": "#c8616b",
+    "success": "#8ec5a3",
+    "foreground": "#d3d6cf",
+    "background": "#101512",
+    "surface": "#171f1a",
+    "panel": "#3b423e",
+    "boost": "#1f2823",
+    "muted": "#6f7770",
+}
+
+WORLDFORGE_LIGHT_PALETTE: Final[dict[str, str]] = {
+    "primary": "#3a7a5a",
+    "secondary": "#2e5d46",
+    "accent": "#a8782a",
+    "warning": "#a8782a",
+    "error": "#9c2a36",
+    "success": "#3a7a5a",
+    "foreground": "#1f2624",
+    "background": "#f4f1e6",
+    "surface": "#ffffff",
+    "panel": "#dcd8c8",
+    "boost": "#e8e3d2",
+    "muted": "#5b635c",
+}
+
+THEME_NAME_DARK: Final[str] = "worldforge-dark"
+THEME_NAME_LIGHT: Final[str] = "worldforge-light"
+
+# Per-flow capability label fallbacks. Source of truth lives on
+# ``HarnessFlow.capability``; this map is only used as a defensive default if
+# a future flow forgets to declare one.
+FLOW_CAPABILITY_FALLBACKS: Final[dict[str, str]] = {
+    "leworldmodel": "score",
+    "lerobot": "policy",
+    "diagnostics": "diagnostics",
+}

--- a/src/worldforge/harness/tui.py
+++ b/src/worldforge/harness/tui.py
@@ -12,14 +12,121 @@ from rich.table import Table
 from rich.text import Text
 from textual import on
 from textual.app import App, ComposeResult
+from textual.binding import Binding
 from textual.containers import Container, Horizontal, Vertical
+from textual.css.query import NoMatches
+from textual.reactive import reactive
+from textual.theme import Theme
 from textual.widgets import Button, Footer, Header, Select, Static
 
 from worldforge.harness.flows import available_flows, run_flow
 from worldforge.harness.models import HarnessFlow, HarnessRun, HarnessStep
+from worldforge.harness.theme import (
+    FLOW_CAPABILITY_FALLBACKS,
+    THEME_NAME_DARK,
+    THEME_NAME_LIGHT,
+    WORLDFORGE_DARK_PALETTE,
+    WORLDFORGE_LIGHT_PALETTE,
+)
 
 
-class HeroPane(Static):
+def _build_theme(name: str, palette: dict[str, str], *, dark: bool) -> Theme:
+    """Construct a Textual ``Theme`` from a palette mapping.
+
+    Keeping this builder local lets ``tui.py`` stay free of literal hex strings;
+    every color token lives in ``harness/theme.py`` instead.
+    """
+    return Theme(
+        name=name,
+        primary=palette["primary"],
+        secondary=palette["secondary"],
+        accent=palette["accent"],
+        warning=palette["warning"],
+        error=palette["error"],
+        success=palette["success"],
+        foreground=palette["foreground"],
+        background=palette["background"],
+        surface=palette["surface"],
+        panel=palette["panel"],
+        boost=palette["boost"],
+        dark=dark,
+        variables={"muted": palette["muted"]},
+    )
+
+
+class _ThemedRenderer:
+    """Mixin that resolves semantic-token names against the active theme.
+
+    Rich renderables (``Panel``, ``Text``) accept inline ``style="..."`` and
+    ``border_style="..."`` strings. We resolve a token name (``"accent"``,
+    ``"success"``, ``"muted"``, ``"panel"``, ``"surface"``) into the concrete
+    color the active Textual theme declares, so the rendered output always
+    matches whichever theme the user toggled to.
+    """
+
+    app: App[None]
+
+    def _color(self, token: str) -> str:
+        variables = self.app.get_css_variables()
+        return variables.get(token, variables.get("foreground", ""))
+
+
+class Breadcrumb(Static):
+    """Header breadcrumb showing ``worldforge › <flow short_title>``.
+
+    Path segments live in a reactive tuple; later milestones can deepen the
+    trail (worlds, runs) without changing the rendering surface.
+    """
+
+    DEFAULT_CSS = """
+    Breadcrumb {
+        height: 1;
+        padding: 0 2;
+        background: $boost;
+        color: $foreground;
+    }
+    """
+
+    path: reactive[tuple[str, ...]] = reactive((), layout=True)
+
+    def watch_path(self, _old: tuple[str, ...], new: tuple[str, ...]) -> None:
+        if not new:
+            self.update("")
+            return
+        separator = Text(" › ", style="dim")
+        rendered = Text()
+        for index, segment in enumerate(new):
+            if index:
+                rendered.append_text(separator)
+            style = "bold" if index == len(new) - 1 else "dim"
+            rendered.append(segment, style=style)
+        self.update(rendered)
+
+
+class ProviderStatusPill(Static):
+    """Header right-side pill showing ``<provider> . <capability>``.
+
+    The label is sourced from the App-level ``current_provider`` reactive so a
+    flow change updates the pill before the next user interaction.
+    """
+
+    DEFAULT_CSS = """
+    ProviderStatusPill {
+        height: 1;
+        padding: 0 2;
+        background: $boost;
+        color: $foreground;
+        text-style: bold;
+    }
+    """
+
+    label: reactive[str] = reactive("")
+
+    def watch_label(self, _old: str, new: str) -> None:
+        self.update(new)
+
+
+class HeroPane(Static, _ThemedRenderer):
     """Top-level harness identity panel."""
 
     def compose_panel(self, flow: HarnessFlow | None, running: bool) -> RenderableType:
@@ -27,7 +134,10 @@ class HeroPane(Static):
         title.append("  /  visual WorldForge integration reference", style="dim")
         command = flow.command if flow else "select a flow"
         status = "RUNNING" if running else "READY"
-        status_style = "black on #d8c46a" if running else "black on #8ec5a3"
+        accent = self._color("accent")
+        success = self._color("success")
+        status_style = f"black on {accent}" if running else f"black on {success}"
+        border = accent if running else success
         return Panel(
             Group(
                 title,
@@ -37,33 +147,37 @@ class HeroPane(Static):
                     style="dim",
                 ),
                 Text(""),
-                Text(f"Command: {command}", style="bold #d8c46a"),
+                Text(f"Command: {command}", style=f"bold {accent}"),
                 Text(f"Status: {status}", style=status_style),
             ),
             title="WORLD FORGE / HARNESS",
-            border_style="#d8c46a" if running else "#8ec5a3",
+            border_style=border,
         )
 
 
-class FlowCard(Static):
+class FlowCard(Static, _ThemedRenderer):
     """Flow selection card."""
 
     def render_flow(self, flow: HarnessFlow, selected: bool) -> None:
         marker = ">>" if selected else "  "
-        style = "bold #d8c46a" if selected else "#d3d6cf"
+        accent = self._color("accent")
+        body = self._color("foreground")
+        success = self._color("success")
+        panel = self._color("panel")
+        style = f"bold {accent}" if selected else body
         self.update(
             Panel(
                 Group(
                     Text(f"{marker} {flow.short_title}", style=style),
                     Text(flow.focus, style="dim"),
-                    Text(flow.provider, style="#8ec5a3"),
+                    Text(flow.provider, style=success),
                 ),
-                border_style=flow.accent if selected else "#3b423e",
+                border_style=accent if selected else panel,
             )
         )
 
 
-class TimelinePane(Static):
+class TimelinePane(Static, _ThemedRenderer):
     """Visual execution timeline."""
 
     def render_steps(
@@ -74,33 +188,37 @@ class TimelinePane(Static):
         complete_count: int,
     ) -> None:
         rows: list[RenderableType] = []
+        accent = self._color("accent")
+        success = self._color("success")
+        muted = self._color("muted")
+        body = self._color("foreground")
         for index, step in enumerate(steps):
             if index < complete_count:
                 symbol = "OK"
-                style = "#8ec5a3"
+                color = success
             elif index == active_index:
                 symbol = ">>"
-                style = "#d8c46a"
+                color = accent
             else:
                 symbol = "--"
-                style = "#6f7770"
-            rows.append(Text(f"{symbol} {index + 1:02d}. {step.title}", style=f"bold {style}"))
+                color = muted
+            rows.append(Text(f"{symbol} {index + 1:02d}. {step.title}", style=f"bold {color}"))
             rows.append(Text(f"    {step.detail}", style="dim"))
             if index < complete_count:
-                rows.append(Text(f"    {step.result}", style="#d3d6cf"))
+                rows.append(Text(f"    {step.result}", style=body))
                 if step.artifact:
-                    rows.append(Text(f"    {step.artifact}", style="#8ec5a3"))
+                    rows.append(Text(f"    {step.artifact}", style=success))
             rows.append(Text(""))
         self.update(
             Panel(
                 Group(*rows),
                 title=f"{flow.title} / execution trace",
-                border_style=flow.accent,
+                border_style=accent,
             )
         )
 
 
-class InspectorPane(Static):
+class InspectorPane(Static, _ThemedRenderer):
     """Run metrics and state summary."""
 
     def render_empty(self) -> None:
@@ -113,30 +231,36 @@ class InspectorPane(Static):
                     vertical="middle",
                 ),
                 title="Inspector",
-                border_style="#3b423e",
+                border_style=self._color("panel"),
             )
         )
 
     def render_run(self, run: HarnessRun) -> None:
+        accent = self._color("accent")
+        success = self._color("success")
         table = Table.grid(expand=True)
         table.add_column(justify="left", ratio=1)
         table.add_column(justify="right", ratio=1)
         for metric in run.metrics:
-            table.add_row(Text(metric.label, style="dim"), Text(metric.value, style="bold #d8c46a"))
+            table.add_row(
+                Text(metric.label, style="dim"), Text(metric.value, style=f"bold {accent}")
+            )
             if metric.detail:
-                table.add_row("", Text(metric.detail, style="#8ec5a3"))
-        self.update(Panel(table, title="Inspector", border_style=run.flow.accent))
+                table.add_row("", Text(metric.detail, style=success))
+        self.update(Panel(table, title="Inspector", border_style=accent))
 
 
-class TranscriptPane(Static):
+class TranscriptPane(Static, _ThemedRenderer):
     """Structured transcript from the completed flow."""
 
     def render_empty(self) -> None:
         self.update(Panel(Text("Awaiting run output.", style="dim"), title="Run Transcript"))
 
     def render_run(self, run: HarnessRun) -> None:
-        lines = [Text(line, style="#d3d6cf") for line in run.transcript]
-        self.update(Panel(Group(*lines), title="Run Transcript", border_style=run.flow.accent))
+        body = self._color("foreground")
+        accent = self._color("accent")
+        lines = [Text(line, style=body) for line in run.transcript]
+        self.update(Panel(Group(*lines), title="Run Transcript", border_style=accent))
 
 
 class TheWorldHarnessApp(App[None]):
@@ -150,21 +274,35 @@ class TheWorldHarnessApp(App[None]):
         ("2", "select_flow('lerobot')", "LeRobot"),
         ("3", "select_flow('diagnostics')", "Diagnostics"),
         ("q", "quit", "Quit"),
+        Binding("ctrl+t", "toggle_theme", "Theme", show=False),
     ]
     CSS = """
     Screen {
-        background: #101512;
-        color: #d3d6cf;
+        background: $background;
+        color: $foreground;
     }
 
     Header {
-        background: #171f1a;
-        color: #e4dfc5;
+        background: $surface;
+        color: $foreground;
     }
 
     Footer {
-        background: #171f1a;
-        color: #9ea89f;
+        background: $surface;
+        color: $foreground;
+    }
+
+    #chrome {
+        height: 1;
+        background: $boost;
+    }
+
+    #breadcrumb {
+        width: 1fr;
+    }
+
+    #provider-pill {
+        width: auto;
     }
 
     #root {
@@ -214,6 +352,9 @@ class TheWorldHarnessApp(App[None]):
     }
     """
 
+    selected_flow_id: reactive[str] = reactive("leworldmodel", init=False)
+    current_provider: reactive[str] = reactive("", init=False)
+
     def __init__(
         self,
         *,
@@ -223,7 +364,12 @@ class TheWorldHarnessApp(App[None]):
     ) -> None:
         super().__init__()
         self.flows = {flow.id: flow for flow in available_flows()}
-        self.selected_flow_id = initial_flow_id if initial_flow_id in self.flows else "leworldmodel"
+        resolved_id = initial_flow_id if initial_flow_id in self.flows else "leworldmodel"
+        self.set_reactive(TheWorldHarnessApp.selected_flow_id, resolved_id)
+        self.set_reactive(
+            TheWorldHarnessApp.current_provider,
+            self._provider_label(self.flows[resolved_id]),
+        )
         self.state_dir = state_dir
         self.step_delay = step_delay
         self.running = False
@@ -231,6 +377,9 @@ class TheWorldHarnessApp(App[None]):
 
     def compose(self) -> ComposeResult:
         yield Header(show_clock=True)
+        with Horizontal(id="chrome"):
+            yield Breadcrumb(id="breadcrumb")
+            yield ProviderStatusPill(id="provider-pill")
         with Container(id="root"):
             yield HeroPane(id="hero")
             with Horizontal(id="body"):
@@ -251,13 +400,16 @@ class TheWorldHarnessApp(App[None]):
         yield Footer()
 
     def on_mount(self) -> None:
+        self.register_theme(_build_theme(THEME_NAME_DARK, WORLDFORGE_DARK_PALETTE, dark=True))
+        self.register_theme(_build_theme(THEME_NAME_LIGHT, WORLDFORGE_LIGHT_PALETTE, dark=False))
+        self.theme = THEME_NAME_DARK
+        self._sync_chrome()
         self._refresh_static()
 
     @on(Select.Changed, "#flow-select")
     def _on_flow_changed(self, event: Select.Changed) -> None:
         if isinstance(event.value, str):
             self.selected_flow_id = event.value
-            self._refresh_static()
 
     @on(Button.Pressed, "#run-button")
     async def _on_run_pressed(self) -> None:
@@ -266,8 +418,37 @@ class TheWorldHarnessApp(App[None]):
     def action_select_flow(self, flow_id: str) -> None:
         if flow_id in self.flows:
             self.selected_flow_id = flow_id
-            self.query_one("#flow-select", Select).value = flow_id
-            self._refresh_static()
+            select = self.query_one("#flow-select", Select)
+            if select.value != flow_id:
+                select.value = flow_id
+
+    def action_toggle_theme(self) -> None:
+        """Cycle between the two registered worldforge themes."""
+        self.theme = THEME_NAME_LIGHT if self.theme == THEME_NAME_DARK else THEME_NAME_DARK
+
+    def watch_selected_flow_id(self, _old: str, new: str) -> None:
+        if new not in self.flows:
+            return
+        self.current_provider = self._provider_label(self.flows[new])
+        self._sync_chrome()
+        self._refresh_static()
+
+    def watch_current_provider(self, _old: str, new: str) -> None:
+        pill = self._maybe_query("#provider-pill", ProviderStatusPill)
+        if pill is not None:
+            pill.label = new
+
+    def _maybe_query(self, selector: str, expected_type):
+        """Return a widget if it has been composed, else ``None``.
+
+        Reactives can fire before all widgets in ``compose()`` are mounted
+        (e.g. when the App is being torn down between Pilot tests). We treat
+        a missing target as a no-op rather than crashing.
+        """
+        try:
+            return self.query_one(selector, expected_type)
+        except NoMatches:
+            return None
 
     async def action_run_selected(self) -> None:
         if self.running:
@@ -292,11 +473,29 @@ class TheWorldHarnessApp(App[None]):
         self.query_one("#run-button", Button).disabled = False
         self._refresh_static()
 
+    def _sync_chrome(self) -> None:
+        flow = self.flows[self.selected_flow_id]
+        breadcrumb = self._maybe_query("#breadcrumb", Breadcrumb)
+        if breadcrumb is not None:
+            breadcrumb.path = ("worldforge", flow.short_title)
+        # Pill mirrors current_provider via watch_current_provider; setting it
+        # here as well keeps on_mount idempotent in case the watcher fires
+        # before the widget exists.
+        pill = self._maybe_query("#provider-pill", ProviderStatusPill)
+        if pill is not None:
+            pill.label = self.current_provider
+
+    def _provider_label(self, flow: HarnessFlow) -> str:
+        capability = flow.capability or FLOW_CAPABILITY_FALLBACKS.get(flow.id, "")
+        suffix = f" · {capability}" if capability else ""
+        return f"{flow.provider}{suffix}"
+
     def _refresh_static(self) -> None:
         selected = self.flows[self.selected_flow_id]
-        self.query_one("#hero", HeroPane).update(
-            self.query_one("#hero", HeroPane).compose_panel(selected, self.running)
-        )
+        hero = self._maybe_query("#hero", HeroPane)
+        if hero is None:
+            return
+        hero.update(hero.compose_panel(selected, self.running))
         for flow in self.flows.values():
             self.query_one(f"#flow-card-{flow.id}", FlowCard).render_flow(
                 flow,

--- a/tests/test_harness_tui.py
+++ b/tests/test_harness_tui.py
@@ -1,8 +1,92 @@
 from __future__ import annotations
 
 import asyncio
+import re
+from pathlib import Path
 
 import pytest
+
+HARNESS_TUI_PATH = Path(__file__).resolve().parents[1] / "src" / "worldforge" / "harness" / "tui.py"
+
+
+def test_harness_tui_has_no_hex_color_literals() -> None:
+    """The semantic-token rule from spec.md is mechanically enforceable here."""
+    pattern = re.compile(r"#[0-9a-fA-F]{3,8}")
+    matches = pattern.findall(HARNESS_TUI_PATH.read_text())
+    assert matches == [], f"hex color literals leaked into tui.py: {matches}"
+
+
+def test_harness_themes_registered_with_dark_default(tmp_path) -> None:
+    pytest.importorskip("textual")
+
+    from worldforge.harness.tui import TheWorldHarnessApp
+
+    async def scenario() -> None:
+        app = TheWorldHarnessApp(initial_flow_id="leworldmodel", state_dir=tmp_path)
+        async with app.run_test(size=(130, 42)):
+            assert "worldforge-dark" in app.available_themes
+            assert "worldforge-light" in app.available_themes
+            assert app.theme == "worldforge-dark"
+
+    asyncio.run(scenario())
+
+
+def test_harness_theme_toggle_cycles_between_registered_themes(tmp_path) -> None:
+    pytest.importorskip("textual")
+
+    from worldforge.harness.tui import TheWorldHarnessApp
+
+    async def scenario() -> None:
+        app = TheWorldHarnessApp(initial_flow_id="leworldmodel", state_dir=tmp_path)
+        async with app.run_test(size=(130, 42)) as pilot:
+            assert app.theme == "worldforge-dark"
+            await pilot.press("ctrl+t")
+            await pilot.pause()
+            assert app.theme == "worldforge-light"
+            await pilot.press("ctrl+t")
+            await pilot.pause()
+            assert app.theme == "worldforge-dark"
+
+    asyncio.run(scenario())
+
+
+def test_harness_breadcrumb_reflects_selected_flow(tmp_path) -> None:
+    pytest.importorskip("textual")
+
+    from worldforge.harness.tui import Breadcrumb, TheWorldHarnessApp
+
+    async def scenario() -> None:
+        app = TheWorldHarnessApp(initial_flow_id="leworldmodel", state_dir=tmp_path)
+        async with app.run_test(size=(130, 42)) as pilot:
+            crumb = app.query_one("#breadcrumb", Breadcrumb)
+            assert crumb.path == ("worldforge", "LeWorldModel")
+            await pilot.press("2")
+            await pilot.pause()
+            assert crumb.path == ("worldforge", "LeRobot")
+
+    asyncio.run(scenario())
+
+
+def test_harness_status_pill_reflects_selected_flow_provider(tmp_path) -> None:
+    pytest.importorskip("textual")
+
+    from worldforge.harness.tui import ProviderStatusPill, TheWorldHarnessApp
+
+    async def scenario() -> None:
+        app = TheWorldHarnessApp(initial_flow_id="leworldmodel", state_dir=tmp_path)
+        async with app.run_test(size=(130, 42)) as pilot:
+            pill = app.query_one("#provider-pill", ProviderStatusPill)
+            assert "LeWorldModelProvider" in pill.label
+            assert pill.label.endswith("· score")
+            await pilot.press("2")
+            await pilot.pause()
+            assert "LeRobotPolicyProvider" in pill.label
+            assert pill.label.endswith("· policy")
+            await pilot.press("3")
+            await pilot.pause()
+            assert pill.label.endswith("· diagnostics")
+
+    asyncio.run(scenario())
 
 
 def test_the_world_harness_app_runs_leworldmodel_flow(tmp_path) -> None:


### PR DESCRIPTION
## Summary

First milestone (M0) of the TheWorldHarness roadmap: retire the hard-coded hex literals in `src/worldforge/harness/tui.py`, register `worldforge-dark` / `worldforge-light` Textual themes, and add the header chrome (breadcrumb + provider-status pill) every later milestone (M1–M5) builds on. No new flows, no new screens; only the colors, theme machinery, and chrome change.

Spec triad: [`specs/theworldharness-M0-theme-chrome/spec.md`](../blob/feat/theworldharness-m0-theme-chrome/specs/theworldharness-M0-theme-chrome/spec.md), [`plan.md`](../blob/feat/theworldharness-m0-theme-chrome/specs/theworldharness-M0-theme-chrome/plan.md), [`tasks.md`](../blob/feat/theworldharness-m0-theme-chrome/specs/theworldharness-M0-theme-chrome/tasks.md).

## Task status

- [x] **T1** — Register `worldforge-dark` (default) and `worldforge-light` themes via `App.register_theme(...)`. Palette lives in a new `src/worldforge/harness/theme.py` (no Textual import — the harness module boundary stays intact).
- [x] **T2** — Strip every hex literal from `tui.py` (TCSS block, Rich `style=`, Rich `border_style=`). Inline strings now resolve semantic tokens against `App.get_css_variables()` at render time. `grep -E '#[0-9a-fA-F]{3,8}' src/worldforge/harness/tui.py` returns nothing, and a regex test guards the rule.
- [x] **T3** — Add `Ctrl+T` (`show=False`) cycle between the two registered themes; Pilot test asserts the cycle.
- [x] **T4** — `Breadcrumb(Static)` with a `path: reactive[tuple[str, ...]]`. Promote `selected_flow_id` to a reactive so the breadcrumb path tracks the active flow.
- [x] **T5** — `ProviderStatusPill(Static)` driven by a new `current_provider: reactive[str]` on the App. Label format is `<provider> · <capability>`; capability comes from the existing `HarnessFlow.capability` field.
- [ ] **T6** — Snapshot tests via `pytest-textual-snapshot`. **Deferred** as a follow-up: adding the dependency is a `<gated>` change per the project's CLAUDE.md, and the spec explicitly downgrades T6 when the dep is not approved. The Pilot assertions from T3/T4/T5 cover the behavioural piece in the meantime; visual snapshots can land alongside the M5 polish work.
- [x] **T7** — Local gate green (lint, format, provider-docs check, full test suite, coverage `--extra harness` at 90.51%, package contract). Roadmap §8 row marked `done · 2026-04-21`. CHANGELOG updated under "Unreleased / Harness".

## Acceptance criteria

- [x] No hex literals in `src/worldforge/harness/tui.py` (regex-tested).
- [x] Exactly two themes registered, both covering all eight semantic tokens; default is `worldforge-dark`.
- [x] Header renders the clock, a `worldforge › <flow short_title>` breadcrumb, and a `<provider> · <capability>` pill.
- [x] `Ctrl+T` toggles `App.theme`; binding is `show=False`.
- [x] Existing footer bindings (`r`, `1`, `2`, `3`, `q`) keep their labels.
- [x] All previous Pilot tests pass unmodified; new Pilot tests cover theme cycle, breadcrumb, and pill.
- [ ] Snapshot tests for both themes — deferred with T6.
- [x] Coverage gate ≥ 90% with `--extra harness`.
- [x] `ruff check` and `ruff format --check` clean.

## Follow-ups

- **Snapshot test coverage for both themes.** Requires adding `pytest-textual-snapshot` to the dev dependency group (gated change). Best landed as part of M5's polish + visual regression sweep.

## Test plan

- [x] `uv lock --check`
- [x] `uv run ruff check src tests examples scripts`
- [x] `uv run ruff format --check src tests examples scripts`
- [x] `uv run python scripts/generate_provider_docs.py --check`
- [x] `uv run pytest`
- [x] `uv run --extra harness pytest --cov=src/worldforge --cov-report=term-missing --cov-fail-under=90`
- [x] `bash scripts/test_package.sh`
- [ ] Manual eyeball: launch `uv run --extra harness worldforge-harness`, press `Ctrl+T`, switch flows with `1` / `2` / `3`, run with `r`.