### PR TITLE
Add optional OpenTelemetry provider event sink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ releases may still include breaking changes when the public API needs to tighten
 
 ## Unreleased
 
-No user-visible changes yet.
+- Added an optional OpenTelemetry provider-event sink that maps sanitized provider events to
+  host-owned tracing spans without adding OpenTelemetry to the base dependency set.
 
 ## 0.5.0 - 2026-04-24
 

--- a/docs/src/api/python.md
+++ b/docs/src/api/python.md
@@ -108,6 +108,7 @@ from pathlib import Path
 from worldforge import WorldForge
 from worldforge.observability import (
     JsonLoggerSink,
+    OpenTelemetryProviderEventSink,
     ProviderMetricsSink,
     RunJsonLogSink,
     compose_event_handlers,
@@ -131,6 +132,8 @@ Provider events are log-safe by default. The `target` field keeps endpoint or ar
 but strips URL userinfo, query strings, and fragments; message, metadata, and sink extra fields
 redact obvious bearer tokens, API keys, signatures, passwords, and signed URLs. `RunJsonLogSink`
 appends one JSON object per line and stamps every record with `run_id` for manifest correlation.
+`OpenTelemetryProviderEventSink` is optional and accepts an injected host tracer, so the base
+package does not import OpenTelemetry or configure collectors.
 
 ## Action Scoring
 

--- a/docs/src/architecture.md
+++ b/docs/src/architecture.md
@@ -689,6 +689,7 @@ from worldforge import WorldForge
 from worldforge.observability import (
     JsonLoggerSink,
     ProviderMetricsSink,
+    OpenTelemetryProviderEventSink,
     RunJsonLogSink,
     compose_event_handlers,
 )

--- a/docs/src/operations.md
+++ b/docs/src/operations.md
@@ -115,6 +115,7 @@ Use `compose_event_handlers(...)` to fan out events to:
 - `JsonLoggerSink` for structured JSON logs.
 - `RunJsonLogSink` for newline-delimited JSON files tied to one run id.
 - `ProviderMetricsSink` for request, retry, error, and latency aggregates.
+- `OpenTelemetryProviderEventSink` for optional host-owned tracing spans.
 - `InMemoryRecorderSink` for tests and local debugging.
 
 `ProviderEvent` sanitizes observable fields before they reach these sinks: HTTP targets keep
@@ -129,6 +130,30 @@ adapter. Optional event fields are `run_id`, `request_id`, `trace_id`, `span_id`
 and `input_digest`; they are strings, omitted when unset, and sanitized before sink consumption.
 The event `phase` is normalized to lowercase so hosts can filter stable `success`, `failure`,
 `retry`, and `budget_exceeded` values.
+
+OpenTelemetry export is optional. Importing `worldforge` does not import OpenTelemetry, and the
+base package does not install a collector, SDK, or exporter. Production hosts either install
+`opentelemetry-api` and let `OpenTelemetryProviderEventSink()` resolve the current tracer lazily, or
+inject their already configured tracer:
+
+```python
+from worldforge import WorldForge
+from worldforge.observability import OpenTelemetryProviderEventSink
+
+forge = WorldForge(
+    event_handler=OpenTelemetryProviderEventSink(
+        tracer=host_tracer,
+        extra_attributes={"service": "batch-eval"},
+    )
+)
+```
+
+Each provider event becomes one span named
+`worldforge.provider.<provider>.<operation>.<phase>`. Span attributes are bounded to provider,
+operation, phase, attempt, max attempts, optional duration, optional correlation IDs, HTTP method,
+HTTP status code, sanitized target, status class, capability, redacted message, and redacted
+metadata JSON. Hosts should not add raw prompts, world IDs, target URLs with query strings, or
+high-cardinality business metadata as trace attributes.
 
 Example JSON log record:
 

--- a/docs/src/providers/README.md
+++ b/docs/src/providers/README.md
@@ -176,6 +176,7 @@ from pathlib import Path
 from worldforge import WorldForge
 from worldforge.observability import (
     JsonLoggerSink,
+    OpenTelemetryProviderEventSink,
     ProviderMetricsSink,
     RunJsonLogSink,
     compose_event_handlers,
@@ -195,6 +196,10 @@ forge = WorldForge(
 `ProviderMetricsSink.request_count` counts emitted provider events, so retry events increment both
 `request_count` and `retry_count`. `RunJsonLogSink` writes one redacted JSON record per line and
 keeps `run_id` on every record so provider logs can be joined with host-owned run manifests.
+`OpenTelemetryProviderEventSink` maps provider events to optional host-owned tracing spans with
+bounded attributes: provider, operation, phase, attempt, duration, status class, sanitized target,
+capability, and correlation IDs. WorldForge does not install OpenTelemetry exporters or own
+collector configuration.
 
 Optional live smoke entrypoints accept `--run-manifest <path>` for a validated
 `run_manifest.json`. The manifest is safe issue evidence: it stores command argv, package version,

--- a/src/worldforge/observability.py
+++ b/src/worldforge/observability.py
@@ -17,6 +17,10 @@ from worldforge.models import (
     dump_json,
     require_json_dict,
 )
+from worldforge.observability_opentelemetry import (
+    OpenTelemetryProviderEventSink,
+    provider_event_span_attributes,
+)
 
 ProviderEventHandler = Callable[[ProviderEvent], None]
 
@@ -300,9 +304,11 @@ __all__ = [
     "InMemoryRecorderSink",
     "JsonLoggerSink",
     "LatencySummary",
+    "OpenTelemetryProviderEventSink",
     "ProviderEventHandler",
     "ProviderMetricsSink",
     "ProviderOperationMetrics",
     "RunJsonLogSink",
     "compose_event_handlers",
+    "provider_event_span_attributes",
 ]

--- a/src/worldforge/observability_opentelemetry.py
+++ b/src/worldforge/observability_opentelemetry.py
@@ -1,0 +1,145 @@
+"""Optional OpenTelemetry bridge for provider events.
+
+The module intentionally has no import-time dependency on OpenTelemetry. Hosts that already own
+OpenTelemetry wiring can inject a tracer directly; otherwise the sink imports ``opentelemetry``
+lazily when it is constructed.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from contextlib import AbstractContextManager
+from dataclasses import dataclass, field
+from typing import Protocol
+
+from worldforge.models import (
+    JSONDict,
+    ProviderEvent,
+    WorldForgeError,
+    _redact_observable_value,
+    dump_json,
+    require_json_dict,
+)
+
+AttributeValue = (
+    str
+    | bool
+    | int
+    | float
+    | tuple[str, ...]
+    | tuple[bool, ...]
+    | tuple[int, ...]
+    | tuple[float, ...]
+)
+SpanAttributes = dict[str, AttributeValue]
+
+
+class _Span(Protocol):
+    def set_attribute(self, key: str, value: AttributeValue) -> None: ...
+
+
+class _Tracer(Protocol):
+    def start_as_current_span(
+        self,
+        name: str,
+        *,
+        attributes: Mapping[str, AttributeValue] | None = None,
+    ) -> AbstractContextManager[_Span]: ...
+
+
+def _status_class(status_code: int | None) -> str | None:
+    if status_code is None:
+        return None
+    return f"{status_code // 100}xx"
+
+
+def _optional_attribute(attributes: SpanAttributes, key: str, value: object | None) -> None:
+    if value is None:
+        return
+    if isinstance(value, str | bool | int | float):
+        attributes[key] = value
+
+
+def provider_event_span_attributes(event: ProviderEvent) -> SpanAttributes:
+    """Return bounded, redacted OpenTelemetry attributes for a provider event."""
+
+    attributes: SpanAttributes = {
+        "worldforge.provider": event.provider,
+        "worldforge.operation": event.operation,
+        "worldforge.phase": event.phase,
+        "worldforge.attempt": event.attempt,
+        "worldforge.max_attempts": event.max_attempts,
+    }
+    _optional_attribute(attributes, "worldforge.duration_ms", event.duration_ms)
+    _optional_attribute(attributes, "worldforge.run_id", event.run_id)
+    _optional_attribute(attributes, "worldforge.request_id", event.request_id)
+    _optional_attribute(attributes, "worldforge.trace_id", event.trace_id)
+    _optional_attribute(attributes, "worldforge.span_id", event.span_id)
+    _optional_attribute(attributes, "worldforge.artifact_id", event.artifact_id)
+    _optional_attribute(attributes, "worldforge.input_digest", event.input_digest)
+    _optional_attribute(attributes, "http.request.method", event.method)
+    _optional_attribute(attributes, "http.response.status_code", event.status_code)
+    _optional_attribute(attributes, "url.full", event.target)
+
+    status_class = _status_class(event.status_code)
+    _optional_attribute(attributes, "worldforge.status_class", status_class)
+    capability = event.metadata.get("capability")
+    _optional_attribute(attributes, "worldforge.capability", capability)
+    if event.message:
+        attributes["worldforge.message"] = event.message
+    if event.metadata:
+        attributes["worldforge.metadata_json"] = dump_json(event.metadata)
+    return attributes
+
+
+def _load_default_tracer() -> _Tracer:
+    try:
+        from opentelemetry import trace
+    except ModuleNotFoundError as exc:
+        raise WorldForgeError(
+            "OpenTelemetry export requires the host to install opentelemetry-api or pass an "
+            "injected tracer."
+        ) from exc
+    return trace.get_tracer("worldforge")
+
+
+@dataclass(slots=True)
+class OpenTelemetryProviderEventSink:
+    """Create one OpenTelemetry span for each provider event."""
+
+    tracer: _Tracer | None = None
+    span_name_prefix: str = "worldforge.provider"
+    extra_attributes: JSONDict = field(default_factory=dict)
+    _tracer: _Tracer = field(init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.span_name_prefix, str) or not self.span_name_prefix.strip():
+            raise WorldForgeError(
+                "OpenTelemetryProviderEventSink span_name_prefix must be a non-empty string."
+            )
+        self.span_name_prefix = self.span_name_prefix.strip()
+        self._tracer = self.tracer if self.tracer is not None else _load_default_tracer()
+        self.extra_attributes = require_json_dict(
+            _redact_observable_value(dict(self.extra_attributes)),
+            name="OpenTelemetryProviderEventSink extra_attributes",
+        )
+
+    def __call__(self, event: ProviderEvent) -> None:
+        attributes = provider_event_span_attributes(event)
+        for key, value in self.extra_attributes.items():
+            if isinstance(value, str | bool | int | float):
+                attributes[f"worldforge.host.{key}"] = value
+            else:
+                attributes[f"worldforge.host.{key}"] = dump_json(value)
+        span_name = f"{self.span_name_prefix}.{event.provider}.{event.operation}.{event.phase}"
+        with self._tracer.start_as_current_span(span_name, attributes=attributes) as span:
+            # Some lightweight test tracers store attributes from construction only; real OTel spans
+            # accept set_attribute calls and this keeps behavior consistent for injected tracers.
+            for key, value in attributes.items():
+                span.set_attribute(key, value)
+
+
+__all__ = [
+    "OpenTelemetryProviderEventSink",
+    "provider_event_span_attributes",
+]

--- a/tests/test_observability_opentelemetry.py
+++ b/tests/test_observability_opentelemetry.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import sys
+from contextlib import AbstractContextManager
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+import worldforge
+from worldforge import ProviderEvent, WorldForgeError
+from worldforge.observability import (
+    OpenTelemetryProviderEventSink,
+    compose_event_handlers,
+    provider_event_span_attributes,
+)
+
+
+@dataclass
+class _FakeSpan:
+    name: str
+    attributes: dict[str, Any] = field(default_factory=dict)
+
+    def set_attribute(self, key: str, value: object) -> None:
+        self.attributes[key] = value
+
+
+@dataclass
+class _SpanContext(AbstractContextManager[_FakeSpan]):
+    span: _FakeSpan
+
+    def __enter__(self) -> _FakeSpan:
+        return self.span
+
+    def __exit__(self, *exc_info: object) -> None:
+        return None
+
+
+@dataclass
+class _FakeTracer:
+    spans: list[_FakeSpan] = field(default_factory=list)
+
+    def start_as_current_span(
+        self,
+        name: str,
+        *,
+        attributes: dict[str, object] | None = None,
+    ) -> _SpanContext:
+        span = _FakeSpan(name=name, attributes=dict(attributes or {}))
+        self.spans.append(span)
+        return _SpanContext(span)
+
+
+def test_importing_worldforge_does_not_import_opentelemetry() -> None:
+    assert worldforge.__version__
+    assert not any(module == "opentelemetry" for module in sys.modules)
+
+
+def test_provider_event_span_attributes_are_bounded_and_sanitized() -> None:
+    event = ProviderEvent(
+        provider="runway",
+        operation="task create",
+        phase="SUCCESS",
+        method="post",
+        target="https://user:secret@api.runwayml.com/v1/tasks?token=secret#fragment",
+        status_code=201,
+        duration_ms=42.5,
+        attempt=2,
+        max_attempts=3,
+        message="Bearer secret-token failed for token=secret",
+        metadata={
+            "capability": "generate",
+            "api_key": "secret",
+            "artifact_url": "https://files.example.test/video.mp4?signature=secret",
+        },
+        run_id="run-123",
+        request_id="req-456",
+        trace_id="trace-789",
+        span_id="span-abc",
+        artifact_id="artifact-def",
+        input_digest="sha256:123",
+    )
+
+    attributes = provider_event_span_attributes(event)
+
+    assert attributes["worldforge.provider"] == "runway"
+    assert attributes["worldforge.operation"] == "task create"
+    assert attributes["worldforge.phase"] == "success"
+    assert attributes["worldforge.status_class"] == "2xx"
+    assert attributes["worldforge.capability"] == "generate"
+    assert attributes["http.request.method"] == "POST"
+    assert attributes["http.response.status_code"] == 201
+    assert attributes["url.full"] == "https://api.runwayml.com/v1/tasks"
+    assert attributes["worldforge.trace_id"] == "trace-789"
+    rendered = str(attributes)
+    assert "secret-token" not in rendered
+    assert "token=secret" not in rendered
+    assert "signature=secret" not in rendered
+    assert '"api_key":"[redacted]"' in attributes["worldforge.metadata_json"]
+
+
+def test_open_telemetry_sink_uses_injected_tracer_without_optional_dependency() -> None:
+    tracer = _FakeTracer()
+    sink = OpenTelemetryProviderEventSink(
+        tracer=tracer,
+        extra_attributes={"service": "batch-host", "api_token": "secret"},
+    )
+
+    sink(
+        ProviderEvent(
+            provider="mock",
+            operation="predict",
+            phase="failure",
+            status_code=503,
+            metadata={"capability": "predict"},
+        )
+    )
+
+    assert len(tracer.spans) == 1
+    span = tracer.spans[0]
+    assert span.name == "worldforge.provider.mock.predict.failure"
+    assert span.attributes["worldforge.provider"] == "mock"
+    assert span.attributes["worldforge.status_class"] == "5xx"
+    assert span.attributes["worldforge.host.service"] == "batch-host"
+    assert span.attributes["worldforge.host.api_token"] == "[redacted]"
+
+
+def test_open_telemetry_sink_composes_with_provider_handlers() -> None:
+    tracer = _FakeTracer()
+    events: list[ProviderEvent] = []
+    handler = compose_event_handlers(events.append, OpenTelemetryProviderEventSink(tracer=tracer))
+
+    assert handler is not None
+    handler(ProviderEvent(provider="mock", operation="generate", phase="retry", attempt=1))
+
+    assert [event.phase for event in events] == ["retry"]
+    assert tracer.spans[0].attributes["worldforge.phase"] == "retry"
+
+
+def test_open_telemetry_sink_requires_tracer_or_optional_dependency(monkeypatch) -> None:
+    monkeypatch.setitem(sys.modules, "opentelemetry", None)
+
+    with pytest.raises(WorldForgeError, match="opentelemetry-api"):
+        OpenTelemetryProviderEventSink()

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -55,9 +55,11 @@ def test_top_level_exports_and_subpackages_import() -> None:
     assert GrootPolicyClientProvider is not None
     assert observability.JsonLoggerSink is not None
     assert observability.InMemoryRecorderSink is not None
+    assert observability.OpenTelemetryProviderEventSink is not None
     assert observability.ProviderMetricsSink is not None
     assert observability.RunJsonLogSink is not None
     assert observability.compose_event_handlers is not None
+    assert observability.provider_event_span_attributes is not None
 
 
 def test_lazy_export_modules_have_expected_dir_and_attribute_errors() -> None:


### PR DESCRIPTION
Closes #75.

## Summary
- add `OpenTelemetryProviderEventSink` for optional provider-event spans
- map sanitized provider events to bounded span attributes
- document host-owned tracer/exporter setup without changing base dependencies

## Validation
- `uv run ruff check src tests examples scripts`
- `uv run ruff format --check src tests examples scripts`
- `uv run pytest tests/test_observability_opentelemetry.py tests/test_observability.py tests/test_public_api.py -q`
- `uv run pytest`
- `uv run pytest -m "not live"`
- `uv run --extra harness pytest --cov=src/worldforge --cov-report=term-missing --cov-fail-under=90`
- `uv run mkdocs build --strict`
- `bash scripts/test_package.sh`
- `uv lock --check`
- `uv run python scripts/generate_provider_docs.py --check`
- `UV_LOCKED=true uv export --all-groups --no-emit-project --no-hashes --output-file <tmp>` + `uvx --from pip-audit pip-audit -r <tmp>`
