### PR TITLE
Add provider conformance helpers

### DIFF
--- a/docs/src/provider-authoring-guide.md
+++ b/docs/src/provider-authoring-guide.md
@@ -523,6 +523,23 @@ Required tests:
 - [ ] Event emission is tested for success and failure.
 - [ ] `worldforge.testing.assert_provider_contract(...)` passes for the provider where applicable.
 
+Reusable conformance helpers are available for narrow provider tests:
+
+| Helper | Capability covered |
+| --- | --- |
+| `assert_predict_conformance(...)` | `predict -> PredictionPayload` |
+| `assert_generate_conformance(...)` | `generate -> VideoClip` |
+| `assert_transfer_conformance(...)` | `transfer -> VideoClip` |
+| `assert_reason_conformance(...)` | `reason -> ReasoningResult` |
+| `assert_embed_conformance(...)` | `embed -> EmbeddingResult` |
+| `assert_score_conformance(...)` | `score_actions -> ActionScoreResult` |
+| `assert_policy_conformance(...)` | `select_actions -> ActionPolicyResult` |
+| `assert_provider_events_conform(...)` | JSON-native, redaction-safe provider events |
+
+Use the capability-specific helper when a fixture or injected runtime exercises one operation.
+Use `assert_provider_contract(...)` when the test can safely exercise every declared capability for
+the provider.
+
 Remote providers:
 
 - [ ] No tests require live credentials.

