### PR TITLE
Add run-scoped provider event logs

### DIFF
--- a/docs/src/api/python.md
+++ b/docs/src/api/python.md
@@ -103,14 +103,22 @@ of being treated as successful no-ops.
 
 ```python
 import logging
+from pathlib import Path
 
 from worldforge import WorldForge
-from worldforge.observability import JsonLoggerSink, ProviderMetricsSink, compose_event_handlers
+from worldforge.observability import (
+    JsonLoggerSink,
+    ProviderMetricsSink,
+    RunJsonLogSink,
+    compose_event_handlers,
+)
 
+run_id = "demo-run"
 metrics = ProviderMetricsSink()
 forge = WorldForge(
     event_handler=compose_event_handlers(
-        JsonLoggerSink(logger=logging.getLogger("demo.worldforge")),
+        JsonLoggerSink(logger=logging.getLogger("demo.worldforge"), extra_fields={"run_id": run_id}),
+        RunJsonLogSink(Path(".worldforge") / "runs" / run_id / "provider-events.jsonl", run_id),
         metrics,
     )
 )
@@ -120,8 +128,9 @@ print(metrics.get("mock", "generate").to_dict())
 ```
 
 Provider events are log-safe by default. The `target` field keeps endpoint or artifact path context
-but strips URL userinfo, query strings, and fragments; message and metadata fields redact obvious
-bearer tokens, API keys, signatures, passwords, and signed URLs.
+but strips URL userinfo, query strings, and fragments; message, metadata, and sink extra fields
+redact obvious bearer tokens, API keys, signatures, passwords, and signed URLs. `RunJsonLogSink`
+appends one JSON object per line and stamps every record with `run_id` for manifest correlation.
 
 ## Action Scoring
 

--- a/docs/src/architecture.md
+++ b/docs/src/architecture.md
@@ -669,26 +669,36 @@ Provider operation
   |
   `-- host event_handler
         |-- JsonLoggerSink
+        |-- RunJsonLogSink
         |-- InMemoryRecorderSink
         `-- ProviderMetricsSink
 ```
 
 Targets in provider events are intentionally route-level. They keep enough context to identify the
 provider endpoint or artifact path, but query strings, fragments, URL userinfo, bearer tokens, and
-secret-like metadata fields are removed before JSON logging or in-memory recording.
+secret-like metadata fields are removed before JSON logging, run log export, or in-memory
+recording.
 
 Example:
 
 ```python
 import logging
+from pathlib import Path
 
 from worldforge import WorldForge
-from worldforge.observability import JsonLoggerSink, ProviderMetricsSink, compose_event_handlers
+from worldforge.observability import (
+    JsonLoggerSink,
+    ProviderMetricsSink,
+    RunJsonLogSink,
+    compose_event_handlers,
+)
 
+run_id = "demo-run"
 metrics = ProviderMetricsSink()
 forge = WorldForge(
     event_handler=compose_event_handlers(
-        JsonLoggerSink(logger=logging.getLogger("demo.worldforge")),
+        JsonLoggerSink(logger=logging.getLogger("demo.worldforge"), extra_fields={"run_id": run_id}),
+        RunJsonLogSink(Path(".worldforge") / "runs" / run_id / "provider-events.jsonl", run_id),
         metrics,
     )
 )

--- a/docs/src/operations.md
+++ b/docs/src/operations.md
@@ -113,6 +113,7 @@ Attach a provider event handler at `WorldForge(event_handler=...)` or provider c
 Use `compose_event_handlers(...)` to fan out events to:
 
 - `JsonLoggerSink` for structured JSON logs.
+- `RunJsonLogSink` for newline-delimited JSON files tied to one run id.
 - `ProviderMetricsSink` for request, retry, error, and latency aggregates.
 - `InMemoryRecorderSink` for tests and local debugging.
 
@@ -124,6 +125,33 @@ metadata.
 
 Host services should add request or trace IDs through `JsonLoggerSink(extra_fields=...)` and
 include those IDs in surrounding application logs.
+
+For batch jobs, harness runs, and release evidence, attach a file sink owned by the host process:
+
+```python
+from pathlib import Path
+
+from worldforge import WorldForge
+from worldforge.observability import JsonLoggerSink, RunJsonLogSink, compose_event_handlers
+
+run_id = "20260430T120000Z-batch-eval"
+forge = WorldForge(
+    event_handler=compose_event_handlers(
+        JsonLoggerSink(extra_fields={"run_id": run_id}),
+        RunJsonLogSink(
+            Path(".worldforge") / "runs" / run_id / "provider-events.jsonl",
+            run_id=run_id,
+            extra_fields={"host": "batch-eval"},
+        ),
+    )
+)
+```
+
+The file sink creates the parent directory and appends one JSON object per provider event. The
+`run_id` should match the host run manifest so operator bundles can join `manifest.json`,
+`provider-events.jsonl`, benchmark reports, and preserved artifacts without relying on timestamps.
+Extra fields are validated as JSON and redacted with the same observable secret rules as provider
+event messages and metadata.
 
 ## Failure Modes
 

