### PR TITLE
Add provider operation budget enforcement

### DIFF
--- a/docs/src/operations.md
+++ b/docs/src/operations.md
@@ -127,8 +127,8 @@ Host services can attach correlation IDs directly to a `ProviderEvent` when the 
 knows them, or through `JsonLoggerSink(extra_fields=...)` when the host owns them outside the
 adapter. Optional event fields are `run_id`, `request_id`, `trace_id`, `span_id`, `artifact_id`,
 and `input_digest`; they are strings, omitted when unset, and sanitized before sink consumption.
-The event `phase` is normalized to lowercase so hosts can filter stable `success`, `failure`, and
-`retry` values.
+The event `phase` is normalized to lowercase so hosts can filter stable `success`, `failure`,
+`retry`, and `budget_exceeded` values.
 
 Example JSON log record:
 
@@ -205,6 +205,14 @@ artifact URLs are stored without query strings or fragments.
   `doctor()`.
 - Remote create-style requests are single-attempt by default; health checks, polling, and
   downloads retry according to `ProviderRequestPolicy`.
+- Provider request budgets are per operation. `timeout_seconds` limits one HTTP attempt;
+  optional `max_elapsed_seconds` limits the whole operation including retries, backoff, and task
+  polling. Budget violations raise `ProviderBudgetExceededError` and emit a `budget_exceeded`
+  provider event when an event handler is attached.
+- Circuit breakers stay host-owned. A service can count recent `failure`, `retry`, and
+  `budget_exceeded` events from `ProviderMetricsSink`, stop routing new work to a degraded
+  provider, and continue serving cached/read-only paths without WorldForge owning alert channels
+  or upstream SLAs.
 - Cosmos and Runway validate typed upstream response payloads before creating returned media
   objects.
 - Runway artifact downloads fail explicitly on expired/unavailable URLs, empty downloads, and

--- a/docs/src/playbooks.md
+++ b/docs/src/playbooks.md
@@ -364,6 +364,10 @@ Operational rules:
 
 - create-style requests are single-attempt unless the provider contract is idempotent.
 - health, polling, and downloads can retry through `ProviderRequestPolicy`.
+- `timeout_seconds` is a per-attempt request timeout; `max_elapsed_seconds` is the host's
+  workflow budget for the operation, including retries, backoff, and poll intervals.
+- budget failures raise `ProviderBudgetExceededError` and emit `phase=="budget_exceeded"` so
+  alerts can distinguish an exhausted host budget from an upstream HTTP failure.
 - returned artifacts are validated before `VideoClip` is returned.
 - signed URLs and temporary artifact URLs are not durable storage. Download or persist them in
   host-owned storage immediately after completion.

