### PR TITLE
Add harness run workspace layout

### DIFF
--- a/docs/src/benchmarking.md
+++ b/docs/src/benchmarking.md
@@ -63,6 +63,19 @@ uv run worldforge benchmark --provider mock --operation embed --format markdown
 uv run worldforge benchmark --provider mock --operation embed --input-file examples/benchmark-inputs.json
 ```
 
+Use `--run-workspace` when benchmark numbers need manifest-backed provenance:
+
+```bash
+uv run worldforge benchmark \
+  --provider mock \
+  --operation predict \
+  --iterations 5 \
+  --run-workspace .worldforge
+```
+
+The run workspace stores the manifest, JSON/Markdown/CSV reports, result summary, budget verdict
+when supplied, and event count under `.worldforge/runs/<run-id>/`.
+
 Use `--input-file` when a benchmark result needs to be reproducible from preserved inputs. The
 file can contain input fields directly, or an `inputs` object plus metadata. The checked-in
 `examples/benchmark-inputs.json` fixture is checkout-safe for the mock provider's `predict`,

--- a/docs/src/evaluation.md
+++ b/docs/src/evaluation.md
@@ -32,6 +32,15 @@ uv run worldforge eval --suite transfer --provider mock
 
 Repeat `--provider` to compare multiple registered providers in one report.
 
+Use `--run-workspace` when an evaluation should leave a manifest-backed evidence bundle:
+
+```bash
+uv run worldforge eval --suite planning --provider mock --run-workspace .worldforge
+```
+
+The run workspace stores `run_manifest.json`, JSON/Markdown/CSV reports, and a result summary under
+`.worldforge/runs/<run-id>/`.
+
 The same built-in suites are available from TheWorldHarness. Launch
 `uv run --extra harness worldforge-harness --flow eval`, pick a suite and provider, and the TUI
 writes the canonical JSON report under `.worldforge/reports/` before opening the Run Inspector.

--- a/docs/src/operations.md
+++ b/docs/src/operations.md
@@ -144,6 +144,28 @@ Supported persistence invariants:
 - Any future built-in persistence backend must be introduced as an explicit adapter with its own
   locking, migration, and recovery documentation.
 
+## Run Workspaces
+
+Evaluation, benchmark, and harness jobs can preserve checkout-safe run evidence under
+`.worldforge/runs/<run-id>/`. This is separate from local JSON world persistence: run workspaces are
+operator evidence bundles, not a database.
+
+```bash
+uv run worldforge eval --suite planning --provider mock --run-workspace .worldforge
+uv run worldforge benchmark --provider mock --operation predict --run-workspace .worldforge
+uv run worldforge runs list
+uv run worldforge runs cleanup --keep 20
+```
+
+Each run directory contains `run_manifest.json`, `inputs/`, `results/`, `reports/`, `artifacts/`,
+and `logs/`. The manifest stores a sortable file-safe run ID, command, provider, operation, status,
+input summary, result summary, event count, and relative artifact paths.
+
+Retention is host-owned. `worldforge runs cleanup --keep <n>` keeps the newest run IDs and removes
+older directories; use `--dry-run` before deleting evidence attached to an incident or release gate.
+For public issues, attach the manifest plus report files and redact any host-created artifacts that
+contain private paths, prompts, credentials, signed URLs, or provider-native payloads.
+
 ## Observability
 
 Attach a provider event handler at `WorldForge(event_handler=...)` or provider construction time.

--- a/docs/src/theworldharness.md
+++ b/docs/src/theworldharness.md
@@ -77,8 +77,35 @@ uv run worldforge benchmark --provider mock --iterations 2 --format json
 uv run worldforge eval --suite planning --provider mock --format json
 ```
 
