### PR TITLE
Add health readiness incident runbooks

### DIFF
--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -91,10 +91,15 @@ The service host exposes:
 | Endpoint | Purpose |
 | --- | --- |
 | `GET /healthz` | Process liveness only. |
-| `GET /readyz` | Framework alive, configured provider, provider health, and `doctor()` summary. |
+| `GET /readyz` | Framework alive, configured provider, provider health, traffic decision, and `doctor()` summary. |
 | `GET /providers` | Registered-provider diagnostics for the current host process. |
 | `POST /workflows/mock-predict` | Safe deterministic mock prediction smoke. |
 | `POST /workflows/generate` | Configurable provider generate workflow using a JSON body with `provider`, `prompt`, and `duration_seconds`. |
+
+`/readyz` reports `ready`, `provider_unconfigured`, or `provider_unhealthy`. Only `ready`
+means the host should accept provider-backed workflow traffic; the other states tell the host
+load balancer or job runner to drain this process while operators inspect `checks.provider_health`
+and the embedded `doctor` summary.
 
 Every response includes or echoes a request id. Provider events are sent through `JsonLoggerSink`
 with that request id so host logs can correlate HTTP requests with provider calls. Public errors

--- a/docs/src/operations.md
+++ b/docs/src/operations.md
@@ -40,6 +40,14 @@ The stdlib reference host in `examples/hosts/service/app.py` uses this model:
 | provider healthy | `forge.provider_health(name).healthy` is true | provider's cheap health check passed | `GET /readyz` |
 | workflow failing | provider is configured and health may pass, but a workflow returns a typed error | request input, upstream response, budget, or artifact handling failed | workflow response body |
 
+The reference host returns one of these readiness statuses from `GET /readyz`:
+
+| `/readyz` status | Traffic decision | How to interpret it |
+| --- | --- | --- |
+| `ready` | accept | framework is alive, the selected provider is registered, and provider health passed. |
+| `provider_unconfigured` | drain | framework is alive, but the selected provider is not registered in this process. |
+| `provider_unhealthy` | drain | provider is registered, but its health check reports missing optional runtime, bad credentials, unreachable upstream, or another provider-owned failure detail. |
+
 Map CLI diagnostics the same way during incidents:
 
 | Command | Readiness signal |

--- a/docs/src/playbooks.md
+++ b/docs/src/playbooks.md
@@ -157,6 +157,24 @@ If it fails:
 | provider is registered but unhealthy | optional dependency, endpoint, or credential is invalid | run provider-specific docs and health command |
 | provider lacks capability | capability flag is truthful and workflow picked the wrong provider | choose another provider or implement the capability end to end |
 