--- a/src/worldforge/testing/__init__.py
+++ b/src/worldforge/testing/__init__.py
@@ -7,8 +7,17 @@ from typing import Any
 
 _EXPORTS: dict[str, str] = {  # pragma: no cover - initialized before pytest-cov by plugins
     "ProviderContractReport": "worldforge.testing.providers",
+    "assert_embed_conformance": "worldforge.testing.providers",
+    "assert_generate_conformance": "worldforge.testing.providers",
+    "assert_policy_conformance": "worldforge.testing.providers",
+    "assert_predict_conformance": "worldforge.testing.providers",
     "assert_provider_contract": "worldforge.testing.providers",
+    "assert_provider_events_conform": "worldforge.testing.providers",
+    "assert_reason_conformance": "worldforge.testing.providers",
+    "assert_score_conformance": "worldforge.testing.providers",
+    "assert_transfer_conformance": "worldforge.testing.providers",
     "sample_contract_action": "worldforge.testing.providers",
+    "sample_contract_policy_info": "worldforge.testing.providers",
     "sample_contract_world_state": "worldforge.testing.providers",
     "PROVIDER_RUNTIME_PROFILES": "worldforge.testing.runtime_profiles",
     "PROVIDER_RUNTIME_PROFILES_BY_NAME": "worldforge.testing.runtime_profiles",

--- a/src/worldforge/testing/providers.py
+++ b/src/worldforge/testing/providers.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
 
 from worldforge.models import (
@@ -13,6 +13,7 @@ from worldforge.models import (
     EmbeddingResult,
     JSONDict,
     Position,
+    ProviderEvent,
     ProviderHealth,
     ProviderProfile,
     ReasoningResult,
@@ -236,6 +237,148 @@ def _validate_action_policy(provider: str, result: ActionPolicyResult) -> None:
     )
 
 
+def assert_predict_conformance(
+    provider: BaseProvider,
+    *,
+    world_state: JSONDict | None = None,
+    action: Action | None = None,
+    steps: int = 2,
+) -> PredictionPayload:
+    """Assert that a provider's predict capability returns a valid payload."""
+
+    if not provider.profile().capabilities.predict:
+        raise AssertionError("Provider does not declare the predict capability.")
+    sample_state = world_state or sample_contract_world_state()
+    sample_action = action or sample_contract_action()
+    prediction = provider.predict(sample_state, sample_action, steps)
+    _validate_prediction(provider.name, prediction)
+    return prediction
+
+
+def assert_reason_conformance(
+    provider: BaseProvider,
+    *,
+    query: str = "How many objects are in the scene?",
+    world_state: JSONDict | None = None,
+) -> ReasoningResult:
+    """Assert that a provider's reason capability returns a valid result."""
+
+    if not provider.profile().capabilities.reason:
+        raise AssertionError("Provider does not declare the reason capability.")
+    result = provider.reason(query, world_state=world_state or sample_contract_world_state())
+    _validate_reasoning(provider.name, result)
+    return result
+
+
+def assert_embed_conformance(
+    provider: BaseProvider,
+    *,
+    text: str = "contract vector",
+) -> EmbeddingResult:
+    """Assert that a provider's embed capability returns a valid result."""
+
+    if not provider.profile().capabilities.embed:
+        raise AssertionError("Provider does not declare the embed capability.")
+    result = provider.embed(text=text)
+    _validate_embedding(provider.name, result)
+    return result
+
+
+def assert_generate_conformance(
+    provider: BaseProvider,
+    *,
+    prompt: str = "contract prompt",
+    duration_seconds: float = 1.0,
+) -> VideoClip:
+    """Assert that a provider's generate capability returns a valid clip."""
+
+    if not provider.profile().capabilities.generate:
+        raise AssertionError("Provider does not declare the generate capability.")
+    clip = provider.generate(prompt, duration_seconds=duration_seconds)
+    _validate_clip(clip)
+    return clip
+
+
+def assert_transfer_conformance(
+    provider: BaseProvider,
+    *,
+    clip: VideoClip | None = None,
+    width: int = 48,
+    height: int = 48,
+    fps: float = 12.0,
+) -> VideoClip:
+    """Assert that a provider's transfer capability returns a valid clip."""
+
+    if not provider.profile().capabilities.transfer:
+        raise AssertionError("Provider does not declare the transfer capability.")
+    transfer_input = clip or VideoClip(
+        frames=[b"contract-frame"],
+        fps=8.0,
+        resolution=(64, 64),
+        duration_seconds=0.125,
+        metadata={"provider": provider.name},
+    )
+    result = provider.transfer(transfer_input, width=width, height=height, fps=fps)
+    _validate_clip(result)
+    return result
+
+
+def assert_score_conformance(
+    provider: BaseProvider,
+    *,
+    info: JSONDict,
+    action_candidates: object,
+) -> ActionScoreResult:
+    """Assert that a provider's score capability returns valid finite scores."""
+
+    if not provider.profile().capabilities.score:
+        raise AssertionError("Provider does not declare the score capability.")
+    result = provider.score_actions(info=info, action_candidates=action_candidates)
+    _validate_action_scores(provider.name, result)
+    return result
+
+
+def assert_policy_conformance(
+    provider: BaseProvider,
+    *,
+    info: JSONDict | None = None,
+) -> ActionPolicyResult:
+    """Assert that a provider's policy capability returns executable actions."""
+
+    if not provider.profile().capabilities.policy:
+        raise AssertionError("Provider does not declare the policy capability.")
+    result = provider.select_actions(info=info or sample_contract_policy_info())
+    _validate_action_policy(provider.name, result)
+    return result
+
+
+def assert_provider_events_conform(
+    events: Sequence[ProviderEvent],
+    *,
+    provider: str | None = None,
+) -> None:
+    """Assert that captured provider events are JSON-native and redaction-safe."""
+
+    for index, event in enumerate(events):
+        _contract_check(
+            isinstance(event, ProviderEvent),
+            f"provider event {index} must be a ProviderEvent.",
+        )
+        payload = event.to_dict()
+        _contract_json(payload, f"provider event {index} must be JSON serializable.")
+        if provider is not None:
+            _contract_check(
+                payload["provider"] == provider,
+                f"provider event {index} provider must match {provider}.",
+            )
+        rendered = dump_json(payload).lower()
+        for forbidden in ("api-secret", "api_secret", "raw-secret", "bearer-secret"):
+            _contract_check(
+                forbidden not in rendered,
+                f"provider event {index} appears to expose secret material.",
+            )
+
+
 def assert_provider_contract(
     provider: BaseProvider,
     *,
@@ -297,8 +440,12 @@ def assert_provider_contract(
 
     if profile.capabilities.predict:
         if can_invoke:
-            prediction = provider.predict(sample_state, sample_action, 2)
-            _validate_prediction(provider.name, prediction)
+            assert_predict_conformance(
+                provider,
+                world_state=sample_state,
+                action=sample_action,
+                steps=2,
+            )
             report.exercised_operations.append("predict")
         else:
             _expect_provider_error(
@@ -308,10 +455,11 @@ def assert_provider_contract(
 
     if profile.capabilities.reason:
         if can_invoke:
-            reasoning = provider.reason(
-                "How many objects are in the scene?", world_state=sample_state
+            assert_reason_conformance(
+                provider,
+                query="How many objects are in the scene?",
+                world_state=sample_state,
             )
-            _validate_reasoning(provider.name, reasoning)
             report.exercised_operations.append("reason")
         else:
             _expect_provider_error(
@@ -324,8 +472,7 @@ def assert_provider_contract(
 
     if profile.capabilities.embed:
         if can_invoke:
-            embedding = provider.embed(text="contract vector")
-            _validate_embedding(provider.name, embedding)
+            assert_embed_conformance(provider, text="contract vector")
             report.exercised_operations.append("embed")
         else:
             _expect_provider_error("embed", lambda: provider.embed(text="contract vector"))
@@ -333,8 +480,7 @@ def assert_provider_contract(
     generated_clip: VideoClip | None = None
     if profile.capabilities.generate:
         if can_invoke:
-            generated_clip = provider.generate("contract prompt", duration_seconds=1.0)
-            _validate_clip(generated_clip)
+            generated_clip = assert_generate_conformance(provider)
             report.exercised_operations.append("generate")
         else:
             _expect_provider_error(
@@ -343,18 +489,17 @@ def assert_provider_contract(
             )
 
     if profile.capabilities.transfer:
-        transfer_input = generated_clip or VideoClip(
-            frames=[b"contract-frame"],
-            fps=8.0,
-            resolution=(64, 64),
-            duration_seconds=0.125,
-            metadata={"provider": provider.name},
-        )
         if can_invoke:
-            transferred = provider.transfer(transfer_input, width=48, height=48, fps=12.0)
-            _validate_clip(transferred)
+            assert_transfer_conformance(provider, clip=generated_clip)
             report.exercised_operations.append("transfer")
         else:
+            transfer_input = generated_clip or VideoClip(
+                frames=[b"contract-frame"],
+                fps=8.0,
+                resolution=(64, 64),
+                duration_seconds=0.125,
+                metadata={"provider": provider.name},
+            )
             _expect_provider_error(
                 "transfer",
                 lambda: provider.transfer(transfer_input, width=48, height=48, fps=12.0),
@@ -367,11 +512,11 @@ def assert_provider_contract(
                     "Provider contract requires score_info and score_action_candidates for "
                     "configured score providers."
                 )
-            scores = provider.score_actions(
+            assert_score_conformance(
+                provider,
                 info=score_info,
                 action_candidates=score_action_candidates,
             )
-            _validate_action_scores(provider.name, scores)
             report.exercised_operations.append("score")
         else:
             _expect_provider_error(
@@ -386,8 +531,7 @@ def assert_provider_contract(
 
     if profile.capabilities.policy:
         if can_invoke:
-            policy = provider.select_actions(info=policy_info or sample_contract_policy_info())
-            _validate_action_policy(provider.name, policy)
+            assert_policy_conformance(provider, info=policy_info or sample_contract_policy_info())
             report.exercised_operations.append("policy")
         else:
             _expect_provider_error(

--- a/tests/test_provider_contracts.py
+++ b/tests/test_provider_contracts.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
+import inspect
+
 import pytest
 
-from worldforge import ProviderCapabilities
+import worldforge.testing.providers as provider_testing
+from worldforge import Action, ActionPolicyResult, ActionScoreResult, ProviderCapabilities
+from worldforge.models import ProviderEvent, ProviderHealth
 from worldforge.providers import (
     BaseProvider,
     CosmosProvider,
@@ -13,11 +17,20 @@ from worldforge.providers import (
     ProviderError,
     ProviderProfileSpec,
 )
-from worldforge.testing import assert_provider_contract
+from worldforge.testing import (
+    assert_generate_conformance,
+    assert_policy_conformance,
+    assert_predict_conformance,
+    assert_provider_contract,
+    assert_provider_events_conform,
+    assert_score_conformance,
+    assert_transfer_conformance,
+)
 
 
 def test_mock_provider_passes_contract_checks() -> None:
-    report = assert_provider_contract(MockProvider())
+    provider = MockProvider()
+    report = assert_provider_contract(provider)
 
     assert report.configured is True
     assert set(report.exercised_operations) == {
@@ -27,6 +40,9 @@ def test_mock_provider_passes_contract_checks() -> None:
         "generate",
         "transfer",
     }
+    assert_predict_conformance(provider)
+    generated = assert_generate_conformance(provider)
+    assert_transfer_conformance(provider, clip=generated)
 
 
 def test_provider_contract_uses_explicit_failure_for_invalid_prediction_state() -> None:
@@ -50,6 +66,104 @@ def test_provider_contract_uses_explicit_failure_for_invalid_prediction_state() 
 
     with pytest.raises(AssertionError, match="invalid world state"):
         assert_provider_contract(BadPredictionProvider())
+
+
+class FakeScoreProvider(BaseProvider):
+    def __init__(self) -> None:
+        super().__init__(
+            name="fake-score",
+            capabilities=ProviderCapabilities(score=True),
+            profile=ProviderProfileSpec(
+                description="Contract score provider",
+                is_local=True,
+                deterministic=True,
+                requires_credentials=False,
+            ),
+        )
+
+    def health(self) -> ProviderHealth:
+        return ProviderHealth(name=self.name, healthy=True, latency_ms=0.1, details="configured")
+
+    def score_actions(self, *, info, action_candidates) -> ActionScoreResult:
+        return ActionScoreResult(
+            provider=self.name,
+            scores=[0.4, 0.1],
+            best_index=1,
+            metadata={"fixture": info["fixture"], "candidates": len(action_candidates)},
+        )
+
+
+class FakePolicyProvider(BaseProvider):
+    def __init__(self) -> None:
+        super().__init__(
+            name="fake-policy",
+            capabilities=ProviderCapabilities(policy=True),
+            profile=ProviderProfileSpec(
+                description="Contract policy provider",
+                is_local=True,
+                deterministic=True,
+                requires_credentials=False,
+            ),
+        )
+
+    def health(self) -> ProviderHealth:
+        return ProviderHealth(name=self.name, healthy=True, latency_ms=0.1, details="configured")
+
+    def select_actions(self, *, info) -> ActionPolicyResult:
+        action = Action.move_to(0.1, 0.2, 0.3)
+        return ActionPolicyResult(
+            provider=self.name,
+            actions=[action],
+            raw_actions={"fixture": info["fixture"]},
+            action_candidates=[[action]],
+            metadata={"runtime": "test"},
+        )
+
+
+def test_capability_specific_score_and_policy_helpers() -> None:
+    score = assert_score_conformance(
+        FakeScoreProvider(),
+        info={"fixture": "score"},
+        action_candidates=[["a"], ["b"]],
+    )
+    policy = assert_policy_conformance(FakePolicyProvider(), info={"fixture": "policy"})
+
+    assert score.best_score == 0.1
+    assert policy.actions == [Action.move_to(0.1, 0.2, 0.3)]
+
+
+def test_provider_event_conformance_helper_rejects_secret_material() -> None:
+    assert_provider_events_conform(
+        [
+            ProviderEvent(
+                provider="runway",
+                operation="download",
+                phase="success",
+                target="https://example.test/artifact.mp4?token=api-secret",
+                metadata={"status": "ok"},
+            )
+        ],
+        provider="runway",
+    )
+
+    with pytest.raises(AssertionError, match="secret material"):
+        assert_provider_events_conform(
+            [
+                ProviderEvent(
+                    provider="runway",
+                    operation="download",
+                    phase="success",
+                    metadata={"safe": "raw-secret"},
+                )
+            ]
+        )
+
+
+def test_provider_conformance_helpers_do_not_use_bare_assert_statements() -> None:
+    source = inspect.getsource(provider_testing)
+    helper_source = source.split("def assert_predict_conformance", 1)[1]
+
+    assert "\n    assert " not in helper_source
 
 
 def test_scaffold_provider_reports_clear_unconfigured_contract(monkeypatch) -> None:


### PR DESCRIPTION
Closes #57.

## Summary
- add capability-specific provider conformance helpers for predict, generate, transfer, reason, embed, score, and policy
- add provider-event conformance checks for JSON-native, redaction-safe event payloads
- keep `assert_provider_contract` as the aggregate helper and route it through the narrower helpers
- document the helper matrix in the provider authoring guide

## Validation
- `uv run pytest tests/test_provider_contracts.py tests/test_observability.py -q`
- `uv run pytest tests/test_*provider*.py tests/test_observability.py -q`
- `uv run --extra harness pytest --cov=src/worldforge --cov-report=term-missing --cov-fail-under=90`
- `uv run ruff check src tests examples scripts`
- `uv run ruff format --check src tests examples scripts`
- `uv run mkdocs build --strict`
- `uv lock --check`
- `uv run python scripts/generate_provider_docs.py --check`
