### PR TITLE
feat(harness): M1 screen architecture (TheWorldHarness)

### DIFF
--- a/.codex/skills/tui-development/references/roadmap.md
+++ b/.codex/skills/tui-development/references/roadmap.md
@@ -269,7 +269,7 @@ the milestone "done" with the date.
 | Milestone | Spec | Plan | Tasks | Implementation status |
 | --- | --- | --- | --- | --- |
 | M0 — Theme + chrome reset | [spec](../../../../specs/theworldharness-M0-theme-chrome/spec.md) | [plan](../../../../specs/theworldharness-M0-theme-chrome/plan.md) | [tasks](../../../../specs/theworldharness-M0-theme-chrome/tasks.md) | done · 2026-04-21 |
-| M1 — Screen architecture | [spec](../../../../specs/theworldharness-M1-screen-architecture/spec.md) | [plan](../../../../specs/theworldharness-M1-screen-architecture/plan.md) | [tasks](../../../../specs/theworldharness-M1-screen-architecture/tasks.md) | not started |
+| M1 — Screen architecture | [spec](../../../../specs/theworldharness-M1-screen-architecture/spec.md) | [plan](../../../../specs/theworldharness-M1-screen-architecture/plan.md) | [tasks](../../../../specs/theworldharness-M1-screen-architecture/tasks.md) | done · 2026-04-21 |
 | M2 — Worlds CRUD | [spec](../../../../specs/theworldharness-M2-worlds-crud/spec.md) | [plan](../../../../specs/theworldharness-M2-worlds-crud/plan.md) | [tasks](../../../../specs/theworldharness-M2-worlds-crud/tasks.md) | not started |
 | M3 — Live providers | [spec](../../../../specs/theworldharness-M3-live-providers/spec.md) | [plan](../../../../specs/theworldharness-M3-live-providers/plan.md) | [tasks](../../../../specs/theworldharness-M3-live-providers/tasks.md) | not started |
 | M4 — Eval + Benchmark | [spec](../../../../specs/theworldharness-M4-eval-benchmark/spec.md) | [plan](../../../../specs/theworldharness-M4-eval-benchmark/plan.md) | [tasks](../../../../specs/theworldharness-M4-eval-benchmark/tasks.md) | not started |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,19 @@ releases may still include breaking changes when the public API needs to tighten
   `<provider> . <capability>` status pill that update reactively when the selected flow changes.
 - Added a hidden `Ctrl+T` binding that cycles between the two registered themes without
   restarting the harness.
+- Split TheWorldHarness into a screen stack: a `HomeScreen` landing page with three jump cards
+  (`n` create a world, `p` run a provider, `e` run an eval), a `RunInspectorScreen` that owns
+  the existing flow visualisation, plus modal `HelpScreen` and `PlaceholderScreen` overlays.
+  `worldforge-harness` opens on Home by default and on the Run Inspector when `--flow` is
+  passed.
+- Added the static command palette layer via `App.get_system_commands` (`Ctrl+P`): "Jump:
+  Home", "Jump: Run Inspector", "Open Help", one "Run flow: <title>" entry per registered
+  flow, "Switch theme", and the stock Quit. The dynamic provider for worlds, providers, and
+  recent runs is reserved for a later milestone.
+- Added `?` to open a modal `HelpScreen` that lists every binding declared on the screen below
+  it, plus chord bindings `g h` / `g r` for jump-to-Home and jump-to-Run-Inspector.
+- Updated the `Header` breadcrumb to reflect the active screen, deepening to the selected flow
+  on the Run Inspector (`worldforge › run-inspector › <flow>`).
 
 ### Added
 

--- a/src/worldforge/harness/cli.py
+++ b/src/worldforge/harness/cli.py
@@ -18,8 +18,12 @@ def _parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--flow",
         choices=[flow.id for flow in available_flows()],