--- a/docs/src/playbooks.md
+++ b/docs/src/playbooks.md
@@ -234,6 +234,58 @@ name substring. Every write or unlink goes through `WorldForge` on a
 raised by the framework (`WorldStateError` / `WorldForgeError`) appear as toasts — the
 in-memory edit buffer stays intact so the user can fix and retry.
 
+### 5b. Capture Run-Scoped Provider Logs
+
+Use this when a CLI job, batch host, service request, or TheWorldHarness run needs provider events
+that can be attached to an issue, release bundle, or incident note.
+
+```python
+from pathlib import Path
+
+from worldforge import WorldForge
+from worldforge.observability import JsonLoggerSink, RunJsonLogSink, compose_event_handlers
+
+run_id = "20260430T120000Z-runway-generate"
+log_path = Path(".worldforge") / "runs" / run_id / "provider-events.jsonl"
+
+forge = WorldForge(
+    event_handler=compose_event_handlers(
+        JsonLoggerSink(extra_fields={"run_id": run_id, "host": "service"}),
+        RunJsonLogSink(log_path, run_id=run_id, extra_fields={"host": "service"}),
+    )
+)
+```
+
+Success signal:
+
+- each line in `provider-events.jsonl` is a complete JSON object.
+- every record has `event_type=provider_event` and the same `run_id` as the host run manifest.
+- `target` values keep only route-level context; URL query strings and fragments are removed.
+- `message`, `metadata`, and sink `extra_fields` redact bearer tokens, API keys, signatures,
+  passwords, signed URLs, and token-like assignments.
+- host applications inject sinks into `WorldForge(event_handler=...)` or provider constructors
+  instead of changing global logging configuration inside WorldForge.
+
+First triage queries:
+
+```bash
+jq 'select(.phase=="failure") | {provider, operation, status_code, target, message}' \
+  .worldforge/runs/<run-id>/provider-events.jsonl
+jq 'select(.phase=="retry") | {provider, operation, attempt, max_attempts, status_code, target}' \
+  .worldforge/runs/<run-id>/provider-events.jsonl
+jq -s 'group_by(.provider,.operation)[] | {provider: .[0].provider, operation: .[0].operation, events: length}' \
+  .worldforge/runs/<run-id>/provider-events.jsonl
+```
+
+If it fails:
+
+| Symptom | First check | Likely owner |
+| --- | --- | --- |
+| no file was written | confirm the host passed `RunJsonLogSink` into the active event handler | host app |
+| records have different run IDs | compare sink construction with the run manifest writer | host app |
+| raw credential appears in an exported log | remove the raw value from custom metadata or exception text and add a regression test | contributor |
+| failures have no status code | inspect provider-specific docs; local dependency failures may not have HTTP status | operator |
+
 ## 6. Run Evaluation And Benchmarks
 
 Use evaluation for deterministic behavior checks and benchmarks for adapter latency and event

--- a/docs/src/providers/README.md
+++ b/docs/src/providers/README.md
@@ -171,21 +171,30 @@ Attach sinks through `WorldForge(event_handler=...)`:
 
 ```python
 import logging
+from pathlib import Path
 
 from worldforge import WorldForge
-from worldforge.observability import JsonLoggerSink, ProviderMetricsSink, compose_event_handlers
+from worldforge.observability import (
+    JsonLoggerSink,
+    ProviderMetricsSink,
+    RunJsonLogSink,
+    compose_event_handlers,
+)
 
+run_id = "provider-smoke"
 metrics = ProviderMetricsSink()
 forge = WorldForge(
     event_handler=compose_event_handlers(
-        JsonLoggerSink(logger=logging.getLogger("demo.worldforge")),
+        JsonLoggerSink(logger=logging.getLogger("demo.worldforge"), extra_fields={"run_id": run_id}),
+        RunJsonLogSink(Path(".worldforge") / "runs" / run_id / "provider-events.jsonl", run_id),
         metrics,
     )
 )
 ```
 
 `ProviderMetricsSink.request_count` counts emitted provider events, so retry events increment both
-`request_count` and `retry_count`.
+`request_count` and `retry_count`. `RunJsonLogSink` writes one redacted JSON record per line and
+keeps `run_id` on every record so provider logs can be joined with host-owned run manifests.
 
 ## Authoring Standard
 

--- a/src/worldforge/observability.py
+++ b/src/worldforge/observability.py
@@ -6,9 +6,17 @@ import logging
 from collections.abc import Callable
 from copy import deepcopy
 from dataclasses import dataclass, field