-Completed eval and benchmark runs write JSON under `.worldforge/reports/` relative to the active
-state directory. The Home screen and `Ctrl+P` index those files as recent runs.
+Completed checkout-safe flows also preserve a sanitized run workspace:
+
+```text
+.worldforge/runs/<run-id>/
+|-- run_manifest.json
+|-- inputs/
+|-- results/
+|-- reports/
+|-- artifacts/
+`-- logs/
+```
+
+Run IDs are UTC-sortable and file-safe (`YYYYMMDDTHHMMSSZ-xxxxxxxx`). The manifest records the
+command, provider surface, status, input summary, result summary, event count, and relative artifact
+paths. It intentionally stores summaries and report renderings, not credentials, raw signed URLs, or
+provider-owned private data.
+
+The CLI can write the same layout for evaluation and benchmark runs:
+
+```bash
+uv run worldforge eval --suite planning --provider mock --run-workspace .worldforge
+uv run worldforge benchmark --provider mock --operation predict --run-workspace .worldforge
+uv run worldforge runs list
+uv run worldforge runs cleanup --keep 20
+```
+
+Completed eval and benchmark TUI screens still write JSON under `.worldforge/reports/` relative to
+the active state directory for the Home screen and `Ctrl+P` recent-report index. Use the run
+workspace when a full issue attachment needs manifest, reports, logs, and result summaries together.
 
 ## Interface Contract
 

--- a/src/worldforge/cli.py
+++ b/src/worldforge/cli.py
@@ -52,6 +52,7 @@ CLI_EPILOG = """Common commands:
   worldforge predict kitchen --provider mock --x 0.3 --y 0.8 --z 0.0 --steps 2
   worldforge eval --suite planning --provider mock --format json
   worldforge benchmark --provider mock --iterations 5 --format json
+  worldforge runs list
 """
 
 EXAMPLE_COMMANDS: tuple[dict[str, str], ...] = (
@@ -210,6 +211,24 @@ def _parse_bool(value: str) -> bool:
     raise WorldForgeError("Boolean values must be 'true' or 'false'.")
 
 
+def _provider_args(providers: list[str]) -> list[str]:
+    args: list[str] = []
+    for provider in providers:
+        args.extend(["--provider", provider])
+    return args
+
+
+def _operation_args(operations: list[str]) -> list[str]:
+    args: list[str] = []
+    for operation in operations:
+        args.extend(["--operation", operation])
+    return args
+
+
+def _command_string(args: list[str]) -> str:
+    return "worldforge " + " ".join(args)
+
+
 def _world_history_payload(world) -> list[dict[str, object]]:
     entries: list[dict[str, object]] = []
     for entry in world.history():
@@ -325,6 +344,33 @@ def _print_examples_markdown() -> None:
             f"{example['requires']} | "
             f"`{example['command']}` |"
         )
+
+
+def _print_run_list_markdown(runs: tuple[dict[str, object], ...]) -> None:
+    print("# WorldForge Runs")
+    print()
+    print("| run_id | kind | status | provider | operation | path |")
+    print("| --- | --- | --- | --- | --- | --- |")
+    for run in runs:
+        print(
+            "| "
+            f"`{run.get('run_id', '')}` | "
+            f"{run.get('kind', '')} | "
+            f"{run.get('status', '')} | "
+            f"{run.get('provider', '')} | "
+            f"{run.get('operation', '')} | "
+            f"`{run.get('path', '')}` |"
+        )
+
+
+def _print_run_cleanup_markdown(paths: tuple[Path, ...], *, dry_run: bool) -> None:
+    title = "WorldForge Run Cleanup Preview" if dry_run else "WorldForge Run Cleanup"
+    print(f"# {title}")
+    print()
+    print(f"- removed_count: {0 if dry_run else len(paths)}")
+    print(f"- selected_count: {len(paths)}")
+    for path in paths:
+        print(f"- `{path}`")
 
 
 def _provider_docs_entries(name: str | None = None) -> tuple[dict[str, str], ...]:
@@ -690,6 +736,46 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Output format for the forked world summary.",
     )
 
+    runs = subparsers.add_parser("runs", help="List and clean preserved run workspaces.")
+    runs_subparsers = runs.add_subparsers(dest="runs_command", required=True, metavar="command")
+    runs_list = runs_subparsers.add_parser("list", help="List preserved run manifests.")
+    runs_list.add_argument(
+        "--workspace-dir",
+        type=Path,
+        default=Path(".worldforge"),
+        help="WorldForge workspace directory containing runs/.",
+    )
+    runs_list.add_argument(
+        "--format",
+        choices=("json", "markdown"),
+        default="json",
+        help="Output format for run summaries.",
+    )
+    runs_cleanup = runs_subparsers.add_parser("cleanup", help="Remove old preserved runs.")
+    runs_cleanup.add_argument(
+        "--workspace-dir",
+        type=Path,
+        default=Path(".worldforge"),
+        help="WorldForge workspace directory containing runs/.",
+    )
+    runs_cleanup.add_argument(
+        "--keep",
+        type=int,
+        default=10,
+        help="Number of newest runs to keep.",
+    )
+    runs_cleanup.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show selected run directories without deleting them.",
+    )
+    runs_cleanup.add_argument(
+        "--format",
+        choices=("json", "markdown"),
+        default="json",
+        help="Output format for cleanup results.",
+    )
+
     doctor = subparsers.add_parser("doctor", help="Inspect the local WorldForge environment.")
     doctor.add_argument("--state-dir", default=".worldforge/worlds", help="World state directory.")
     doctor.add_argument(
@@ -759,6 +845,11 @@ def _build_parser() -> argparse.ArgumentParser:
     evaluate.add_argument(
         "--state-dir", default=".worldforge/worlds", help="World state directory."
     )
+    evaluate.add_argument(
+        "--run-workspace",
+        type=Path,
+        help="Preserve sanitized eval artifacts under RUN_WORKSPACE/runs/<run-id>/.",
+    )
 
     benchmark = subparsers.add_parser(
         "benchmark",
@@ -799,6 +890,11 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     benchmark.add_argument(
         "--state-dir", default=".worldforge/worlds", help="World state directory."
+    )
+    benchmark.add_argument(
+        "--run-workspace",
+        type=Path,
+        help="Preserve sanitized benchmark artifacts under RUN_WORKSPACE/runs/<run-id>/.",
     )
 
     harness = subparsers.add_parser("harness", help="Launch TheWorldHarness TUI.")
@@ -859,6 +955,39 @@ def _cmd_harness(args: argparse.Namespace) -> int:
         output_format=args.format,
         animate=not args.no_animation,
     )
+
+
+def _cmd_runs(args: argparse.Namespace) -> int:
+    from worldforge.harness.workspace import cleanup_run_workspaces, list_run_workspaces
+
+    if args.runs_command == "list":
+        runs = list_run_workspaces(args.workspace_dir)
+        if args.format == "markdown":
+            _print_run_list_markdown(runs)
+        else:
+            _print_json(runs)
+        return 0
+
+    if args.runs_command == "cleanup":
+        removed = cleanup_run_workspaces(
+            args.workspace_dir,
+            keep=args.keep,
+            dry_run=args.dry_run,
+        )
+        if args.format == "markdown":
+            _print_run_cleanup_markdown(removed, dry_run=args.dry_run)
+        else:
+            _print_json(
+                {
+                    "dry_run": args.dry_run,
+                    "selected_count": len(removed),
+                    "removed_count": 0 if args.dry_run else len(removed),
+                    "paths": [str(path) for path in removed],
+                }
+            )
+        return 0
+
+    return 2
 
 
 def _cmd_providers(args: argparse.Namespace, forge: WorldForge) -> int:
@@ -1233,12 +1362,24 @@ def _cmd_eval(args: argparse.Namespace, forge: WorldForge) -> int:
     suite = EvaluationSuite.from_builtin(args.suite)
     providers = args.providers or ["mock"]
     report = suite.run_report(providers, forge=forge)
+    artifacts = report.artifacts()
+    if args.run_workspace is not None:
+        from worldforge.harness.flows import preserve_eval_run_workspace
+
+        preserve_eval_run_workspace(
+            args.run_workspace,
+            suite_id=args.suite,
+            providers=providers,
+            artifacts=artifacts,
+            report=report,
+            command=_command_string(["eval", "--suite", args.suite, *_provider_args(providers)]),
+        )
     if args.format == "json":
-        print(report.to_json())
+        print(artifacts["json"])
     elif args.format == "csv":
-        print(report.to_csv())
+        print(artifacts["csv"])
     else:
-        print(report.to_markdown())
+        print(artifacts["markdown"])
     return 0
 
 
@@ -1305,6 +1446,29 @@ def _cmd_benchmark(args: argparse.Namespace, forge: WorldForge) -> int:
         }
         gate_report = report.evaluate_budgets(load_benchmark_budgets(budget_payload))
 
+    if args.run_workspace is not None:
+        from worldforge.harness.flows import preserve_benchmark_run_workspace
+
+        preserve_benchmark_run_workspace(
+            args.run_workspace,
+            providers=providers,
+            operations=args.operations,
+            artifacts=report.artifacts(),
+            report=report,
+            command=_command_string(
+                [
+                    "benchmark",
+                    *_provider_args(providers),
+                    *_operation_args(args.operations or []),
+                    "--iterations",
+                    str(args.iterations),
+                    "--concurrency",
+                    str(args.concurrency),
+                ]
+            ),
+            budget_passed=None if gate_report is None else gate_report.passed,
+        )
+
     if args.format == "json":
         if gate_report is None:
             print(report.to_json())
@@ -1358,6 +1522,12 @@ def main() -> int:
 
     if args.command == "harness":
         return _cmd_harness(args)
+
+    if args.command == "runs":
+        try:
+            return _cmd_runs(args)
+        except (WorldForgeError, ValueError) as exc:
+            parser.exit(2, f"{exc}\n")
 
     forge = WorldForge(state_dir=args.state_dir)
 

--- a/src/worldforge/harness/__init__.py
+++ b/src/worldforge/harness/__init__.py
@@ -4,13 +4,23 @@ from __future__ import annotations
 
 from worldforge.harness.flows import available_flows, flow_index, run_flow
 from worldforge.harness.models import HarnessFlow, HarnessMetric, HarnessRun, HarnessStep
+from worldforge.harness.workspace import (
+    RunWorkspace,
+    cleanup_run_workspaces,
+    create_run_workspace,
+    list_run_workspaces,
+)
 
 __all__ = [
     "HarnessFlow",
     "HarnessMetric",
     "HarnessRun",
     "HarnessStep",
+    "RunWorkspace",
     "available_flows",
+    "cleanup_run_workspaces",
+    "create_run_workspace",
     "flow_index",
+    "list_run_workspaces",
     "run_flow",
 ]

--- a/src/worldforge/harness/flows.py
+++ b/src/worldforge/harness/flows.py
@@ -13,6 +13,12 @@ from worldforge.benchmark import BenchmarkReport, BenchmarkResult, ProviderBench
 from worldforge.evaluation import EvaluationReport, EvaluationResult, EvaluationSuite
 from worldforge.framework import WorldForge
 from worldforge.harness.models import HarnessFlow, HarnessMetric, HarnessRun, HarnessStep
+from worldforge.harness.workspace import (
+    RunWorkspace,
+    create_run_workspace,
+    workspace_root_for_state_dir,
+    write_run_manifest,
+)
 from worldforge.models import JSONDict
 
 FlowRunner = Callable[..., JSONDict]
@@ -171,15 +177,25 @@ def run_flow(flow_id: str, *, state_dir: Path | None = None) -> HarnessRun:
     resolved_state_dir = state_dir or Path(
         tempfile.mkdtemp(prefix=f"worldforge-harness-{flow_id}-")
     )
+    workspace = create_run_workspace(
+        workspace_root_for_state_dir(resolved_state_dir),
+        kind="flow",
+        command=flow.command,
+        provider=flow.provider,
+        operation=flow.id,
+    )
     summary = _RUNNERS[flow_id](state_dir=resolved_state_dir, emit=False)
-    return HarnessRun(
+    run = HarnessRun(
         flow=flow,
         state_dir=resolved_state_dir,
         summary=summary,
         steps=_steps_for(flow_id, summary),
         metrics=_metrics_for(flow_id, summary),
         transcript=_transcript_for(flow_id, summary),
+        workspace_path=workspace.path,
     )
+    _write_flow_workspace(workspace, run)
+    return run
 
 
 def eval_run_artifacts(
@@ -242,6 +258,97 @@ def write_report(forge: WorldForge, kind: str, artifacts: dict[str, str]) -> Pat
     path = reports_dir / f"{safe_kind}-{timestamp}-{run_id}.json"
     path.write_text(artifacts["json"], encoding="utf-8")
     return path.resolve()
+
+
+def preserve_eval_run_workspace(
+    workspace_dir: Path,
+    *,
+    suite_id: str,
+    providers: Sequence[str],
+    artifacts: dict[str, str],
+    report: EvaluationReport,
+    command: str,
+) -> RunWorkspace:
+    """Preserve an evaluation report in the shared run workspace layout."""
+
+    workspace = create_run_workspace(
+        workspace_dir,
+        kind="eval",
+        command=command,
+        provider=", ".join(providers),
+        operation=suite_id,
+        input_summary={"suite_id": suite_id, "providers": list(providers)},
+    )
+    paths = _write_report_artifacts(workspace, artifacts)
+    result_summary = {
+        "suite_id": report.suite_id,
+        "suite": report.suite,
+        "result_count": len(report.results),
+        "passed_count": sum(1 for result in report.results if result.passed),
+    }
+    workspace.write_json("results/summary.json", result_summary)
+    write_run_manifest(
+        workspace,
+        kind="eval",
+        command=command,
+        provider=", ".join(providers),
+        operation=suite_id,
+        status="completed",
+        input_summary={"suite_id": suite_id, "providers": list(providers)},
+        result_summary=result_summary,
+        artifact_paths=paths,
+    )
+    return workspace
+
+
+def preserve_benchmark_run_workspace(
+    workspace_dir: Path,
+    *,
+    providers: Sequence[str],
+    operations: Sequence[str] | None,
+    artifacts: dict[str, str],
+    report: BenchmarkReport,
+    command: str,
+    budget_passed: bool | None = None,
+) -> RunWorkspace:
+    """Preserve a benchmark report in the shared run workspace layout."""
+
+    operation_label = ", ".join(operations or ProviderBenchmarkHarness.benchmarkable_operations)
+    input_summary = {"providers": list(providers), "operations": list(operations or [])}
+    workspace = create_run_workspace(
+        workspace_dir,
+        kind="benchmark",
+        command=command,
+        provider=", ".join(providers),
+        operation=operation_label,
+        input_summary=input_summary,
+    )
+    paths = _write_report_artifacts(workspace, artifacts)
+    result_summary = {
+        "result_count": len(report.results),
+        "error_count": sum(result.error_count for result in report.results),
+        "retry_count": sum(result.retry_count for result in report.results),
+        "budget_passed": budget_passed,
+    }
+    workspace.write_json("results/summary.json", result_summary)
+    write_run_manifest(
+        workspace,
+        kind="benchmark",
+        command=command,
+        provider=", ".join(providers),
+        operation=operation_label,
+        status="completed" if budget_passed is not False else "failed",
+        input_summary=input_summary,
+        result_summary=result_summary,
+        artifact_paths=paths,
+        event_count=sum(
+            int(event.get("request_count", 0))
+            for result in report.results
+            for event in result.operation_metrics.get("events", [])
+            if isinstance(event, dict)
+        ),
+    )
+    return workspace
 
 
 def report_run_from_path(path: Path, *, state_dir: Path) -> HarnessRun:
@@ -423,6 +530,66 @@ def _benchmark_artifacts_from_payload(payload: JSONDict) -> dict[str, str]:
         run_metadata=dict(payload.get("run_metadata", {})),
     )
     return report.artifacts()
+
+
+def _write_flow_workspace(workspace: RunWorkspace, run: HarnessRun) -> None:
+    summary_path = workspace.write_json("results/summary.json", run.summary)
+    steps_path = workspace.write_json("results/steps.json", [step.to_dict() for step in run.steps])
+    metrics_path = workspace.write_json(
+        "results/metrics.json",
+        [metric.to_dict() for metric in run.metrics],
+    )
+    transcript_path = workspace.write_text("logs/transcript.txt", "\n".join(run.transcript))
+    event_count = 0
+    event_phases = run.summary.get("event_phases")
+    if isinstance(event_phases, list):
+        event_count = len(event_phases)
+        workspace.write_text(
+            "logs/provider-events.jsonl",
+            "\n".join(
+                json.dumps(
+                    {
+                        "event_type": "provider_event_summary",
+                        "provider": run.flow.provider,
+                        "operation": run.flow.id,
+                        "phase": str(phase),
+                    },
+                    sort_keys=True,
+                )
+                for phase in event_phases
+            ),
+        )
+    artifact_paths = {
+        "summary": str(summary_path.relative_to(workspace.path)),
+        "steps": str(steps_path.relative_to(workspace.path)),
+        "metrics": str(metrics_path.relative_to(workspace.path)),
+        "transcript": str(transcript_path.relative_to(workspace.path)),
+    }
+    write_run_manifest(
+        workspace,
+        kind="flow",
+        command=run.flow.command,
+        provider=run.flow.provider,
+        operation=run.flow.id,
+        status="completed",
+        input_summary={"flow_id": run.flow.id, "state_dir": str(run.state_dir)},
+        result_summary={
+            "step_count": len(run.steps),
+            "metric_count": len(run.metrics),
+            "summary_keys": sorted(run.summary),
+        },
+        artifact_paths=artifact_paths,
+        event_count=event_count,
+    )
+
+
+def _write_report_artifacts(workspace: RunWorkspace, artifacts: dict[str, str]) -> dict[str, str]:
+    paths: dict[str, str] = {}
+    for name, content in artifacts.items():
+        suffix = "md" if name == "markdown" else name
+        path = workspace.write_text(f"reports/report.{suffix}", content)
+        paths[name] = str(path.relative_to(workspace.path))
+    return paths
 
 
 def _steps_for(flow_id: str, summary: JSONDict) -> tuple[HarnessStep, ...]:

--- a/src/worldforge/harness/models.py
+++ b/src/worldforge/harness/models.py
@@ -83,6 +83,7 @@ class HarnessRun:
     transcript: tuple[str, ...]
     kind: Literal["flow", "eval", "benchmark"] = "flow"
     report_path: Path | None = None
+    workspace_path: Path | None = None
     artifacts: dict[str, str] | None = None
 
     def to_dict(self) -> JSONDict:
@@ -95,6 +96,7 @@ class HarnessRun:
             "transcript": list(self.transcript),
             "kind": self.kind,
             "report_path": str(self.report_path) if self.report_path is not None else None,
+            "workspace_path": str(self.workspace_path) if self.workspace_path is not None else None,
             "artifacts": dict(self.artifacts or {}),
         }
 

--- a/src/worldforge/harness/workspace.py
+++ b/src/worldforge/harness/workspace.py
@@ -1,0 +1,229 @@
+"""Run workspace layout helpers for harness and CLI flows."""
+
+from __future__ import annotations
+
+import json
+import re
+import shutil
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from uuid import uuid4
+
+from worldforge.models import JSONDict
+
+RUN_WORKSPACE_SCHEMA_VERSION = 1
+RUN_ID_PATTERN = re.compile(r"^\d{8}T\d{6}Z-[a-f0-9]{8}$")
+
+
+@dataclass(frozen=True, slots=True)
+class RunWorkspace:
+    """Filesystem locations for one preserved WorldForge run."""
+
+    run_id: str
+    path: Path
+
+    @property
+    def inputs_dir(self) -> Path:
+        return self.path / "inputs"
+
+    @property
+    def results_dir(self) -> Path:
+        return self.path / "results"
+
+    @property
+    def reports_dir(self) -> Path:
+        return self.path / "reports"
+
+    @property
+    def artifacts_dir(self) -> Path:
+        return self.path / "artifacts"
+
+    @property
+    def logs_dir(self) -> Path:
+        return self.path / "logs"
+
+    @property
+    def manifest_path(self) -> Path:
+        return self.path / "run_manifest.json"
+
+    def write_json(self, relative_path: str, payload: object) -> Path:
+        """Write a stable JSON artifact below this run workspace."""
+
+        target = self._resolve_child(relative_path)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(
+            json.dumps(payload, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        return target
+
+    def write_text(self, relative_path: str, text: str) -> Path:
+        """Write a text artifact below this run workspace."""
+
+        target = self._resolve_child(relative_path)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(text if text.endswith("\n") else f"{text}\n", encoding="utf-8")
+        return target
+
+    def _resolve_child(self, relative_path: str) -> Path:
+        target = self.path / relative_path
+        resolved = target.resolve()
+        root = self.path.resolve()
+        if root != resolved and root not in resolved.parents:
+            raise ValueError(f"run artifact path escapes workspace: {relative_path}")
+        return target
+
+
+def create_run_id(now: datetime | None = None) -> str:
+    """Return a sortable, file-safe run id."""
+
+    timestamp = (now or datetime.now(UTC)).astimezone(UTC).strftime("%Y%m%dT%H%M%SZ")
+    return f"{timestamp}-{uuid4().hex[:8]}"
+
+
+def validate_run_id(run_id: str) -> str:
+    """Validate and return a run id."""
+
+    if not RUN_ID_PATTERN.fullmatch(run_id):
+        raise ValueError("run_id must match YYYYMMDDTHHMMSSZ-xxxxxxxx with a lowercase hex suffix")
+    return run_id
+
+
+def workspace_root_for_state_dir(state_dir: Path) -> Path:
+    """Return the workspace root associated with a world state directory."""
+
+    if state_dir.name == "worlds" and state_dir.parent.name == ".worldforge":
+        return state_dir.parent
+    return state_dir
+
+
+def runs_dir(workspace_dir: Path) -> Path:
+    """Return the canonical runs directory for a WorldForge workspace."""
+
+    return workspace_dir / "runs"
+
+
+def create_run_workspace(
+    workspace_dir: Path,
+    *,
+    kind: str,
+    command: str,
+    provider: str | None = None,
+    operation: str | None = None,
+    run_id: str | None = None,
+    input_summary: JSONDict | None = None,
+) -> RunWorkspace:
+    """Create a `.worldforge/runs/<run-id>/` workspace and initial manifest."""
+
+    resolved_run_id = validate_run_id(run_id) if run_id is not None else create_run_id()
+    workspace = RunWorkspace(
+        run_id=resolved_run_id,
+        path=runs_dir(workspace_dir).resolve() / resolved_run_id,
+    )
+    for directory in (
+        workspace.inputs_dir,
+        workspace.results_dir,
+        workspace.reports_dir,
+        workspace.artifacts_dir,
+        workspace.logs_dir,
+    ):
+        directory.mkdir(parents=True, exist_ok=False)
+    write_run_manifest(
+        workspace,
+        kind=kind,
+        command=command,
+        provider=provider,
+        operation=operation,
+        status="running",
+        input_summary=input_summary or {},
+    )
+    return workspace
+
+
+def write_run_manifest(
+    workspace: RunWorkspace,
+    *,
+    kind: str,
+    command: str,
+    status: str,
+    provider: str | None = None,
+    operation: str | None = None,
+    input_summary: JSONDict | None = None,
+    result_summary: JSONDict | None = None,
+    artifact_paths: dict[str, str] | None = None,
+    event_count: int = 0,
+) -> Path:
+    """Write the sanitized manifest for a preserved run."""
+
+    payload: JSONDict = {
+        "schema_version": RUN_WORKSPACE_SCHEMA_VERSION,
+        "run_id": workspace.run_id,
+        "created_at": _created_at_from_run_id(workspace.run_id),
+        "kind": kind,
+        "command": command,
+        "status": status,
+        "provider": provider,
+        "operation": operation,
+        "input_summary": input_summary or {},
+        "result_summary": result_summary or {},
+        "artifact_paths": artifact_paths or {},
+        "event_count": event_count,
+        "layout": {
+            "inputs": "inputs/",
+            "results": "results/",
+            "reports": "reports/",
+            "artifacts": "artifacts/",
+            "logs": "logs/",
+        },
+    }
+    workspace.manifest_path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return workspace.manifest_path
+
+
+def list_run_workspaces(workspace_dir: Path) -> tuple[JSONDict, ...]:
+    """Return run manifests sorted newest first."""
+
+    root = runs_dir(workspace_dir)
+    if not root.exists():
+        return ()
+    runs: list[JSONDict] = []
+    for manifest_path in root.glob("*/run_manifest.json"):
+        try:
+            payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if not isinstance(payload, dict):
+            continue
+        payload = dict(payload)
+        payload["path"] = str(manifest_path.parent)
+        runs.append(payload)
+    return tuple(sorted(runs, key=lambda item: str(item.get("run_id", "")), reverse=True))
+
+
+def cleanup_run_workspaces(
+    workspace_dir: Path,
+    *,
+    keep: int,
+    dry_run: bool = False,
+) -> tuple[Path, ...]:
+    """Remove old run workspaces while keeping the newest `keep` runs."""
+
+    if keep < 0:
+        raise ValueError("keep must be greater than or equal to 0")
+    manifests = list_run_workspaces(workspace_dir)
+    stale_paths = tuple(Path(str(item["path"])) for item in manifests[keep:])
+    if dry_run:
+        return stale_paths
+    for path in stale_paths:
+        shutil.rmtree(path)
+    return stale_paths
+
+
+def _created_at_from_run_id(run_id: str) -> str:
+    timestamp = run_id.split("-", 1)[0]
+    parsed = datetime.strptime(timestamp, "%Y%m%dT%H%M%SZ").replace(tzinfo=UTC)
+    return parsed.isoformat().replace("+00:00", "Z")

--- a/tests/test_cli_help_snapshots.py
+++ b/tests/test_cli_help_snapshots.py
@@ -118,7 +118,7 @@ options:
 usage: worldforge eval [-h]
                        [--suite {generation,physics,planning,reasoning,transfer}]
                        [--provider PROVIDERS] [--format {markdown,json,csv}]
-                       [--state-dir STATE_DIR]
+                       [--state-dir STATE_DIR] [--run-workspace RUN_WORKSPACE]
 
 options:
   -h, --help            show this help message and exit
@@ -129,6 +129,9 @@ options:
                         Evaluation report format.
   --state-dir STATE_DIR
                         World state directory.
+  --run-workspace RUN_WORKSPACE
+                        Preserve sanitized eval artifacts under
+                        RUN_WORKSPACE/runs/<run-id>/.
 """,
     ("benchmark", "--help"): """\
 usage: worldforge benchmark [-h] [--provider PROVIDERS]
@@ -139,6 +142,7 @@ usage: worldforge benchmark [-h] [--provider PROVIDERS]
                             [--input-file INPUT_FILE]
                             [--budget-file BUDGET_FILE]
                             [--state-dir STATE_DIR]
+                            [--run-workspace RUN_WORKSPACE]
 
 options:
   -h, --help            show this help message and exit
@@ -159,6 +163,9 @@ options:
                         after printing the report.
   --state-dir STATE_DIR
                         World state directory.
+  --run-workspace RUN_WORKSPACE
+                        Preserve sanitized benchmark artifacts under
+                        RUN_WORKSPACE/runs/<run-id>/.
 """,
 }
 
@@ -207,6 +214,7 @@ def test_top_level_help_lists_command_surface(monkeypatch, capsys) -> None:
         "eval",
         "benchmark",
         "harness",
+        "runs",
     ):
         assert command in output
     for common_command in (
@@ -218,6 +226,7 @@ def test_top_level_help_lists_command_surface(monkeypatch, capsys) -> None:
         "worldforge provider info mock",
         "worldforge harness --list",
         "worldforge eval --suite planning --provider mock --format json",
+        "worldforge runs list",
     ):
         assert common_command in output
 

--- a/tests/test_harness_workspace.py
+++ b/tests/test_harness_workspace.py
@@ -1,0 +1,234 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from worldforge.cli import main
+from worldforge.harness import run_flow
+from worldforge.harness.workspace import (
+    cleanup_run_workspaces,
+    create_run_workspace,
+    list_run_workspaces,
+    validate_run_id,
+    workspace_root_for_state_dir,
+)
+
+
+def test_run_flow_preserves_shared_workspace_layout(tmp_path) -> None:
+    run = run_flow("diagnostics", state_dir=tmp_path)
+
+    assert run.workspace_path is not None
+    assert run.workspace_path.parent == tmp_path / "runs"
+    manifest = json.loads((run.workspace_path / "run_manifest.json").read_text())
+
+    assert manifest["kind"] == "flow"
+    assert manifest["status"] == "completed"
+    assert manifest["operation"] == "diagnostics"
+    assert manifest["artifact_paths"]["summary"] == "results/summary.json"
+    assert (run.workspace_path / "results" / "summary.json").exists()
+    assert (run.workspace_path / "results" / "steps.json").exists()
+    assert (run.workspace_path / "results" / "metrics.json").exists()
+    assert (run.workspace_path / "logs" / "transcript.txt").exists()
+
+
+def test_eval_cli_preserves_run_workspace(tmp_path, monkeypatch, capsys) -> None:
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "worldforge",
+            "eval",
+            "--suite",
+            "planning",
+            "--provider",
+            "mock",
+            "--run-workspace",
+            str(tmp_path),
+            "--format",
+            "json",
+        ],
+    )
+
+    assert main() == 0
+    assert json.loads(capsys.readouterr().out)["suite_id"] == "planning"
+    runs = list_run_workspaces(tmp_path)
+
+    assert len(runs) == 1
+    assert runs[0]["kind"] == "eval"
+    assert runs[0]["operation"] == "planning"
+    run_path = Path(str(runs[0]["path"]))
+    assert json.loads((run_path / "reports" / "report.json").read_text())["suite_id"] == "planning"
+    assert (run_path / "reports" / "report.md").exists()
+    assert (run_path / "reports" / "report.csv").exists()
+
+
+def test_benchmark_cli_preserves_failed_budget_workspace(tmp_path, monkeypatch, capsys) -> None:
+    budget_file = tmp_path / "budget.json"
+    budget_file.write_text(
+        json.dumps(
+            {
+                "budgets": [
+                    {
+                        "provider": "mock",
+                        "operation": "predict",
+                        "max_error_count": 0,
+                        "max_average_latency_ms": 0.0,
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "worldforge",
+            "benchmark",
+            "--provider",
+            "mock",
+            "--operation",
+            "predict",
+            "--iterations",
+            "1",
+            "--budget-file",
+            str(budget_file),
+            "--run-workspace",
+            str(tmp_path),
+            "--format",
+            "json",
+        ],
+    )
+
+    assert main() == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["gate"]["passed"] is False
+    run = list_run_workspaces(tmp_path)[0]
+
+    assert run["kind"] == "benchmark"
+    assert run["status"] == "failed"
+    assert run["result_summary"]["budget_passed"] is False
+    assert Path(str(run["path"]), "reports", "report.json").exists()
+
+
+def test_runs_cleanup_keeps_newest_run_workspaces(tmp_path, monkeypatch, capsys) -> None:
+    create_run_workspace(
+        tmp_path,
+        kind="eval",
+        command="worldforge eval",
+        run_id="20260101T000000Z-00000001",
+    )
+    create_run_workspace(
+        tmp_path,
+        kind="eval",
+        command="worldforge eval",
+        run_id="20260102T000000Z-00000002",
+    )
+
+    selected = cleanup_run_workspaces(tmp_path, keep=1, dry_run=True)
+    assert [path.name for path in selected] == ["20260101T000000Z-00000001"]
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "worldforge",
+            "runs",
+            "cleanup",
+            "--workspace-dir",
+            str(tmp_path),
+            "--keep",
+            "1",
+        ],
+    )
+
+    assert main() == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["removed_count"] == 1
+    assert [run["run_id"] for run in list_run_workspaces(tmp_path)] == ["20260102T000000Z-00000002"]
+
+
+def test_runs_cli_markdown_and_dry_run_cleanup(tmp_path, monkeypatch, capsys) -> None:
+    create_run_workspace(
+        tmp_path,
+        kind="eval",
+        command="worldforge eval",
+        provider="mock",
+        run_id="20260101T000000Z-00000001",
+    )
+    create_run_workspace(
+        tmp_path,
+        kind="benchmark",
+        command="worldforge benchmark",
+        provider="mock",
+        run_id="20260102T000000Z-00000002",
+    )
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "worldforge",
+            "runs",
+            "list",
+            "--workspace-dir",
+            str(tmp_path),
+            "--format",
+            "markdown",
+        ],
+    )
+    assert main() == 0
+    list_output = capsys.readouterr().out
+    assert "# WorldForge Runs" in list_output
+    assert "20260102T000000Z-00000002" in list_output
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "worldforge",
+            "runs",
+            "cleanup",
+            "--workspace-dir",
+            str(tmp_path),
+            "--keep",
+            "1",
+            "--dry-run",
+            "--format",
+            "markdown",
+        ],
+    )
+    assert main() == 0
+    cleanup_output = capsys.readouterr().out
+    assert "# WorldForge Run Cleanup Preview" in cleanup_output
+    assert "selected_count: 1" in cleanup_output
+    assert len(list_run_workspaces(tmp_path)) == 2
+
+
+def test_run_id_validation_rejects_non_sortable_names() -> None:
+    with pytest.raises(ValueError, match="run_id must match"):
+        validate_run_id("not safe")
+
+
+def test_workspace_helpers_reject_escape_and_invalid_cleanup(tmp_path) -> None:
+    workspace = create_run_workspace(
+        tmp_path,
+        kind="eval",
+        command="worldforge eval",
+        run_id="20260101T000000Z-00000001",
+    )
+
+    assert workspace_root_for_state_dir(Path(".worldforge/worlds")) == Path(".worldforge")
+    assert list_run_workspaces(tmp_path / "missing") == ()
+    with pytest.raises(ValueError, match="escapes workspace"):
+        workspace.write_json("../escape.json", {})
+    with pytest.raises(ValueError, match="keep must be"):
+        cleanup_run_workspaces(tmp_path, keep=-1)
+
+    bad_manifest = tmp_path / "runs" / "bad" / "run_manifest.json"
+    bad_manifest.parent.mkdir(parents=True)
+    bad_manifest.write_text("not-json", encoding="utf-8")
+    assert [run["run_id"] for run in list_run_workspaces(tmp_path)] == ["20260101T000000Z-00000001"]


### PR DESCRIPTION
Closes #66.

## Summary
- add a shared `.worldforge/runs/<run-id>/` workspace layout with sanitized manifests, result summaries, report artifacts, logs, and cleanup helpers
- preserve the same layout from harness flows and opt-in CLI eval/benchmark runs via `--run-workspace`
- add `worldforge runs list` and `worldforge runs cleanup` for retention, plus docs for issue-safe artifacts

## Validation
- `uv run ruff check src tests examples scripts`
- `uv run ruff format --check src tests examples scripts`
- `uv run pytest tests/test_harness_workspace.py tests/test_harness_flows.py tests/test_harness_cli.py tests/test_evaluation_and_planning.py tests/test_benchmark.py -q`
- `uv run pytest`
- `uv run pytest -m "not live"`
- `uv run --extra harness pytest tests/test_harness_tui.py`
- `uv run --extra harness pytest --cov=src/worldforge --cov-report=term-missing --cov-fail-under=90`
- `uv run mkdocs build --strict`
- `bash scripts/test_package.sh`
- `uv lock --check`
- `uv run python scripts/generate_provider_docs.py --check`
- `UV_LOCKED=true uv export --all-groups --no-emit-project --no-hashes --output-file <tmp>` + `uvx --from pip-audit pip-audit -r <tmp>`

Note: the issue validation references `tests/test_cli_reports.py`, which is not present in this checkout. I covered that surface with the new workspace tests plus existing harness/eval/benchmark suites.