-        default="leworldmodel",
-        help="Harness flow to open.",
+        default=None,
+        help=(
+            "Harness flow to open. When omitted the harness opens on the Home screen; "
+            "when supplied the harness opens directly on the Run Inspector screen with "
+            "the flow pre-selected."
+        ),
     )
     parser.add_argument(
         "--state-dir",
@@ -63,11 +67,16 @@ def print_flow_index(*, output_format: str = "markdown") -> None:
 
 def launch_harness(
     *,
-    flow_id: str = "leworldmodel",
+    flow_id: str | None = None,
     state_dir: Path | None = None,
     animate: bool = True,
 ) -> int:
-    """Launch the Textual harness, returning a process exit code."""
+    """Launch the Textual harness, returning a process exit code.
+
+    ``flow_id=None`` means the user did not pass ``--flow`` — the harness
+    opens on the Home screen. Any explicit flow id pushes the Run Inspector
+    screen with that flow pre-selected.
+    """
 
     try:
         from worldforge.harness.tui import TheWorldHarnessApp
@@ -82,8 +91,11 @@ def launch_harness(
             return 2
         raise
 
+    initial_screen = "run-inspector" if flow_id is not None else "home"
+    resolved_flow_id = flow_id if flow_id is not None else "leworldmodel"
     app = TheWorldHarnessApp(
-        initial_flow_id=flow_id,
+        initial_flow_id=resolved_flow_id,
+        initial_screen=initial_screen,
         state_dir=state_dir,
         step_delay=0.0 if not animate else 0.18,
     )
@@ -93,7 +105,7 @@ def launch_harness(
 
 def run_from_args(
     *,
-    flow_id: str,
+    flow_id: str | None,
     state_dir: Path | None,
     list_only: bool,
     output_format: str,

--- a/src/worldforge/harness/tui.py
+++ b/src/worldforge/harness/tui.py
@@ -3,21 +3,25 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Iterable
 from pathlib import Path
+from typing import Literal
 
 from rich.align import Align
 from rich.console import Group, RenderableType
 from rich.panel import Panel
 from rich.table import Table
 from rich.text import Text
-from textual import on
-from textual.app import App, ComposeResult
+from textual import events, on
+from textual.app import App, ComposeResult, SystemCommand
 from textual.binding import Binding
 from textual.containers import Container, Horizontal, Vertical
 from textual.css.query import NoMatches
+from textual.message import Message
 from textual.reactive import reactive
+from textual.screen import ModalScreen, Screen
 from textual.theme import Theme
-from textual.widgets import Button, Footer, Header, Select, Static
+from textual.widgets import Button, DataTable, Footer, Header, Select, Static
 
 from worldforge.harness.flows import available_flows, run_flow
 from worldforge.harness.models import HarnessFlow, HarnessRun, HarnessStep
@@ -28,6 +32,8 @@ from worldforge.harness.theme import (
     WORLDFORGE_DARK_PALETTE,
     WORLDFORGE_LIGHT_PALETTE,
 )
+
+InitialScreen = Literal["home", "run-inspector"]
 
 
 def _build_theme(name: str, palette: dict[str, str], *, dark: bool) -> Theme:
@@ -71,8 +77,21 @@ class _ThemedRenderer:
         return variables.get(token, variables.get("foreground", ""))
 
 
+def _maybe_query(node, selector: str, expected_type):
+    """Return a widget from ``node`` if composed, else ``None``.
+
+    Reactives can fire before all widgets in ``compose()`` are mounted (and
+    chrome updates can fire on a screen that hasn't mounted yet). Treat a
+    missing target as a no-op rather than crashing.
+    """
+    try:
+        return node.query_one(selector, expected_type)
+    except NoMatches:
+        return None
+
+
 class Breadcrumb(Static):
-    """Header breadcrumb showing ``worldforge › <flow short_title>``.
+    """Header breadcrumb showing ``worldforge › <screen> [› <flow>]``.
 
     Path segments live in a reactive tuple; later milestones can deepen the
     trail (worlds, runs) without changing the rendering surface.
@@ -263,46 +282,219 @@ class TranscriptPane(Static, _ThemedRenderer):
         self.update(Panel(Group(*lines), title="Run Transcript", border_style=accent))
 
 
-class TheWorldHarnessApp(App[None]):
-    """Visual TUI harness for WorldForge E2E demos."""
+# ---------------------------------------------------------------------------
+# Jump cards & messages (Home screen)
+# ---------------------------------------------------------------------------
 
-    TITLE = "TheWorldHarness"
-    SUB_TITLE = "WorldForge visual integration harness"
+
+class JumpRequested(Message):
+    """Posted by a ``JumpCard`` when the user activates it."""
+
+    def __init__(self, target: str) -> None:
+        super().__init__()
+        self.target = target
+
+
+class JumpCard(Static, _ThemedRenderer):
+    """Focusable Home-screen jump target.
+
+    Activates on ``enter``, click, or its bound letter key (handled by
+    the parent screen). Posts a :class:`JumpRequested` so the parent
+    screen owns the routing decision per the skill's "messages over
+    reach-across" rule.
+    """
+
+    DEFAULT_CSS = """
+    JumpCard {
+        height: 7;
+        padding: 1 2;
+        margin-bottom: 1;
+        border: round $panel;
+        background: $surface;
+        color: $foreground;
+    }
+    JumpCard:focus, JumpCard:focus-within {
+        border: round $accent;
+        background: $boost;
+    }
+    """
+
     BINDINGS = [
-        ("r", "run_selected", "Run"),
-        ("1", "select_flow('leworldmodel')", "LeWorldModel"),
-        ("2", "select_flow('lerobot')", "LeRobot"),
-        ("3", "select_flow('diagnostics')", "Diagnostics"),
-        ("q", "quit", "Quit"),
-        Binding("ctrl+t", "toggle_theme", "Theme", show=False),
+        Binding("enter", "activate", "Activate", show=False),
     ]
-    CSS = """
-    Screen {
+
+    can_focus = True
+
+    def __init__(
+        self,
+        *,
+        target: str,
+        title: str,
+        binding: str,
+        description: str,
+        widget_id: str | None = None,
+    ) -> None:
+        super().__init__(id=widget_id)
+        self._target = target
+        self._title = title
+        self._binding = binding
+        self._description = description
+
+    def on_mount(self) -> None:
+        accent = self._color("accent")
+        body = Text()
+        body.append(self._title, style=f"bold {accent}")
+        body.append(f"   [{self._binding}]\n", style="dim")
+        body.append(self._description, style="dim")
+        self.update(body)
+
+    def action_activate(self) -> None:
+        self.post_message(JumpRequested(self._target))
+
+    def on_click(self, event: events.Click) -> None:  # pragma: no cover - thin wrapper
+        event.stop()
+        self.focus()
+        self.post_message(JumpRequested(self._target))
+
+
+# ---------------------------------------------------------------------------
+# Screens
+# ---------------------------------------------------------------------------
+
+
+class HomeScreen(Screen):
+    """Landing screen with a 30-second intro and three jump cards."""
+
+    BINDINGS = [
+        Binding("n", "jump('worlds')", "Create a world", show=True),
+        Binding("p", "jump('providers')", "Run a provider", show=True),
+        Binding("e", "jump('eval')", "Run an eval", show=True),
+    ]
+
+    DEFAULT_CSS = """
+    HomeScreen {
         background: $background;
         color: $foreground;
     }
 
-    Header {
+    #home-root {
+        padding: 1 2;
+        height: 1fr;
+    }
+
+    #home-intro {
+        height: auto;
+        padding: 1 2;
+        margin-bottom: 1;
+        border: round $panel;
         background: $surface;
-        color: $foreground;
     }
 
-    Footer {
+    #home-cards {
+        height: auto;
+    }
+
+    #home-recent {
+        height: auto;
+        margin-top: 1;
+        padding: 1 2;
+        border: round $panel;
         background: $surface;
+        color: $text-muted;
+    }
+    """
+
+    def compose(self) -> ComposeResult:
+        yield Header(show_clock=True)
+        with Horizontal(id="chrome"):
+            yield Breadcrumb(id="breadcrumb")
+            yield ProviderStatusPill(id="provider-pill")
+        with Container(id="home-root"):
+            yield Static(
+                Text.from_markup(
+                    "[bold]TheWorldHarness[/] is the visual integration reference for "
+                    "WorldForge.\n"
+                    "It runs the same provider, planning, evaluation, and persistence APIs "
+                    "you would use in a script — wired into a keyboard-first workspace so "
+                    "you can see every boundary as it executes.\n\n"
+                    "Pick a jump target below, press [bold]Ctrl+P[/] to search every action, "
+                    "or [bold]?[/] to see this screen's bindings."
+                ),
+                id="home-intro",
+            )
+            with Vertical(id="home-cards"):
+                yield JumpCard(
+                    target="worlds",
+                    title="Create a world",
+                    binding="n",
+                    description="Open the Worlds screen — create, edit, save, fork.",
+                    widget_id="jump-create-world",
+                )
+                yield JumpCard(
+                    target="providers",
+                    title="Run a provider",
+                    binding="p",
+                    description="Stream live provider events with cancellable workers.",
+                    widget_id="jump-run-provider",
+                )
+                yield JumpCard(
+                    target="eval",
+                    title="Run an eval",
+                    binding="e",
+                    description="Execute a deterministic evaluation suite against a provider.",
+                    widget_id="jump-run-eval",
+                )
+            yield Static(
+                "No recent items yet — jump targets will appear here once you open them.",
+                id="home-recent",
+            )
+        yield Footer()
+
+    def on_mount(self) -> None:
+        self._update_chrome()
+        first_card = _maybe_query(self, "#jump-create-world", JumpCard)
+        if first_card is not None:
+            first_card.focus()
+
+    def on_screen_resume(self) -> None:
+        self._update_chrome()
+
+    def _update_chrome(self) -> None:
+        breadcrumb = _maybe_query(self, "#breadcrumb", Breadcrumb)
+        if breadcrumb is not None:
+            breadcrumb.path = ("worldforge", "home")
+        pill = _maybe_query(self, "#provider-pill", ProviderStatusPill)
+        if pill is not None:
+            pill.label = ""
+
+    def action_jump(self, target: str) -> None:
+        self.post_message(JumpRequested(target))
+
+    def on_jump_requested(self, event: JumpRequested) -> None:
+        event.stop()
+        routing = {
+            "worlds": ("M2", "Worlds CRUD lands in M2 — see roadmap §8."),
+            "providers": ("M3", "Live provider streaming lands in M3 — see roadmap §8."),
+            "eval": ("M4", "Eval and benchmark land in M4 — see roadmap §8."),
+        }
+        milestone, message = routing.get(event.target, ("?", "Target not yet routed."))
+        self.app.push_screen(PlaceholderScreen(target_milestone=milestone, next_action=message))
+
+
+class RunInspectorScreen(Screen):
+    """Hosts the existing flow visualisation (hero, rail, timeline, inspector, transcript)."""
+
+    BINDINGS = [
+        Binding("r", "run_selected", "Run", show=True),
+        Binding("1", "select_flow('leworldmodel')", "LeWorldModel", show=True),
+        Binding("2", "select_flow('lerobot')", "LeRobot", show=True),
+        Binding("3", "select_flow('diagnostics')", "Diagnostics", show=True),
+    ]
+
+    DEFAULT_CSS = """
+    RunInspectorScreen {
+        background: $background;
         color: $foreground;
-    }
-
-    #chrome {
-        height: 1;
-        background: $boost;
-    }
-
-    #breadcrumb {
-        width: 1fr;
-    }
-
-    #provider-pill {
-        width: auto;
     }
 
     #root {