+### 4a. Map Health And Readiness During Incidents
+
+Use this when a service host, batch job, or operator dashboard needs to decide whether to send
+traffic to a provider-backed workflow. Keep process liveness separate from provider readiness.
+
+| State | Symptom | Likely cause | First command | Expected signal | Escalation point |
+| --- | --- | --- | --- | --- | --- |
+| process live | `GET /healthz` succeeds, but provider workflows may still fail | HTTP process is running; provider path has not been proven | `curl -fsS http://127.0.0.1:8080/healthz` | JSON status is `live`; no provider fields are implied | host service owner if the process is down |
+| provider unconfigured | `/readyz` returns `provider_unconfigured` or `doctor` shows the provider absent from registered providers | missing env vars, missing host injection, or wrong provider name | `uv run worldforge doctor --registered-only` | selected provider is absent; `registered_provider_count` and issues explain the local process | host deployment or credential owner |
+| provider unhealthy | `/readyz` returns `provider_unhealthy` or `provider health` reports `healthy=false` | optional runtime missing, bad credentials, unreachable upstream, or failed provider health parsing | `uv run worldforge provider health <name>` | health details name the missing env var, dependency, endpoint, or sanitized upstream error | host runtime owner first; provider adapter maintainer if details are wrong or unsafe |
+| upstream degraded | provider health is intermittently false, provider events show retries, 5xx, 429, or budget exhaustion | remote provider outage, throttling, expired credentials, or host budget too tight | `jq 'select(.phase=="retry" or .phase=="budget_exceeded") | {provider, operation, status_code, target, message}' .worldforge/runs/<run-id>/provider-events.jsonl` | sanitized targets, retry counts, status class, and `budget_exceeded` events identify the failing operation | upstream provider support or host SRE; WorldForge does not own upstream SLA |
+| workflow failing | `/readyz` stays `ready`, but one request returns a typed error | malformed world state, unsupported capability, invalid input, parser failure, or expired artifact | `uv run worldforge provider info <name>` | profile, capability flags, redacted config summary, and health show whether the request matched the provider contract | application owner for bad input; adapter maintainer for parser/contract bugs |
+
+The stdlib service reference uses the same model: `/healthz` is process-only liveness, while
+`/readyz` returns `ready`, `provider_unconfigured`, or `provider_unhealthy` plus a `traffic`
+decision of `accept` or `drain`. Alert routing, paging policy, retry orchestration outside a single
+provider call, and upstream SLA ownership remain host responsibilities.
+
 ## 5. Operate Local JSON Persistence
 
 Use this for local jobs, demos, tests, and single-writer workflows.

--- a/examples/hosts/service/app.py
+++ b/examples/hosts/service/app.py
@@ -40,7 +40,10 @@ def readiness_snapshot(forge: WorldForge, provider: str) -> JSON:
     configured = provider in forge.providers()
     health = forge.provider_health(provider) if configured else None
     provider_healthy = bool(health and health.healthy)
-    readiness = "ready" if configured and provider_healthy else "degraded"
+    readiness = _readiness_state(
+        provider_configured=configured,
+        provider_healthy=provider_healthy,
+    )
     checks: JSON = {
         "framework_alive": True,
         "provider": provider,
@@ -59,6 +62,7 @@ def readiness_snapshot(forge: WorldForge, provider: str) -> JSON:
     return {
         "status": readiness,
         "checks": checks,
+        "traffic": "accept" if readiness == "ready" else "drain",
         "doctor": _doctor_summary(doctor),
     }
 
@@ -188,6 +192,14 @@ def _doctor_summary(report: DoctorReport) -> JSON:
         "issue_count": len(report.issues),
         "issues": list(report.issues),
     }
+
+
+def _readiness_state(*, provider_configured: bool, provider_healthy: bool) -> str:
+    if not provider_configured:
+        return "provider_unconfigured"
+    if not provider_healthy:
+        return "provider_unhealthy"
+    return "ready"
 
 
 def _build_forge(config: ServiceConfig, request_id: str) -> WorldForge:

--- a/tests/test_docs_site.py
+++ b/tests/test_docs_site.py
@@ -61,3 +61,28 @@ def test_built_docs_image_sources_resolve_to_site_files() -> None:
                 missing.append(f"{page.relative_to(SITE)} -> {source}")
 
     assert missing == []
+
+
+def test_health_readiness_runbook_documents_required_operational_signals() -> None:
+    operations = (ROOT / "docs/src/operations.md").read_text(encoding="utf-8")
+    playbooks = (ROOT / "docs/src/playbooks.md").read_text(encoding="utf-8")
+
+    for status in ("ready", "provider_unconfigured", "provider_unhealthy"):
+        assert status in operations
+        assert status in playbooks
+
+    required_header = (
+        "| State | Symptom | Likely cause | First command | Expected signal | Escalation point |"
+    )
+    assert required_header in playbooks
+    for incident in (
+        "process live",
+        "provider unconfigured",
+        "provider unhealthy",
+        "upstream degraded",
+        "workflow failing",
+    ):
+        assert incident in playbooks
+
+    assert "WorldForge does not own upstream SLA" in playbooks
+    assert "Alert routing, paging policy" in playbooks

