### PR TITLE
Add redacted provider config summaries

### DIFF
--- a/docs/src/providers/README.md
+++ b/docs/src/providers/README.md
@@ -103,6 +103,18 @@ uv run worldforge doctor --capability score
 configuration visible before a workflow fails. Use `--registered-only` when a process needs to
 check only the providers enabled for that process.
 
+Providers also expose `config_summary()` for issue evidence and host diagnostics. It reports
+whether documented fields are present, where they came from (`env:<NAME>`, `direct`, `default`, or
+`unset`), whether the field is required, and whether it is secret-like. It never returns raw values,
+tokens, endpoint strings, checkpoint paths, or constructor arguments.
+
+```python
+from worldforge.providers import RunwayProvider
+
+summary = RunwayProvider().config_summary().to_dict()
+print(summary["fields"])
+```
+
 ## Runtime Manifests
 
 Real optional providers also have packaged JSON runtime manifests in
@@ -126,6 +138,8 @@ Schema version `1` includes:
 
 WorldForge never auto-installs optional provider runtimes from these manifests. Missing optional
 dependencies stay explicit in `health()` output and point back to the manifest-backed smoke path.
+Manifests also provide the same value-free `config_summary()` shape for tools that need to inspect
+declared provider env vars without importing or constructing the provider runtime.
 
 ## Runtime Ownership
 

--- a/docs/src/security.md
+++ b/docs/src/security.md
@@ -13,5 +13,11 @@ released source distributions. Host-owned optional runtimes, CUDA stacks, robot 
 checkpoints, datasets, credentials, and third-party provider services remain outside the base
 package security boundary.
 