+from pathlib import Path
 from threading import Lock
 
-from worldforge.models import JSONDict, ProviderEvent, WorldForgeError, dump_json
+from worldforge.models import (
+    JSONDict,
+    ProviderEvent,
+    WorldForgeError,
+    _redact_observable_value,
+    dump_json,
+    require_json_dict,
+)
 
 ProviderEventHandler = Callable[[ProviderEvent], None]
 
@@ -60,6 +68,13 @@ def compose_event_handlers(*handlers: ProviderEventHandler | None) -> ProviderEv
     return _EventHandlerFanout(tuple(resolved_handlers))
 
 
+def _redacted_extra_fields(extra_fields: JSONDict, *, name: str) -> JSONDict:
+    return require_json_dict(
+        _redact_observable_value(deepcopy(extra_fields)),
+        name=name,
+    )
+
+
 @dataclass(slots=True)
 class JsonLoggerSink:
     """Log provider events as a single structured JSON record."""
@@ -73,11 +88,53 @@ class JsonLoggerSink:
     def __post_init__(self) -> None:
         # Deep-copy once; isolating callers from later extra-field mutation only
         # matters at construction time, so don't pay the cost per event.
-        self.extra_fields = deepcopy(self.extra_fields)
+        self.extra_fields = _redacted_extra_fields(
+            self.extra_fields,
+            name="JsonLoggerSink extra_fields",
+        )
 
     def __call__(self, event: ProviderEvent) -> None:
         payload = {"event_type": "provider_event", **self.extra_fields, **event.to_dict()}
         self.logger.log(self.level, dump_json(payload))
+
+
+@dataclass(slots=True)
+class RunJsonLogSink:
+    """Append provider events to a run-scoped JSONL file."""
+
+    path: Path | str
+    run_id: str
+    extra_fields: JSONDict = field(default_factory=dict)
+    _path: Path = field(init=False, repr=False)
+    _lock: Lock = field(default_factory=Lock, init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.run_id, str) or not self.run_id.strip():
+            raise WorldForgeError("RunJsonLogSink run_id must be a non-empty string.")
+        self.run_id = self.run_id.strip()
+        self._path = Path(self.path)
+        self.extra_fields = _redacted_extra_fields(
+            self.extra_fields,
+            name="RunJsonLogSink extra_fields",
+        )
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+
+    @property
+    def log_path(self) -> Path:
+        """Return the concrete JSONL file path used by this sink."""
+
+        return self._path
+
+    def __call__(self, event: ProviderEvent) -> None:
+        payload = {
+            "event_type": "provider_event",
+            **self.extra_fields,
+            **event.to_dict(),
+            "run_id": self.run_id,
+        }
+        line = f"{dump_json(payload)}\n"
+        with self._lock, self._path.open("a", encoding="utf-8") as handle:
+            handle.write(line)
 
 
 @dataclass(slots=True)
@@ -240,5 +297,6 @@ __all__ = [
     "ProviderEventHandler",
     "ProviderMetricsSink",
     "ProviderOperationMetrics",
+    "RunJsonLogSink",
     "compose_event_handlers",
 ]

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -55,6 +55,7 @@ def test_top_level_exports_and_subpackages_import() -> None:
     assert observability.JsonLoggerSink is not None
     assert observability.InMemoryRecorderSink is not None
     assert observability.ProviderMetricsSink is not None
+    assert observability.RunJsonLogSink is not None
     assert observability.compose_event_handlers is not None
 
 