--- a/src/worldforge/__init__.py
+++ b/src/worldforge/__init__.py
@@ -67,6 +67,7 @@ _EXPORTS: dict[str, str] = {  # pragma: no cover - initialized before pytest-cov
     "WorldForge": "worldforge.framework",
     "list_eval_suites": "worldforge.framework",
     "run_eval": "worldforge.framework",
+    "ProviderBudgetExceededError": "worldforge.providers",
     "CAPABILITY_NAMES": "worldforge.models",
     "Action": "worldforge.models",
     "ActionPolicyResult": "worldforge.models",

--- a/src/worldforge/models.py
+++ b/src/worldforge/models.py
@@ -1124,6 +1124,7 @@ class RequestOperationPolicy:
 
     timeout_seconds: float
     retry: RetryPolicy = field(default_factory=RetryPolicy)
+    max_elapsed_seconds: float | None = None
 
     def __post_init__(self) -> None:
         object.__setattr__(
@@ -1136,11 +1137,25 @@ class RequestOperationPolicy:
         )
         if self.timeout_seconds <= 0.0:
             raise WorldForgeError("RequestOperationPolicy timeout_seconds must be greater than 0.")
+        if self.max_elapsed_seconds is not None:
+            object.__setattr__(
+                self,
+                "max_elapsed_seconds",
+                require_finite_number(
+                    self.max_elapsed_seconds,
+                    name="RequestOperationPolicy max_elapsed_seconds",
+                ),
+            )
+            if self.max_elapsed_seconds <= 0.0:
+                raise WorldForgeError(
+                    "RequestOperationPolicy max_elapsed_seconds must be greater than 0."
+                )
 
     def to_dict(self) -> JSONDict:
         return {
             "timeout_seconds": self.timeout_seconds,
             "retry": self.retry.to_dict(),
+            "max_elapsed_seconds": self.max_elapsed_seconds,
         }
 
 
@@ -1161,6 +1176,10 @@ class ProviderRequestPolicy:
         health_timeout_seconds: float | None = None,
         polling_timeout_seconds: float | None = None,
         download_timeout_seconds: float | None = None,
+        health_max_elapsed_seconds: float | None = None,
+        request_max_elapsed_seconds: float | None = None,
+        polling_max_elapsed_seconds: float | None = None,
+        download_max_elapsed_seconds: float | None = None,
         read_retry_attempts: int = 3,
         read_backoff_seconds: float = 0.25,
         read_backoff_multiplier: float = 2.0,
@@ -1197,18 +1216,22 @@ class ProviderRequestPolicy:
             health=RequestOperationPolicy(
                 timeout_seconds=resolved_health_timeout,
                 retry=read_retry,
+                max_elapsed_seconds=health_max_elapsed_seconds,
             ),
             request=RequestOperationPolicy(
                 timeout_seconds=resolved_request_timeout,
                 retry=no_retry,
+                max_elapsed_seconds=request_max_elapsed_seconds,
             ),
             polling=RequestOperationPolicy(
                 timeout_seconds=resolved_polling_timeout,
                 retry=read_retry,
+                max_elapsed_seconds=polling_max_elapsed_seconds,
             ),
             download=RequestOperationPolicy(
                 timeout_seconds=resolved_download_timeout,
                 retry=read_retry,
+                max_elapsed_seconds=download_max_elapsed_seconds,
             ),
         )
 