@@ -354,6 +546,8 @@ class TheWorldHarnessApp(App[None]):
 
     selected_flow_id: reactive[str] = reactive("leworldmodel", init=False)
     current_provider: reactive[str] = reactive("", init=False)
+    running: reactive[bool] = reactive(False, init=False)
+    last_run: reactive[HarnessRun | None] = reactive(None, init=False)
 
     def __init__(
         self,
@@ -365,15 +559,13 @@ class TheWorldHarnessApp(App[None]):
         super().__init__()
         self.flows = {flow.id: flow for flow in available_flows()}
         resolved_id = initial_flow_id if initial_flow_id in self.flows else "leworldmodel"
-        self.set_reactive(TheWorldHarnessApp.selected_flow_id, resolved_id)
+        self.set_reactive(RunInspectorScreen.selected_flow_id, resolved_id)
         self.set_reactive(
-            TheWorldHarnessApp.current_provider,
+            RunInspectorScreen.current_provider,
             self._provider_label(self.flows[resolved_id]),
         )
         self.state_dir = state_dir
         self.step_delay = step_delay
-        self.running = False
-        self.last_run: HarnessRun | None = None
 
     def compose(self) -> ComposeResult:
         yield Header(show_clock=True)
@@ -400,10 +592,11 @@ class TheWorldHarnessApp(App[None]):
         yield Footer()
 
     def on_mount(self) -> None:
-        self.register_theme(_build_theme(THEME_NAME_DARK, WORLDFORGE_DARK_PALETTE, dark=True))
-        self.register_theme(_build_theme(THEME_NAME_LIGHT, WORLDFORGE_LIGHT_PALETTE, dark=False))
-        self.theme = THEME_NAME_DARK
-        self._sync_chrome()
+        self._update_chrome()
+        self._refresh_static()
+
+    def on_screen_resume(self) -> None:
+        self._update_chrome()
         self._refresh_static()
 
     @on(Select.Changed, "#flow-select")
@@ -418,37 +611,21 @@ class TheWorldHarnessApp(App[None]):
     def action_select_flow(self, flow_id: str) -> None:
         if flow_id in self.flows:
             self.selected_flow_id = flow_id
-            select = self.query_one("#flow-select", Select)
-            if select.value != flow_id:
+            select = _maybe_query(self, "#flow-select", Select)
+            if select is not None and select.value != flow_id:
                 select.value = flow_id
-
-    def action_toggle_theme(self) -> None:
-        """Cycle between the two registered worldforge themes."""
-        self.theme = THEME_NAME_LIGHT if self.theme == THEME_NAME_DARK else THEME_NAME_DARK
 
     def watch_selected_flow_id(self, _old: str, new: str) -> None:
         if new not in self.flows:
             return
         self.current_provider = self._provider_label(self.flows[new])
-        self._sync_chrome()
+        self._update_chrome()
         self._refresh_static()
 
     def watch_current_provider(self, _old: str, new: str) -> None:
-        pill = self._maybe_query("#provider-pill", ProviderStatusPill)
+        pill = _maybe_query(self, "#provider-pill", ProviderStatusPill)
         if pill is not None:
             pill.label = new
-
-    def _maybe_query(self, selector: str, expected_type):
-        """Return a widget if it has been composed, else ``None``.
-
-        Reactives can fire before all widgets in ``compose()`` are mounted
-        (e.g. when the App is being torn down between Pilot tests). We treat
-        a missing target as a no-op rather than crashing.
-        """
-        try:
-            return self.query_one(selector, expected_type)
-        except NoMatches:
-            return None
 
     async def action_run_selected(self) -> None:
         if self.running:
@@ -473,15 +650,12 @@ class TheWorldHarnessApp(App[None]):
         self.query_one("#run-button", Button).disabled = False
         self._refresh_static()
 
-    def _sync_chrome(self) -> None:
+    def _update_chrome(self) -> None:
         flow = self.flows[self.selected_flow_id]
-        breadcrumb = self._maybe_query("#breadcrumb", Breadcrumb)
+        breadcrumb = _maybe_query(self, "#breadcrumb", Breadcrumb)
         if breadcrumb is not None:
-            breadcrumb.path = ("worldforge", flow.short_title)
-        # Pill mirrors current_provider via watch_current_provider; setting it
-        # here as well keeps on_mount idempotent in case the watcher fires
-        # before the widget exists.
-        pill = self._maybe_query("#provider-pill", ProviderStatusPill)
+            breadcrumb.path = ("worldforge", "run-inspector", flow.short_title)
+        pill = _maybe_query(self, "#provider-pill", ProviderStatusPill)
         if pill is not None:
             pill.label = self.current_provider
 
@@ -492,7 +666,7 @@ class TheWorldHarnessApp(App[None]):
 
     def _refresh_static(self) -> None:
         selected = self.flows[self.selected_flow_id]
-        hero = self._maybe_query("#hero", HeroPane)
+        hero = _maybe_query(self, "#hero", HeroPane)
         if hero is None:
             return
         hero.update(hero.compose_panel(selected, self.running))
@@ -516,3 +690,326 @@ class TheWorldHarnessApp(App[None]):
             )
             self.query_one("#inspector", InspectorPane).render_empty()
             self.query_one("#transcript", TranscriptPane).render_empty()
