### PR TITLE
Add service host reference example

### DIFF
--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -80,6 +80,27 @@ Both packaged demos validate the WorldForge adapter, planning, execution, persis
 event path in a clean checkout. They do not install optional ML runtimes or run upstream neural
 checkpoint inference.
 
+## Service Host Reference
+
+| Example | Command | Runtime boundary |
+| --- | --- | --- |
+| `service-host` | `uv run python examples/hosts/service/app.py --provider mock --port 8080` | Stdlib HTTP reference host; the embedding service owns deployment, credentials, telemetry export, alerting, and upstream SLA handling. |
+
+The service host exposes:
+
+| Endpoint | Purpose |
+| --- | --- |
+| `GET /healthz` | Process liveness only. |
+| `GET /readyz` | Framework alive, configured provider, provider health, and `doctor()` summary. |
+| `GET /providers` | Registered-provider diagnostics for the current host process. |
+| `POST /workflows/mock-predict` | Safe deterministic mock prediction smoke. |
+| `POST /workflows/generate` | Configurable provider generate workflow using a JSON body with `provider`, `prompt`, and `duration_seconds`. |
+
+Every response includes or echoes a request id. Provider events are sent through `JsonLoggerSink`
+with that request id so host logs can correlate HTTP requests with provider calls. Public errors
+use typed JSON payloads and redact obvious secret-shaped values, but production services still own
+credential storage, request authentication, dashboards, alert routing, and provider SLA policy.
+
 ## Optional Runtime Smoke
 
 | Example | Command | Runtime boundary |

