### PR TITLE
Add live smoke run manifests

### DIFF
--- a/docs/src/operations.md
+++ b/docs/src/operations.md
@@ -153,6 +153,19 @@ The file sink creates the parent directory and appends one JSON object per provi
 Extra fields are validated as JSON and redacted with the same observable secret rules as provider
 event messages and metadata.
 
+Optional live smoke commands can also write a sanitized `run_manifest.json`:
+
+```bash
+scripts/robotics-showcase \
+  --json-output /tmp/worldforge-robotics-showcase/real-run.json \
+  --run-manifest /tmp/worldforge-robotics-showcase/run_manifest.json
+```
+
+The manifest records command argv, package version, provider profile, capability, value-free
+environment presence, runtime manifest id when available, input fixture digest, event count, result
+digest, and artifact paths. Validation rejects raw secret-like fields and unsanitized signed URLs;
+artifact URLs are stored without query strings or fragments.
+
 ## Failure Modes
 
 - Invalid caller input raises `WorldForgeError`.

--- a/docs/src/playbooks.md
+++ b/docs/src/playbooks.md
@@ -277,6 +277,16 @@ jq -s 'group_by(.provider,.operation)[] | {provider: .[0].provider, operation: .
   .worldforge/runs/<run-id>/provider-events.jsonl
 ```
 
+For optional live smokes, preserve the manifest beside the event log:
+
+```bash
+scripts/robotics-showcase \
+  --json-output .worldforge/runs/<run-id>/real-run.json \
+  --run-manifest .worldforge/runs/<run-id>/run_manifest.json
+jq '{run_id, provider_profile, capability, status, event_count, artifact_paths}' \
+  .worldforge/runs/<run-id>/run_manifest.json
+```
+
 If it fails:
 
 | Symptom | First check | Likely owner |

--- a/docs/src/providers/README.md
+++ b/docs/src/providers/README.md
@@ -196,6 +196,12 @@ forge = WorldForge(
 `request_count` and `retry_count`. `RunJsonLogSink` writes one redacted JSON record per line and
 keeps `run_id` on every record so provider logs can be joined with host-owned run manifests.
 
+Optional live smoke entrypoints accept `--run-manifest <path>` for a validated
+`run_manifest.json`. The manifest is safe issue evidence: it stores command argv, package version,
+provider profile, capability, value-free env presence, runtime manifest id, input fixture digest,
+event count, result digest, and artifact paths. It does not store credential values, raw signed URL
+query strings, checkpoint bytes, or generated media bytes.
+
 ## Authoring Standard
 
 Before adding or promoting a provider, document:

--- a/docs/src/robotics-showcase.md
+++ b/docs/src/robotics-showcase.md
@@ -229,10 +229,14 @@ Default artifact path:
 
 ```text
 /tmp/worldforge-robotics-showcase/real-run.json
+/tmp/worldforge-robotics-showcase/run_manifest.json
 ```
 
 Use `--json-output <path>` on the lower-level runner when you need to preserve a specific artifact
-location.
+location. Use `--run-manifest <path>` to place the evidence manifest beside the summary in another
+directory. The manifest links the policy, score, replay, and report evidence back to the preserved
+summary JSON and state directory without embedding checkpoint bytes, raw policy inputs, or
+credentials.
 
 ## Customizing The Showcase
 

--- a/docs/src/support.md
+++ b/docs/src/support.md
@@ -22,10 +22,11 @@ uv run worldforge provider info <provider>
 ```
 
 It is safe to attach provider profiles, doctor output, provider health, runtime manifests,
-`config_summary().to_dict()` output, benchmark reports, and preserved JSON inputs after checking
-that host-specific object names are acceptable to share. Do not attach `.env` files, raw provider
-request bodies, bearer tokens, signed artifact URLs with query strings, private checkpoint files,
-robot controller credentials, or logs captured before provider-event redaction.
+`config_summary().to_dict()` output, smoke `run_manifest.json` files, benchmark reports, and
+preserved JSON inputs after checking that host-specific object names are acceptable to share. Do
+not attach `.env` files, raw provider request bodies, bearer tokens, signed artifact URLs with
+query strings, private checkpoint files, robot controller credentials, or logs captured before
+provider-event redaction.
 
 For optional runtimes, include the exact wrapper command, host OS, Python version, checkpoint or
 policy identifier, and the stage that failed: dependency import, checkpoint loading, provider call,

--- a/scripts/smoke_gr00t_policy.py
+++ b/scripts/smoke_gr00t_policy.py
@@ -18,6 +18,7 @@ from typing import Any
 
 from worldforge.models import JSONDict
 from worldforge.providers import GrootPolicyClientProvider
+from worldforge.smoke.run_manifest import build_run_manifest, write_run_manifest
 
 DEFAULT_MODEL_PATH = "nvidia/GR00T-N1.6-3B"
 DEFAULT_EMBODIMENT_TAG = "GR1"