+
+
+class HelpScreen(ModalScreen[None]):
+    """Modal overlay that lists the bindings of the screen below it."""
+
+    BINDINGS = [
+        Binding("escape", "dismiss", "Close", show=True),
+        Binding("q", "dismiss", "Close", show=False),
+    ]
+
+    DEFAULT_CSS = """
+    HelpScreen {
+        align: center middle;
+    }
+
+    HelpScreen > #help-card {
+        width: 70%;
+        max-width: 90;
+        height: auto;
+        max-height: 80%;
+        padding: 1 2;
+        border: round $accent;
+        background: $surface;
+    }
+
+    HelpScreen #help-title {
+        height: auto;
+        padding: 0 0 1 0;
+        text-style: bold;
+        color: $accent;
+    }
+
+    HelpScreen DataTable {
+        height: auto;
+        max-height: 30;
+        background: $surface;
+    }
+
+    HelpScreen #help-footnote {
+        height: auto;
+        padding: 1 0 0 0;
+        color: $text-muted;
+    }
+    """
+
+    def __init__(self, source_screen: Screen | None = None) -> None:
+        super().__init__()
+        self._source_screen = source_screen
+
+    def compose(self) -> ComposeResult:
+        with Container(id="help-card"):
+            yield Static("Bindings on this screen", id="help-title")
+            yield DataTable(id="help-table", cursor_type="row", zebra_stripes=True)
+            yield Static(
+                "Press [bold]Esc[/] or [bold]q[/] to close. "
+                "[bold]Ctrl+P[/] opens the command palette.",
+                id="help-footnote",
+            )
+
+    def on_mount(self) -> None:
+        # Update breadcrumb (sits on the screen below this modal) and
+        # populate the table from that same source screen.
+        breadcrumb = _maybe_query(self.app, "#breadcrumb", Breadcrumb)
+        if breadcrumb is not None:
+            breadcrumb.path = ("worldforge", "help")
+        table = self.query_one("#help-table", DataTable)
+        table.add_columns("Key", "Description", "Action")
+        source = self._source_screen or self._previous_screen()
+        for binding in self._iter_bindings(source):
+            table.add_row(
+                binding.key,
+                binding.description or "",
+                binding.action,
+            )
+
+    def _previous_screen(self) -> Screen | None:
+        """Return the screen below this modal on the stack, if any."""
+        stack = list(self.app.screen_stack)
+        if self in stack:
+            stack.remove(self)
+        return stack[-1] if stack else None
+
+    @staticmethod
+    def _iter_bindings(screen: Screen | None) -> Iterable[Binding]:
+        if screen is None:
+            return ()
+        # Surface every binding declared on the source screen — discovery is
+        # the whole point of this overlay, so ``show=False`` entries are
+        # included alongside footer-visible ones. We also fold in App-level
+        # bindings so the user can see "Help / Quit / Ctrl+P" alongside the
+        # screen-local ones.
+        seen: set[tuple[str, str]] = set()
+        bindings: list[Binding] = []
+        sources = (screen, screen.app)
+        for source in sources:
+            try:
+                items = source._bindings.key_to_bindings.items()  # type: ignore[attr-defined]
+            except AttributeError:  # pragma: no cover - defensive
+                continue
+            for _key, binding_list in items:
+                for binding in binding_list:
+                    fingerprint = (binding.key, binding.action)
+                    if fingerprint in seen:
+                        continue
+                    seen.add(fingerprint)
+                    bindings.append(binding)
+        return bindings
+
+
+class PlaceholderScreen(ModalScreen[None]):
+    """Modal explaining a jump target that lands in a later milestone."""
+
+    BINDINGS = [
+        Binding("escape", "dismiss", "Close", show=True),
+        Binding("q", "dismiss", "Close", show=False),
+        Binding("enter", "dismiss", "Close", show=False),
+    ]
+
+    DEFAULT_CSS = """
+    PlaceholderScreen {
+        align: center middle;
+    }
+
+    PlaceholderScreen > #placeholder-card {
+        width: 60%;
+        max-width: 80;
+        height: auto;
+        padding: 1 2;
+        border: round $warning;
+        background: $surface;
+    }
+
+    PlaceholderScreen #placeholder-title {
+        height: auto;
+        padding: 0 0 1 0;
+        text-style: bold;
+        color: $warning;
+    }
+
+    PlaceholderScreen #placeholder-body {
+        height: auto;
+        color: $foreground;
+    }
+
+    PlaceholderScreen #placeholder-footnote {
+        height: auto;
+        padding: 1 0 0 0;
+        color: $text-muted;
+    }
+    """
+
+    def __init__(self, *, target_milestone: str, next_action: str) -> None:
+        super().__init__()
+        self._target_milestone = target_milestone
+        self._next_action = next_action
+
+    def compose(self) -> ComposeResult:
+        with Container(id="placeholder-card"):
+            yield Static(
+                f"Coming in milestone {self._target_milestone}",
+                id="placeholder-title",
+            )
+            yield Static(self._next_action, id="placeholder-body")
+            yield Static(
+                "Press [bold]Esc[/], [bold]q[/], or [bold]Enter[/] to close.",
+                id="placeholder-footnote",
+            )
+
+    def on_mount(self) -> None:
+        breadcrumb = _maybe_query(self.app, "#breadcrumb", Breadcrumb)
+        if breadcrumb is not None:
+            breadcrumb.path = ("worldforge", "placeholder")
+
+
+# ---------------------------------------------------------------------------
+# App
+# ---------------------------------------------------------------------------
+
+
+class TheWorldHarnessApp(App[None]):
+    """Visual TUI harness for WorldForge E2E demos."""
+
+    TITLE = "TheWorldHarness"
+    SUB_TITLE = "WorldForge visual integration harness"
+    BINDINGS = [
+        Binding("?", "show_help", "Help", show=True),
+        Binding("q", "quit", "Quit", show=True),
+        Binding("ctrl+t", "toggle_theme", "Theme", show=False),
+        Binding("g,h", "switch_screen('home')", "Jump: Home", show=False),
+        Binding("g,r", "switch_screen('run-inspector')", "Jump: Run Inspector", show=False),
+    ]
+    SCREENS = {"home": HomeScreen, "run-inspector": RunInspectorScreen}
+    CSS = """
+    Header {
+        background: $surface;
+        color: $foreground;
+    }
+
+    Footer {
+        background: $surface;
+        color: $foreground;
+    }
+
+    #chrome {
+        height: 1;
+        background: $boost;
+    }
+
+    #breadcrumb {
+        width: 1fr;
+    }
+
+    #provider-pill {
+        width: auto;
+    }
+    """
+
+    def __init__(
+        self,
+        *,
+        initial_flow_id: str = "leworldmodel",
+        initial_screen: InitialScreen = "home",
+        state_dir: Path | None = None,
+        step_delay: float = 0.18,
+    ) -> None:
+        super().__init__()
+        self._initial_flow_id = initial_flow_id
+        self._initial_screen: InitialScreen = initial_screen
+        self._state_dir = state_dir
+        self._step_delay = step_delay
+
+    # The harness keeps its own screen factories so we can pass per-instance
+    # construction args (state_dir, step_delay, initial flow) into screens
+    # without resorting to module-level globals.
+    def _make_run_inspector(self) -> RunInspectorScreen:
+        return RunInspectorScreen(
+            initial_flow_id=self._initial_flow_id,
+            state_dir=self._state_dir,
+            step_delay=self._step_delay,
+        )
+
+    def _make_home(self) -> HomeScreen:
+        return HomeScreen()
+
+    async def on_mount(self) -> None:
+        self.register_theme(_build_theme(THEME_NAME_DARK, WORLDFORGE_DARK_PALETTE, dark=True))
+        self.register_theme(_build_theme(THEME_NAME_LIGHT, WORLDFORGE_LIGHT_PALETTE, dark=False))
+        self.theme = THEME_NAME_DARK
+        # Replace the stock default screen with the harness landing screen
+        # (Home unless the CLI passed --flow). Awaiting the push keeps the
+        # active screen consistent before any test/Pilot interaction runs.
+        if self._initial_screen == "run-inspector":
+            await self.push_screen(self._make_run_inspector())
+        else:
+            await self.push_screen(self._make_home())
+
+    def action_show_help(self) -> None:
+        self.push_screen(HelpScreen(source_screen=self.screen))
+
+    def action_toggle_theme(self) -> None:
+        """Cycle between the two registered worldforge themes."""
+        self.theme = THEME_NAME_LIGHT if self.theme == THEME_NAME_DARK else THEME_NAME_DARK
+
+    def action_switch_screen(self, screen_name: str) -> None:
+        """Switch to ``screen_name`` if not already the active screen.
+
+        Replaces (rather than stacks on top of) the active non-modal screen
+        so chord navigation does not grow the stack indefinitely. Modal
+        overlays are popped first so the user does not get stuck behind
+        them.
+        """
+        while isinstance(self.screen, ModalScreen):
+            self.pop_screen()
+        target_cls = self.SCREENS.get(screen_name)
+        if target_cls is None or isinstance(self.screen, target_cls):
+            return
+        if screen_name == "run-inspector":
+            self.switch_screen(self._make_run_inspector())
+        elif screen_name == "home":
+            self.switch_screen(self._make_home())
+        else:  # pragma: no cover - defensive
+            self.switch_screen(screen_name)
+
+    def get_system_commands(self, screen: Screen) -> Iterable[SystemCommand]:
+        # Yield the stock Textual commands first (theme, quit) so they stay
+        # discoverable, then layer the harness-specific entries.
+        yield from super().get_system_commands(screen)
+        yield SystemCommand(
+            "Jump: Home",
+            "Open the Home screen",
+            lambda: self.action_switch_screen("home"),
+        )
+        yield SystemCommand(
+            "Jump: Run Inspector",
+            "Open the Run Inspector screen",
+            lambda: self.action_switch_screen("run-inspector"),
+        )
+        yield SystemCommand(
+            "Open Help",
+            "Show the bindings on the active screen",
+            self.action_show_help,
+        )
+        for flow in available_flows():
+            yield SystemCommand(
+                f"Run flow: {flow.title}",
+                f"Switch the Run Inspector to {flow.short_title} and run it",
+                self._make_run_flow_command(flow.id),
+            )
+        yield SystemCommand(
+            "Switch theme",
+            "Toggle between worldforge-dark and worldforge-light",
+            self.action_toggle_theme,
+        )
+
+    def _make_run_flow_command(self, flow_id: str):
+        async def _run() -> None:
+            self.action_switch_screen("run-inspector")
+            screen = self.screen
+            if isinstance(screen, RunInspectorScreen):
+                screen.action_select_flow(flow_id)
+                await screen.action_run_selected()
+
+        return _run

