### PR TITLE
Add provider promotion gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,16 +320,16 @@ observe state
 ## Provider Surfaces
 
 <!-- provider-catalog-readme:start -->
-| Provider | Capability surface | Registration | Runtime ownership |
-| --- | --- | --- | --- |
-| `mock` | `predict`, `generate`, `transfer`, `reason`, `embed` | always registered | in-repo deterministic local provider |
-| [`cosmos`](https://abdelstark.github.io/worldforge/providers/cosmos/) | `generate` | `COSMOS_BASE_URL` | host supplies a reachable Cosmos deployment and optional `NVIDIA_API_KEY` |
-| [`runway`](https://abdelstark.github.io/worldforge/providers/runway/) | `generate`, `transfer` | `RUNWAYML_API_SECRET` or `RUNWAY_API_SECRET` | host supplies Runway credentials and persists returned artifacts |
-| [`leworldmodel`](https://abdelstark.github.io/worldforge/providers/leworldmodel/) | `score` | `LEWORLDMODEL_POLICY` or `LEWM_POLICY` | host installs the official LeWM loading path (`stable_worldmodel.policy.AutoCostModel`), torch, and compatible checkpoints |
-| [`gr00t`](https://abdelstark.github.io/worldforge/providers/gr00t/) | `policy` | `GROOT_POLICY_HOST` | host runs or reaches an Isaac GR00T policy server |
-| [`lerobot`](https://abdelstark.github.io/worldforge/providers/lerobot/) | `policy` | `LEROBOT_POLICY_PATH` or `LEROBOT_POLICY` | host installs LeRobot and compatible policy checkpoints |
-| `jepa` | scaffold | `JEPA_MODEL_PATH` | capability-fail-closed reservation, not a real JEPA runtime |
-| `genie` | scaffold | `GENIE_API_KEY` | capability-fail-closed reservation, not a real Genie runtime |
+| Provider | Maturity | Capability surface | Registration | Runtime ownership |
+| --- | --- | --- | --- | --- |
+| `mock` | `stable` | `predict`, `generate`, `transfer`, `reason`, `embed` | always registered | in-repo deterministic local provider |
+| [`cosmos`](https://abdelstark.github.io/worldforge/providers/cosmos/) | `beta` | `generate` | `COSMOS_BASE_URL` | host supplies a reachable Cosmos deployment and optional `NVIDIA_API_KEY` |
+| [`runway`](https://abdelstark.github.io/worldforge/providers/runway/) | `beta` | `generate`, `transfer` | `RUNWAYML_API_SECRET` or `RUNWAY_API_SECRET` | host supplies Runway credentials and persists returned artifacts |
+| [`leworldmodel`](https://abdelstark.github.io/worldforge/providers/leworldmodel/) | `beta` | `score` | `LEWORLDMODEL_POLICY` or `LEWM_POLICY` | host installs the official LeWM loading path (`stable_worldmodel.policy.AutoCostModel`), torch, and compatible checkpoints |
+| [`gr00t`](https://abdelstark.github.io/worldforge/providers/gr00t/) | `experimental` | `policy` | `GROOT_POLICY_HOST` | host runs or reaches an Isaac GR00T policy server |
+| [`lerobot`](https://abdelstark.github.io/worldforge/providers/lerobot/) | `beta` | `policy` | `LEROBOT_POLICY_PATH` or `LEROBOT_POLICY` | host installs LeRobot and compatible policy checkpoints |
+| `jepa` | `scaffold` | scaffold | `JEPA_MODEL_PATH` | capability-fail-closed reservation, not a real JEPA runtime |
+| `genie` | `scaffold` | scaffold | `GENIE_API_KEY` | capability-fail-closed reservation, not a real Genie runtime |
 <!-- provider-catalog-readme:end -->
 
 `jepa` and `genie` are capability-closed reservations. Executable scaffold candidates stay outside

--- a/docs/src/provider-authoring-guide.md
+++ b/docs/src/provider-authoring-guide.md
@@ -162,7 +162,45 @@ Implementation choices:
 - Use `RunnableModel` only when one logical model genuinely groups several protocol
   implementations under one registration call.
 
-## Step 3: Define the Contract Before Code
+## Step 3: Apply the Promotion Gate
+
+`ProviderProfileSpec.implementation_status` is the maturity claim that appears in diagnostics and
+generated provider catalog docs. Change it only when the provider has the evidence for the target
+status.
+
+| Status | Allowed public claim | Required evidence before promotion | Required wording |
+| --- | --- | --- | --- |
+| `scaffold` | Reserved provider name or candidate contract. | Provider docs say it is not real; public capability flags are disabled or the candidate stays outside auto-registration; methods fail closed unless a test-only opt-in is explicit. | "scaffold", "reservation", or "candidate"; never "integration" or "usable provider". |
+| `experimental` | Real upstream path exists, but the contract may change. | Injected-runtime or fixture tests cover the callable boundary, health reports missing runtime/config clearly, and docs list known gaps or blockers. | "experimental", "known gaps", and host-owned runtime limits. |
+| `beta` | Prepared hosts can use the provider for the documented capability. | Capability tests, runtime manifest, generated provider docs, fixture-backed failure modes, redacted events, and a documented smoke command or explicit live-smoke blocker. | "prepared host", supported models/env vars, failure modes, and artifact retention where relevant. |
+| `stable` | Recommended provider path for its capability. | Repeated smoke evidence, release evidence, parser and validation coverage, incident/runbook notes, compatibility expectations, and no unresolved runtime contract blockers. | "stable" only with supported operator use and compatibility limits. |
+
+Promotion checklist:
+
+- [ ] Update `ProviderProfileSpec.implementation_status` and profile metadata in the provider.
+- [ ] Update `runtime_ownership` or `docs_page` in `src/worldforge/providers/catalog.py` when the
+      generated catalog row would otherwise be misleading.
+- [ ] Run `uv run python scripts/generate_provider_docs.py` after catalog/profile changes, then
+      `uv run python scripts/generate_provider_docs.py --check`.
+- [ ] Run provider-specific pytest files plus `uv run pytest tests/test_provider_catalog_docs.py`.
+- [ ] Run `uv run mkdocs build --strict`.
+- [ ] Keep the behavior change separate from promotion wording when either part is large.
+
+Current classifications:
+
+| Provider | Status | Why it is classified this way |
+| --- | --- | --- |
+| `mock` | `stable` | Deterministic in-repo provider with no optional runtime and broad checkout-safe test coverage. |
+| `cosmos` | `beta` | Real remote generate adapter with fixture coverage and runtime manifest; prepared hosts own the Cosmos deployment. |
+| `runway` | `beta` | Real remote generate/transfer adapter with parser and artifact checks; prepared hosts own credentials and artifact retention. |
+| `leworldmodel` | `beta` | Real score adapter for the official LeWM loading path; prepared hosts own torch, `stable_worldmodel`, and checkpoints. |
+| `gr00t` | `experimental` | Real PolicyClient boundary exists, but prepared-host operation and failure coverage still need beta hardening. |
+| `lerobot` | `beta` | Real policy adapter with host-owned LeRobot/checkpoint runtime and documented translator boundary. |
+| `jepa` | `scaffold` | Fail-closed reservation until a real upstream JEPA runtime and single capability are selected. |
+| `genie` | `scaffold` | Fail-closed reservation until a concrete upstream runtime/API contract exists. |
+| `jepa-wms` | `scaffold` | Direct-construction candidate only; not exported or auto-registered until runtime limits and smoke evidence are credible. |
+
+## Step 4: Define the Contract Before Code
 
 Write down the provider contract in the PR description or docs before implementation.
 
@@ -199,7 +237,7 @@ Questions to answer:
 - [ ] What does the provider return when output is partial, expired, missing, malformed, or
       physically implausible?
 
-## Step 4: Use the Standard Adapter Shape
+## Step 5: Use the Standard Adapter Shape
 
 Provider adapters should be small boundary objects. Choose the smallest shape that honestly
 represents the integration.
@@ -295,7 +333,7 @@ forge = WorldForge(auto_register_remote=False)
 forge.register_cost(ExampleCost())
 ```
 
-## Step 5: Boundary Validation Checklist
+## Step 6: Boundary Validation Checklist
 
 Validate at the narrowest boundary. Do not let malformed upstream or caller data leak into public
 models.
@@ -332,7 +370,7 @@ State mutation:
 - [ ] Do not mutate the caller's `World` during comparison workflows.
 - [ ] Preserve history and metadata intentionally.
 
-## Step 6: LeWorldModel-Style Score Provider Checklist
+## Step 7: LeWorldModel-Style Score Provider Checklist
 
 Use this checklist for JEPA and latent cost-model providers.
 
@@ -370,7 +408,7 @@ Do not:
 - [ ] Do not hide score direction in prose only.
 - [ ] Do not infer raw image transforms unless the adapter actually implements and tests them.
 
-## Step 7: Embodied Policy Provider Checklist
+## Step 8: Embodied Policy Provider Checklist
 
 Use this checklist for VLA and robot policy providers such as NVIDIA Isaac GR00T.
 
@@ -403,7 +441,7 @@ Do not:
 - [ ] Do not set `score=True` unless it ranks candidates with explicit score semantics.
 - [ ] Do not hide real-robot safety checks inside WorldForge. Safety interlocks are host-owned.
 
-## Step 8: Predictive Provider Checklist
+## Step 9: Predictive Provider Checklist
 
 Use this checklist for providers that roll a world state forward.
 
@@ -416,7 +454,7 @@ Use this checklist for providers that roll a world state forward.
 - [ ] Tests cover malformed world state, missing scene objects, impossible actions if applicable,
       non-finite metrics, and provider failure propagation.
 
-## Step 9: Generative and Transfer Provider Checklist
+## Step 10: Generative and Transfer Provider Checklist
 
 Use this checklist for video or artifact providers.
 
@@ -431,7 +469,7 @@ Use this checklist for video or artifact providers.
 - [ ] Tests cover bad content types, expired artifacts, missing outputs, task failures, malformed
       JSON, timeout, retry, and provider-specific limits.
 
-## Step 10: Observability and Failure Semantics
+## Step 11: Observability and Failure Semantics
 
 Every real provider should emit useful `ProviderEvent` records.
 
@@ -453,7 +491,7 @@ Checklist:
       "request failed."
 - [ ] Unexpected exceptions are wrapped in `ProviderError` with context.
 
-## Step 11: Test Requirements
+## Step 12: Test Requirements
 
 Provider tests should be fixture-driven and contract-driven.
 
@@ -497,7 +535,7 @@ Local model providers:
 - [ ] A real-model smoke script is optional, documented, and not part of the default unit suite.
 - [ ] Checkpoint paths and cache directories are host-owned.
 
-## Step 12: Documentation Requirements
+## Step 13: Documentation Requirements
 
 A provider PR is incomplete without docs.
 

--- a/docs/src/providers/README.md
+++ b/docs/src/providers/README.md
@@ -10,16 +10,16 @@ Keep this page and the provider pages aligned with that catalog.
 ## Provider Catalog
 
 <!-- provider-catalog:start -->
-| Provider | Capability surface | Registration | Runtime ownership |
-| --- | --- | --- | --- |
-| `mock` | `predict`, `generate`, `transfer`, `reason`, `embed` | always registered | in-repo deterministic local provider |
-| [`cosmos`](./cosmos.md) | `generate` | `COSMOS_BASE_URL` | host supplies a reachable Cosmos deployment and optional `NVIDIA_API_KEY` |
-| [`runway`](./runway.md) | `generate`, `transfer` | `RUNWAYML_API_SECRET` or `RUNWAY_API_SECRET` | host supplies Runway credentials and persists returned artifacts |
-| [`leworldmodel`](./leworldmodel.md) | `score` | `LEWORLDMODEL_POLICY` or `LEWM_POLICY` | host installs the official LeWM loading path (`stable_worldmodel.policy.AutoCostModel`), torch, and compatible checkpoints |
-| [`gr00t`](./gr00t.md) | `policy` | `GROOT_POLICY_HOST` | host runs or reaches an Isaac GR00T policy server |
-| [`lerobot`](./lerobot.md) | `policy` | `LEROBOT_POLICY_PATH` or `LEROBOT_POLICY` | host installs LeRobot and compatible policy checkpoints |
-| `jepa` | scaffold | `JEPA_MODEL_PATH` | capability-fail-closed reservation, not a real JEPA runtime |
-| `genie` | scaffold | `GENIE_API_KEY` | capability-fail-closed reservation, not a real Genie runtime |
+| Provider | Maturity | Capability surface | Registration | Runtime ownership |
+| --- | --- | --- | --- | --- |
+| `mock` | `stable` | `predict`, `generate`, `transfer`, `reason`, `embed` | always registered | in-repo deterministic local provider |
+| [`cosmos`](./cosmos.md) | `beta` | `generate` | `COSMOS_BASE_URL` | host supplies a reachable Cosmos deployment and optional `NVIDIA_API_KEY` |
+| [`runway`](./runway.md) | `beta` | `generate`, `transfer` | `RUNWAYML_API_SECRET` or `RUNWAY_API_SECRET` | host supplies Runway credentials and persists returned artifacts |
+| [`leworldmodel`](./leworldmodel.md) | `beta` | `score` | `LEWORLDMODEL_POLICY` or `LEWM_POLICY` | host installs the official LeWM loading path (`stable_worldmodel.policy.AutoCostModel`), torch, and compatible checkpoints |
+| [`gr00t`](./gr00t.md) | `experimental` | `policy` | `GROOT_POLICY_HOST` | host runs or reaches an Isaac GR00T policy server |
+| [`lerobot`](./lerobot.md) | `beta` | `policy` | `LEROBOT_POLICY_PATH` or `LEROBOT_POLICY` | host installs LeRobot and compatible policy checkpoints |
+| `jepa` | `scaffold` | scaffold | `JEPA_MODEL_PATH` | capability-fail-closed reservation, not a real JEPA runtime |
+| `genie` | `scaffold` | scaffold | `GENIE_API_KEY` | capability-fail-closed reservation, not a real Genie runtime |
 <!-- provider-catalog:end -->
 
 ## Candidate Scaffolds

--- a/src/worldforge/providers/catalog.py
+++ b/src/worldforge/providers/catalog.py
@@ -26,6 +26,7 @@ DOC_CAPABILITY_ORDER = (
     "embed",
     "plan",
 )
+PROVIDER_PROMOTION_STATUSES = ("scaffold", "experimental", "beta", "stable")
 
 
 @dataclass(frozen=True, slots=True)
@@ -165,8 +166,8 @@ def render_provider_catalog_markdown(*, docs_link_prefix: str = "./") -> str:
     """Render the provider catalog table used by the provider documentation index."""
 
     lines = [
-        "| Provider | Capability surface | Registration | Runtime ownership |",
-        "| --- | --- | --- | --- |",
+        "| Provider | Maturity | Capability surface | Registration | Runtime ownership |",
+        "| --- | --- | --- | --- | --- |",
     ]
     for entry in PROVIDER_CATALOG:
         profile = entry.create().profile()
@@ -185,6 +186,7 @@ def render_provider_catalog_markdown(*, docs_link_prefix: str = "./") -> str:
         lines.append(
             "| "
             f"{entry.display_name(docs_link_prefix=docs_link_prefix)} | "
+            f"`{profile.implementation_status}` | "
             f"{capability_surface} | "
             f"{registration} | "
             f"{entry.runtime_ownership} |"
@@ -215,6 +217,7 @@ def provider_docs_index(
             {
                 "name": entry.name,
                 "docs_path": docs_path,
+                "implementation_status": profile.implementation_status,
                 "capabilities": capabilities,
                 "registration": (
                     "always registered"

--- a/tests/test_cli_doctor.py
+++ b/tests/test_cli_doctor.py
@@ -79,6 +79,7 @@ def test_provider_docs_cli_outputs_markdown_and_json(monkeypatch, capsys) -> Non
         {
             "name": "runway",
             "docs_path": "docs/src/providers/runway.md",
+            "implementation_status": "beta",
             "capabilities": "generate, transfer",
             "registration": "RUNWAYML_API_SECRET or RUNWAY_API_SECRET",
             "runtime_ownership": "host supplies Runway credentials and persists returned artifacts",

--- a/tests/test_provider_catalog.py
+++ b/tests/test_provider_catalog.py
@@ -3,7 +3,11 @@ from __future__ import annotations
 import pytest
 
 from worldforge import WorldForge
-from worldforge.providers.catalog import PROVIDER_CATALOG, create_known_providers
+from worldforge.providers.catalog import (
+    PROVIDER_CATALOG,
+    PROVIDER_PROMOTION_STATUSES,
+    create_known_providers,
+)
 
 
 def test_provider_catalog_names_are_unique_and_explicit() -> None:
@@ -35,6 +39,29 @@ def test_provider_catalog_instantiates_known_provider_profiles() -> None:
     assert profiles["jepa"].capabilities.enabled_names() == []
     assert profiles["genie"].implementation_status == "scaffold"
     assert profiles["genie"].capabilities.enabled_names() == []
+
+
+def test_provider_catalog_statuses_match_promotion_gate() -> None:
+    profiles = {provider.name: provider.profile() for provider in create_known_providers()}
+
+    assert set(PROVIDER_PROMOTION_STATUSES) == {
+        "scaffold",
+        "experimental",
+        "beta",
+        "stable",
+    }
+    assert {name: profile.implementation_status for name, profile in profiles.items()} == {
+        "mock": "stable",
+        "cosmos": "beta",
+        "runway": "beta",
+        "leworldmodel": "beta",
+        "gr00t": "experimental",
+        "lerobot": "beta",
+        "jepa": "scaffold",
+        "genie": "scaffold",
+    }
+    for profile in profiles.values():
+        assert profile.implementation_status in PROVIDER_PROMOTION_STATUSES
 
 
 # Pairs of (canonical_env_var, legacy_alias) that provider auto-registration must continue

--- a/tests/test_provider_catalog_docs.py
+++ b/tests/test_provider_catalog_docs.py
@@ -62,5 +62,11 @@ def test_provider_catalog_docs_pages_exist_for_linked_entries() -> None:
 def test_provider_docs_index_points_to_existing_docs() -> None:
     for entry in provider_docs_index():
         assert (ROOT / entry["docs_path"]).exists()
+        assert entry["implementation_status"] in {
+            "scaffold",
+            "experimental",
+            "beta",
+            "stable",
+        }
         assert entry["capabilities"]
         assert entry["registration"]


### PR DESCRIPTION
## Summary
- add a documented provider promotion gate for scaffold, experimental, beta, and stable statuses
- include provider maturity in generated catalog docs and CLI docs metadata
- classify current providers against the gate without changing provider behavior

## Validation
- uv run ruff check src tests examples scripts
- uv run ruff format --check src tests examples scripts
- uv run pytest
- uv run --extra harness pytest --cov=src/worldforge --cov-report=term-missing --cov-fail-under=90
- uv run python scripts/generate_provider_docs.py --check
- uv run mkdocs build --strict
- bash scripts/test_package.sh
- uv lock --check
- UV_LOCKED=true uv export --all-groups --no-emit-project --no-hashes --output-file /tmp/worldforge-requirements.txt
- uvx --from pip-audit pip-audit -r /tmp/worldforge-requirements.txt

Closes #53.
