### PR TITLE
Add provider event schema v2 correlation fields

### DIFF
--- a/docs/src/operations.md
+++ b/docs/src/operations.md
@@ -123,8 +123,37 @@ fields redact obvious bearer tokens, API keys, signatures, passwords, and signed
 applications should still avoid placing raw credentials in provider exception messages or custom
 metadata.
 
-Host services should add request or trace IDs through `JsonLoggerSink(extra_fields=...)` and
-include those IDs in surrounding application logs.
+Host services can attach correlation IDs directly to a `ProviderEvent` when the provider adapter
+knows them, or through `JsonLoggerSink(extra_fields=...)` when the host owns them outside the
+adapter. Optional event fields are `run_id`, `request_id`, `trace_id`, `span_id`, `artifact_id`,
+and `input_digest`; they are strings, omitted when unset, and sanitized before sink consumption.
+The event `phase` is normalized to lowercase so hosts can filter stable `success`, `failure`, and
+`retry` values.
+
+Example JSON log record:
+
+```json
+{
+  "artifact_id": "artifact-local-id",
+  "attempt": 1,
+  "duration_ms": 812.4,
+  "event_type": "provider_event",
+  "input_digest": "sha256:9fd7...",
+  "max_attempts": 3,
+  "message": "",
+  "metadata": {"status": "submitted"},
+  "method": "POST",
+  "operation": "task create",
+  "phase": "success",
+  "provider": "runway",
+  "request_id": "host-request-id",
+  "run_id": "20260430T120000Z-batch-eval",
+  "span_id": "span-456",
+  "status_code": 200,
+  "target": "https://api.runwayml.com/v1/tasks",
+  "trace_id": "trace-123"
+}
+```
 
 For batch jobs, harness runs, and release evidence, attach a file sink owned by the host process:
 