--- a/docs/src/operations.md
+++ b/docs/src/operations.md
@@ -24,6 +24,35 @@ uv run worldforge doctor --registered-only
 uv run worldforge provider health
 ```
 
+## Health And Readiness
+
+Host applications should expose liveness separately from readiness. Liveness answers whether the
+service process can handle an HTTP request. Readiness answers whether the specific provider-backed
+workflow should receive traffic.
+
+The stdlib reference host in `examples/hosts/service/app.py` uses this model:
+
+| State | Source | Meaning | Typical HTTP endpoint |
+| --- | --- | --- | --- |
+| process live | service handler returns `{"status": "live"}` | process and web stack are running | `GET /healthz` |
+| framework alive | `WorldForge(...)` can be constructed and `doctor()` can run | library import, local state path, and provider registry are usable | `GET /readyz` |
+| provider configured | provider appears in `forge.providers()` | required env vars or host injection registered the provider | `GET /readyz` |
+| provider healthy | `forge.provider_health(name).healthy` is true | provider's cheap health check passed | `GET /readyz` |
+| workflow failing | provider is configured and health may pass, but a workflow returns a typed error | request input, upstream response, budget, or artifact handling failed | workflow response body |
+
+Map CLI diagnostics the same way during incidents:
+
+| Command | Readiness signal |
+| --- | --- |
+| `uv run worldforge doctor --registered-only` | registered provider count, health count, and local configuration issues. |
+| `uv run worldforge doctor --capability <capability>` | whether any known provider can satisfy the requested surface. |
+| `uv run worldforge provider health <name>` | provider-specific configured/healthy details. |
+| `uv run worldforge provider info <name>` | redacted config summary plus profile, capability, and health. |
+
+WorldForge reports local provider state and adapter errors. It does not own upstream provider SLAs,
+deployment load balancers, alert channels, retry orchestration outside one provider call, or
+credential rotation.
+
 ## Configuration
 
 Configuration comes from constructor arguments and environment variables documented in

--- a/docs/src/provider-platform-roadmap.md
+++ b/docs/src/provider-platform-roadmap.md
@@ -1110,10 +1110,10 @@ Scope:
 
 Acceptance criteria:
 
-- [ ] Service host runs with only optional example dependencies.
-- [ ] Health/readiness distinguish framework alive, provider configured, and provider healthy.
-- [ ] Provider errors return typed public error payloads without internal secrets.
-- [ ] Docs state this is a reference host, not the WorldForge product boundary.
+- [x] Service host runs with only optional example dependencies.
+- [x] Health/readiness distinguish framework alive, provider configured, and provider healthy.
+- [x] Provider errors return typed public error payloads without internal secrets.
+- [x] Docs state this is a reference host, not the WorldForge product boundary.
 
 Validation:
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -49,6 +49,17 @@ comparison flows.
 | --- | --- | --- |
 | `lerobot-policy-score-planning` | policy provider, score provider, planning, persistence | `uv run worldforge-demo-lerobot` |
 
+## Service Host Reference
+
+| Example | Surface | Command |
+| --- | --- | --- |
+| `service-host` | HTTP liveness/readiness, provider diagnostics, mock workflow, configurable generate workflow | `uv run python examples/hosts/service/app.py --provider mock --port 8080` |
+
+The service host uses Python's stdlib HTTP server so it does not add a base dependency. It is a
+reference for embedding WorldForge in a host process, not a WorldForge deployment boundary:
+production services still own authentication, alerting, telemetry export, upstream SLA handling,
+and artifact retention.
+
 ## Optional Runtime Smoke
 
 | Example | Surface | Command |

--- a/examples/hosts/service/app.py
+++ b/examples/hosts/service/app.py
@@ -1,0 +1,319 @@
+"""Stdlib reference service host for embedding WorldForge."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+from dataclasses import dataclass
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+from worldforge import Action, BBox, Position, SceneObject, WorldForge, WorldForgeError
+from worldforge.models import DoctorReport, ProviderHealth
+from worldforge.observability import JsonLoggerSink
+from worldforge.providers import ProviderError
+
+JSON = dict[str, Any]
+DEFAULT_PROVIDER = os.environ.get("WORLDFORGE_SERVICE_PROVIDER", "mock")
+DEFAULT_STATE_DIR = os.environ.get("WORLDFORGE_SERVICE_STATE_DIR", ".worldforge/service-worlds")
+DEFAULT_HOST = os.environ.get("WORLDFORGE_SERVICE_HOST", "127.0.0.1")
+DEFAULT_PORT = int(os.environ.get("WORLDFORGE_SERVICE_PORT", "8080"))
+
+
+@dataclass(slots=True, frozen=True)
+class ServiceConfig:
+    """Runtime settings owned by the embedding service host."""
+
+    provider: str = DEFAULT_PROVIDER
+    state_dir: Path = Path(DEFAULT_STATE_DIR)
+
+
+def readiness_snapshot(forge: WorldForge, provider: str) -> JSON:
+    """Map WorldForge diagnostics to a host-facing readiness payload."""
+
+    doctor = forge.doctor(registered_only=True)
+    configured = provider in forge.providers()
+    health = forge.provider_health(provider) if configured else None
+    provider_healthy = bool(health and health.healthy)
+    readiness = "ready" if configured and provider_healthy else "degraded"
+    checks: JSON = {
+        "framework_alive": True,
+        "provider": provider,
+        "provider_configured": configured,
+        "provider_healthy": provider_healthy,
+    }
+    if health is not None:
+        checks["provider_health"] = health.to_dict()
+    else:
+        checks["provider_health"] = {
+            "name": provider,
+            "healthy": False,
+            "latency_ms": 0.0,
+            "details": "provider is not registered in this host process",
+        }
+    return {
+        "status": readiness,
+        "checks": checks,
+        "doctor": _doctor_summary(doctor),
+    }
+
+
+def provider_list_payload(forge: WorldForge) -> JSON:
+    """Return provider diagnostics suitable for a service readiness page."""
+
+    report = forge.doctor(registered_only=True)
+    return {
+        "providers": [provider.to_dict() for provider in report.providers],
+        "summary": _doctor_summary(report),
+    }
+
+
+def mock_prediction_payload(forge: WorldForge, *, request_id: str) -> JSON:
+    """Run one deterministic, non-mutating mock workflow for service smoke checks."""
+
+    world = forge.create_world("service-smoke", provider="mock")
+    world.add_object(
+        SceneObject(
+            "cube",
+            Position(0.0, 0.5, 0.0),
+            BBox(Position(-0.05, 0.45, -0.05), Position(0.05, 0.55, 0.05)),
+        )
+    )
+    prediction = world.predict(Action.move_to(0.2, 0.5, 0.0), steps=1, provider="mock")
+    return {
+        "request_id": request_id,
+        "provider": prediction.provider,
+        "confidence": prediction.confidence,
+        "physics_score": prediction.physics_score,
+        "world": {
+            "id": world.id,
+            "object_count": world.object_count,
+            "step": world.step,
+        },
+    }
+
+
+def generate_payload(
+    forge: WorldForge,
+    payload: JSON,
+    *,
+    provider: str,
+    request_id: str,
+) -> JSON:
+    """Run the configurable provider generate workflow with explicit inputs."""
+
+    prompt = payload.get("prompt", "service host smoke clip")
+    duration_seconds = payload.get("duration_seconds", 1.0)
+    clip = forge.generate(
+        prompt,
+        provider=provider,
+        duration_seconds=duration_seconds,
+    )
+    return {
+        "request_id": request_id,
+        "provider": str(clip.metadata.get("provider", provider)),
+        "duration_seconds": clip.duration_seconds,
+        "fps": clip.fps,
+        "resolution": list(clip.resolution),
+        "frame_count": len(clip.frames),
+        "metadata": clip.metadata,
+    }
+
+
+def public_error_payload(exc: Exception, *, request_id: str, status: int) -> JSON:
+    """Convert internal exceptions to a typed public error without leaking internals."""
+
+    if isinstance(exc, ProviderError):
+        error_type = "provider_error"
+    elif isinstance(exc, WorldForgeError):
+        error_type = "validation_error"
+    else:
+        error_type = "internal_error"
+    message = str(exc) if error_type != "internal_error" else "request failed"
+    message = ProviderHealth(
+        name="service-error",
+        healthy=False,
+        latency_ms=0.0,
+        details=message,
+    ).details
+    return {
+        "error": {
+            "type": error_type,
+            "message": message,
+            "status": status,
+            "request_id": request_id,
+        }
+    }
+
+
+def create_server(
+    host: str = DEFAULT_HOST,
+    port: int = DEFAULT_PORT,
+    *,
+    config: ServiceConfig | None = None,
+) -> ThreadingHTTPServer:
+    """Create the reference HTTP server without starting its serve loop."""
+
+    resolved = config or ServiceConfig()
+    handler = _handler_factory(resolved)
+    server = ThreadingHTTPServer((host, port), handler)
+    server.daemon_threads = True
+    return server
+
+
+def run(
+    host: str = DEFAULT_HOST,
+    port: int = DEFAULT_PORT,
+    *,
+    config: ServiceConfig | None = None,
+) -> None:
+    """Run the reference service until interrupted."""
+
+    server = create_server(host, port, config=config)
+    with server:
+        print(f"WorldForge service host listening on http://{host}:{server.server_port}")
+        server.serve_forever()
+
+
+def _doctor_summary(report: DoctorReport) -> JSON:
+    return {
+        "provider_count": report.provider_count,
+        "registered_provider_count": report.registered_provider_count,
+        "healthy_provider_count": report.healthy_provider_count,
+        "issue_count": len(report.issues),
+        "issues": list(report.issues),
+    }
+
+
+def _build_forge(config: ServiceConfig, request_id: str) -> WorldForge:
+    return WorldForge(
+        state_dir=config.state_dir,
+        event_handler=JsonLoggerSink(extra_fields={"request_id": request_id, "host": "service"}),
+    )
+
+
+def _handler_factory(config: ServiceConfig) -> type[BaseHTTPRequestHandler]:
+    class WorldForgeServiceHandler(BaseHTTPRequestHandler):
+        server_version = "WorldForgeServiceHost/0.1"
+
+        def do_GET(self) -> None:
+            self._dispatch("GET")
+
+        def do_POST(self) -> None:
+            self._dispatch("POST")
+
+        def log_message(self, format: str, *args: object) -> None:
+            logging.getLogger("worldforge.service_host").info(format, *args)
+
+        def _dispatch(self, method: str) -> None:
+            request_id = self.headers.get("x-request-id") or uuid4().hex
+            forge = _build_forge(config, request_id)
+            try:
+                payload = self._route(method, forge, request_id)
+                self._send_json(payload, request_id=request_id)
+            except (WorldForgeError, ProviderError) as exc:
+                self._send_json(
+                    public_error_payload(
+                        exc,
+                        request_id=request_id,
+                        status=HTTPStatus.BAD_REQUEST,
+                    ),
+                    request_id=request_id,
+                    status=HTTPStatus.BAD_REQUEST,
+                )
+            except Exception as exc:  # pragma: no cover - defensive service boundary
+                logging.getLogger("worldforge.service_host").exception("request failed")
+                self._send_json(
+                    public_error_payload(
+                        exc,
+                        request_id=request_id,
+                        status=HTTPStatus.INTERNAL_SERVER_ERROR,
+                    ),
+                    request_id=request_id,
+                    status=HTTPStatus.INTERNAL_SERVER_ERROR,
+                )
+
+        def _route(self, method: str, forge: WorldForge, request_id: str) -> JSON:
+            if method == "GET" and self.path == "/healthz":
+                return {"status": "live", "request_id": request_id}
+            if method == "GET" and self.path == "/readyz":
+                return {
+                    "request_id": request_id,
+                    **readiness_snapshot(forge, config.provider),
+                }
+            if method == "GET" and self.path == "/providers":
+                return {"request_id": request_id, **provider_list_payload(forge)}
+            if method == "POST" and self.path == "/workflows/mock-predict":
+                self._read_json_body()
+                return mock_prediction_payload(forge, request_id=request_id)
+            if method == "POST" and self.path == "/workflows/generate":
+                body = self._read_json_body()
+                provider = str(body.get("provider") or config.provider)
+                return generate_payload(
+                    forge,
+                    body,
+                    provider=provider,
+                    request_id=request_id,
+                )
+            raise WorldForgeError(f"Unknown route: {method} {self.path}")
+
+        def _read_json_body(self) -> JSON:
+            length_header = self.headers.get("content-length", "0")
+            try:
+                length = int(length_header)
+            except ValueError as exc:
+                raise WorldForgeError("content-length must be an integer") from exc
+            if length == 0:
+                return {}
+            try:
+                payload = json.loads(self.rfile.read(length).decode("utf-8"))
+            except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+                raise WorldForgeError("request body must be a JSON object") from exc
+            if not isinstance(payload, dict):
+                raise WorldForgeError("request body must be a JSON object")
+            return payload
+
+        def _send_json(
+            self,
+            payload: JSON,
+            *,
+            request_id: str,
+            status: HTTPStatus = HTTPStatus.OK,
+        ) -> None:
+            body = json.dumps(payload, sort_keys=True).encode("utf-8")
+            self.send_response(status)
+            self.send_header("content-type", "application/json")
+            self.send_header("content-length", str(len(body)))
+            self.send_header("x-request-id", request_id)
+            self.end_headers()
+            self.wfile.write(body)
+
+    return WorldForgeServiceHandler
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--host", default=DEFAULT_HOST)
+    parser.add_argument("--port", type=int, default=DEFAULT_PORT)
+    parser.add_argument("--provider", default=DEFAULT_PROVIDER)
+    parser.add_argument("--state-dir", type=Path, default=Path(DEFAULT_STATE_DIR))
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    run(
+        host=args.host,
+        port=args.port,
+        config=ServiceConfig(provider=args.provider, state_dir=args.state_dir),
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_service_host.py
+++ b/tests/test_service_host.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import json
+import sys
+import threading
+from pathlib import Path
+from urllib.error import HTTPError
+from urllib.request import Request, urlopen
+
+import pytest
+
+from worldforge import WorldForge, WorldForgeError
+
+ROOT = Path(__file__).resolve().parents[1]
+SERVICE_APP = ROOT / "examples" / "hosts" / "service" / "app.py"
+
+
+def _load_service_app():
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("worldforge_service_host_example", SERVICE_APP)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def service_app():
+    return _load_service_app()
+
+
+def _request_json(url: str, *, method: str = "GET", payload: dict[str, object] | None = None):
+    body = None if payload is None else json.dumps(payload).encode("utf-8")
+    request = Request(
+        url,
+        data=body,
+        method=method,
+        headers={"content-type": "application/json", "x-request-id": "request-123"},
+    )
+    with urlopen(request, timeout=5) as response:
+        return response.status, dict(response.headers), json.loads(response.read().decode("utf-8"))
+
+
+def test_service_host_readiness_maps_provider_state(tmp_path, service_app) -> None:
+    forge = WorldForge(state_dir=tmp_path)
+
+    ready = service_app.readiness_snapshot(forge, "mock")
+    assert ready["status"] == "ready"
+    assert ready["checks"]["framework_alive"] is True
+    assert ready["checks"]["provider_configured"] is True
+    assert ready["checks"]["provider_healthy"] is True
+    assert ready["doctor"]["registered_provider_count"] >= 1
+
+    degraded = service_app.readiness_snapshot(forge, "missing-provider")
+    assert degraded["status"] == "degraded"
+    assert degraded["checks"]["provider_configured"] is False
+    assert degraded["checks"]["provider_healthy"] is False
+
+
+def test_service_host_endpoints_exercise_reference_workflows(tmp_path, service_app) -> None:
+    server = service_app.create_server(
+        "127.0.0.1",
+        0,
+        config=service_app.ServiceConfig(provider="mock", state_dir=tmp_path),
+    )
+    with server:
+        thread = threading.Thread(
+            target=server.serve_forever,
+            daemon=True,
+        )
+        thread.start()
+        base_url = f"http://127.0.0.1:{server.server_port}"
+
+        status, headers, health = _request_json(f"{base_url}/healthz")
+        assert status == 200
+        assert headers["x-request-id"] == "request-123"
+        assert health == {"request_id": "request-123", "status": "live"}
+
+        _status, _headers, ready = _request_json(f"{base_url}/readyz")
+        assert ready["status"] == "ready"
+        assert ready["checks"]["provider"] == "mock"
+
+        _status, _headers, providers = _request_json(f"{base_url}/providers")
+        assert "mock" in {provider["name"] for provider in providers["providers"]}
+
+        _status, _headers, prediction = _request_json(
+            f"{base_url}/workflows/mock-predict",
+            method="POST",
+            payload={},
+        )
+        assert prediction["provider"] == "mock"
+        assert prediction["confidence"] > 0
+
+        _status, _headers, generated = _request_json(
+            f"{base_url}/workflows/generate",
+            method="POST",
+            payload={"provider": "mock", "prompt": "service smoke", "duration_seconds": 0.25},
+        )
+        assert generated["provider"] == "mock"
+        assert generated["frame_count"] >= 1
+
+        server.shutdown()
+        thread.join(timeout=5)
+
+
+def test_service_host_errors_are_public_and_redacted(service_app) -> None:
+    payload = service_app.public_error_payload(
+        WorldForgeError("token=super-secret-value failed"),
+        request_id="request-123",
+        status=400,
+    )
+
+    assert payload["error"]["type"] == "validation_error"
+    assert payload["error"]["request_id"] == "request-123"
+    assert "super-secret-value" not in payload["error"]["message"]
+
+
+def test_service_host_unknown_route_returns_typed_error(tmp_path, service_app) -> None:
+    server = service_app.create_server(
+        "127.0.0.1",
+        0,
+        config=service_app.ServiceConfig(provider="mock", state_dir=tmp_path),
+    )
+    with server:
+        thread = threading.Thread(
+            target=server.serve_forever,
+            daemon=True,
+        )
+        thread.start()
+        base_url = f"http://127.0.0.1:{server.server_port}"
+
+        with pytest.raises(HTTPError) as exc_info:
+            _request_json(f"{base_url}/missing")
+        body = json.loads(exc_info.value.read().decode("utf-8"))
+        assert exc_info.value.code == 400
+        assert body["error"]["type"] == "validation_error"
+        assert body["error"]["request_id"] == "request-123"
+
+        server.shutdown()
+        thread.join(timeout=5)


### PR DESCRIPTION
Closes #76.

## Summary
- add a stdlib-only service host reference under `examples/hosts/service/`
- expose liveness, readiness, provider diagnostics, mock prediction, and configurable generate endpoints
- return typed redacted public errors and document the host/application boundary

## Validation
- `uv run ruff check src tests examples scripts`
- `uv run ruff format --check src tests examples scripts`
- `uv run pytest tests/test_service_host.py tests/test_examples_index.py -q`
- `uv run mkdocs build --strict`
- `uv run --extra harness pytest --cov=src/worldforge --cov-report=term-missing --cov-fail-under=90`
- `uv run pytest`
- `uv lock --check`
- `uv run python scripts/generate_provider_docs.py --check`
- `bash scripts/test_package.sh`
- `UV_LOCKED=true uv export --all-groups --no-emit-project --no-hashes --output-file <tmp>; uvx --from pip-audit pip-audit -r <tmp>`
