### PR TITLE
Add provider runtime manifests

### DIFF
--- a/docs/src/providers/README.md
+++ b/docs/src/providers/README.md
@@ -103,6 +103,30 @@ uv run worldforge doctor --capability score
 configuration visible before a workflow fails. Use `--registered-only` when a process needs to
 check only the providers enabled for that process.
 
+## Runtime Manifests
+
+Real optional providers also have packaged JSON runtime manifests in
+`src/worldforge/providers/runtime_manifests/`. The manifests are dependency-free records that host
+applications, release checks, and docs can read without installing a live runtime.
+
+Schema version `1` includes:
+
+- `provider`: catalog provider name
+- `capabilities`: callable WorldForge capabilities covered by the runtime
+- `optional_dependencies`: host-owned packages or import paths
+- `required_env_vars` and `optional_env_vars`: configuration surface
+- `default_model`: default model, checkpoint, or host-selected model slot
+- `device_support`: supported device classes such as `cpu`, `cuda`, or `remote`
+- `host_owned_artifacts`: checkpoints, policy servers, generated media, or translators the host
+  must retain
+- `minimum_smoke_command`: smallest live command that proves the runtime is wired
+- `expected_success_signal`: concrete pass condition for smoke evidence
+- `setup_hint`: short remediation hint used by provider health messages
+- `docs_path`: provider page that explains the manifest in context
+
+WorldForge never auto-installs optional provider runtimes from these manifests. Missing optional
+dependencies stay explicit in `health()` output and point back to the manifest-backed smoke path.
+
 ## Runtime Ownership
 
 WorldForge owns:

--- a/docs/src/providers/cosmos.md
+++ b/docs/src/providers/cosmos.md
@@ -36,6 +36,10 @@ The host owns:
 - `COSMOS_BASE_URL`: required for auto-registration. Example: `http://localhost:8000`.
 - `NVIDIA_API_KEY`: optional bearer token sent as `Authorization: Bearer ...`.
 
+Runtime manifest:
+`src/worldforge/providers/runtime_manifests/cosmos.json` records the required endpoint, optional
+bearer token, host-owned artifacts, minimum live smoke command, and expected health signal.
+
 Programmatic construction:
 
 ```python

--- a/docs/src/providers/gr00t.md
+++ b/docs/src/providers/gr00t.md
@@ -45,6 +45,11 @@ WorldForge never drives hardware directly.
 The adapter does not add Isaac GR00T, PyTorch, CUDA, TensorRT, checkpoints, or robot runtime
 dependencies to WorldForge's base install.
 
+Runtime manifest:
+`src/worldforge/providers/runtime_manifests/gr00t.json` records the policy-server environment,
+optional client settings, host-owned policy/runtime artifacts, minimum live smoke command, and
+expected policy-client health signal.
+
 ## Runtime Contract
 
 Direct construction with an injected test client or host-owned client:

--- a/docs/src/providers/lerobot.md
+++ b/docs/src/providers/lerobot.md
@@ -45,6 +45,11 @@ WorldForge never drives hardware directly.
 The adapter does not add LeRobot, PyTorch, NumPy, checkpoints, simulation packages, or robot
 runtime dependencies to WorldForge's base install.
 
+Runtime manifest:
+`src/worldforge/providers/runtime_manifests/lerobot.json` records the policy path aliases,
+optional device/cache settings, host-owned checkpoint and translator artifacts, minimum smoke
+command, and expected policy selection signal.
+
 ## Runtime Contract
 
 Direct construction with an injected test policy or host-owned policy:

--- a/docs/src/providers/leworldmodel.md
+++ b/docs/src/providers/leworldmodel.md
@@ -37,6 +37,11 @@ WorldForge does not add LeWorldModel, torch, checkpoint archives, or datasets to
 - `LEWORLDMODEL_CACHE_DIR`: optional checkpoint root override.
 - `LEWORLDMODEL_DEVICE`: optional torch device string such as `cpu`, `cuda`, or `cuda:0`.
 
+Runtime manifest:
+`src/worldforge/providers/runtime_manifests/leworldmodel.json` records the policy aliases,
+optional checkpoint/device settings, host-owned checkpoint artifacts, minimum real-checkpoint smoke
+command, and expected finite-cost signal.
+
 Programmatic construction can inject a loader and tensor module for tests or host-owned runtimes:
 
 ```python