--- a/tests/test_harness_cli.py
+++ b/tests/test_harness_cli.py
@@ -35,3 +35,59 @@ def test_worldforge_harness_lists_json_without_textual(monkeypatch, capsys) -> N
 def test_worldforge_harness_console_entry_lists_flows(capsys) -> None:
     assert harness_main(["--list"]) == 0
     assert "TheWorldHarness Flows" in capsys.readouterr().out
+
+
+def test_launch_harness_passes_home_when_no_flow(monkeypatch) -> None:
+    """No --flow → initial_screen='home', resolved_flow_id falls back to leworldmodel."""
+    import pytest as _pytest
+
+    _pytest.importorskip("rich")
+    _pytest.importorskip("textual")
+
+    captured: dict[str, object] = {}
+
+    class _StubApp:
+        def __init__(self, **kwargs: object) -> None:
+            captured.update(kwargs)
+
+        def run(self) -> None:
+            return None
+
+    import worldforge.harness.tui as tui
+
+    monkeypatch.setattr(tui, "TheWorldHarnessApp", _StubApp)
+
+    from worldforge.harness.cli import launch_harness
+
+    rc = launch_harness(flow_id=None, state_dir=None, animate=False)
+    assert rc == 0
+    assert captured["initial_screen"] == "home"
+    assert captured["initial_flow_id"] == "leworldmodel"
+
+
+def test_launch_harness_passes_run_inspector_when_flow_supplied(monkeypatch) -> None:
+    """--flow X → initial_screen='run-inspector', initial_flow_id=X."""
+    import pytest as _pytest
+
+    _pytest.importorskip("rich")
+    _pytest.importorskip("textual")
+
+    captured: dict[str, object] = {}
+
+    class _StubApp:
+        def __init__(self, **kwargs: object) -> None:
+            captured.update(kwargs)
+
+        def run(self) -> None:
+            return None
+
+    import worldforge.harness.tui as tui
+
+    monkeypatch.setattr(tui, "TheWorldHarnessApp", _StubApp)
+
+    from worldforge.harness.cli import launch_harness
+
+    rc = launch_harness(flow_id="lerobot", state_dir=None, animate=True)
+    assert rc == 0
+    assert captured["initial_screen"] == "run-inspector"
+    assert captured["initial_flow_id"] == "lerobot"