--- a/src/worldforge/providers/__init__.py
+++ b/src/worldforge/providers/__init__.py
@@ -11,6 +11,7 @@ from ._config import ConfigFieldSummary, ProviderConfigSummary
 from .base import (
     BaseProvider,
     PredictionPayload,
+    ProviderBudgetExceededError,
     ProviderError,
     ProviderProfileSpec,
     RemoteProvider,
@@ -38,6 +39,7 @@ __all__ = [
     "LeWorldModelProvider",
     "MockProvider",
     "PredictionPayload",
+    "ProviderBudgetExceededError",
     "ProviderCatalogEntry",
     "ProviderConfigSummary",
     "ProviderError",

--- a/src/worldforge/providers/base.py
+++ b/src/worldforge/providers/base.py
@@ -40,6 +40,10 @@ class ProviderError(RuntimeError):
     """Raised when a provider cannot satisfy a request."""
 
 
+class ProviderBudgetExceededError(ProviderError):
+    """Raised when a provider operation exceeds its configured host budget."""
+
+
 def validate_generation_request(
     prompt: object,
     duration_seconds: object,

--- a/src/worldforge/providers/http_utils.py
+++ b/src/worldforge/providers/http_utils.py
@@ -19,7 +19,7 @@ from worldforge.models import (
     _redact_observable_text,
 )
 
-from .base import ProviderError
+from .base import ProviderBudgetExceededError, ProviderError
 
 _RETRYABLE_EXCEPTIONS = (httpx.TransportError,)
 
@@ -105,6 +105,83 @@ def _raise_status_error(
     )
 
 
+def _elapsed_seconds(started: float) -> float:
+    return max(0.0, perf_counter() - started)
+
+
+def _budget_exceeded_message(
+    *,
+    provider_name: str,
+    operation_name: str,
+    elapsed_seconds: float,
+    max_elapsed_seconds: float,
+) -> str:
+    return (
+        f"Provider '{provider_name}' {operation_name} exceeded budget "
+        f"{max_elapsed_seconds:.3f}s after {elapsed_seconds:.3f}s."
+    )
+
+
+def _emit_budget_exceeded(
+    *,
+    provider_name: str,
+    operation_name: str,
+    method: str,
+    url: str,
+    attempt: int,
+    max_attempts: int,
+    elapsed_seconds: float,
+    max_elapsed_seconds: float,
+    emit_event: Callable[[ProviderEvent], None] | None,
+    status_code: int | None = None,
+) -> None:
+    if emit_event is None:
+        return
+    emit_event(
+        ProviderEvent(
+            provider=provider_name,
+            operation=operation_name,
+            phase="budget_exceeded",
+            attempt=attempt,
+            max_attempts=max_attempts,
+            method=method,
+            target=url,
+            status_code=status_code,
+            duration_ms=elapsed_seconds * 1000,
+            message=_budget_exceeded_message(
+                provider_name=provider_name,
+                operation_name=operation_name,
+                elapsed_seconds=elapsed_seconds,
+                max_elapsed_seconds=max_elapsed_seconds,
+            ),
+            metadata={"max_elapsed_seconds": max_elapsed_seconds},
+        )
+    )
+
+
+def _raise_budget_exceeded(
+    *,
+    provider_name: str,
+    operation_name: str,
+    elapsed_seconds: float,
+    max_elapsed_seconds: float,
+) -> None:
+    raise ProviderBudgetExceededError(
+        _budget_exceeded_message(
+            provider_name=provider_name,
+            operation_name=operation_name,
+            elapsed_seconds=elapsed_seconds,
+            max_elapsed_seconds=max_elapsed_seconds,
+        )
+    )
+
+
+def _remaining_budget_seconds(policy: RequestOperationPolicy, *, started: float) -> float | None:
+    if policy.max_elapsed_seconds is None:
+        return None
+    return policy.max_elapsed_seconds - _elapsed_seconds(started)
+
+
 def _content_type_is_allowed(content_type: str, accepted_content_types: tuple[str, ...]) -> bool:
     normalized = content_type.split(";", maxsplit=1)[0].strip().lower()
     for accepted in accepted_content_types:
@@ -129,13 +206,38 @@ def request_with_policy(
 ) -> httpx.Response:
     """Send an HTTP request using the configured timeout and retry policy."""
 
+    operation_started = perf_counter()
     for attempt_number in range(1, policy.retry.max_attempts + 1):
+        remaining_seconds = _remaining_budget_seconds(policy, started=operation_started)
+        if remaining_seconds is not None and remaining_seconds <= 0.0:
+            elapsed_seconds = _elapsed_seconds(operation_started)
+            _emit_budget_exceeded(
+                provider_name=provider_name,
+                operation_name=operation_name,
+                method=method,
+                url=url,
+                attempt=attempt_number,
+                max_attempts=policy.retry.max_attempts,
+                elapsed_seconds=elapsed_seconds,
+                max_elapsed_seconds=policy.max_elapsed_seconds,
+                emit_event=emit_event,
+            )
+            _raise_budget_exceeded(
+                provider_name=provider_name,
+                operation_name=operation_name,
+                elapsed_seconds=elapsed_seconds,
+                max_elapsed_seconds=policy.max_elapsed_seconds,
+            )
         started = perf_counter()
         try:
             response = client.request(
                 method,
                 url,
-                timeout=policy.timeout_seconds,
+                timeout=(
+                    policy.timeout_seconds
+                    if remaining_seconds is None
+                    else min(policy.timeout_seconds, max(remaining_seconds, 0.001))
+                ),
                 **kwargs,
             )
         except _RETRYABLE_EXCEPTIONS as exc:
@@ -160,6 +262,29 @@ def request_with_policy(
                     f"{attempt_number} attempt(s): {exc}"
                 ) from exc
             delay = policy.retry.delay_for_attempt(attempt_number + 1)
+            elapsed_after_delay = _elapsed_seconds(operation_started) + delay
+            if (
+                policy.max_elapsed_seconds is not None
+                and elapsed_after_delay > policy.max_elapsed_seconds
+            ):
+                elapsed_seconds = _elapsed_seconds(operation_started)
+                _emit_budget_exceeded(
+                    provider_name=provider_name,
+                    operation_name=operation_name,
+                    method=method,
+                    url=url,
+                    attempt=attempt_number,
+                    max_attempts=policy.retry.max_attempts,
+                    elapsed_seconds=elapsed_seconds,
+                    max_elapsed_seconds=policy.max_elapsed_seconds,
+                    emit_event=emit_event,
+                )
+                _raise_budget_exceeded(
+                    provider_name=provider_name,
+                    operation_name=operation_name,
+                    elapsed_seconds=elapsed_seconds,
+                    max_elapsed_seconds=policy.max_elapsed_seconds,
+                )
             if emit_event is not None:
                 emit_event(
                     ProviderEvent(
@@ -222,6 +347,31 @@ def request_with_policy(
                     response=response,
                 )
             delay = policy.retry.delay_for_attempt(attempt_number + 1)
+            elapsed_after_delay = _elapsed_seconds(operation_started) + delay
+            if (
+                policy.max_elapsed_seconds is not None
+                and elapsed_after_delay > policy.max_elapsed_seconds
+            ):
+                elapsed_seconds = _elapsed_seconds(operation_started)
+                _emit_budget_exceeded(
+                    provider_name=provider_name,
+                    operation_name=operation_name,
+                    method=method,
+                    url=url,
+                    attempt=attempt_number,
+                    max_attempts=policy.retry.max_attempts,
+                    elapsed_seconds=elapsed_seconds,
+                    max_elapsed_seconds=policy.max_elapsed_seconds,
+                    emit_event=emit_event,
+                    status_code=response.status_code,
+                )
+                response.close()
+                _raise_budget_exceeded(
+                    provider_name=provider_name,
+                    operation_name=operation_name,
+                    elapsed_seconds=elapsed_seconds,
+                    max_elapsed_seconds=policy.max_elapsed_seconds,
+                )
             if emit_event is not None:
                 emit_event(
                     ProviderEvent(
@@ -375,7 +525,28 @@ def poll_json_task(
 ) -> dict[str, object]:
     """Poll an HTTP task endpoint until it completes or fails."""
 
-    for _ in range(max_polls):
+    operation_started = perf_counter()
+    for poll_number in range(1, max_polls + 1):
+        remaining_seconds = _remaining_budget_seconds(operation_policy, started=operation_started)
+        if remaining_seconds is not None and remaining_seconds <= 0.0:
+            elapsed_seconds = _elapsed_seconds(operation_started)
+            _emit_budget_exceeded(
+                provider_name=provider_name,
+                operation_name="task poll",
+                method="GET",
+                url=path,
+                attempt=min(poll_number, operation_policy.retry.max_attempts),
+                max_attempts=operation_policy.retry.max_attempts,
+                elapsed_seconds=elapsed_seconds,
+                max_elapsed_seconds=operation_policy.max_elapsed_seconds,
+                emit_event=emit_event,
+            )
+            _raise_budget_exceeded(
+                provider_name=provider_name,
+                operation_name="task poll",
+                elapsed_seconds=elapsed_seconds,
+                max_elapsed_seconds=operation_policy.max_elapsed_seconds,
+            )
         payload = request_json_with_policy(
             client,
             method="GET",
@@ -390,5 +561,28 @@ def poll_json_task(
             return dict(payload)
         if status in failure_values:
             raise ProviderError(f"Provider '{provider_name}' task failed with status {status}.")
+        elapsed_after_delay = _elapsed_seconds(operation_started) + poll_interval_seconds
+        if (
+            operation_policy.max_elapsed_seconds is not None
+            and elapsed_after_delay > operation_policy.max_elapsed_seconds
+        ):
+            elapsed_seconds = _elapsed_seconds(operation_started)
+            _emit_budget_exceeded(
+                provider_name=provider_name,
+                operation_name="task poll",
+                method="GET",
+                url=path,
+                attempt=operation_policy.retry.max_attempts,
+                max_attempts=operation_policy.retry.max_attempts,
+                elapsed_seconds=elapsed_seconds,
+                max_elapsed_seconds=operation_policy.max_elapsed_seconds,
+                emit_event=emit_event,
+            )
+            _raise_budget_exceeded(
+                provider_name=provider_name,
+                operation_name="task poll",
+                elapsed_seconds=elapsed_seconds,
+                max_elapsed_seconds=operation_policy.max_elapsed_seconds,
+            )
         sleep(poll_interval_seconds)
     raise ProviderError(f"Provider '{provider_name}' task did not complete before timeout.")

--- a/tests/test_harness_tui.py
+++ b/tests/test_harness_tui.py
@@ -232,7 +232,7 @@ def test_robotics_arm_pane_advances_frame(tmp_path) -> None:
             summary=_robotics_summary(),
             summary_path=tmp_path / "summary.json",
             stage_delay=0.0,
-            animate_arm=True,
+            animate_arm=False,
         )
         async with app.run_test(size=(150, 48)) as pilot:
             await pilot.pause()

--- a/tests/test_helper_validations.py
+++ b/tests/test_helper_validations.py
@@ -6,6 +6,7 @@ import math
 import httpx
 import pytest
 
+import worldforge.providers.http_utils as http_utils
 from worldforge import (
     Action,
     ActionPolicyResult,
@@ -15,11 +16,13 @@ from worldforge import (
     GenerationOptions,
     Pose,
     Position,
+    ProviderBudgetExceededError,
     ProviderCapabilities,
     ProviderEvent,
     ProviderHealth,
     ProviderRequestPolicy,
     ReasoningResult,
+    RequestOperationPolicy,
     RetryPolicy,
     Rotation,
     SceneObject,
@@ -32,7 +35,12 @@ from worldforge import (
 )
 from worldforge.models import HistoryEntry, average, dump_json
 from worldforge.providers import PredictionPayload, ProviderError
-from worldforge.providers.http_utils import asset_to_uri, parse_size, poll_json_task
+from worldforge.providers.http_utils import (
+    asset_to_uri,
+    parse_size,
+    poll_json_task,
+    request_json_with_policy,
+)
 
 
 def test_http_utils_validate_assets_size_and_polling(tmp_path) -> None:
@@ -107,6 +115,18 @@ def test_http_utils_validate_assets_size_and_polling(tmp_path) -> None:
     assert default_request_policy.request.retry.max_attempts == 1
     assert default_request_policy.download.retry.max_attempts == 3
     assert default_request_policy.to_dict()["health"]["timeout_seconds"] == 10.0
+    budgeted_request_policy = ProviderRequestPolicy.remote_defaults(
+        request_timeout_seconds=12.0,
+        health_max_elapsed_seconds=2.0,
+        request_max_elapsed_seconds=3.0,
+        polling_max_elapsed_seconds=4.0,
+        download_max_elapsed_seconds=5.0,
+    )
+    assert budgeted_request_policy.health.max_elapsed_seconds == 2.0
+    assert budgeted_request_policy.to_dict()["request"]["max_elapsed_seconds"] == 3.0
+
+    with pytest.raises(WorldForgeError, match="max_elapsed_seconds"):
+        RequestOperationPolicy(timeout_seconds=1.0, max_elapsed_seconds=0.0)
 
     event = ProviderEvent(
         provider="mock",
@@ -119,6 +139,104 @@ def test_http_utils_validate_assets_size_and_polling(tmp_path) -> None:
 
     with pytest.raises(WorldForgeError, match="duration_ms"):
         ProviderEvent(provider="mock", operation="predict", phase="success", duration_ms=-1.0)
+
+
+def test_http_request_policy_budget_failures_are_observable() -> None:
+    events: list[ProviderEvent] = []
+    attempts = {"count": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        attempts["count"] += 1
+        return httpx.Response(503, text="warming")
+
+    client = httpx.Client(transport=httpx.MockTransport(handler), base_url="http://providers.test")
+    with (
+        client,
+        pytest.raises(ProviderBudgetExceededError, match="exceeded budget"),
+    ):
+        request_json_with_policy(
+            client,
+            method="GET",
+            url="/health",
+            provider_name="mock",
+            operation_name="healthcheck",
+            policy=RequestOperationPolicy(
+                timeout_seconds=1.0,
+                retry=RetryPolicy(max_attempts=3, backoff_seconds=2.0),
+                max_elapsed_seconds=1.0,
+            ),
+            emit_event=events.append,
+        )
+
+    assert attempts["count"] == 1
+    assert [(event.operation, event.phase) for event in events] == [
+        ("healthcheck", "budget_exceeded")
+    ]
+    assert events[0].metadata == {"max_elapsed_seconds": 1.0}
+
+
+def test_http_request_policy_budget_can_fail_before_first_attempt(monkeypatch) -> None:
+    events: list[ProviderEvent] = []
+    attempts = {"count": 0}
+    times = iter([0.0, 2.0, 2.0, 2.0])
+
+    monkeypatch.setattr(http_utils, "perf_counter", lambda: next(times))
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        attempts["count"] += 1
+        return httpx.Response(200, json={"ok": True})
+
+    client = httpx.Client(transport=httpx.MockTransport(handler), base_url="http://providers.test")
+    with (
+        client,
+        pytest.raises(ProviderBudgetExceededError, match="exceeded budget"),
+    ):
+        request_json_with_policy(
+            client,
+            method="GET",
+            url="/health",
+            provider_name="mock",
+            operation_name="healthcheck",
+            policy=RequestOperationPolicy(timeout_seconds=1.0, max_elapsed_seconds=1.0),
+            emit_event=events.append,
+        )
+
+    assert attempts["count"] == 0
+    assert events[0].phase == "budget_exceeded"
+    assert events[0].duration_ms == 2000.0
+
+
+def test_poll_json_task_budget_blocks_silent_poll_loops() -> None:
+    events: list[ProviderEvent] = []
+    attempts = {"count": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        attempts["count"] += 1
+        return httpx.Response(200, json={"status": "PROCESSING"})
+
+    client = httpx.Client(transport=httpx.MockTransport(handler), base_url="http://providers.test")
+    with (
+        client,
+        pytest.raises(ProviderBudgetExceededError, match="task poll exceeded budget"),
+    ):
+        poll_json_task(
+            client,
+            path="/tasks/1",
+            success_values={"SUCCEEDED"},
+            failure_values={"FAILED"},
+            poll_interval_seconds=2.0,
+            max_polls=5,
+            provider_name="mock",
+            operation_policy=RequestOperationPolicy(
+                timeout_seconds=1.0,
+                max_elapsed_seconds=1.0,
+            ),
+            emit_event=events.append,
+        )
+
+    assert attempts["count"] == 1
+    assert events[-1].operation == "task poll"
+    assert events[-1].phase == "budget_exceeded"
 
 
 def test_framework_helpers_and_error_paths(tmp_path) -> None:

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -36,6 +36,7 @@ def test_top_level_exports_and_subpackages_import() -> None:
     assert worldforge.GenerationEvaluationSuite is not None
     assert worldforge.ProviderEvent is not None
     assert worldforge.ProviderBenchmarkHarness is not None
+    assert worldforge.ProviderBudgetExceededError is not None
     assert worldforge.ProviderRequestPolicy is not None
     assert worldforge.RequestOperationPolicy is not None
     assert worldforge.RetryPolicy is not None


### PR DESCRIPTION
Closes #80.

## Summary
- add optional `max_elapsed_seconds` budgets to provider operation policies
- enforce budgets in HTTP requests, retries, backoff, and task polling with `ProviderBudgetExceededError`
- emit `budget_exceeded` provider events and document host-owned circuit-breaker handling
- make the robotics arm manual-advance test deterministic under coverage

## Validation
- `uv run pytest tests/test_helper_validations.py tests/test_remote_video_providers.py -q`
- `uv run pytest`
- `uv run pytest -m "not live"`
- `uv run --extra harness pytest --cov=src/worldforge --cov-report=term-missing --cov-fail-under=90`
- `bash scripts/test_package.sh`
- `uv run ruff check src tests examples scripts`
- `uv run ruff format --check src tests examples scripts`
- `uv run mkdocs build --strict`
- `uv lock --check`
- `uv run python scripts/generate_provider_docs.py --check`
- `UV_LOCKED=true uv export --all-groups --no-emit-project --no-hashes --output-file /tmp/worldforge-requirements.txt`
- `uvx --from pip-audit pip-audit -r /tmp/worldforge-requirements.txt`