--- a/tests/test_service_host.py
+++ b/tests/test_service_host.py
@@ -10,6 +10,7 @@ from urllib.request import Request, urlopen
 import pytest
 
 from worldforge import WorldForge, WorldForgeError
+from worldforge.providers import BaseProvider, ProviderProfileSpec
 
 ROOT = Path(__file__).resolve().parents[1]
 SERVICE_APP = ROOT / "examples" / "hosts" / "service" / "app.py"
@@ -49,15 +50,42 @@ def test_service_host_readiness_maps_provider_state(tmp_path, service_app) -> No
 
     ready = service_app.readiness_snapshot(forge, "mock")
     assert ready["status"] == "ready"
+    assert ready["traffic"] == "accept"
     assert ready["checks"]["framework_alive"] is True
     assert ready["checks"]["provider_configured"] is True
     assert ready["checks"]["provider_healthy"] is True
     assert ready["doctor"]["registered_provider_count"] >= 1
 
     degraded = service_app.readiness_snapshot(forge, "missing-provider")
-    assert degraded["status"] == "degraded"
+    assert degraded["status"] == "provider_unconfigured"
+    assert degraded["traffic"] == "drain"
     assert degraded["checks"]["provider_configured"] is False
     assert degraded["checks"]["provider_healthy"] is False
+
+
+def test_service_host_readiness_distinguishes_unhealthy_registered_provider(
+    tmp_path,
+    monkeypatch,
+    service_app,
+) -> None:
+    monkeypatch.delenv("SERVICE_HOST_REQUIRED_TOKEN", raising=False)
+    forge = WorldForge(state_dir=tmp_path)
+    forge.register_provider(
+        BaseProvider(
+            "configured-but-unhealthy",
+            profile=ProviderProfileSpec(
+                required_env_vars=("SERVICE_HOST_REQUIRED_TOKEN",),
+            ),
+        )
+    )
+
+    payload = service_app.readiness_snapshot(forge, "configured-but-unhealthy")
+
+    assert payload["status"] == "provider_unhealthy"
+    assert payload["traffic"] == "drain"
+    assert payload["checks"]["provider_configured"] is True
+    assert payload["checks"]["provider_healthy"] is False
+    assert "SERVICE_HOST_REQUIRED_TOKEN" in payload["checks"]["provider_health"]["details"]
 
 
 def test_service_host_endpoints_exercise_reference_workflows(tmp_path, service_app) -> None:
@@ -81,6 +109,7 @@ def test_service_host_endpoints_exercise_reference_workflows(tmp_path, service_a
 
         _status, _headers, ready = _request_json(f"{base_url}/readyz")
         assert ready["status"] == "ready"
+        assert ready["traffic"] == "accept"
         assert ready["checks"]["provider"] == "mock"
 
         _status, _headers, providers = _request_json(f"{base_url}/providers")


### PR DESCRIPTION
## Summary

- add explicit service-host readiness states and traffic decisions
- document the health/readiness model across operations and examples
- add incident runbooks with symptom, cause, first command, expected signal, and escalation point

## Validation

- `uv run pytest tests/test_service_host.py tests/test_cli_doctor.py -q`
- `uv run pytest tests/test_docs_site.py -q`
- `uv run mkdocs build --strict`
- `uv run ruff check src tests examples scripts`
- `uv run ruff format --check src tests examples scripts`
- `uv run pytest`
- `uv run --extra harness pytest --cov=src/worldforge --cov-report=term-missing --cov-fail-under=90`
- `uv run python scripts/generate_provider_docs.py --check`
- `uv lock --check`
- `bash scripts/test_package.sh`
- `UV_LOCKED=true uv export --all-groups --no-emit-project --no-hashes ...`
- `uvx --from pip-audit pip-audit -r ... --no-deps --disable-pip --progress-spinner off`

Closes #79.