--- a/tests/test_harness_tui.py
+++ b/tests/test_harness_tui.py
@@ -56,13 +56,17 @@ def test_harness_breadcrumb_reflects_selected_flow(tmp_path) -> None:
     from worldforge.harness.tui import Breadcrumb, TheWorldHarnessApp
 
     async def scenario() -> None:
-        app = TheWorldHarnessApp(initial_flow_id="leworldmodel", state_dir=tmp_path)
+        app = TheWorldHarnessApp(
+            initial_flow_id="leworldmodel",
+            initial_screen="run-inspector",
+            state_dir=tmp_path,
+        )
         async with app.run_test(size=(130, 42)) as pilot:
-            crumb = app.query_one("#breadcrumb", Breadcrumb)
-            assert crumb.path == ("worldforge", "LeWorldModel")
+            crumb = app.screen.query_one("#breadcrumb", Breadcrumb)
+            assert crumb.path == ("worldforge", "run-inspector", "LeWorldModel")
             await pilot.press("2")
             await pilot.pause()
-            assert crumb.path == ("worldforge", "LeRobot")
+            assert crumb.path == ("worldforge", "run-inspector", "LeRobot")
 
     asyncio.run(scenario())
 
@@ -73,9 +77,13 @@ def test_harness_status_pill_reflects_selected_flow_provider(tmp_path) -> None:
     from worldforge.harness.tui import ProviderStatusPill, TheWorldHarnessApp
 
     async def scenario() -> None:
-        app = TheWorldHarnessApp(initial_flow_id="leworldmodel", state_dir=tmp_path)
+        app = TheWorldHarnessApp(
+            initial_flow_id="leworldmodel",
+            initial_screen="run-inspector",
+            state_dir=tmp_path,
+        )
         async with app.run_test(size=(130, 42)) as pilot:
-            pill = app.query_one("#provider-pill", ProviderStatusPill)
+            pill = app.screen.query_one("#provider-pill", ProviderStatusPill)
             assert "LeWorldModelProvider" in pill.label
             assert pill.label.endswith("· score")
             await pilot.press("2")
@@ -92,21 +100,24 @@ def test_harness_status_pill_reflects_selected_flow_provider(tmp_path) -> None:
 def test_the_world_harness_app_runs_leworldmodel_flow(tmp_path) -> None:
     pytest.importorskip("textual")
 
-    from worldforge.harness.tui import TheWorldHarnessApp
+    from worldforge.harness.tui import RunInspectorScreen, TheWorldHarnessApp
 
     async def scenario() -> None:
         app = TheWorldHarnessApp(
             initial_flow_id="leworldmodel",
+            initial_screen="run-inspector",
             state_dir=tmp_path,
             step_delay=0.0,
         )
         async with app.run_test(size=(130, 42)) as pilot:
             await pilot.press("r")
             await pilot.pause()
-            assert app.last_run is not None
-            assert app.last_run.flow.id == "leworldmodel"
-            assert app.last_run.summary["selected_candidate_index"] == 1
-            assert app.query_one("#inspector") is not None
+            screen = app.screen
+            assert isinstance(screen, RunInspectorScreen)
+            assert screen.last_run is not None
+            assert screen.last_run.flow.id == "leworldmodel"
+            assert screen.last_run.summary["selected_candidate_index"] == 1
+            assert screen.query_one("#inspector") is not None
 
     asyncio.run(scenario())
 