--- a/docs/src/providers/runway.md
+++ b/docs/src/providers/runway.md
@@ -40,6 +40,11 @@ The host owns:
 - `RUNWAYML_BASE_URL`: optional API endpoint override; defaults to
   `https://api.dev.runwayml.com`.
 
+Runtime manifest:
+`src/worldforge/providers/runtime_manifests/runway.json` records the credential aliases, optional
+endpoint override, host-owned artifact retention, minimum live smoke command, and expected Runway
+task signal.
+
 Programmatic construction:
 
 ```python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,9 @@ package = true
 packages = ["src/worldforge"]
 only-packages = true
 
+[tool.hatch.build.targets.wheel.force-include]
+"src/worldforge/providers/runtime_manifests" = "worldforge/providers/runtime_manifests"
+
 [tool.hatch.build.targets.sdist]
 include = [
     "/src",

--- a/src/worldforge/providers/gr00t.py
+++ b/src/worldforge/providers/gr00t.py
@@ -19,6 +19,10 @@ from worldforge.models import (
 from ._config import env_value, optional_bool, optional_non_empty, optional_positive_int
 from ._policy import json_compatible, json_object, normalize_policy_action_candidates
 from .base import BaseProvider, ProviderError, ProviderProfileSpec
+from .runtime_manifest import (
+    missing_optional_dependency_detail,
+    missing_runtime_configuration_detail,
+)
 
 GROOT_POLICY_HOST_ENV_VAR = "GROOT_POLICY_HOST"
 GROOT_POLICY_PORT_ENV_VAR = "GROOT_POLICY_PORT"
@@ -134,7 +138,11 @@ class GrootPolicyClientProvider(BaseProvider):
     def health(self) -> ProviderHealth:
         started = perf_counter()
         if not self.configured():
-            return self._health(started, f"missing {GROOT_POLICY_HOST_ENV_VAR}", healthy=False)
+            return self._health(
+                started,
+                missing_runtime_configuration_detail("gr00t"),
+                healthy=False,
+            )
         if self._policy_client is None:
             dependency_error = self._runtime_dependency_error()
             if dependency_error is not None:
@@ -156,7 +164,7 @@ class GrootPolicyClientProvider(BaseProvider):
         try:
             policy_module = importlib.import_module("gr00t.policy.server_client")
         except ImportError:
-            return "missing optional dependency gr00t.policy.server_client"
+            return missing_optional_dependency_detail("gr00t", "gr00t.policy.server_client")
         except Exception as exc:
             message = str(exc).strip()
             suffix = f": {message}" if message else ""

--- a/src/worldforge/providers/lerobot.py
+++ b/src/worldforge/providers/lerobot.py
@@ -36,6 +36,10 @@ from worldforge.models import (
 from ._config import env_value, first_env_value, optional_non_empty
 from ._policy import json_object, no_grad_context, normalize_policy_action_candidates, prepare_model
 from .base import BaseProvider, ProviderError, ProviderProfileSpec
+from .runtime_manifest import (
+    missing_optional_dependency_detail,
+    missing_runtime_configuration_detail,
+)
 
 LEROBOT_POLICY_PATH_ENV_VAR = "LEROBOT_POLICY_PATH"
 LEROBOT_POLICY_PATH_ENV_ALIASES = (LEROBOT_POLICY_PATH_ENV_VAR, "LEROBOT_POLICY")
@@ -196,7 +200,7 @@ class LeRobotPolicyProvider(BaseProvider):
         if not self.configured():
             return self._health(
                 started,
-                f"missing {LEROBOT_POLICY_PATH_ENV_VAR} (or injected policy)",
+                missing_runtime_configuration_detail("lerobot") + " (or injected policy)",
                 healthy=False,
             )
         if self._policy is None:
@@ -214,7 +218,7 @@ class LeRobotPolicyProvider(BaseProvider):
         try:
             importlib.import_module("lerobot")
         except ImportError:
-            return "missing optional dependency lerobot"
+            return missing_optional_dependency_detail("lerobot", "lerobot")
         except Exception as exc:
             return (
                 "LeRobot optional dependency import failed ("

--- a/src/worldforge/providers/leworldmodel.py
+++ b/src/worldforge/providers/leworldmodel.py
@@ -21,6 +21,10 @@ from ._config import env_value, first_env_value, optional_non_empty
 from ._policy import no_grad_context, prepare_model
 from ._tensor_validation import _is_sequence, _shape
 from .base import BaseProvider, ProviderError, ProviderProfileSpec
+from .runtime_manifest import (
+    missing_optional_dependency_detail,
+    missing_runtime_configuration_detail,
+)
 
 LEWORLDMODEL_OFFICIAL_REPO_URL = "https://github.com/lucas-maes/le-wm"
 LEWORLDMODEL_RUNTIME_API = "stable_worldmodel.policy.AutoCostModel"
@@ -136,7 +140,7 @@ class LeWorldModelProvider(BaseProvider):
         if not self.configured():
             return self._health(
                 started,
-                "missing LEWORLDMODEL_POLICY or LEWM_POLICY",
+                missing_runtime_configuration_detail("leworldmodel"),
                 healthy=False,
             )
         dependency_error = self._runtime_dependency_error()
@@ -155,7 +159,7 @@ class LeWorldModelProvider(BaseProvider):
             try:
                 importlib.import_module("torch")
             except ImportError:
-                return "missing optional dependency torch"
+                return missing_optional_dependency_detail("leworldmodel", "torch")
             except Exception as exc:
                 return (
                     "LeWorldModel optional dependency torch import failed ("
@@ -166,7 +170,13 @@ class LeWorldModelProvider(BaseProvider):
             try:
                 stable_worldmodel = importlib.import_module("stable_worldmodel")
             except ImportError as exc:
-                return _missing_import_detail("stable_worldmodel", exc)
+                return (
+                    missing_optional_dependency_detail(
+                        "leworldmodel",
+                        "stable_worldmodel",
+                    )
+                    + f" ({_missing_import_detail('stable_worldmodel', exc)})"
+                )
             except Exception as exc:
                 return (
                     "LeWorldModel optional dependency stable_worldmodel import failed ("

--- a/src/worldforge/providers/runtime_manifest.py
+++ b/src/worldforge/providers/runtime_manifest.py
@@ -1,0 +1,172 @@
+"""Provider runtime manifest loading and validation."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from importlib import resources
+from typing import Any
+
+from worldforge.models import WorldForgeError
+
+from . import runtime_manifests
+
+MANIFEST_PACKAGE = "worldforge.providers.runtime_manifests"
+_MANIFEST_FILES = resources.files(runtime_manifests)
+MANIFEST_SCHEMA_VERSION = 1
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderRuntimeManifest:
+    """Machine-readable host-runtime requirements for an optional provider."""
+
+    provider: str
+    schema_version: int
+    capabilities: tuple[str, ...]
+    optional_dependencies: tuple[str, ...]
+    required_env_vars: tuple[str, ...]
+    optional_env_vars: tuple[str, ...]
+    default_model: str
+    device_support: tuple[str, ...]
+    host_owned_artifacts: tuple[str, ...]
+    minimum_smoke_command: str
+    expected_success_signal: str
+    setup_hint: str
+    docs_path: str
+
+    @classmethod
+    def from_json(cls, payload: dict[str, Any], *, source: str) -> ProviderRuntimeManifest:
+        """Build and validate a runtime manifest from decoded JSON."""
+
+        provider = _required_str(payload, "provider", source=source)
+        schema_version = _required_int(payload, "schema_version", source=source)
+        if schema_version != MANIFEST_SCHEMA_VERSION:
+            raise WorldForgeError(
+                f"{source} schema_version must be {MANIFEST_SCHEMA_VERSION}, got {schema_version}."
+            )
+        return cls(
+            provider=provider,
+            schema_version=schema_version,
+            capabilities=_required_str_tuple(payload, "capabilities", source=source),
+            optional_dependencies=_required_str_tuple(
+                payload,
+                "optional_dependencies",
+                source=source,
+                allow_empty=True,
+            ),
+            required_env_vars=_required_str_tuple(payload, "required_env_vars", source=source),
+            optional_env_vars=_required_str_tuple(
+                payload,
+                "optional_env_vars",
+                source=source,
+                allow_empty=True,
+            ),
+            default_model=_required_str(payload, "default_model", source=source),
+            device_support=_required_str_tuple(payload, "device_support", source=source),
+            host_owned_artifacts=_required_str_tuple(
+                payload,
+                "host_owned_artifacts",
+                source=source,
+            ),
+            minimum_smoke_command=_required_str(
+                payload,
+                "minimum_smoke_command",
+                source=source,
+            ),
+            expected_success_signal=_required_str(
+                payload,
+                "expected_success_signal",
+                source=source,
+            ),
+            setup_hint=_required_str(payload, "setup_hint", source=source),
+            docs_path=_required_str(payload, "docs_path", source=source),
+        )
+
+    def missing_dependency_detail(self, dependency: str) -> str:
+        """Return an actionable health detail for a missing optional dependency."""
+
+        if dependency not in self.optional_dependencies:
+            return f"missing optional dependency {dependency}"
+        return (
+            f"missing optional dependency {dependency}; {self.setup_hint}; "
+            f"minimum smoke: {self.minimum_smoke_command}"
+        )
+
+    def missing_configuration_detail(self) -> str:
+        """Return a health detail for missing runtime configuration."""
+
+        required = " or ".join(self.required_env_vars)
+        return f"missing {required}; configure runtime using {self.docs_path}"
+
+
+def load_runtime_manifest(provider: str) -> ProviderRuntimeManifest:
+    """Load one provider runtime manifest by provider name."""
+
+    source = f"{provider}.json"
+    try:
+        text = _MANIFEST_FILES.joinpath(source).read_text(encoding="utf-8")
+    except FileNotFoundError as exc:
+        raise WorldForgeError(f"Runtime manifest not found for provider '{provider}'.") from exc
+    payload = json.loads(text)
+    if not isinstance(payload, dict):
+        raise WorldForgeError(f"{source} must contain a JSON object.")
+    return ProviderRuntimeManifest.from_json(payload, source=source)
+
+
+def load_runtime_manifests() -> tuple[ProviderRuntimeManifest, ...]:
+    """Load every in-repo optional provider runtime manifest."""
+
+    manifests: list[ProviderRuntimeManifest] = []
+    for manifest_file in sorted(_MANIFEST_FILES.iterdir()):
+        if manifest_file.name.endswith(".json"):
+            payload = json.loads(manifest_file.read_text(encoding="utf-8"))
+            if not isinstance(payload, dict):
+                raise WorldForgeError(f"{manifest_file.name} must contain a JSON object.")
+            manifests.append(ProviderRuntimeManifest.from_json(payload, source=manifest_file.name))
+    return tuple(manifests)
+
+
+def missing_optional_dependency_detail(provider: str, dependency: str) -> str:
+    """Return a manifest-backed health detail for a missing optional dependency."""
+
+    return load_runtime_manifest(provider).missing_dependency_detail(dependency)
+
+
+def missing_runtime_configuration_detail(provider: str) -> str:
+    """Return a manifest-backed health detail for missing runtime configuration."""
+
+    return load_runtime_manifest(provider).missing_configuration_detail()
+
+
+def _required_str(payload: dict[str, Any], field: str, *, source: str) -> str:
+    value = payload.get(field)
+    if not isinstance(value, str) or not value.strip():
+        raise WorldForgeError(f"{source} field '{field}' must be a non-empty string.")
+    return value.strip()
+
+
+def _required_int(payload: dict[str, Any], field: str, *, source: str) -> int:
+    value = payload.get(field)
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise WorldForgeError(f"{source} field '{field}' must be an integer.")
+    return value
+
+
+def _required_str_tuple(
+    payload: dict[str, Any],
+    field: str,
+    *,
+    source: str,
+    allow_empty: bool = False,
+) -> tuple[str, ...]:
+    value = payload.get(field)
+    if not isinstance(value, list) or (not value and not allow_empty):
+        raise WorldForgeError(f"{source} field '{field}' must be a non-empty string list.")
+    items: list[str] = []
+    for index, item in enumerate(value):
+        if not isinstance(item, str) or not item.strip():
+            raise WorldForgeError(
+                f"{source} field '{field}' item {index} must be a non-empty string."
+            )
+        items.append(item.strip())
+    return tuple(items)

--- a/src/worldforge/providers/runtime_manifests/__init__.py
+++ b/src/worldforge/providers/runtime_manifests/__init__.py
@@ -1,0 +1,1 @@
+"""Packaged JSON runtime manifests for optional providers."""

--- a/src/worldforge/providers/runtime_manifests/cosmos.json
+++ b/src/worldforge/providers/runtime_manifests/cosmos.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": 1,
+  "provider": "cosmos",
+  "capabilities": ["generate"],
+  "optional_dependencies": [],
+  "required_env_vars": ["COSMOS_BASE_URL"],
+  "optional_env_vars": ["NVIDIA_API_KEY"],
+  "default_model": "Cosmos-Predict1-7B-Text2World",
+  "device_support": ["remote"],
+  "host_owned_artifacts": ["generated video bytes", "artifact retention path"],
+  "minimum_smoke_command": "WORLD_FORGE_RUN_LIVE=1 COSMOS_BASE_URL=https://cosmos.example uv run pytest tests/test_remote_video_providers.py -m live --provider-profile cosmos",
+  "expected_success_signal": "Cosmos health returns ready and generate() returns a validated VideoClip",
+  "setup_hint": "run against a host-owned Cosmos endpoint; base package does not install or launch Cosmos",
+  "docs_path": "docs/src/providers/cosmos.md"
+}

--- a/src/worldforge/providers/runtime_manifests/gr00t.json
+++ b/src/worldforge/providers/runtime_manifests/gr00t.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": 1,
+  "provider": "gr00t",
+  "capabilities": ["policy"],
+  "optional_dependencies": ["gr00t.policy.server_client"],
+  "required_env_vars": ["GROOT_POLICY_HOST"],
+  "optional_env_vars": ["GROOT_POLICY_PORT", "GROOT_POLICY_TIMEOUT_MS", "GROOT_POLICY_API_TOKEN", "GROOT_POLICY_STRICT", "GROOT_EMBODIMENT_TAG"],
+  "default_model": "host-selected GR00T policy server",
+  "device_support": ["remote-policy-server", "gpu-host-owned"],
+  "host_owned_artifacts": ["GR00T policy server", "embodiment assets", "action translator"],
+  "minimum_smoke_command": "WORLD_FORGE_RUN_LIVE=1 GROOT_POLICY_HOST=127.0.0.1 uv run pytest tests/test_gr00t_provider.py -m live --provider-profile gr00t",
+  "expected_success_signal": "health() can create PolicyClient and ping the policy server",
+  "setup_hint": "install the host-owned Isaac GR00T client/server runtime before live policy checks",
+  "docs_path": "docs/src/providers/gr00t.md"
+}

--- a/src/worldforge/providers/runtime_manifests/lerobot.json
+++ b/src/worldforge/providers/runtime_manifests/lerobot.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": 1,
+  "provider": "lerobot",
+  "capabilities": ["policy"],
+  "optional_dependencies": ["lerobot"],
+  "required_env_vars": ["LEROBOT_POLICY_PATH", "LEROBOT_POLICY"],
+  "optional_env_vars": ["LEROBOT_POLICY_TYPE", "LEROBOT_DEVICE", "LEROBOT_CACHE_DIR", "LEROBOT_EMBODIMENT_TAG"],
+  "default_model": "host-selected Hugging Face repo id or local checkpoint directory",
+  "device_support": ["cpu", "cuda", "mps"],
+  "host_owned_artifacts": ["policy checkpoint", "policy cache", "embodiment action translator"],
+  "minimum_smoke_command": "scripts/smoke_lerobot_policy.py --policy-path <repo-or-checkpoint> --device cpu",
+  "expected_success_signal": "select_actions() returns validated WorldForge Action candidates",
+  "setup_hint": "install LeRobot in the host runtime and provide an action_translator for the embodiment",
+  "docs_path": "docs/src/providers/lerobot.md"
+}

--- a/src/worldforge/providers/runtime_manifests/leworldmodel.json
+++ b/src/worldforge/providers/runtime_manifests/leworldmodel.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": 1,
+  "provider": "leworldmodel",
+  "capabilities": ["score"],
+  "optional_dependencies": ["torch", "stable_worldmodel"],
+  "required_env_vars": ["LEWORLDMODEL_POLICY", "LEWM_POLICY"],
+  "optional_env_vars": ["STABLEWM_HOME", "LEWORLDMODEL_CACHE_DIR", "LEWORLDMODEL_DEVICE"],
+  "default_model": "pusht/lewm",
+  "device_support": ["cpu", "cuda", "mps"],
+  "host_owned_artifacts": ["LeWorldModel checkpoint", "checkpoint cache", "task-shaped tensors"],
+  "minimum_smoke_command": "scripts/lewm-real --checkpoint ~/.stable-wm/pusht/lewm_object.ckpt --device cpu",
+  "expected_success_signal": "AutoCostModel.get_cost(...) returns finite candidate costs",
+  "setup_hint": "install torch plus the official stable_worldmodel loading path in the host runtime",
+  "docs_path": "docs/src/providers/leworldmodel.md"
+}

--- a/src/worldforge/providers/runtime_manifests/runway.json
+++ b/src/worldforge/providers/runtime_manifests/runway.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": 1,
+  "provider": "runway",
+  "capabilities": ["generate", "transfer"],
+  "optional_dependencies": [],
+  "required_env_vars": ["RUNWAYML_API_SECRET", "RUNWAY_API_SECRET"],
+  "optional_env_vars": ["RUNWAYML_BASE_URL"],
+  "default_model": "gen4.5",
+  "device_support": ["remote"],
+  "host_owned_artifacts": ["Runway task ids", "downloaded video artifacts", "artifact retention path"],
+  "minimum_smoke_command": "WORLD_FORGE_RUN_LIVE=1 RUNWAYML_API_SECRET=<secret> uv run pytest tests/test_remote_video_providers.py -m live --provider-profile runway",
+  "expected_success_signal": "Runway organization health succeeds and task output downloads as video bytes",
+  "setup_hint": "configure Runway credentials and persist returned task artifacts before URLs expire",
+  "docs_path": "docs/src/providers/runway.md"
+}

--- a/tests/test_provider_runtime_manifests.py
+++ b/tests/test_provider_runtime_manifests.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import json
+from importlib import resources
+
+import pytest
+
+from worldforge.models import WorldForgeError
+from worldforge.providers.catalog import PROVIDER_CATALOG
+from worldforge.providers.gr00t import GrootPolicyClientProvider
+from worldforge.providers.lerobot import LeRobotPolicyProvider
+from worldforge.providers.leworldmodel import LeWorldModelProvider
+from worldforge.providers.runtime_manifest import (
+    MANIFEST_PACKAGE,
+    ProviderRuntimeManifest,
+    load_runtime_manifests,
+    missing_optional_dependency_detail,
+)
+
+EXPECTED_MANIFEST_PROVIDERS = ("cosmos", "gr00t", "lerobot", "leworldmodel", "runway")
+
+
+def test_runtime_manifests_cover_real_optional_providers() -> None:
+    manifests = load_runtime_manifests()
+    manifest_names = tuple(manifest.provider for manifest in manifests)
+
+    assert manifest_names == EXPECTED_MANIFEST_PROVIDERS
+    catalog = {entry.name: entry.create().profile() for entry in PROVIDER_CATALOG}
+    for manifest in manifests:
+        profile = catalog[manifest.provider]
+        assert manifest.schema_version == 1
+        assert set(manifest.capabilities) <= set(profile.capabilities.enabled_names())
+        assert manifest.docs_path == f"docs/src/providers/{manifest.provider}.md"
+        assert manifest.minimum_smoke_command
+        assert manifest.expected_success_signal
+        assert manifest.host_owned_artifacts
+
+
+def test_runtime_manifest_json_files_validate_without_optional_dependencies() -> None:
+    for manifest_file in sorted(resources.files(MANIFEST_PACKAGE).iterdir()):
+        if not manifest_file.name.endswith(".json"):
+            continue
+        payload = json.loads(manifest_file.read_text(encoding="utf-8"))
+        assert isinstance(payload, dict)
+        manifest = ProviderRuntimeManifest.from_json(payload, source=manifest_file.name)
+        assert manifest.provider == manifest_file.name.removesuffix(".json")
+
+
+def test_runtime_manifest_validation_rejects_weak_records() -> None:
+    payload = {
+        "schema_version": 1,
+        "provider": "example",
+        "capabilities": ["score"],
+        "optional_dependencies": ["runtime"],
+        "required_env_vars": ["EXAMPLE_MODEL"],
+        "optional_env_vars": [],
+        "default_model": "example/model",
+        "device_support": ["cpu"],
+        "host_owned_artifacts": ["checkpoint"],
+        "minimum_smoke_command": "",
+        "expected_success_signal": "scores returned",
+        "setup_hint": "install runtime",
+        "docs_path": "docs/src/providers/example.md",
+    }
+
+    with pytest.raises(WorldForgeError, match="minimum_smoke_command"):
+        ProviderRuntimeManifest.from_json(payload, source="example.json")
+
+
+def test_manifest_backed_dependency_health_messages_are_actionable(monkeypatch) -> None:
+    monkeypatch.setenv("LEWORLDMODEL_POLICY", "pusht/lewm")
+    health = LeWorldModelProvider().health()
+
+    assert health.healthy is False
+    assert "missing optional dependency torch" in health.details
+    assert "minimum smoke:" in health.details
+    assert "scripts/lewm-real" in health.details
+
+
+def test_manifest_backed_configuration_health_messages_include_docs(monkeypatch) -> None:
+    for name in ("LEWORLDMODEL_POLICY", "LEWM_POLICY", "LEROBOT_POLICY_PATH", "LEROBOT_POLICY"):
+        monkeypatch.delenv(name, raising=False)
+
+    leworldmodel = LeWorldModelProvider().health()
+    lerobot = LeRobotPolicyProvider().health()
+    gr00t = GrootPolicyClientProvider().health()
+
+    assert "docs/src/providers/leworldmodel.md" in leworldmodel.details
+    assert "docs/src/providers/lerobot.md" in lerobot.details
+    assert "docs/src/providers/gr00t.md" in gr00t.details
+
+
+def test_manifest_dependency_detail_falls_back_for_unknown_dependency() -> None:
+    assert (
+        missing_optional_dependency_detail("lerobot", "not-in-manifest")
+        == "missing optional dependency not-in-manifest"
+    )


### PR DESCRIPTION
Closes #55.

## Summary
- add packaged JSON runtime manifests for Cosmos, Runway, LeWorldModel, GR00T, and LeRobot
- add a dependency-free manifest loader/validator and tests
- use manifest data in optional-runtime health messages for actionable setup and smoke hints
- document the manifest schema and link provider pages to their manifests

## Validation
- `uv run ruff check src tests examples scripts`
- `uv run ruff format --check src tests examples scripts`
- `uv run python scripts/generate_provider_docs.py --check`
- `uv lock --check`
- `uv run mkdocs build --strict`
- `uv run --extra harness pytest --cov=src/worldforge --cov-report=term-missing --cov-fail-under=90`
- `uv run pytest`
- `bash scripts/test_package.sh`
- `UV_LOCKED=true uv export --all-groups --no-emit-project --no-hashes -o /tmp/worldforge-requirements-ci.txt && uvx --from pip-audit pip-audit -r /tmp/worldforge-requirements-ci.txt`
- `uv build --out-dir dist --clear --no-build-logs`
