### PR TITLE
Add optional provider metrics exporter

### DIFF
--- a/docs/src/api/python.md
+++ b/docs/src/api/python.md
@@ -108,6 +108,7 @@ from pathlib import Path
 from worldforge import WorldForge
 from worldforge.observability import (
     JsonLoggerSink,
+    ProviderMetricsExporterSink,
     OpenTelemetryProviderEventSink,
     ProviderMetricsSink,
     RunJsonLogSink,
@@ -117,10 +118,12 @@ from worldforge.rerun import RerunArtifactLogger, RerunEventSink, RerunRecording
 
 run_id = "demo-run"
 metrics = ProviderMetricsSink()
+host_metrics_exporter = ...  # supplied by your service
 forge = WorldForge(
     event_handler=compose_event_handlers(
         JsonLoggerSink(logger=logging.getLogger("demo.worldforge"), extra_fields={"run_id": run_id}),
         RunJsonLogSink(Path(".worldforge") / "runs" / run_id / "provider-events.jsonl", run_id),
+        ProviderMetricsExporterSink(host_metrics_exporter),
         metrics,
     )
 )
@@ -135,6 +138,8 @@ redact obvious bearer tokens, API keys, signatures, passwords, and signed URLs. 
 appends one JSON object per line and stamps every record with `run_id` for manifest correlation.
 `OpenTelemetryProviderEventSink` is optional and accepts an injected host tracer, so the base
 package does not import OpenTelemetry or configure collectors.
+`ProviderMetricsExporterSink` is also optional and accepts a host-owned metrics exporter with
+bounded labels for provider, operation, phase, status class, and capability.
 
 Rerun is available as an optional observability and artifact layer:
 

--- a/docs/src/architecture.md
+++ b/docs/src/architecture.md
@@ -675,6 +675,7 @@ Provider operation
         |-- RunJsonLogSink
         |-- InMemoryRecorderSink
         |-- ProviderMetricsSink
+        |-- ProviderMetricsExporterSink
         `-- RerunEventSink
 ```
 
@@ -692,8 +693,9 @@ from pathlib import Path
 from worldforge import WorldForge
 from worldforge.observability import (
     JsonLoggerSink,
-    ProviderMetricsSink,
     OpenTelemetryProviderEventSink,
+    ProviderMetricsExporterSink,
+    ProviderMetricsSink,
     RunJsonLogSink,
     compose_event_handlers,
 )
@@ -701,12 +703,14 @@ from worldforge.rerun import RerunEventSink, RerunRecordingConfig, RerunSession
 
 run_id = "demo-run"
 metrics = ProviderMetricsSink()
+host_metrics_exporter = ...  # supplied by your service
 rerun_session = RerunSession(RerunRecordingConfig(save_path=".worldforge/rerun/events.rrd"))
 forge = WorldForge(
     event_handler=compose_event_handlers(
         JsonLoggerSink(logger=logging.getLogger("demo.worldforge"), extra_fields={"run_id": run_id}),
         RunJsonLogSink(Path(".worldforge") / "runs" / run_id / "provider-events.jsonl", run_id),
         RerunEventSink(session=rerun_session),
+        ProviderMetricsExporterSink(host_metrics_exporter),
         metrics,
     )
 )

--- a/docs/src/operations.md
+++ b/docs/src/operations.md
@@ -115,6 +115,7 @@ Use `compose_event_handlers(...)` to fan out events to:
 - `JsonLoggerSink` for structured JSON logs.
 - `RunJsonLogSink` for newline-delimited JSON files tied to one run id.
 - `ProviderMetricsSink` for request, retry, error, and latency aggregates.
+- `ProviderMetricsExporterSink` for optional host-owned counters and latency histograms.
 - `OpenTelemetryProviderEventSink` for optional host-owned tracing spans.
 - `InMemoryRecorderSink` for tests and local debugging.
 - `RerunEventSink` for optional Rerun recordings of provider events.
@@ -155,6 +156,40 @@ operation, phase, attempt, max attempts, optional duration, optional correlation
 HTTP status code, sanitized target, status class, capability, redacted message, and redacted
 metadata JSON. Hosts should not add raw prompts, world IDs, target URLs with query strings, or
 high-cardinality business metadata as trace attributes.
+
+Metrics export is also optional and dependency-free. `ProviderMetricsExporterSink` accepts any
+host exporter with `increment_counter(...)` and `observe_histogram(...)` methods, so production
+services can bridge provider events to Prometheus, OpenTelemetry Metrics, StatsD, or an internal
+collector without adding dependencies to the base package.
+
+```python
+from worldforge import WorldForge
+from worldforge.observability import ProviderMetricsExporterSink, compose_event_handlers
+
+host_metrics_exporter = ...  # supplied by your service
+forge = WorldForge(
+    event_handler=compose_event_handlers(
+        ProviderMetricsExporterSink(host_metrics_exporter),
+    )
+)
+```
+
+The sink emits:
+
+| Metric | Meaning |
+| --- | --- |
+| `worldforge_provider_events_total` | Every provider event, including retries. |
+| `worldforge_provider_operations_total` | Logical non-retry outcomes such as `success`, `failure`, and `budget_exceeded`. |
+| `worldforge_provider_retries_total` | Retry events only, separate from logical operation totals. |
+| `worldforge_provider_errors_total` | Failed or budget-exceeded operation outcomes. |
+| `worldforge_provider_latency_ms` | Event `duration_ms` values when providers include them. |
+
+Labels are bounded to `provider`, `operation`, `phase`, `status_class`, and `capability`.
+`capability` is exported only when it matches a known WorldForge capability; otherwise it becomes
+`unknown`. Do not add raw target URLs, prompts, metadata keys, world IDs, artifact IDs, request IDs,
+or user/business identifiers as metric labels. Those values have high cardinality, and some can
+carry secrets. Good first alerts are retry-rate or error-rate thresholds by provider/operation, and
+latency percentile alerts on `worldforge_provider_latency_ms` grouped by provider/operation.
 
 Example JSON log record:
 

--- a/docs/src/provider-platform-roadmap.md
+++ b/docs/src/provider-platform-roadmap.md
@@ -1265,10 +1265,10 @@ Scope:
 
 Acceptance criteria:
 
-- [ ] Metrics bridge is optional and has bounded labels.
-- [ ] Retry events increment retry metrics distinctly from logical operation count.
-- [ ] Docs explain metric meanings and alert examples.
-- [ ] Base package dependency set remains unchanged.
+- [x] Metrics bridge is optional and has bounded labels.
+- [x] Retry events increment retry metrics distinctly from logical operation count.
+- [x] Docs explain metric meanings and alert examples.
+- [x] Base package dependency set remains unchanged.
 
 Validation:
 

--- a/src/worldforge/observability.py
+++ b/src/worldforge/observability.py
@@ -3,13 +3,15 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from copy import deepcopy
 from dataclasses import dataclass, field
 from pathlib import Path
 from threading import Lock
+from typing import Protocol
 
 from worldforge.models import (
+    CAPABILITY_NAMES,
     JSONDict,
     ProviderEvent,
     WorldForgeError,
@@ -23,6 +25,27 @@ from worldforge.observability_opentelemetry import (
 )
 
 ProviderEventHandler = Callable[[ProviderEvent], None]
+MetricLabels = dict[str, str]
+
+
+class ProviderMetricsExporter(Protocol):
+    """Host-owned metrics backend used by :class:`ProviderMetricsExporterSink`."""
+
+    def increment_counter(
+        self,
+        name: str,
+        *,
+        value: float = 1.0,
+        labels: Mapping[str, str],
+    ) -> None: ...
+
+    def observe_histogram(
+        self,
+        name: str,
+        value: float,
+        *,
+        labels: Mapping[str, str],
+    ) -> None: ...
 
 
 def _copy_event(event: ProviderEvent) -> ProviderEvent:
@@ -300,15 +323,164 @@ class ProviderMetricsSink:
         return payload
 
 
+def _status_class(status_code: int | None) -> str:
+    if status_code is None:
+        return "none"
+    return f"{status_code // 100}xx"
+
+
+def _capability_label(event: ProviderEvent) -> str:
+    capability = event.metadata.get("capability")
+    if isinstance(capability, str) and capability in CAPABILITY_NAMES:
+        return capability
+    return "unknown"
+
+
+def provider_event_metric_labels(event: ProviderEvent) -> MetricLabels:
+    """Return bounded metric labels for a provider event."""
+
+    return {
+        "provider": event.provider,
+        "operation": event.operation,
+        "phase": event.phase,
+        "status_class": _status_class(event.status_code),
+        "capability": _capability_label(event),
+    }
+
+
+@dataclass(slots=True, frozen=True)
+class MetricSample:
+    """One exported metric observation captured by the in-memory exporter."""
+
+    name: str
+    labels: MetricLabels
+    value: float
+
+    def to_dict(self) -> JSONDict:
+        return {"name": self.name, "labels": dict(self.labels), "value": self.value}
+
+
+@dataclass(slots=True)
+class InMemoryMetricsExporter:
+    """Dependency-free metrics exporter useful for tests and local host wiring."""
+
+    _counters: dict[tuple[str, tuple[tuple[str, str], ...]], float] = field(
+        default_factory=dict,
+        init=False,
+        repr=False,
+    )
+    _histograms: list[MetricSample] = field(default_factory=list, init=False, repr=False)
+    _lock: Lock = field(default_factory=Lock, init=False, repr=False)
+
+    def increment_counter(
+        self,
+        name: str,
+        *,
+        value: float = 1.0,
+        labels: Mapping[str, str],
+    ) -> None:
+        label_tuple = tuple(sorted(dict(labels).items()))
+        with self._lock:
+            counter_key = (name, label_tuple)
+            self._counters[counter_key] = self._counters.get(counter_key, 0.0) + value
+
+    def observe_histogram(
+        self,
+        name: str,
+        value: float,
+        *,
+        labels: Mapping[str, str],
+    ) -> None:
+        with self._lock:
+            self._histograms.append(MetricSample(name=name, labels=dict(labels), value=value))
+
+    def clear(self) -> None:
+        with self._lock:
+            self._counters.clear()
+            self._histograms.clear()
+
+    def counter_value(self, name: str, *, labels: Mapping[str, str]) -> float:
+        label_tuple = tuple(sorted(dict(labels).items()))
+        with self._lock:
+            return self._counters.get((name, label_tuple), 0.0)
+
+    def counter_samples(self) -> list[MetricSample]:
+        with self._lock:
+            return [
+                MetricSample(
+                    name=name,
+                    labels=dict(label_tuple),
+                    value=value,
+                )
+                for (name, label_tuple), value in sorted(self._counters.items())
+            ]
+
+    def histogram_samples(self) -> list[MetricSample]:
+        with self._lock:
+            return [
+                MetricSample(name=sample.name, labels=dict(sample.labels), value=sample.value)
+                for sample in self._histograms
+            ]
+
+
+@dataclass(slots=True)
+class ProviderMetricsExporterSink:
+    """Export provider event counters and latency histograms to a host metrics backend."""
+
+    exporter: ProviderMetricsExporter
+    metric_prefix: str = "worldforge_provider"
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.metric_prefix, str) or not self.metric_prefix.strip():
+            raise WorldForgeError(
+                "ProviderMetricsExporterSink metric_prefix must be a non-empty string."
+            )
+        self.metric_prefix = self.metric_prefix.strip()
+
+    def __call__(self, event: ProviderEvent) -> None:
+        labels = provider_event_metric_labels(event)
+        self.exporter.increment_counter(
+            f"{self.metric_prefix}_events_total",
+            labels=labels,
+        )
+        if event.phase == "retry":
+            self.exporter.increment_counter(
+                f"{self.metric_prefix}_retries_total",
+                labels=labels,
+            )
+        else:
+            self.exporter.increment_counter(
+                f"{self.metric_prefix}_operations_total",
+                labels=labels,
+            )
+        if event.phase in {"failure", "budget_exceeded"}:
+            self.exporter.increment_counter(
+                f"{self.metric_prefix}_errors_total",
+                labels=labels,
+            )
+        if event.duration_ms is not None:
+            self.exporter.observe_histogram(
+                f"{self.metric_prefix}_latency_ms",
+                event.duration_ms,
+                labels=labels,
+            )
+
+
 __all__ = [
+    "InMemoryMetricsExporter",
     "InMemoryRecorderSink",
     "JsonLoggerSink",
     "LatencySummary",
+    "MetricLabels",
+    "MetricSample",
     "OpenTelemetryProviderEventSink",
     "ProviderEventHandler",
+    "ProviderMetricsExporter",
+    "ProviderMetricsExporterSink",
     "ProviderMetricsSink",
     "ProviderOperationMetrics",
     "RunJsonLogSink",
     "compose_event_handlers",
+    "provider_event_metric_labels",
     "provider_event_span_attributes",
 ]

--- a/tests/test_observability_metrics_export.py
+++ b/tests/test_observability_metrics_export.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import pytest
+
+from worldforge import ProviderEvent, WorldForgeError
+from worldforge.observability import (
+    InMemoryMetricsExporter,
+    ProviderMetricsExporterSink,
+    compose_event_handlers,
+    provider_event_metric_labels,
+)
+
+
+def _labels(
+    phase: str,
+    *,
+    status_class: str = "none",
+    capability: str = "unknown",
+) -> dict[str, str]:
+    return {
+        "capability": capability,
+        "operation": "task poll",
+        "phase": phase,
+        "provider": "runway",
+        "status_class": status_class,
+    }
+
+
+def test_provider_metrics_exporter_sink_exports_bounded_counters_and_latency() -> None:
+    exporter = InMemoryMetricsExporter()
+    sink = ProviderMetricsExporterSink(exporter)
+
+    sink(
+        ProviderEvent(
+            provider="runway",
+            operation="task poll",
+            phase="retry",
+            status_code=429,
+            duration_ms=25.0,
+            metadata={
+                "capability": "generate",
+                "prompt": "do not export as a label",
+                "world_id": "world-123",
+                "metadata_key": "unsafe-cardinality",
+            },
+        )
+    )
+    sink(
+        ProviderEvent(
+            provider="runway",
+            operation="task poll",
+            phase="success",
+            status_code=200,
+            duration_ms=40.0,
+            metadata={"capability": "generate"},
+        )
+    )
+
+    retry_labels = _labels("retry", status_class="4xx", capability="generate")
+    success_labels = _labels("success", status_class="2xx", capability="generate")
+    assert exporter.counter_value("worldforge_provider_events_total", labels=retry_labels) == 1.0
+    assert exporter.counter_value("worldforge_provider_retries_total", labels=retry_labels) == 1.0
+    assert (
+        exporter.counter_value("worldforge_provider_operations_total", labels=retry_labels) == 0.0
+    )
+    assert exporter.counter_value("worldforge_provider_events_total", labels=success_labels) == 1.0
+    assert (
+        exporter.counter_value("worldforge_provider_operations_total", labels=success_labels) == 1.0
+    )
+    assert exporter.counter_value("worldforge_provider_retries_total", labels=success_labels) == 0.0
+
+    histogram_samples = exporter.histogram_samples()
+    assert [sample.value for sample in histogram_samples] == [25.0, 40.0]
+    assert {sample.name for sample in histogram_samples} == {"worldforge_provider_latency_ms"}
+    for sample in exporter.counter_samples() + histogram_samples:
+        assert set(sample.labels) == {
+            "provider",
+            "operation",
+            "phase",
+            "status_class",
+            "capability",
+        }
+        assert "do not export" not in str(sample.to_dict())
+        assert "world-123" not in str(sample.to_dict())
+
+
+def test_provider_metrics_exporter_sink_counts_errors_without_retries() -> None:
+    exporter = InMemoryMetricsExporter()
+    sink = ProviderMetricsExporterSink(exporter, metric_prefix="wf")
+
+    sink(
+        ProviderEvent(
+            provider="runway",
+            operation="task poll",
+            phase="failure",
+            status_code=503,
+        )
+    )
+    sink(
+        ProviderEvent(
+            provider="runway",
+            operation="task poll",
+            phase="budget_exceeded",
+        )
+    )
+
+    failure_labels = _labels("failure", status_class="5xx")
+    budget_labels = _labels("budget_exceeded")
+    assert exporter.counter_value("wf_errors_total", labels=failure_labels) == 1.0
+    assert exporter.counter_value("wf_operations_total", labels=failure_labels) == 1.0
+    assert exporter.counter_value("wf_errors_total", labels=budget_labels) == 1.0
+    assert exporter.counter_value("wf_operations_total", labels=budget_labels) == 1.0
+    assert exporter.counter_value("wf_retries_total", labels=failure_labels) == 0.0
+
+
+def test_provider_event_metric_labels_ignore_unknown_capability_values() -> None:
+    labels = provider_event_metric_labels(
+        ProviderEvent(
+            provider="mock",
+            operation="predict",
+            phase="success",
+            metadata={"capability": "per-world-user-label"},
+        )
+    )
+
+    assert labels == {
+        "capability": "unknown",
+        "operation": "predict",
+        "phase": "success",
+        "provider": "mock",
+        "status_class": "none",
+    }
+
+
+def test_provider_metrics_exporter_sink_composes_with_other_handlers() -> None:
+    exporter = InMemoryMetricsExporter()
+    events: list[ProviderEvent] = []
+    handler = compose_event_handlers(events.append, ProviderMetricsExporterSink(exporter))
+    assert handler is not None
+
+    handler(ProviderEvent(provider="mock", operation="predict", phase="success"))
+
+    assert len(events) == 1
+    assert exporter.counter_samples()[0].name == "worldforge_provider_events_total"
+
+
+def test_provider_metrics_exporter_sink_validates_metric_prefix() -> None:
+    with pytest.raises(WorldForgeError, match="metric_prefix"):
+        ProviderMetricsExporterSink(InMemoryMetricsExporter(), metric_prefix=" ")

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -59,11 +59,14 @@ def test_top_level_exports_and_subpackages_import() -> None:
     assert MockProvider is not None
     assert GrootPolicyClientProvider is not None
     assert observability.JsonLoggerSink is not None
+    assert observability.InMemoryMetricsExporter is not None
     assert observability.InMemoryRecorderSink is not None
     assert observability.OpenTelemetryProviderEventSink is not None
+    assert observability.ProviderMetricsExporterSink is not None
     assert observability.ProviderMetricsSink is not None
     assert observability.RunJsonLogSink is not None
     assert observability.compose_event_handlers is not None
+    assert observability.provider_event_metric_labels is not None
     assert observability.provider_event_span_attributes is not None
     assert rerun.RerunArtifactLogger is not None
     assert rerun.create_rerun_event_handler is not None


### PR DESCRIPTION
Closes #77.

## Summary
- add dependency-free ProviderMetricsExporterSink with bounded provider-event labels
- export event, operation, retry, error, and latency metrics through host-owned exporter hooks
- add in-memory exporter tests and docs for metric semantics, alerts, and label cardinality

## Validation
- uv run ruff check src tests examples scripts
- uv run ruff format --check src tests examples scripts
- uv run pytest tests/test_observability_metrics_export.py tests/test_observability.py tests/test_public_api.py -q
- uv run pytest
- uv run pytest -m "not live"
- uv run --extra harness pytest --cov=src/worldforge --cov-report=term-missing --cov-fail-under=90
- uv run mkdocs build --strict
- bash scripts/test_package.sh
- uv lock --check
- uv run python scripts/generate_provider_docs.py --check
- UV_LOCKED=true uv export --all-groups --no-emit-project --no-hashes --output-file <tmp> && uvx --from pip-audit pip-audit -r <tmp>