--- a/tests/test_run_logs.py
+++ b/tests/test_run_logs.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from worldforge import Action, ProviderEvent, WorldForge, WorldForgeError
+from worldforge.observability import JsonLoggerSink, RunJsonLogSink, compose_event_handlers
+
+
+def _read_jsonl(path) -> list[dict[str, object]]:
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()]
+
+
+def test_run_json_log_sink_writes_run_scoped_jsonl(tmp_path) -> None:
+    log_path = tmp_path / "runs" / "run-123" / "provider-events.jsonl"
+    sink = RunJsonLogSink(
+        log_path,
+        run_id="run-123",
+        extra_fields={"host": "batch-eval", "request_id": "req-456", "run_id": "wrong"},
+    )
+
+    sink(
+        ProviderEvent(
+            provider="mock",
+            operation="predict",
+            phase="success",
+            duration_ms=12.5,
+            metadata={"steps": 2},
+        )
+    )
+
+    assert sink.log_path == log_path
+    records = _read_jsonl(log_path)
+    assert records == [
+        {
+            "attempt": 1,
+            "duration_ms": 12.5,
+            "event_type": "provider_event",
+            "host": "batch-eval",
+            "max_attempts": 1,
+            "message": "",
+            "metadata": {"steps": 2},
+            "method": None,
+            "operation": "predict",
+            "phase": "success",
+            "provider": "mock",
+            "request_id": "req-456",
+            "run_id": "run-123",
+            "status_code": None,
+            "target": None,
+        }
+    ]
+
+
+def test_run_json_log_sink_redacts_exported_secrets(tmp_path) -> None:
+    log_path = tmp_path / "provider-events.jsonl"
+    sink = RunJsonLogSink(
+        log_path,
+        run_id="run-123",
+        extra_fields={
+            "authorization": "Bearer extra-secret",
+            "artifact_url": "https://example.test/video.mp4?X-Amz-Signature=query-secret",
+        },
+    )
+
+    sink(
+        ProviderEvent(
+            provider="runway",
+            operation="artifact download",
+            phase="failure",
+            method="get",
+            target="https://user:pass@example.test/video.mp4?token=target-secret",
+            message="failed with api_key=message-secret and Bearer bearer-secret",
+            metadata={
+                "api_token": "metadata-secret",
+                "signed_url": "https://example.test/video.mp4?signature=metadata-secret",
+            },
+        )
+    )
+
+    exported = log_path.read_text(encoding="utf-8")
+    assert "extra-secret" not in exported
+    assert "query-secret" not in exported
+    assert "target-secret" not in exported
+    assert "message-secret" not in exported
+    assert "bearer-secret" not in exported
+    assert "metadata-secret" not in exported
+
+    record = _read_jsonl(log_path)[0]
+    assert record["authorization"] == "[redacted]"
+    assert record["artifact_url"] == "https://example.test/video.mp4"
+    assert record["target"] == "https://example.test/video.mp4"
+    assert record["metadata"] == {"api_token": "[redacted]", "signed_url": "[redacted]"}
+
+
+def test_run_json_log_sink_validates_inputs(tmp_path) -> None:
+    with pytest.raises(WorldForgeError, match="run_id"):
+        RunJsonLogSink(tmp_path / "events.jsonl", run_id=" ")
+
+    with pytest.raises(WorldForgeError, match="extra_fields"):
+        RunJsonLogSink(
+            tmp_path / "events.jsonl",
+            run_id="run-123",
+            extra_fields={"not_json": object()},  # type: ignore[dict-item]
+        )
+
+
+def test_run_json_log_sink_integrates_with_worldforge_event_handler(tmp_path) -> None:
+    run_sink = RunJsonLogSink(tmp_path / "events.jsonl", run_id="run-123")
+    forge = WorldForge(
+        state_dir=tmp_path / "worlds",
+        auto_register_remote=False,
+        event_handler=compose_event_handlers(run_sink),
+    )
+
+    world = forge.create_world_from_prompt("empty room", provider="mock")
+    world.predict(Action.move_to(0.2, 0.5, 0.0))
+
+    records = _read_jsonl(run_sink.log_path)
+    assert [(record["run_id"], record["provider"], record["operation"]) for record in records] == [
+        ("run-123", "mock", "predict")
+    ]
+
+
+def test_json_logger_sink_redacts_extra_fields(caplog) -> None:
+    import logging
+
+    logger = logging.getLogger("worldforge.tests.run_logs")
+    sink = JsonLoggerSink(
+        logger=logger,
+        extra_fields={"authorization": "Bearer extra-secret", "safe": "visible"},
+    )
+
+    with caplog.at_level(logging.INFO, logger=logger.name):
+        sink(ProviderEvent(provider="mock", operation="predict", phase="success"))
+
+    record = json.loads(caplog.records[0].message)
+    assert record["authorization"] == "[redacted]"
+    assert record["safe"] == "visible"
+    assert "extra-secret" not in caplog.records[0].message


### PR DESCRIPTION
Closes #78.

## Summary
- add `RunJsonLogSink` for run-scoped provider-event JSONL exports with stable `run_id`
- redact sink `extra_fields` before JSON logger or file export output
- document host-owned logging injection, run-manifest correlation, and first triage queries

## Validation
- `uv run ruff check src tests examples scripts`
- `uv run ruff format --check src tests examples scripts`
- `uv run pytest tests/test_observability.py tests/test_run_logs.py tests/test_public_api.py -q`
- `uv run mkdocs build --strict`
- `uv run pytest`
- `uv run --extra harness pytest --cov=src/worldforge --cov-report=term-missing --cov-fail-under=90`
- `uv run pytest -m "not live"`
- `uv lock --check`
- `uv run python scripts/generate_provider_docs.py --check`
- `bash scripts/test_package.sh`
- `UV_LOCKED=true uv export --all-groups --no-emit-project --no-hashes --output-file <tmp>` + `uvx --from pip-audit pip-audit -r <tmp>`
- `uv build --out-dir dist --clear --no-build-logs`