+Provider diagnostics are designed to be value-free. `config_summary()` reports field names,
+presence, source, validation status, and secret classification without returning raw values.
+Provider events and health details redact common bearer/API key/password/signature shapes and strip
+query strings from URLs before serialization. Hosts should still avoid putting raw secrets into
+custom exception messages, artifact metadata, or issue attachments.
+
 For scope, response targets, and supported versions, see the canonical
 [Security Policy](https://github.com/AbdelStark/worldforge/blob/main/SECURITY.md).

--- a/docs/src/support.md
+++ b/docs/src/support.md
@@ -21,6 +21,12 @@ uv run worldforge doctor
 uv run worldforge provider info <provider>
 ```
 
+It is safe to attach provider profiles, doctor output, provider health, runtime manifests,
+`config_summary().to_dict()` output, benchmark reports, and preserved JSON inputs after checking
+that host-specific object names are acceptable to share. Do not attach `.env` files, raw provider
+request bodies, bearer tokens, signed artifact URLs with query strings, private checkpoint files,
+robot controller credentials, or logs captured before provider-event redaction.
+
 For optional runtimes, include the exact wrapper command, host OS, Python version, checkpoint or
 policy identifier, and the stage that failed: dependency import, checkpoint loading, provider call,
 or action translation.

--- a/src/worldforge/cli.py
+++ b/src/worldforge/cli.py
@@ -881,6 +881,7 @@ def _cmd_provider_info(args: argparse.Namespace, forge: WorldForge) -> int:
         "registered": name in forge.providers(),
         "profile": forge.provider_profile(name).to_dict(),
         "health": forge.provider_health(name).to_dict(),
+        "config_summary": forge.provider_config_summary(name).to_dict(),
     }
     if name in forge.providers():
         payload["info"] = forge.provider_info(name).to_dict()

--- a/src/worldforge/framework.py
+++ b/src/worldforge/framework.py
@@ -69,6 +69,7 @@ from worldforge.models import (
 from worldforge.providers import (
     BaseProvider,
     PredictionPayload,
+    ProviderConfigSummary,
     ProviderError,
     validate_generation_request,
     validate_transfer_request,
@@ -1774,6 +1775,17 @@ class WorldForge:
             legacy_provider=legacy_provider,
             wrappers=wrappers,
         )
+
+    def provider_config_summary(self, name: str) -> ProviderConfigSummary:
+        """Return value-free configuration status for a registered or known provider."""
+
+        provider_name = _require_non_empty_text(name, name="Provider name")
+        legacy_provider = self._registered_or_known_provider(provider_name, include_known=True)
+        if legacy_provider is not None:
+            return legacy_provider.config_summary()
+        if self._capability_wrappers_for_name(provider_name):
+            return ProviderConfigSummary(provider=provider_name, configured=True, fields=())
+        raise ProviderError(f"Provider '{provider_name}' is unknown.")
 
     def provider_healths(self, capability: str | None = None) -> list[ProviderHealth]:
         names = self.providers()

--- a/src/worldforge/providers/__init__.py
+++ b/src/worldforge/providers/__init__.py
@@ -7,6 +7,7 @@ from worldforge.models import (
     RetryPolicy,
 )
 
+from ._config import ConfigFieldSummary, ProviderConfigSummary
 from .base import (
     BaseProvider,
     PredictionPayload,
@@ -28,6 +29,7 @@ from .runway import RunwayProvider
 __all__ = [
     "PROVIDER_CATALOG",
     "BaseProvider",
+    "ConfigFieldSummary",
     "CosmosProvider",
     "GenieProvider",
     "GrootPolicyClientProvider",
@@ -37,6 +39,7 @@ __all__ = [
     "MockProvider",
     "PredictionPayload",
     "ProviderCatalogEntry",
+    "ProviderConfigSummary",
     "ProviderError",
     "ProviderEvent",
     "ProviderProfileSpec",

--- a/src/worldforge/providers/_config.py
+++ b/src/worldforge/providers/_config.py
@@ -3,9 +3,69 @@
 from __future__ import annotations
 
 import os
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
 
-from worldforge.models import WorldForgeError, require_positive_int
+from worldforge.models import JSONDict, WorldForgeError, require_json_dict, require_positive_int
+
+
+@dataclass(frozen=True, slots=True)
+class ConfigFieldSummary:
+    """Value-free provider configuration status for diagnostics and issue evidence."""
+
+    name: str
+    present: bool
+    source: str
+    required: bool
+    secret: bool
+    valid: bool
+    detail: str = ""
+    aliases: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.name, str) or not self.name.strip():
+            raise WorldForgeError("ConfigFieldSummary name must be a non-empty string.")
+        if not isinstance(self.source, str) or not self.source.strip():
+            raise WorldForgeError("ConfigFieldSummary source must be a non-empty string.")
+        if not isinstance(self.detail, str):
+            raise WorldForgeError("ConfigFieldSummary detail must be a string.")
+        if any(not isinstance(alias, str) or not alias.strip() for alias in self.aliases):
+            raise WorldForgeError("ConfigFieldSummary aliases must be non-empty strings.")
+
+    def to_dict(self) -> JSONDict:
+        return {
+            "name": self.name,
+            "present": self.present,
+            "source": self.source,
+            "required": self.required,
+            "secret": self.secret,
+            "valid": self.valid,
+            "detail": self.detail,
+            "aliases": list(self.aliases),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderConfigSummary:
+    """Value-free provider configuration summary safe for logs and issue attachments."""
+
+    provider: str
+    configured: bool
+    fields: tuple[ConfigFieldSummary, ...]
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.provider, str) or not self.provider.strip():
+            raise WorldForgeError("ProviderConfigSummary provider must be a non-empty string.")
+
+    def to_dict(self) -> JSONDict:
+        return require_json_dict(
+            {
+                "provider": self.provider,
+                "configured": self.configured,
+                "fields": [field.to_dict() for field in self.fields],
+            },
+            name="ProviderConfigSummary",
+        )
 
 
 def env_value(name: str) -> str | None:
@@ -25,6 +85,62 @@ def first_env_value(names: Sequence[str]) -> str | None:
         if value is not None:
             return value
     return None
+
+
+def config_field_summary(
+    name: str,
+    *,
+    aliases: Sequence[str] = (),
+    required: bool = True,
+    secret: bool = False,
+    source: str | None = None,
+    present: bool | None = None,
+    valid: bool | None = None,
+    detail: str = "",
+    environ: Mapping[str, str] | None = None,
+) -> ConfigFieldSummary:
+    """Build a value-free configuration summary for one env-backed field."""
+
+    env = os.environ if environ is None else environ
+    names = (name, *tuple(aliases))
+    resolved_name = next((env_name for env_name in names if env_value_from(env, env_name)), None)
+    resolved_present = present if present is not None else resolved_name is not None
+    resolved_source = source or (f"env:{resolved_name}" if resolved_name else "unset")
+    resolved_valid = valid if valid is not None else (not required or resolved_present)
+    resolved_detail = detail
+    if not resolved_detail and required and not resolved_present:
+        resolved_detail = "missing"
+    return ConfigFieldSummary(
+        name=name,
+        present=resolved_present,
+        source=resolved_source,
+        required=required,
+        secret=secret,
+        valid=resolved_valid,
+        detail=resolved_detail,
+        aliases=tuple(aliases),
+    )
+
+
+def config_source(name: str, *, direct: bool = False, default: bool = False) -> str:
+    """Return the value-free source label for an env/direct/default-backed field."""
+
+    if env_value(name) is not None:
+        return f"env:{name}"
+    if direct:
+        return "direct"
+    if default:
+        return "default"
+    return "unset"
+
+
+def env_value_from(environ: Mapping[str, str], name: str) -> str | None:
+    """Return a stripped value from a supplied environment mapping."""
+
+    value = environ.get(name)
+    if value is None or not value.strip():
+        return None
+    return value.strip()
 
 
 def optional_non_empty(value: str | None, *, name: str) -> str | None:

--- a/src/worldforge/providers/base.py
+++ b/src/worldforge/providers/base.py
@@ -29,6 +29,12 @@ from worldforge.models import (
     require_probability,
 )
 
+from ._config import (
+    ConfigFieldSummary,
+    ProviderConfigSummary,
+    config_field_summary,
+)
+
 
 class ProviderError(RuntimeError):
     """Raised when a provider cannot satisfy a request."""
@@ -245,6 +251,29 @@ class BaseProvider:
             return all(bool(os.environ.get(env_var)) for env_var in self.required_env_vars)
         return True
 
+    def config_summary(self) -> ProviderConfigSummary:
+        """Return value-free provider configuration status safe for diagnostics.
+
+        The summary reports names, aliases, source, presence, and validation status only.
+        It never includes raw environment values, endpoints, tokens, checkpoint paths, or
+        constructor-provided values.
+        """
+
+        names = (self.env_var,) if self.env_var is not None else tuple(self.required_env_vars)
+        fields = tuple(
+            config_field_summary(
+                name,
+                required=True,
+                secret=_looks_secret_name(name),
+            )
+            for name in names
+        )
+        return ProviderConfigSummary(
+            provider=self.name,
+            configured=self.configured(),
+            fields=fields,
+        )
+
     def health(self) -> ProviderHealth:
         started = perf_counter()
         healthy = self.configured()
@@ -405,3 +434,35 @@ class RemoteProvider(BaseProvider):
         if self.request_policy is None:
             raise ProviderError(f"Provider '{self.name}' does not define a request policy.")
         return self.request_policy
+
+
+def _looks_secret_name(name: str) -> bool:
+    return any(
+        marker in name.lower()
+        for marker in ("api_key", "api_secret", "secret", "token", "password", "credential")
+    )
+
+
+def _field_summary(
+    name: str,
+    *,
+    aliases: tuple[str, ...] = (),
+    required: bool = True,
+    secret: bool = False,
+    source: str | None = None,
+    present: bool | None = None,
+    valid: bool | None = None,
+    detail: str = "",
+) -> ConfigFieldSummary:
+    """Internal adapter helper kept here so providers can share summary semantics."""
+
+    return config_field_summary(
+        name,
+        aliases=aliases,
+        required=required,
+        secret=secret,
+        source=source,
+        present=present,
+        valid=valid,
+        detail=detail,
+    )

--- a/src/worldforge/providers/cosmos.py
+++ b/src/worldforge/providers/cosmos.py
@@ -18,8 +18,14 @@ from worldforge.models import (
     VideoClip,
 )
 
-from ._config import env_value
-from .base import ProviderError, ProviderProfileSpec, RemoteProvider, validate_generation_request
+from ._config import ProviderConfigSummary, config_source, env_value
+from .base import (
+    ProviderError,
+    ProviderProfileSpec,
+    RemoteProvider,
+    _field_summary,
+    validate_generation_request,
+)
 from .http_utils import asset_to_uri, parse_size, request_json_with_policy
 
 
@@ -150,6 +156,28 @@ class CosmosProvider(RemoteProvider):
 
     def configured(self) -> bool:
         return bool(self._resolved_base_url())
+
+    def config_summary(self) -> ProviderConfigSummary:
+        api_key_from_env = env_value("NVIDIA_API_KEY") is not None
+        return ProviderConfigSummary(
+            provider=self.name,
+            configured=self.configured(),
+            fields=(
+                _field_summary(
+                    "COSMOS_BASE_URL",
+                    required=True,
+                    source=config_source("COSMOS_BASE_URL", direct=self._base_url is not None),
+                    present=self._resolved_base_url() is not None,
+                ),
+                _field_summary(
+                    "NVIDIA_API_KEY",
+                    required=False,
+                    secret=True,
+                    source="env:NVIDIA_API_KEY" if api_key_from_env else "unset",
+                    present=api_key_from_env,
+                ),
+            ),
+        )
 
     def _resolved_base_url(self) -> str | None:
         return self._base_url or env_value("COSMOS_BASE_URL")

--- a/src/worldforge/providers/gr00t.py
+++ b/src/worldforge/providers/gr00t.py
@@ -16,9 +16,16 @@ from worldforge.models import (
     ProviderHealth,
 )
 
-from ._config import env_value, optional_bool, optional_non_empty, optional_positive_int
+from ._config import (
+    ProviderConfigSummary,
+    config_source,
+    env_value,
+    optional_bool,
+    optional_non_empty,
+    optional_positive_int,
+)
 from ._policy import json_compatible, json_object, normalize_policy_action_candidates
-from .base import BaseProvider, ProviderError, ProviderProfileSpec
+from .base import BaseProvider, ProviderError, ProviderProfileSpec, _field_summary
 from .runtime_manifest import (
     missing_optional_dependency_detail,
     missing_runtime_configuration_detail,
@@ -134,6 +141,72 @@ class GrootPolicyClientProvider(BaseProvider):
 
     def configured(self) -> bool:
         return self._policy_client is not None or self.host is not None
+
+    def config_summary(self) -> ProviderConfigSummary:
+        return ProviderConfigSummary(
+            provider=self.name,
+            configured=self.configured(),
+            fields=(
+                _field_summary(
+                    GROOT_POLICY_HOST_ENV_VAR,
+                    required=True,
+                    source=config_source(
+                        GROOT_POLICY_HOST_ENV_VAR,
+                        direct=self.host is not None or self._policy_client is not None,
+                    ),
+                    present=self.host is not None or self._policy_client is not None,
+                ),
+                _field_summary(
+                    GROOT_POLICY_PORT_ENV_VAR,
+                    required=False,
+                    source=config_source(
+                        GROOT_POLICY_PORT_ENV_VAR,
+                        direct=self.port != DEFAULT_GROOT_POLICY_PORT,
+                        default=True,
+                    ),
+                    present=self.port != DEFAULT_GROOT_POLICY_PORT,
+                ),
+                _field_summary(
+                    GROOT_POLICY_TIMEOUT_MS_ENV_VAR,
+                    required=False,
+                    source=config_source(
+                        GROOT_POLICY_TIMEOUT_MS_ENV_VAR,
+                        direct=self.timeout_ms != DEFAULT_GROOT_POLICY_TIMEOUT_MS,
+                        default=True,
+                    ),
+                    present=self.timeout_ms != DEFAULT_GROOT_POLICY_TIMEOUT_MS,
+                ),
+                _field_summary(
+                    GROOT_POLICY_API_TOKEN_ENV_VAR,
+                    required=False,
+                    secret=True,
+                    source=config_source(
+                        GROOT_POLICY_API_TOKEN_ENV_VAR,
+                        direct=self.api_token is not None,
+                    ),
+                    present=self.api_token is not None,
+                ),
+                _field_summary(
+                    GROOT_POLICY_STRICT_ENV_VAR,
+                    required=False,
+                    source=config_source(
+                        GROOT_POLICY_STRICT_ENV_VAR,
+                        direct=self.strict,
+                        default=True,
+                    ),
+                    present=self.strict,
+                ),
+                _field_summary(
+                    GROOT_EMBODIMENT_TAG_ENV_VAR,
+                    required=False,
+                    source=config_source(
+                        GROOT_EMBODIMENT_TAG_ENV_VAR,
+                        direct=self.embodiment_tag is not None,
+                    ),
+                    present=self.embodiment_tag is not None,
+                ),
+            ),
+        )
 
     def health(self) -> ProviderHealth:
         started = perf_counter()

--- a/src/worldforge/providers/lerobot.py
+++ b/src/worldforge/providers/lerobot.py
@@ -33,9 +33,15 @@ from worldforge.models import (
     require_positive_int,
 )
 
-from ._config import env_value, first_env_value, optional_non_empty
+from ._config import (
+    ProviderConfigSummary,
+    config_source,
+    env_value,
+    first_env_value,
+    optional_non_empty,
+)
 from ._policy import json_object, no_grad_context, normalize_policy_action_candidates, prepare_model
-from .base import BaseProvider, ProviderError, ProviderProfileSpec
+from .base import BaseProvider, ProviderError, ProviderProfileSpec, _field_summary
 from .runtime_manifest import (
     missing_optional_dependency_detail,
     missing_runtime_configuration_detail,
@@ -194,6 +200,63 @@ class LeRobotPolicyProvider(BaseProvider):
 
     def configured(self) -> bool:
         return self._policy is not None or self.policy_path is not None
+
+    def config_summary(self) -> ProviderConfigSummary:
+        policy_source = next(
+            (env_name for env_name in LEROBOT_POLICY_PATH_ENV_ALIASES if env_value(env_name)),
+            None,
+        )
+        return ProviderConfigSummary(
+            provider=self.name,
+            configured=self.configured(),
+            fields=(
+                _field_summary(
+                    LEROBOT_POLICY_PATH_ENV_VAR,
+                    aliases=("LEROBOT_POLICY",),
+                    required=True,
+                    source=f"env:{policy_source}"
+                    if policy_source
+                    else config_source(
+                        LEROBOT_POLICY_PATH_ENV_VAR,
+                        direct=self.policy_path is not None or self._policy is not None,
+                    ),
+                    present=self.policy_path is not None or self._policy is not None,
+                ),
+                _field_summary(
+                    LEROBOT_POLICY_TYPE_ENV_VAR,
+                    required=False,
+                    source=config_source(
+                        LEROBOT_POLICY_TYPE_ENV_VAR,
+                        direct=self.policy_type is not None,
+                    ),
+                    present=self.policy_type is not None,
+                ),
+                _field_summary(
+                    LEROBOT_DEVICE_ENV_VAR,
+                    required=False,
+                    source=config_source(LEROBOT_DEVICE_ENV_VAR, direct=self.device is not None),
+                    present=self.device is not None,
+                ),
+                _field_summary(
+                    LEROBOT_CACHE_DIR_ENV_VAR,
+                    required=False,
+                    source=config_source(
+                        LEROBOT_CACHE_DIR_ENV_VAR,
+                        direct=self.cache_dir is not None,
+                    ),
+                    present=self.cache_dir is not None,
+                ),
+                _field_summary(
+                    LEROBOT_EMBODIMENT_TAG_ENV_VAR,
+                    required=False,
+                    source=config_source(
+                        LEROBOT_EMBODIMENT_TAG_ENV_VAR,
+                        direct=self.embodiment_tag is not None,
+                    ),
+                    present=self.embodiment_tag is not None,
+                ),
+            ),
+        )
 
     def health(self) -> ProviderHealth:
         started = perf_counter()

--- a/src/worldforge/providers/leworldmodel.py
+++ b/src/worldforge/providers/leworldmodel.py
@@ -17,10 +17,16 @@ from worldforge.models import (
     require_finite_number,
 )
 
-from ._config import env_value, first_env_value, optional_non_empty
+from ._config import (
+    ProviderConfigSummary,
+    config_source,
+    env_value,
+    first_env_value,
+    optional_non_empty,
+)
 from ._policy import no_grad_context, prepare_model
 from ._tensor_validation import _is_sequence, _shape
-from .base import BaseProvider, ProviderError, ProviderProfileSpec
+from .base import BaseProvider, ProviderError, ProviderProfileSpec, _field_summary
 from .runtime_manifest import (
     missing_optional_dependency_detail,
     missing_runtime_configuration_detail,
@@ -134,6 +140,45 @@ class LeWorldModelProvider(BaseProvider):
 
     def configured(self) -> bool:
         return self.policy is not None
+
+    def config_summary(self) -> ProviderConfigSummary:
+        policy_source = next(
+            (env_name for env_name in LEWORLDMODEL_POLICY_ENV_ALIASES if env_value(env_name)),
+            None,
+        )
+        return ProviderConfigSummary(
+            provider=self.name,
+            configured=self.configured(),
+            fields=(
+                _field_summary(
+                    LEWORLDMODEL_POLICY_ENV_VAR,
+                    aliases=("LEWM_POLICY",),
+                    required=True,
+                    source=f"env:{policy_source}"
+                    if policy_source
+                    else config_source(LEWORLDMODEL_POLICY_ENV_VAR, direct=self.policy is not None),
+                    present=self.policy is not None,
+                ),
+                _field_summary(
+                    LEWORLDMODEL_CACHE_DIR_ENV_VAR,
+                    required=False,
+                    source=config_source(
+                        LEWORLDMODEL_CACHE_DIR_ENV_VAR,
+                        direct=self.cache_dir is not None,
+                    ),
+                    present=self.cache_dir is not None,
+                ),
+                _field_summary(
+                    LEWORLDMODEL_DEVICE_ENV_VAR,
+                    required=False,
+                    source=config_source(
+                        LEWORLDMODEL_DEVICE_ENV_VAR,
+                        direct=self.device is not None,
+                    ),
+                    present=self.device is not None,
+                ),
+            ),
+        )
 
     def health(self) -> ProviderHealth:
         started = perf_counter()

--- a/src/worldforge/providers/runtime_manifest.py
+++ b/src/worldforge/providers/runtime_manifest.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Mapping
 from dataclasses import dataclass
 from importlib import resources
 from typing import Any
@@ -10,6 +11,7 @@ from typing import Any
 from worldforge.models import WorldForgeError
 
 from . import runtime_manifests
+from ._config import ProviderConfigSummary, config_field_summary
 
 MANIFEST_PACKAGE = "worldforge.providers.runtime_manifests"
 _MANIFEST_FILES = resources.files(runtime_manifests)
@@ -98,6 +100,41 @@ class ProviderRuntimeManifest:
         required = " or ".join(self.required_env_vars)
         return f"missing {required}; configure runtime using {self.docs_path}"
 
+    def config_summary(
+        self,
+        *,
+        configured: bool | None = None,
+        environ: Mapping[str, str] | None = None,
+    ) -> ProviderConfigSummary:
+        """Return manifest-declared env presence without exposing values."""
+
+        fields = [
+            config_field_summary(
+                self.required_env_vars[0],
+                aliases=self.required_env_vars[1:],
+                required=True,
+                secret=_looks_secret_name(self.required_env_vars[0]),
+                environ=environ,
+            )
+        ]
+        fields.extend(
+            config_field_summary(
+                env_var,
+                required=False,
+                secret=_looks_secret_name(env_var),
+                environ=environ,
+            )
+            for env_var in self.optional_env_vars
+        )
+        resolved_configured = configured
+        if resolved_configured is None:
+            resolved_configured = fields[0].present and all(field.valid for field in fields)
+        return ProviderConfigSummary(
+            provider=self.provider,
+            configured=resolved_configured,
+            fields=tuple(fields),
+        )
+
 
 def load_runtime_manifest(provider: str) -> ProviderRuntimeManifest:
     """Load one provider runtime manifest by provider name."""
@@ -136,6 +173,13 @@ def missing_runtime_configuration_detail(provider: str) -> str:
     """Return a manifest-backed health detail for missing runtime configuration."""
 
     return load_runtime_manifest(provider).missing_configuration_detail()
+
+
+def _looks_secret_name(name: str) -> bool:
+    return any(
+        marker in name.lower()
+        for marker in ("api_key", "api_secret", "secret", "token", "password", "credential")
+    )
 
 
 def _required_str(payload: dict[str, Any], field: str, *, source: str) -> str:

--- a/src/worldforge/providers/runway.py
+++ b/src/worldforge/providers/runway.py
@@ -19,11 +19,12 @@ from worldforge.models import (
     require_positive_int,
 )
 
-from ._config import env_value, first_env_value
+from ._config import ProviderConfigSummary, config_source, env_value, first_env_value
 from .base import (
     ProviderError,
     ProviderProfileSpec,
     RemoteProvider,
+    _field_summary,
     validate_generation_request,
     validate_transfer_request,
 )
@@ -267,6 +268,37 @@ class RunwayProvider(RemoteProvider):
 
     def configured(self) -> bool:
         return bool(self._api_key())
+
+    def config_summary(self) -> ProviderConfigSummary:
+        api_source = next(
+            (
+                env_name
+                for env_name in ("RUNWAYML_API_SECRET", "RUNWAY_API_SECRET")
+                if env_value(env_name) is not None
+            ),
+            None,
+        )
+        base_url_from_env = env_value("RUNWAYML_BASE_URL") is not None
+        return ProviderConfigSummary(
+            provider=self.name,
+            configured=self.configured(),
+            fields=(
+                _field_summary(
+                    "RUNWAYML_API_SECRET",
+                    aliases=("RUNWAY_API_SECRET",),
+                    required=True,
+                    secret=True,
+                    source=f"env:{api_source}" if api_source else "unset",
+                    present=api_source is not None,
+                ),
+                _field_summary(
+                    "RUNWAYML_BASE_URL",
+                    required=False,
+                    source=config_source("RUNWAYML_BASE_URL", default=True),
+                    present=base_url_from_env,
+                ),
+            ),
+        )
 
     def _api_key(self) -> str | None:
         return first_env_value(("RUNWAYML_API_SECRET", "RUNWAY_API_SECRET"))

--- a/tests/test_provider_config.py
+++ b/tests/test_provider_config.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import json
+
+from worldforge.providers import (
+    CosmosProvider,
+    GrootPolicyClientProvider,
+    LeRobotPolicyProvider,
+    LeWorldModelProvider,
+    RunwayProvider,
+)
+from worldforge.providers.catalog import create_known_providers
+from worldforge.providers.runtime_manifest import load_runtime_manifest, load_runtime_manifests
+
+SECRET_VALUES = (
+    "cosmos-secret",
+    "runway-secret",
+    "gr00t-secret",
+    "signed-query-secret",
+    "password-secret",
+)
+
+
+def _assert_no_secret_values(payload: object) -> None:
+    serialized = json.dumps(payload, sort_keys=True)
+    for secret in SECRET_VALUES:
+        assert secret not in serialized
+
+
+def test_provider_config_summaries_are_value_free_json(monkeypatch) -> None:
+    monkeypatch.setenv("COSMOS_BASE_URL", "https://cosmos.example.test")
+    monkeypatch.setenv("NVIDIA_API_KEY", "cosmos-secret")
+    monkeypatch.setenv("RUNWAYML_API_SECRET", "runway-secret")
+    monkeypatch.setenv("GROOT_POLICY_HOST", "127.0.0.1")
+    monkeypatch.setenv("GROOT_POLICY_API_TOKEN", "gr00t-secret")
+    monkeypatch.setenv("LEROBOT_POLICY_PATH", "lerobot/checkpoint")
+    monkeypatch.setenv("LEWORLDMODEL_POLICY", "pusht/lewm")
+
+    summaries = [provider.config_summary().to_dict() for provider in create_known_providers()]
+
+    assert {summary["provider"] for summary in summaries} == {
+        "mock",
+        "cosmos",
+        "runway",
+        "leworldmodel",
+        "gr00t",
+        "lerobot",
+        "jepa",
+        "genie",
+    }
+    for summary in summaries:
+        assert set(summary) == {"provider", "configured", "fields"}
+        for field in summary["fields"]:
+            assert set(field) == {
+                "name",
+                "present",
+                "source",
+                "required",
+                "secret",
+                "valid",
+                "detail",
+                "aliases",
+            }
+            assert "value" not in field
+    _assert_no_secret_values(summaries)
+
+
+def test_provider_config_summary_reports_alias_source_without_value(monkeypatch) -> None:
+    monkeypatch.delenv("RUNWAYML_API_SECRET", raising=False)
+    monkeypatch.setenv("RUNWAY_API_SECRET", "runway-secret")
+
+    summary = RunwayProvider().config_summary().to_dict()
+
+    api_field = summary["fields"][0]
+    assert api_field["name"] == "RUNWAYML_API_SECRET"
+    assert api_field["aliases"] == ["RUNWAY_API_SECRET"]
+    assert api_field["present"] is True
+    assert api_field["source"] == "env:RUNWAY_API_SECRET"
+    assert api_field["secret"] is True
+    _assert_no_secret_values(summary)
+
+
+def test_direct_provider_config_summary_reports_source_not_value(monkeypatch) -> None:
+    monkeypatch.delenv("COSMOS_BASE_URL", raising=False)
+    monkeypatch.delenv("RUNWAYML_API_SECRET", raising=False)
+    monkeypatch.delenv("RUNWAY_API_SECRET", raising=False)
+    monkeypatch.delenv("GROOT_POLICY_HOST", raising=False)
+    monkeypatch.delenv("LEROBOT_POLICY_PATH", raising=False)
+    monkeypatch.delenv("LEWORLDMODEL_POLICY", raising=False)
+
+    summaries = [
+        CosmosProvider(base_url="https://cosmos.example.test").config_summary().to_dict(),
+        GrootPolicyClientProvider(host="127.0.0.1", api_token="gr00t-secret")
+        .config_summary()
+        .to_dict(),
+        LeRobotPolicyProvider(policy_path="lerobot/checkpoint").config_summary().to_dict(),
+        LeWorldModelProvider(policy="pusht/lewm").config_summary().to_dict(),
+    ]
+
+    for summary in summaries:
+        assert summary["configured"] is True
+        assert summary["fields"][0]["source"] == "direct"
+    _assert_no_secret_values(summaries)
+
+
+def test_runtime_manifest_config_summaries_cover_declared_env_without_values() -> None:
+    env = {
+        "RUNWAY_API_SECRET": "runway-secret",
+        "RUNWAYML_BASE_URL": "https://api.example.test",
+        "NVIDIA_API_KEY": "cosmos-secret",
+    }
+
+    runway_summary = load_runtime_manifest("runway").config_summary(environ=env).to_dict()
+
+    assert runway_summary["configured"] is True
+    assert runway_summary["fields"][0]["source"] == "env:RUNWAY_API_SECRET"
+    assert runway_summary["fields"][0]["aliases"] == ["RUNWAY_API_SECRET"]
+    assert runway_summary["fields"][0]["secret"] is True
+    assert runway_summary["fields"][1]["name"] == "RUNWAYML_BASE_URL"
+    for manifest in load_runtime_manifests():
+        summary = manifest.config_summary(environ={}).to_dict()
+        assert summary["provider"] == manifest.provider
+        assert [field["name"] for field in summary["fields"]] == [
+            manifest.required_env_vars[0],
+            *manifest.optional_env_vars,
+        ]
+    _assert_no_secret_values(runway_summary)


### PR DESCRIPTION
Closes #56.

## Summary
- add value-free provider config summaries for known providers and runtime manifests
- include config summaries in `worldforge provider info` for safe issue evidence
- document safe attachments and credential redaction expectations

## Validation
- `uv run ruff check src tests examples scripts`
- `uv run ruff format --check src tests examples scripts`
- `uv run pytest`
- `uv run pytest -m "not live"`
- `uv run --extra harness pytest --cov=src/worldforge --cov-report=term-missing --cov-fail-under=90`
- `uv run mkdocs build --strict`
- `bash scripts/test_package.sh`
- `uv lock --check`
- `uv run python scripts/generate_provider_docs.py --check`
- `UV_LOCKED=true uv export --all-groups --no-emit-project --no-hashes --output-file <tmp>`
- `uvx --from pip-audit pip-audit -r <tmp>`