@@ -147,11 +176,12 @@ forge = WorldForge(
 )
 ```
 
-The file sink creates the parent directory and appends one JSON object per provider event. The
-`run_id` should match the host run manifest so operator bundles can join `manifest.json`,
-`provider-events.jsonl`, benchmark reports, and preserved artifacts without relying on timestamps.
-Extra fields are validated as JSON and redacted with the same observable secret rules as provider
-event messages and metadata.
+The file sink creates the parent directory and appends one JSON object per provider event. Its
+configured `run_id` wins over any `run_id` supplied by extra fields or adapter events so every line
+in the file joins to the same host run manifest. Operator bundles can then correlate
+`manifest.json`, `provider-events.jsonl`, benchmark reports, and preserved artifacts without
+relying on timestamps. Extra fields are validated as JSON and redacted with the same observable
+secret rules as provider event messages and metadata.
 
 Optional live smoke commands can also write a sanitized `run_manifest.json`:
 

--- a/src/worldforge/models.py
+++ b/src/worldforge/models.py
@@ -210,6 +210,17 @@ def _sanitize_observable_target(value: object | None) -> str | None:
     return target
 
 
+def _sanitize_observable_id(value: object | None, *, name: str) -> str | None:
+    """Return a provider event correlation identifier safe for logs."""
+
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise WorldForgeError(f"{name} must be a string when provided.")
+    sanitized = _redact_observable_text(value.strip())
+    return sanitized or None
+
+
 def _redact_observable_text(value: str) -> str:
     """Redact common secret shapes from provider event text."""
 
@@ -1338,6 +1349,12 @@ class ProviderEvent:
     duration_ms: float | None = None
     message: str = ""
     metadata: JSONDict = field(default_factory=dict)
+    run_id: str | None = None
+    request_id: str | None = None
+    trace_id: str | None = None
+    span_id: str | None = None
+    artifact_id: str | None = None
+    input_digest: str | None = None
 
     def __post_init__(self) -> None:
         if not isinstance(self.provider, str) or not self.provider.strip():
@@ -1378,7 +1395,7 @@ class ProviderEvent:
             raise WorldForgeError("ProviderEvent metadata must be a JSON object.")
         self.provider = self.provider.strip()
         self.operation = self.operation.strip()
-        self.phase = self.phase.strip()
+        self.phase = self.phase.strip().lower()
         self.method = self.method.strip().upper() if self.method else None
         self.target = _sanitize_observable_target(self.target)
         self.message = _redact_observable_text(self.message)
@@ -1386,9 +1403,24 @@ class ProviderEvent:
             _redact_observable_value(dict(self.metadata)),
             name="ProviderEvent metadata",
         )
+        self.run_id = _sanitize_observable_id(self.run_id, name="ProviderEvent run_id")
+        self.request_id = _sanitize_observable_id(
+            self.request_id,
+            name="ProviderEvent request_id",
+        )
+        self.trace_id = _sanitize_observable_id(self.trace_id, name="ProviderEvent trace_id")
+        self.span_id = _sanitize_observable_id(self.span_id, name="ProviderEvent span_id")
+        self.artifact_id = _sanitize_observable_id(
+            self.artifact_id,
+            name="ProviderEvent artifact_id",
+        )
+        self.input_digest = _sanitize_observable_id(
+            self.input_digest,
+            name="ProviderEvent input_digest",
+        )
 
     def to_dict(self) -> JSONDict:
-        return {
+        payload: JSONDict = {
             "provider": self.provider,
             "operation": self.operation,
             "phase": self.phase,
@@ -1401,6 +1433,22 @@ class ProviderEvent:
             "message": self.message,
             "metadata": dict(self.metadata),
         }
+        optional_fields = {
+            "run_id": self.run_id,
+            "request_id": self.request_id,
+            "trace_id": self.trace_id,
+            "span_id": self.span_id,
+            "artifact_id": self.artifact_id,
+            "input_digest": self.input_digest,
+        }
+        payload.update(
+            {
+                field_name: value
+                for field_name, value in optional_fields.items()
+                if value is not None
+            }
+        )
+        return payload
 
 
 @dataclass(slots=True)

--- a/src/worldforge/observability.py
+++ b/src/worldforge/observability.py
@@ -34,6 +34,12 @@ def _copy_event(event: ProviderEvent) -> ProviderEvent:
         duration_ms=event.duration_ms,
         message=event.message,
         metadata=deepcopy(event.metadata),
+        run_id=event.run_id,
+        request_id=event.request_id,
+        trace_id=event.trace_id,
+        span_id=event.span_id,
+        artifact_id=event.artifact_id,
+        input_digest=event.input_digest,
     )
 
 

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -99,9 +99,10 @@ def test_provider_event_validates_and_normalizes_observable_fields() -> None:
     blank_target = ProviderEvent(
         provider="runway",
         operation="artifact download",
-        phase="success",
+        phase=" Success ",
         target="   ",
     )
+    assert blank_target.phase == "success"
     assert blank_target.target is None
 
     invalid_url = ProviderEvent(
@@ -142,6 +143,62 @@ def test_provider_event_validates_and_normalizes_observable_fields() -> None:
             operation="artifact download",
             phase="failure",
             metadata={"shape": (1, 2, 3)},
+        )
+
+
+def test_provider_event_correlation_fields_are_optional_sanitized_and_json_native() -> None:
+    event = ProviderEvent(
+        provider=" runway ",
+        operation=" task create ",
+        phase=" Success ",
+        run_id=" run-123 ",
+        request_id=" req-456 ",
+        trace_id=" trace-abc ",
+        span_id=" span-def ",
+        artifact_id=" artifact-789 ",
+        input_digest="sha256:abc123",
+        metadata={"status": "submitted"},
+    )
+
+    assert event.to_dict() == {
+        "artifact_id": "artifact-789",
+        "attempt": 1,
+        "duration_ms": None,
+        "input_digest": "sha256:abc123",
+        "max_attempts": 1,
+        "message": "",
+        "metadata": {"status": "submitted"},
+        "method": None,
+        "operation": "task create",
+        "phase": "success",
+        "provider": "runway",
+        "request_id": "req-456",
+        "run_id": "run-123",
+        "span_id": "span-def",
+        "status_code": None,
+        "target": None,
+        "trace_id": "trace-abc",
+    }
+
+    redacted = ProviderEvent(
+        provider="runway",
+        operation="artifact download",
+        phase="success",
+        request_id="token=secret-request",
+        artifact_id="https://example.test/video.mp4?X-Amz-Signature=artifact-secret",
+        input_digest=" ",
+    ).to_dict()
+
+    assert redacted["request_id"] == "token=[redacted]"
+    assert redacted["artifact_id"] == "https://example.test/video.mp4"
+    assert "input_digest" not in redacted
+
+    with pytest.raises(WorldForgeError, match="request_id"):
+        ProviderEvent(
+            provider="runway",
+            operation="artifact download",
+            phase="success",
+            request_id=object(),  # type: ignore[arg-type]
         )
 
 

--- a/tests/test_run_logs.py
+++ b/tests/test_run_logs.py
@@ -26,6 +26,8 @@ def test_run_json_log_sink_writes_run_scoped_jsonl(tmp_path) -> None:
             operation="predict",
             phase="success",
             duration_ms=12.5,
+            request_id="event-req",
+            trace_id="trace-abc",
             metadata={"steps": 2},
         )
     )
@@ -45,10 +47,11 @@ def test_run_json_log_sink_writes_run_scoped_jsonl(tmp_path) -> None:
             "operation": "predict",
             "phase": "success",
             "provider": "mock",
-            "request_id": "req-456",
+            "request_id": "event-req",
             "run_id": "run-123",
             "status_code": None,
             "target": None,
+            "trace_id": "trace-abc",
         }
     ]
 


### PR DESCRIPTION
## Summary

Closes #72.

- add optional sanitized `ProviderEvent` correlation fields: `run_id`, `request_id`, `trace_id`, `span_id`, `artifact_id`, and `input_digest`
- normalize event phases to lowercase while preserving existing `to_dict()` output when correlation fields are unset
- preserve v2 fields through observability fanout and document sample JSON log records

## Validation

- `uv run ruff check src tests examples scripts`
- `uv run ruff format --check src tests examples scripts`
- `uv run pytest`
- `uv run pytest -m "not live"`
- `uv run --extra harness pytest --cov=src/worldforge --cov-report=term-missing --cov-fail-under=90`
- `uv run mkdocs build --strict`
- `bash scripts/test_package.sh`
- `uv lock --check`
- `uv run python scripts/generate_provider_docs.py --check`
- `UV_LOCKED=true uv export --all-groups --no-emit-project --no-hashes --output-file /tmp/worldforge-requirements.txt && uvx --from pip-audit pip-audit -r /tmp/worldforge-requirements.txt`