@@ -231,6 +232,12 @@ def _parser() -> argparse.ArgumentParser:
     parser.add_argument("--embodiment-tag", default=os.environ.get("GROOT_EMBODIMENT_TAG"))
     parser.add_argument("--action-horizon", type=int, default=None)
     parser.add_argument("--health-only", action="store_true")
+    parser.add_argument(
+        "--run-manifest",
+        type=Path,
+        default=None,
+        help="Write a sanitized run_manifest.json evidence file for this live smoke.",
+    )
 
     input_group = parser.add_mutually_exclusive_group()
     input_group.add_argument(
@@ -309,6 +316,7 @@ def main() -> int:
     translator = (
         None if args.translator is None else _load_callable(args.translator, name="translator")
     )
+    provider_events = []
     provider = GrootPolicyClientProvider(
         host=args.host,
         port=args.port,
@@ -317,6 +325,7 @@ def main() -> int:
         strict=args.strict,
         embodiment_tag=args.embodiment_tag,
         action_translator=translator,
+        event_handler=provider_events.append,
     )
 
     process = _start_server(args)
@@ -337,6 +346,32 @@ def main() -> int:
         if not args.health_only:
             result = provider.select_actions(info=_load_policy_info(args))
             output["result"] = result.to_dict()
+        if args.run_manifest is not None:
+            input_fixture = args.policy_info_json or args.observation_json
+            write_run_manifest(
+                args.run_manifest,
+                build_run_manifest(
+                    run_id=args.run_manifest.parent.name,
+                    provider_profile="gr00t",
+                    capability="policy",
+                    status="skipped" if args.health_only else "passed",
+                    env_vars=(
+                        "GROOT_POLICY_HOST",
+                        "GROOT_POLICY_PORT",
+                        "GROOT_POLICY_TIMEOUT_MS",
+                        "GROOT_POLICY_API_TOKEN",
+                        "GROOT_POLICY_STRICT",
+                        "GROOT_EMBODIMENT_TAG",
+                        "GROOT_REPO",
+                        "GROOT_MODEL_PATH",
+                        "GROOT_DATASET_PATH",
+                        "GROOT_POLICY_DEVICE",
+                    ),
+                    event_count=len(provider_events),
+                    input_fixture=input_fixture,
+                    result=output,
+                ),
+            )
         print(json.dumps(output, indent=2, sort_keys=True))
         return 0
     finally:

--- a/scripts/smoke_lerobot_policy.py
+++ b/scripts/smoke_lerobot_policy.py
@@ -42,6 +42,7 @@ from typing import Any
 
 from worldforge.models import JSONDict
 from worldforge.providers import LeRobotPolicyProvider
+from worldforge.smoke.run_manifest import build_run_manifest, write_run_manifest
 
 DEFAULT_DEVICE = "cpu"
 DEFAULT_MODE = "select_action"
@@ -177,6 +178,12 @@ def _parser() -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument("--health-only", action="store_true")
+    parser.add_argument(
+        "--run-manifest",
+        type=Path,
+        default=None,
+        help="Write a sanitized run_manifest.json evidence file for this live smoke.",
+    )
 
     input_group = parser.add_mutually_exclusive_group()
     input_group.add_argument(
@@ -224,6 +231,7 @@ def main() -> int:
     translator = (
         None if args.translator is None else _load_callable(args.translator, name="translator")
     )
+    provider_events = []
     provider = LeRobotPolicyProvider(
         policy_path=args.policy_path,
         policy_type=args.policy_type,
@@ -231,6 +239,7 @@ def main() -> int:
         cache_dir=args.cache_dir,
         embodiment_tag=args.embodiment_tag,
         action_translator=translator,
+        event_handler=provider_events.append,
     )
     health = provider.health()
     if not health.healthy:
@@ -240,6 +249,27 @@ def main() -> int:
     if not args.health_only:
         result = provider.select_actions(info=_load_policy_info(args))
         output["result"] = result.to_dict()
+    if args.run_manifest is not None:
+        input_fixture = args.policy_info_json or args.observation_json
+        write_run_manifest(
+            args.run_manifest,
+            build_run_manifest(
+                run_id=args.run_manifest.parent.name,
+                provider_profile="lerobot",
+                capability="policy",
+                status="skipped" if args.health_only else "passed",
+                env_vars=(
+                    "LEROBOT_POLICY_PATH",
+                    "LEROBOT_POLICY",
+                    "LEROBOT_POLICY_TYPE",
+                    "LEROBOT_DEVICE",
+                    "LEROBOT_CACHE_DIR",
+                ),
+                event_count=len(provider_events),
+                input_fixture=input_fixture,
+                result=output,
+            ),
+        )
     print(json.dumps(output, indent=2, sort_keys=True))
     return 0
 

--- a/src/worldforge/smoke/lerobot_leworldmodel.py
+++ b/src/worldforge/smoke/lerobot_leworldmodel.py
@@ -27,6 +27,7 @@ from worldforge import Action, BBox, Position, SceneObject, StructuredGoal, Worl
 from worldforge.models import ProviderEvent
 from worldforge.providers import LeRobotPolicyProvider, LeWorldModelProvider
 from worldforge.providers._config import env_value as _env_value
+from worldforge.smoke.run_manifest import build_run_manifest, write_run_manifest
 
 from .leworldmodel import (
     DEFAULT_STABLEWM_HOME,
@@ -842,6 +843,12 @@ def _parser() -> argparse.ArgumentParser:
         default=None,
         help="Write the full run summary JSON while keeping visual terminal output.",
     )
+    parser.add_argument(
+        "--run-manifest",
+        type=Path,
+        default=None,
+        help="Write a sanitized run_manifest.json evidence file for this live robotics smoke.",
+    )
     parser.add_argument("--json-only", action="store_true")
     parser.add_argument(
         "--color",
@@ -1044,6 +1051,34 @@ def main(argv: Sequence[str] | None = None) -> int:
         }
         if args.json_output is not None:
             _write_json_output(args.json_output, payload)
+        if args.run_manifest is not None:
+            json_artifacts = (
+                {"report_summary": args.json_output} if args.json_output is not None else {}
+            )
+            write_run_manifest(
+                args.run_manifest,
+                build_run_manifest(
+                    run_id=args.run_manifest.parent.name,
+                    provider_profile="lerobot-leworldmodel",
+                    capability="policy+score",
+                    status="skipped" if args.health_only and preflight_ok else "failed",
+                    env_vars=(
+                        "LEROBOT_POLICY_PATH",
+                        "LEROBOT_POLICY",
+                        "LEROBOT_POLICY_TYPE",
+                        "LEROBOT_DEVICE",
+                        "LEROBOT_CACHE_DIR",
+                        "LEWORLDMODEL_CHECKPOINT",
+                        "LEWORLDMODEL_POLICY",
+                        "LEWM_POLICY",
+                        "LEWORLDMODEL_DEVICE",
+                        "STABLEWM_HOME",
+                    ),
+                    event_count=len(provider_events),
+                    result=payload,
+                    artifact_paths=json_artifacts,
+                ),
+            )
         if args.json_only:
             print(json.dumps(payload, indent=2, sort_keys=True))
         elif not preflight_ok:
@@ -1240,6 +1275,45 @@ def main(argv: Sequence[str] | None = None) -> int:
         },
     }
     json_output_path = _write_json_output(args.json_output, payload) if args.json_output else None