@@ -114,11 +125,12 @@ def test_the_world_harness_app_runs_leworldmodel_flow(tmp_path) -> None:
 def test_the_world_harness_app_switches_to_lerobot_flow(tmp_path) -> None:
     pytest.importorskip("textual")
 
-    from worldforge.harness.tui import TheWorldHarnessApp
+    from worldforge.harness.tui import RunInspectorScreen, TheWorldHarnessApp
 
     async def scenario() -> None:
         app = TheWorldHarnessApp(
             initial_flow_id="leworldmodel",
+            initial_screen="run-inspector",
             state_dir=tmp_path,
             step_delay=0.0,
         )
@@ -126,9 +138,11 @@ def test_the_world_harness_app_switches_to_lerobot_flow(tmp_path) -> None:
             await pilot.press("2")
             await pilot.press("r")
             await pilot.pause()
-            assert app.last_run is not None
-            assert app.last_run.flow.id == "lerobot"
-            assert app.last_run.summary["policy_candidate_count"] == 3
+            screen = app.screen
+            assert isinstance(screen, RunInspectorScreen)
+            assert screen.last_run is not None
+            assert screen.last_run.flow.id == "lerobot"
+            assert screen.last_run.summary["policy_candidate_count"] == 3
 
     asyncio.run(scenario())
 
@@ -136,11 +150,12 @@ def test_the_world_harness_app_switches_to_lerobot_flow(tmp_path) -> None:
 def test_the_world_harness_app_switches_to_diagnostics_flow(tmp_path) -> None:
     pytest.importorskip("textual")
 
-    from worldforge.harness.tui import TheWorldHarnessApp
+    from worldforge.harness.tui import RunInspectorScreen, TheWorldHarnessApp
 
     async def scenario() -> None:
         app = TheWorldHarnessApp(
             initial_flow_id="leworldmodel",
+            initial_screen="run-inspector",
             state_dir=tmp_path,
             step_delay=0.0,
         )
@@ -148,8 +163,144 @@ def test_the_world_harness_app_switches_to_diagnostics_flow(tmp_path) -> None:
             await pilot.press("3")
             await pilot.press("r")
             await pilot.pause()
-            assert app.last_run is not None
-            assert app.last_run.flow.id == "diagnostics"
-            assert app.last_run.summary["benchmark_operation_count"] == 5
+            screen = app.screen
+            assert isinstance(screen, RunInspectorScreen)
+            assert screen.last_run is not None
+            assert screen.last_run.flow.id == "diagnostics"
+            assert screen.last_run.summary["benchmark_operation_count"] == 5
+
+    asyncio.run(scenario())
+
+
+# ---------------------------------------------------------------------------
+# M1 — Screen architecture tests
+# ---------------------------------------------------------------------------
+
+
+def test_initial_screen_is_home_when_no_flow_flag(tmp_path) -> None:
+    pytest.importorskip("textual")
+
+    from worldforge.harness.tui import HomeScreen, TheWorldHarnessApp
+
+    async def scenario() -> None:
+        app = TheWorldHarnessApp(state_dir=tmp_path)  # no initial_screen → "home"
+        async with app.run_test(size=(130, 42)):
+            assert isinstance(app.screen, HomeScreen)
+
+    asyncio.run(scenario())
+
+
+def test_initial_screen_is_run_inspector_when_flow_flag_passed(tmp_path) -> None:
+    pytest.importorskip("textual")
+
+    from worldforge.harness.tui import RunInspectorScreen, TheWorldHarnessApp
+
+    async def scenario() -> None:
+        app = TheWorldHarnessApp(
+            initial_flow_id="lerobot",
+            initial_screen="run-inspector",
+            state_dir=tmp_path,
+        )
+        async with app.run_test(size=(130, 42)):
+            assert isinstance(app.screen, RunInspectorScreen)
+            assert app.screen.selected_flow_id == "lerobot"
+
+    asyncio.run(scenario())
+
+
+def test_jump_to_home_from_run_inspector(tmp_path) -> None:
+    pytest.importorskip("textual")
+
+    from worldforge.harness.tui import Breadcrumb, HomeScreen, TheWorldHarnessApp
+
+    async def scenario() -> None:
+        app = TheWorldHarnessApp(
+            initial_flow_id="leworldmodel",
+            initial_screen="run-inspector",
+            state_dir=tmp_path,
+        )
+        async with app.run_test(size=(130, 42)) as pilot:
+            await pilot.press("g", "h")
+            await pilot.pause()
+            assert isinstance(app.screen, HomeScreen)
+            crumb = app.screen.query_one("#breadcrumb", Breadcrumb)
+            assert crumb.path == ("worldforge", "home")
+
+    asyncio.run(scenario())
+
+
+def test_jump_to_run_inspector_from_home(tmp_path) -> None:
+    pytest.importorskip("textual")
+
+    from worldforge.harness.tui import RunInspectorScreen, TheWorldHarnessApp
+
+    async def scenario() -> None:
+        app = TheWorldHarnessApp(state_dir=tmp_path)
+        async with app.run_test(size=(130, 42)) as pilot:
+            await pilot.press("g", "r")
+            await pilot.pause()
+            assert isinstance(app.screen, RunInspectorScreen)
+
+    asyncio.run(scenario())
+
+
+def test_help_overlay_opens_and_closes(tmp_path) -> None:
+    pytest.importorskip("textual")
+
+    from worldforge.harness.tui import HelpScreen, RunInspectorScreen, TheWorldHarnessApp
+
+    async def scenario() -> None:
+        app = TheWorldHarnessApp(
+            initial_flow_id="leworldmodel",
+            initial_screen="run-inspector",
+            state_dir=tmp_path,
+        )
+        async with app.run_test(size=(130, 42)) as pilot:
+            assert isinstance(app.screen, RunInspectorScreen)
+            await pilot.press("?")
+            await pilot.pause()
+            assert isinstance(app.screen, HelpScreen)
+            await pilot.press("escape")
+            await pilot.pause()
+            assert isinstance(app.screen, RunInspectorScreen)
+
+    asyncio.run(scenario())
+
+
+def test_command_palette_lists_screens_and_flows(tmp_path) -> None:
+    pytest.importorskip("textual")
+
+    from worldforge.harness.flows import available_flows
+    from worldforge.harness.tui import TheWorldHarnessApp
+
+    async def scenario() -> None:
+        app = TheWorldHarnessApp(state_dir=tmp_path)
+        async with app.run_test(size=(130, 42)):
+            commands = list(app.get_system_commands(app.screen))
+            titles = [cmd.title for cmd in commands]
+            assert "Jump: Home" in titles
+            assert "Jump: Run Inspector" in titles
+            assert "Open Help" in titles
+            assert "Switch theme" in titles
+            for flow in available_flows():
+                assert f"Run flow: {flow.title}" in titles
+            # Quit comes from the stock Textual SystemCommands.
+            assert any("uit" in t for t in titles)
+
+    asyncio.run(scenario())
+
+
+def test_home_jump_card_keyboard_activation(tmp_path) -> None:
+    pytest.importorskip("textual")
+
+    from worldforge.harness.tui import HomeScreen, PlaceholderScreen, TheWorldHarnessApp
+
+    async def scenario() -> None:
+        app = TheWorldHarnessApp(state_dir=tmp_path)
+        async with app.run_test(size=(130, 42)) as pilot:
+            assert isinstance(app.screen, HomeScreen)
+            await pilot.press("n")
+            await pilot.pause()
+            assert isinstance(app.screen, PlaceholderScreen)
 
     asyncio.run(scenario())