+    run_manifest_path = None
+    if args.run_manifest is not None:
+        artifact_paths: dict[str, Path | str] = {"worldforge_state": state_dir}
+        if json_output_path is not None:
+            artifact_paths.update(
+                {
+                    "policy_summary": json_output_path,
+                    "score_summary": json_output_path,
+                    "report_summary": json_output_path,
+                }
+            )
+            if execution_summary is not None:
+                artifact_paths["replay_summary"] = json_output_path
+        input_fixture = args.policy_info_json or args.observation_json
+        run_manifest_path = write_run_manifest(
+            args.run_manifest,
+            build_run_manifest(
+                run_id=args.run_manifest.parent.name,
+                provider_profile="lerobot-leworldmodel",
+                capability="policy+score",
+                status="passed",
+                env_vars=(
+                    "LEROBOT_POLICY_PATH",
+                    "LEROBOT_POLICY",
+                    "LEROBOT_POLICY_TYPE",
+                    "LEROBOT_DEVICE",
+                    "LEROBOT_CACHE_DIR",
+                    "LEWORLDMODEL_CHECKPOINT",
+                    "LEWORLDMODEL_POLICY",
+                    "LEWM_POLICY",
+                    "LEWORLDMODEL_DEVICE",
+                    "STABLEWM_HOME",
+                ),
+                event_count=len(event_payload),
+                input_fixture=input_fixture,
+                result=payload,
+                artifact_paths=artifact_paths,
+            ),
+        )
     if args.json_only:
         print(json.dumps(payload, indent=2, sort_keys=True))
         return 0
@@ -1284,6 +1358,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         print("\nArtifacts")
         print("---------")
         print(f"  json summary           {_display_path(json_output_path)}")
+        if run_manifest_path is not None:
+            print(f"  run manifest           {_display_path(run_manifest_path)}")
     print("\nCompleted real LeRobot + LeWorldModel policy+score inference.")
     print("Use --json-only for the machine-readable summary.")
     return 0

--- a/src/worldforge/smoke/leworldmodel.py
+++ b/src/worldforge/smoke/leworldmodel.py
@@ -25,6 +25,7 @@ from time import perf_counter
 from typing import Any
 
 from worldforge.providers import LeWorldModelProvider