### PR DESCRIPTION
## Summary

Splits `TheWorldHarnessApp` into a screen stack so navigation, discovery, and per-screen bindings stop fighting each other. First-time users land on a `HomeScreen` that explains the harness in one screen and offers three jump cards; the existing flow visualisation moves behind a routed `RunInspectorScreen`. Every action is reachable from `Ctrl+P` or the new `?` help overlay so users never have to read source to find a key.

Spec triad: [`specs/theworldharness-M1-screen-architecture/spec.md`](../blob/main/specs/theworldharness-M1-screen-architecture/spec.md) · [plan.md](../blob/main/specs/theworldharness-M1-screen-architecture/plan.md) · [tasks.md](../blob/main/specs/theworldharness-M1-screen-architecture/tasks.md). Builds on M0 (themes, breadcrumb, provider status pill).

## Per-task status

- T1 done — `RunInspectorScreen` wraps the existing flow visualisation; `r` / `1` / `2` / `3` move off the App so they stop polluting Home's footer.
- T2 done — `HomeScreen` + `JumpCard(Static)`. `JumpCard` posts a `JumpRequested(target)` `Message`; Home routes it.
- T3 done — `--flow` distinguishes "user passed it" (push `RunInspectorScreen`) from "no flag" (push `HomeScreen`). `initial_screen` literal is threaded through.
- T4 done — `HelpScreen(ModalScreen[None])` bound to `?`. Lists every binding on the screen below it (plus App-level entries) in a `DataTable`. Dismisses on `escape` / `q`.
- T5 done — `App.get_system_commands` yields static entries: Jump: Home, Jump: Run Inspector, Open Help, one Run flow per registered flow, Switch theme. Stock Quit comes from Textual's `super().get_system_commands`.
- T6 done — Chord bindings `g h` / `g r` via a custom `action_switch_screen` that pops modals and replaces (rather than stacks on top of) the active screen. Footer hygiene audited; only user-facing actions stay `show=True`.
- T7 done — `PlaceholderScreen(ModalScreen[None])` for jump targets that land in M2 / M3 / M4. Renders the milestone label and a one-line follow-up.
- T8 done — Each screen updates the breadcrumb on mount and resume: `worldforge › home`, `worldforge › run-inspector › <flow>`, `worldforge › help`, `worldforge › placeholder`.
- T9 done — All TCSS in the new screens uses semantic variables (`$accent`, `$panel`, `$surface`, `$boost`, `$background`, `$foreground`, `$warning`, `$text-muted`). The hex-literal regression test keeps the file honest.
- T10 done — Roadmap §8 marks M1 `done · 2026-04-21`; CHANGELOG Unreleased / Harness section gains the M1 bullets.

## Deferred follow-ups

- Snapshot tests for `HomeScreen`, `RunInspectorScreen` mid-flow, `HelpScreen` overlay, and `PlaceholderScreen` overlay at `terminal_size=(120, 40)` are deferred along with the gated `pytest-textual-snapshot` dependency that M0 also deferred. Pilot interaction tests fully cover the behavioural contract for M1; the snapshot matrix is best landed alongside M5 polish.

## Test plan

- [x] `uv lock --check`
- [x] `uv run ruff check src tests examples scripts`
- [x] `uv run ruff format --check src tests examples scripts`
- [x] `uv run python scripts/generate_provider_docs.py --check`
- [x] `uv run pytest`
- [x] `uv run --extra harness pytest --cov=src/worldforge --cov-fail-under=90` (90.66%)
- [x] `bash scripts/test_package.sh`

New Pilot tests (in `tests/test_harness_tui.py`):
- `test_initial_screen_is_home_when_no_flow_flag`
- `test_initial_screen_is_run_inspector_when_flow_flag_passed`
- `test_jump_to_home_from_run_inspector`
- `test_jump_to_run_inspector_from_home`
- `test_help_overlay_opens_and_closes`
- `test_command_palette_lists_screens_and_flows`
- `test_home_jump_card_keyboard_activation`

New CLI tests (in `tests/test_harness_cli.py`):
- `test_launch_harness_passes_home_when_no_flow`
- `test_launch_harness_passes_run_inspector_when_flow_supplied`

The five existing M0 / pre-M0 tests were updated to push `RunInspectorScreen` first and to query through the active screen.

## Boundaries respected

- `flows.py`, `cli.py`, `models.py`, `theme.py` stay Textual-free. Every screen lives in `tui.py`.
- No new runtime dependency in the `harness` extra.
- No hex literals in TCSS — semantic variables only (M0 contract). Mechanically enforced by `test_harness_tui_has_no_hex_color_literals`.
- No public model / persistence / catalog / workflow file touched.