+from worldforge.smoke.run_manifest import build_run_manifest, write_run_manifest
 
 DEFAULT_STABLEWM_HOME = "~/.stable-wm"
 ANSI_CODES = {
@@ -409,6 +410,12 @@ def _parser() -> argparse.ArgumentParser:
         help="Write the full inference summary JSON to this path while keeping visual output.",
     )
     parser.add_argument(
+        "--run-manifest",
+        type=Path,
+        default=None,
+        help="Write a sanitized run_manifest.json evidence file for this live smoke.",
+    )
+    parser.add_argument(
         "--color",
         choices=("auto", "always", "never"),
         default="auto",
@@ -517,6 +524,22 @@ def main() -> int:
         }
         if args.json_output is not None:
             _write_json_output(args.json_output, payload)
+        if args.run_manifest is not None:
+            write_run_manifest(
+                args.run_manifest,
+                build_run_manifest(
+                    run_id=args.run_manifest.parent.name,
+                    provider_profile="leworldmodel",
+                    capability="score",
+                    status="failed",
+                    env_vars=("LEWORLDMODEL_CHECKPOINT", "LEWORLDMODEL_POLICY", "STABLEWM_HOME"),
+                    event_count=len(provider_events),
+                    result=payload,
+                    artifact_paths=(
+                        {"summary_json": args.json_output} if args.json_output is not None else {}
+                    ),
+                ),
+            )
         if args.json_only:
             print(json.dumps(payload, indent=2, sort_keys=True))
             return 1
@@ -622,6 +645,23 @@ def main() -> int:
         json_output_path = _write_json_output(args.json_output, payload)
     else:
         json_output_path = None
+    run_manifest_path = None
+    if args.run_manifest is not None:
+        run_manifest_path = write_run_manifest(
+            args.run_manifest,
+            build_run_manifest(
+                run_id=args.run_manifest.parent.name,
+                provider_profile="leworldmodel",
+                capability="score",
+                status="passed",
+                env_vars=("LEWORLDMODEL_CHECKPOINT", "LEWORLDMODEL_POLICY", "STABLEWM_HOME"),
+                event_count=len(provider_events),
+                result=payload,
+                artifact_paths=(
+                    {"summary_json": json_output_path} if json_output_path is not None else {}
+                ),
+            ),
+        )
     if args.json_only:
         print(json.dumps(payload, indent=2, sort_keys=True))
         return 0
@@ -652,6 +692,8 @@ def main() -> int:
         print("\nArtifacts", flush=True)
         print("---------", flush=True)
         print(f"  json summary       {_display_path(json_output_path)}", flush=True)
+        if run_manifest_path is not None:
+            print(f"  run manifest       {_display_path(run_manifest_path)}", flush=True)
     print("\nCompleted real LeWorldModel checkpoint inference.", flush=True)
     print("Use --json-only for the machine-readable summary.", flush=True)
     return 0

--- a/src/worldforge/smoke/robotics_showcase.py
+++ b/src/worldforge/smoke/robotics_showcase.py
@@ -96,6 +96,12 @@ def _parser() -> argparse.ArgumentParser:
         help="Write the full summary JSON. Defaults to /tmp to keep the repo clean.",
     )
     parser.add_argument(
+        "--run-manifest",
+        type=Path,
+        default=DEFAULT_JSON_OUTPUT.with_name("run_manifest.json"),
+        help="Write a sanitized run_manifest.json beside the default summary artifact.",
+    )
+    parser.add_argument(
         "--no-json-output",
         action="store_true",
         help="Skip writing the default /tmp JSON artifact.",
@@ -212,6 +218,7 @@ def _forward_args(args: argparse.Namespace) -> list[str]:
     _append_optional_path(forwarded, "--state-dir", args.state_dir)
     if not args.no_json_output:
         _append_optional_path(forwarded, "--json-output", args.json_output)
+        _append_optional_path(forwarded, "--run-manifest", args.run_manifest)
     if args.json_only:
         forwarded.append("--json-only")
     if args.health_only:

--- a/src/worldforge/smoke/run_manifest.py
+++ b/src/worldforge/smoke/run_manifest.py
@@ -1,0 +1,315 @@
+"""Run manifest helpers for optional live provider smokes."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import sys
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import worldforge
+from worldforge.models import (
+    JSONDict,
+    WorldForgeError,
+    _redact_observable_value,
+    _sanitize_observable_target,
+    dump_json,
+    require_json_dict,
+    require_non_negative_int,
+)
+from worldforge.providers.runtime_manifest import load_runtime_manifest
+
+RUN_MANIFEST_SCHEMA_VERSION = 1
+
+
+@dataclass(frozen=True, slots=True)
+class LiveSmokeRunManifest:
+    """Serializable evidence manifest for host-owned live smoke artifacts."""
+
+    run_id: str
+    command_argv: tuple[str, ...]
+    provider_profile: str
+    capability: str
+    status: str
+    env_summary: tuple[JSONDict, ...]
+    artifact_paths: Mapping[str, str] = field(default_factory=dict)
+    event_count: int = 0
+    input_fixture_digest: str | None = None
+    result_digest: str | None = None
+    runtime_manifest_id: str | None = None
+    package_version: str = field(default_factory=lambda: worldforge.__version__)
+    created_at: str = field(
+        default_factory=lambda: datetime.now(UTC).replace(microsecond=0).isoformat()
+    )
+
+    def __post_init__(self) -> None:
+        if not self.run_id.strip():
+            raise WorldForgeError("Run manifest run_id must be a non-empty string.")
+        if not self.command_argv:
+            raise WorldForgeError("Run manifest command_argv must not be empty.")
+        if not self.provider_profile.strip():
+            raise WorldForgeError("Run manifest provider_profile must be a non-empty string.")
+        if not self.capability.strip():
+            raise WorldForgeError("Run manifest capability must be a non-empty string.")
+        if self.status not in {"passed", "failed", "skipped"}:
+            raise WorldForgeError("Run manifest status must be passed, failed, or skipped.")
+        require_non_negative_int(self.event_count, name="Run manifest event_count")
+
+    def to_dict(self) -> JSONDict:
+        payload = {
+            "schema_version": RUN_MANIFEST_SCHEMA_VERSION,
+            "run_id": self.run_id,
+            "created_at": self.created_at,
+            "package_version": self.package_version,
+            "command_argv": list(self.command_argv),
+            "provider_profile": self.provider_profile,
+            "capability": self.capability,
+            "status": self.status,
+            "runtime_manifest_id": self.runtime_manifest_id,
+            "env_summary": [dict(item) for item in self.env_summary],
+            "input_fixture_digest": self.input_fixture_digest,
+            "event_count": self.event_count,
+            "result_digest": self.result_digest,
+            "artifact_paths": dict(self.artifact_paths),
+        }
+        return validate_run_manifest(payload)
+
+
+def build_run_manifest(
+    *,
+    run_id: str,
+    provider_profile: str,
+    capability: str,
+    status: str,
+    env_vars: Sequence[str],
+    artifact_paths: Mapping[str, Path | str] | None = None,
+    command_argv: Sequence[str] | None = None,
+    event_count: int = 0,
+    input_fixture: Path | str | None = None,
+    result: Mapping[str, Any] | None = None,
+    result_digest: str | None = None,
+    environ: Mapping[str, str] | None = None,
+) -> LiveSmokeRunManifest:
+    """Build a validated live smoke run manifest without exposing secrets."""
+
+    runtime_manifest_id = None
+    try:
+        runtime_manifest = load_runtime_manifest(provider_profile)
+    except WorldForgeError:
+        runtime_manifest = None
+    if runtime_manifest is not None:
+        runtime_manifest_id = (
+            f"{runtime_manifest.provider}:schema-{runtime_manifest.schema_version}"
+        )
+
+    resolved_result_digest = result_digest
+    if resolved_result_digest is None and result is not None:
+        resolved_result_digest = digest_json_value(dict(result))
+
+    return LiveSmokeRunManifest(
+        run_id=run_id,
+        command_argv=tuple(command_argv or sys.argv),
+        provider_profile=provider_profile,
+        capability=capability,
+        status=status,
+        runtime_manifest_id=runtime_manifest_id,
+        env_summary=tuple(env_summary(env_vars, environ=environ)),
+        input_fixture_digest=digest_file(input_fixture) if input_fixture is not None else None,
+        event_count=event_count,
+        result_digest=resolved_result_digest,
+        artifact_paths=_artifact_path_summary(artifact_paths or {}),
+    )
+
+
+def write_run_manifest(
+    path: Path | str, manifest: LiveSmokeRunManifest | Mapping[str, Any]
+) -> Path:
+    """Write a validated run manifest to ``path`` and return the resolved path."""
+
+    payload = manifest.to_dict() if isinstance(manifest, LiveSmokeRunManifest) else dict(manifest)
+    output_path = Path(path).expanduser()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(dump_json(validate_run_manifest(payload)) + "\n", encoding="utf-8")
+    return output_path
+
+
+def env_summary(
+    names: Sequence[str],
+    *,
+    environ: Mapping[str, str] | None = None,
+) -> list[JSONDict]:
+    """Return value-free env presence records for manifest evidence."""
+
+    env = os.environ if environ is None else environ
+    records: list[JSONDict] = []
+    for raw_name in names:
+        name = raw_name.strip()
+        if not name:
+            raise WorldForgeError("Run manifest env var names must be non-empty strings.")
+        records.append(
+            {
+                "name": name,
+                "present": bool(env.get(name, "").strip()),
+                "source": f"env:{name}" if env.get(name, "").strip() else "unset",
+                "secret": _looks_secret_name(name),
+            }
+        )
+    return records
+
+
+def digest_file(path: Path | str) -> str:
+    """Return a sha256 digest for a smoke input fixture or preserved artifact."""
+
+    digest = hashlib.sha256()
+    with Path(path).expanduser().open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return f"sha256:{digest.hexdigest()}"
+
+
+def digest_json_value(value: Mapping[str, Any]) -> str:
+    """Return a stable sha256 digest for a JSON-like result summary."""
+
+    payload = dump_json(require_json_dict(_json_native(dict(value)), name="Run manifest result"))
+    return f"sha256:{hashlib.sha256(payload.encode('utf-8')).hexdigest()}"
+
+
+def validate_run_manifest(payload: Mapping[str, Any]) -> JSONDict:
+    """Validate the manifest shape and reject unsanitized secrets or signed URLs."""
+
+    manifest = require_json_dict(dict(payload), name="Run manifest")
+    if manifest.get("schema_version") != RUN_MANIFEST_SCHEMA_VERSION:
+        raise WorldForgeError(f"Run manifest schema_version must be {RUN_MANIFEST_SCHEMA_VERSION}.")
+    for field_name in (
+        "run_id",
+        "created_at",
+        "package_version",
+        "provider_profile",
+        "capability",
+        "status",
+    ):
+        _require_non_empty_str(manifest.get(field_name), field_name)
+    argv = manifest.get("command_argv")
+    if (
+        not isinstance(argv, list)
+        or not argv
+        or any(not isinstance(item, str) or not item.strip() for item in argv)
+    ):
+        raise WorldForgeError("Run manifest command_argv must be a non-empty string list.")
+    require_non_negative_int(manifest.get("event_count"), name="Run manifest event_count")
+    if not isinstance(manifest.get("env_summary"), list):
+        raise WorldForgeError("Run manifest env_summary must be a list.")
+    if not isinstance(manifest.get("artifact_paths"), dict):
+        raise WorldForgeError("Run manifest artifact_paths must be an object.")
+    _reject_secret_like_values(manifest)
+    _reject_unsafe_strings(manifest)
+    return manifest
+
+
+def _artifact_path_summary(paths: Mapping[str, Path | str]) -> JSONDict:
+    artifacts: JSONDict = {}
+    for name, raw_path in paths.items():
+        if not isinstance(name, str) or not name.strip():
+            raise WorldForgeError("Run manifest artifact names must be non-empty strings.")
+        artifacts[name] = _sanitize_path_or_url(str(raw_path))
+    return artifacts
+
+
+def _sanitize_path_or_url(value: str) -> str:
+    sanitized = _sanitize_observable_target(value)
+    if sanitized is None:
+        raise WorldForgeError("Run manifest artifact path must be non-empty.")
+    return sanitized
+
+
+def _reject_unsafe_strings(value: object, *, path: str = "manifest") -> None:
+    if isinstance(value, str):
+        try:
+            sanitized = _sanitize_observable_target(value)
+        except WorldForgeError:
+            sanitized = value
+        if sanitized != value:
+            raise WorldForgeError(f"Run manifest {path} contains an unsafe URL or secret.")
+    elif isinstance(value, list):
+        for index, item in enumerate(value):
+            _reject_unsafe_strings(item, path=f"{path}[{index}]")
+    elif isinstance(value, dict):
+        for key, item in value.items():
+            _reject_unsafe_strings(item, path=f"{path}.{key}")
+
+
+def _reject_secret_like_values(value: object, *, path: str = "manifest") -> None:
+    if isinstance(value, dict):
+        for key, item in value.items():
+            child_path = f"{path}.{key}"
+            if _looks_sensitive_key(str(key)) and not child_path.startswith(
+                "manifest.env_summary["
+            ):
+                raise WorldForgeError("Run manifest contains secret-like metadata.")
+            _reject_secret_like_values(item, path=child_path)
+    elif isinstance(value, list):
+        for index, item in enumerate(value):
+            _reject_secret_like_values(item, path=f"{path}[{index}]")
+    elif isinstance(value, str) and _redact_observable_value(value) != value:
+        raise WorldForgeError("Run manifest contains secret-like metadata.")
+
+
+def _json_native(value: object) -> Any:
+    if value is None or isinstance(value, str | bool | int | float):
+        return value
+    if isinstance(value, Path):
+        return str(value)
+    if isinstance(value, tuple | list):
+        return [_json_native(item) for item in value]
+    if isinstance(value, dict):
+        return {str(key): _json_native(item) for key, item in value.items()}
+    return str(value)
+
+
+def _require_non_empty_str(value: object, field_name: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise WorldForgeError(f"Run manifest {field_name} must be a non-empty string.")
+    return value
+
+
+def _looks_secret_name(name: str) -> bool:
+    normalized = name.lower()
+    return any(
+        marker in normalized
+        for marker in ("api_key", "api_secret", "secret", "token", "password", "credential")
+    )
+
+
+def _looks_sensitive_key(name: str) -> bool:
+    normalized = name.lower()
+    return any(
+        marker in normalized
+        for marker in (
+            "api_key",
+            "api_secret",
+            "authorization",
+            "bearer",
+            "credential",
+            "password",
+            "secret",
+            "signature",
+            "signed_url",
+            "token",
+        )
+    )
+
+
+__all__ = [
+    "RUN_MANIFEST_SCHEMA_VERSION",
+    "LiveSmokeRunManifest",
+    "build_run_manifest",
+    "digest_file",
+    "digest_json_value",
+    "env_summary",
+    "validate_run_manifest",
+    "write_run_manifest",
+]

--- a/tests/test_lerobot_leworldmodel_smoke_script.py
+++ b/tests/test_lerobot_leworldmodel_smoke_script.py
@@ -426,6 +426,7 @@ def test_main_runs_policy_score_plan_with_fake_real_runtimes(
 ) -> None:
     checkpoint, observation_path, score_info_path = _write_common_inputs(tmp_path)
     bridge_path = _write_candidate_builder(tmp_path)
+    run_manifest = tmp_path / "run_manifest.json"
     _patch_fake_providers(monkeypatch)
     monkeypatch.setattr(
         sys,
@@ -447,6 +448,8 @@ def test_main_runs_policy_score_plan_with_fake_real_runtimes(
             "--expected-horizon",
             "2",
             "--json-only",
+            "--run-manifest",
+            str(run_manifest),
         ],
     )
 
@@ -462,6 +465,13 @@ def test_main_runs_policy_score_plan_with_fake_real_runtimes(
     assert payload["execution"]["actions_applied"] == 2
     assert payload["visualization"]["selected_candidate"] == 1
     assert payload["visualization"]["candidate_targets"][1]["index"] == 1
+    manifest = json.loads(run_manifest.read_text())
+    assert manifest["provider_profile"] == "lerobot-leworldmodel"
+    assert manifest["capability"] == "policy+score"
+    assert manifest["status"] == "passed"
+    assert manifest["event_count"] == len(payload["provider_events"])
+    assert manifest["input_fixture_digest"].startswith("sha256:")
+    assert set(manifest["artifact_paths"]) == {"worldforge_state"}
 
 
 def test_main_visual_static_candidate_path_skips_execution(
@@ -484,6 +494,7 @@ def test_main_visual_static_candidate_path_skips_execution(
         )
     )
     json_output = tmp_path / "summary.json"
+    run_manifest = tmp_path / "run_manifest.json"
     _patch_fake_providers(monkeypatch)
     monkeypatch.setattr(
         sys,
@@ -506,6 +517,8 @@ def test_main_visual_static_candidate_path_skips_execution(
             "2",
             "--json-output",
             str(json_output),
+            "--run-manifest",
+            str(run_manifest),
             "--no-execute",
             "--no-color",
         ],
@@ -525,6 +538,13 @@ def test_main_visual_static_candidate_path_skips_execution(
     payload = json.loads(json_output.read_text())
     assert payload["execution"] is None
     assert payload["visualization"]["candidate_targets"][0]["index"] == 0
+    manifest = json.loads(run_manifest.read_text())
+    assert manifest["artifact_paths"] == {
+        "policy_summary": str(json_output),
+        "score_summary": str(json_output),
+        "report_summary": str(json_output),
+        "worldforge_state": payload["state_dir"],
+    }
 
 
 def test_main_preflight_failure_prints_runtime_command(

--- a/tests/test_robotics_showcase.py
+++ b/tests/test_robotics_showcase.py
@@ -281,6 +281,9 @@ def test_robotics_showcase_uses_tmp_json_output_by_default(monkeypatch) -> None:
     assert forwarded[forwarded.index("--json-output") + 1] == str(
         robotics_showcase.DEFAULT_JSON_OUTPUT
     )
+    assert forwarded[forwarded.index("--run-manifest") + 1] == str(
+        robotics_showcase.DEFAULT_JSON_OUTPUT.with_name("run_manifest.json")
+    )
 
 
 def test_robotics_showcase_auto_downloads_missing_checkpoint(

--- a/tests/test_smoke_run_manifest.py
+++ b/tests/test_smoke_run_manifest.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from worldforge.models import WorldForgeError
+from worldforge.smoke.run_manifest import (
+    build_run_manifest,
+    digest_file,
+    digest_json_value,
+    env_summary,
+    validate_run_manifest,
+    write_run_manifest,
+)
+
+
+def test_build_run_manifest_records_value_free_runtime_evidence(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    input_fixture = tmp_path / "policy-info.json"
+    input_fixture.write_text(json.dumps({"observation": {"x": 1}}), encoding="utf-8")
+    monkeypatch.setenv("RUNWAYML_API_SECRET", "real-secret-value")
+
+    manifest = build_run_manifest(
+        run_id="run-123",
+        provider_profile="runway",
+        capability="generate",
+        status="passed",
+        env_vars=("RUNWAYML_API_SECRET", "RUNWAY_BASE_URL"),
+        command_argv=("worldforge-smoke", "--provider", "runway"),
+        event_count=2,
+        input_fixture=input_fixture,
+        result={"task_id": "task-1", "status": "succeeded"},
+        artifact_paths={"downloaded_video": tmp_path / "video.mp4"},
+    ).to_dict()
+
+    assert manifest["schema_version"] == 1
+    assert manifest["runtime_manifest_id"] == "runway:schema-1"
+    assert manifest["input_fixture_digest"] == digest_file(input_fixture)
+    assert manifest["result_digest"] == digest_json_value(
+        {"task_id": "task-1", "status": "succeeded"}
+    )
+    assert manifest["event_count"] == 2
+    assert manifest["artifact_paths"] == {"downloaded_video": str(tmp_path / "video.mp4")}
+    assert manifest["env_summary"] == [
+        {
+            "name": "RUNWAYML_API_SECRET",
+            "present": True,
+            "source": "env:RUNWAYML_API_SECRET",
+            "secret": True,
+        },
+        {
+            "name": "RUNWAY_BASE_URL",
+            "present": False,
+            "source": "unset",
+            "secret": False,
+        },
+    ]
+    assert "real-secret-value" not in json.dumps(manifest)
+
+
+def test_write_run_manifest_validates_before_writing(tmp_path: Path) -> None:
+    path = tmp_path / "run_manifest.json"
+    manifest = build_run_manifest(
+        run_id="run-1",
+        provider_profile="cosmos",
+        capability="generate",
+        status="skipped",
+        env_vars=("COSMOS_BASE_URL",),
+        command_argv=("smoke",),
+    )
+
+    assert write_run_manifest(path, manifest) == path
+    assert json.loads(path.read_text(encoding="utf-8"))["provider_profile"] == "cosmos"
+
+
+def test_run_manifest_rejects_secret_like_values_and_signed_urls(tmp_path: Path) -> None:
+    manifest = build_run_manifest(
+        run_id="run-1",
+        provider_profile="runway",
+        capability="generate",
+        status="passed",
+        env_vars=("RUNWAYML_API_SECRET",),
+        command_argv=("smoke",),
+    ).to_dict()
+
+    with pytest.raises(WorldForgeError, match="secret-like metadata"):
+        validate_run_manifest({**manifest, "api_token": "sk-test-token"})
+
+    sanitized = build_run_manifest(
+        run_id="run-1",
+        provider_profile="runway",
+        capability="generate",
+        status="passed",
+        env_vars=("RUNWAYML_API_SECRET",),
+        command_argv=("smoke",),
+        artifact_paths={"video": "https://example.test/video.mp4?X-Amz-Signature=secret"},
+    ).to_dict()
+    assert sanitized["artifact_paths"] == {"video": "https://example.test/video.mp4"}
+
+    with pytest.raises(WorldForgeError, match=r"secret-like metadata|unsafe URL"):
+        validate_run_manifest(
+            {
+                **manifest,
+                "artifact_paths": {
+                    "video": "https://example.test/video.mp4?X-Amz-Signature=secret"
+                },
+            }
+        )
+
+
+def test_env_summary_rejects_blank_names() -> None:
+    with pytest.raises(WorldForgeError, match="env var names"):
+        env_summary((" ",))
+
+
+def test_build_run_manifest_defaults_to_process_argv(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sys, "argv", ["smoke", "--flag"])
+
+    manifest = build_run_manifest(
+        run_id="run-1",
+        provider_profile="unknown-local",
+        capability="policy",
+        status="skipped",
+        env_vars=(),
+    ).to_dict()
+
+    assert manifest["command_argv"] == ["smoke", "--flag"]
+    assert manifest["runtime_manifest_id"] is None


### PR DESCRIPTION
Closes #64.

## Summary
- add validated live smoke `run_manifest.json` helpers with digests, env presence summaries, runtime manifest IDs, artifact paths, and secret/signed-URL rejection
- add `--run-manifest` support to LeWorldModel, LeRobot, GR00T, and robotics showcase smoke paths
- document safe issue evidence and robotics manifest artifacts

## Validation
- `uv run ruff check src tests examples scripts`
- `uv run ruff format --check src tests examples scripts`
- `uv run pytest`
- `uv run pytest -m "not live"`
- `uv run --extra harness pytest --cov=src/worldforge --cov-report=term-missing --cov-fail-under=90`
- `uv run pytest tests/test_smoke_run_manifest.py tests/test_observability.py -q`
- `uv run mkdocs build --strict`
- `uv run python scripts/generate_provider_docs.py --check`
- `uv lock --check`
- `bash scripts/test_package.sh`
- `UV_LOCKED=true uv export --all-groups --no-emit-project --no-hashes --output-file /tmp/worldforge-requirements.txt && uvx --from pip-audit pip-audit -r /tmp/worldforge-requirements.txt`
- `uv build --out-dir dist --clear --no-build-logs`
