### PR TITLE
Add preserved run report comparison

### DIFF
--- a/docs/src/benchmarking.md
+++ b/docs/src/benchmarking.md
@@ -76,6 +76,26 @@ uv run worldforge benchmark \
 The run workspace stores the manifest, JSON/Markdown/CSV reports, result summary, budget verdict
 when supplied, and event count under `.worldforge/runs/<run-id>/`.
 
+Compare preserved benchmark runs before citing a regression, release claim, or provider change:
+
+```bash
+uv run worldforge runs compare \
+  .worldforge/runs/<baseline-run-id> \
+  .worldforge/runs/<candidate-run-id> \
+  --format markdown
+
+uv run worldforge runs compare \
+  .worldforge/runs/<baseline-run-id> \
+  .worldforge/runs/<candidate-run-id> \
+  --format csv \
+  --output .worldforge/runs/benchmark-comparison.csv
+```
+
+`runs compare` accepts run directories, `run_manifest.json` files, or `reports/report.json` files.
+It refuses mixed eval and benchmark reports. Markdown includes each run command, provider,
+operation, UTC date, report artifact paths, and input or budget provenance references. JSON and CSV
+are stable enough to attach to issues.
+
 Use `--input-file` when a benchmark result needs to be reproducible from preserved inputs. The
 file can contain input fields directly, or an `inputs` object plus metadata. The checked-in
 `examples/benchmark-inputs.json` fixture is checkout-safe for the mock provider's `predict`,

--- a/docs/src/theworldharness.md
+++ b/docs/src/theworldharness.md
@@ -100,12 +100,15 @@ The CLI can write the same layout for evaluation and benchmark runs:
 uv run worldforge eval --suite planning --provider mock --run-workspace .worldforge
 uv run worldforge benchmark --provider mock --operation predict --run-workspace .worldforge
 uv run worldforge runs list
+uv run worldforge runs compare .worldforge/runs/<run-a> .worldforge/runs/<run-b>
 uv run worldforge runs cleanup --keep 20
 ```
 
 Completed eval and benchmark TUI screens still write JSON under `.worldforge/reports/` relative to
 the active state directory for the Home screen and `Ctrl+P` recent-report index. Use the run
 workspace when a full issue attachment needs manifest, reports, logs, and result summaries together.
+Use `runs compare --format json|markdown|csv` to export attachment-safe comparisons across
+preserved eval runs or preserved benchmark runs.
 
 ## Interface Contract
 

--- a/src/worldforge/cli.py
+++ b/src/worldforge/cli.py
@@ -751,6 +751,27 @@ def _build_parser() -> argparse.ArgumentParser:
         default="json",
         help="Output format for run summaries.",
     )
+    runs_compare = runs_subparsers.add_parser(
+        "compare",
+        help="Compare preserved eval or benchmark run reports.",
+    )
+    runs_compare.add_argument(
+        "paths",
+        nargs="+",
+        type=Path,
+        help="Run workspace directories, run_manifest.json files, or report JSON files.",
+    )
+    runs_compare.add_argument(
+        "--format",
+        choices=("json", "markdown", "csv"),
+        default="markdown",
+        help="Output format for the comparison summary.",
+    )
+    runs_compare.add_argument(
+        "--output",
+        type=Path,
+        help="Optional path to write the comparison artifact instead of stdout.",
+    )
     runs_cleanup = runs_subparsers.add_parser("cleanup", help="Remove old preserved runs.")
     runs_cleanup.add_argument(
         "--workspace-dir",
@@ -966,6 +987,24 @@ def _cmd_runs(args: argparse.Namespace) -> int:
             _print_run_list_markdown(runs)
         else:
             _print_json(runs)
+        return 0
+
+    if args.runs_command == "compare":
+        from worldforge.harness.report_compare import (
+            compare_preserved_run_reports,
+            comparison_artifact,
+        )
+
+        payload = compare_preserved_run_reports(args.paths)
+        rendered = comparison_artifact(payload, output_format=args.format)
+        if args.output is not None:
+            args.output.parent.mkdir(parents=True, exist_ok=True)
+            args.output.write_text(
+                rendered + ("\n" if not rendered.endswith("\n") else ""),
+                encoding="utf-8",
+            )
+            return 0
+        print(rendered)
         return 0
 
     if args.runs_command == "cleanup":

--- a/src/worldforge/harness/report_compare.py
+++ b/src/worldforge/harness/report_compare.py
@@ -1,0 +1,399 @@
+"""Compare preserved WorldForge run reports."""
+
+from __future__ import annotations
+
+import csv
+import io
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+from worldforge.models import JSONDict, WorldForgeError, dump_json
+
+_SUPPORTED_KINDS = {"benchmark", "eval"}
+
+
+@dataclass(frozen=True, slots=True)
+class PreservedRunReport:
+    """Loaded report and manifest from one preserved run workspace."""
+
+    manifest: JSONDict
+    report: JSONDict
+    run_path: Path
+    report_path: Path
+
+    @property
+    def kind(self) -> str:
+        return str(self.manifest.get("kind", ""))
+
+    @property
+    def run_id(self) -> str:
+        return str(self.manifest.get("run_id", self.run_path.name))
+
+
+def load_preserved_run_report(path: Path) -> PreservedRunReport:
+    """Load a preserved run workspace, manifest path, or report JSON path."""
+
+    source = path.expanduser()
+    if source.is_dir():
+        run_path = source
+        manifest_path = run_path / "run_manifest.json"
+    elif source.name == "run_manifest.json":
+        manifest_path = source
+        run_path = source.parent
+    else:
+        run_path = source.parent.parent if source.parent.name == "reports" else source.parent
+        manifest_path = run_path / "run_manifest.json"
+
+    manifest = _read_json_object(manifest_path, name="run manifest")
+    kind = str(manifest.get("kind", ""))
+    if kind not in _SUPPORTED_KINDS:
+        raise WorldForgeError(
+            f"Run {manifest.get('run_id', run_path.name)} has unsupported report kind "
+            f"'{kind}'. Supported kinds: {', '.join(sorted(_SUPPORTED_KINDS))}."
+        )
+
+    report_path = (
+        source
+        if source.is_file() and source.name != "run_manifest.json"
+        else _report_path(run_path)
+    )
+    report = _read_json_object(report_path, name="run report")
+    _validate_report_kind(kind, report, report_path=report_path)
+    return PreservedRunReport(
+        manifest=manifest,
+        report=report,
+        run_path=run_path.resolve(),
+        report_path=report_path.resolve(),
+    )
+
+
+def compare_preserved_run_reports(paths: list[Path]) -> JSONDict:
+    """Return a stable, issue-attachable comparison payload for preserved runs."""
+
+    if len(paths) < 2:
+        raise WorldForgeError(
+            "runs compare requires at least two run directories or manifest paths."
+        )
+    reports = [load_preserved_run_report(path) for path in paths]
+    kinds = {report.kind for report in reports}
+    if len(kinds) != 1:
+        details = ", ".join(f"{report.run_id}:{report.kind}" for report in reports)
+        raise WorldForgeError(f"Cannot compare incompatible report types: {details}.")
+
+    kind = reports[0].kind
+    rows = _benchmark_rows(reports) if kind == "benchmark" else _evaluation_rows(reports)
+    payload: JSONDict = {
+        "schema_version": 1,
+        "kind": kind,
+        "baseline_run_id": reports[0].run_id,
+        "run_count": len(reports),
+        "runs": [_run_summary(report) for report in reports],
+        "rows": rows,
+    }
+    return payload
+
+
+def comparison_to_markdown(payload: JSONDict) -> str:
+    """Render a comparison payload as Markdown."""
+
+    lines = [
+        "# WorldForge Run Comparison",
+        "",
+        f"Kind: {payload['kind']}",
+        f"Baseline: `{payload['baseline_run_id']}`",
+        "",
+        "## Runs",
+        "",
+        "| run_id | date | status | command | provider | operation | artifacts | provenance |",
+        "| --- | --- | --- | --- | --- | --- | --- | --- |",
+    ]
+    lines.extend(
+        (
+            "| "
+            f"`{run['run_id']}` | {run['created_at']} | {run['status']} | "
+            f"`{run['command']}` | {run['provider']} | {run['operation']} | "
+            f"{_markdown_join(run['artifact_refs'])} | {_markdown_join(run['provenance_refs'])} |"
+        )
+        for run in payload["runs"]
+    )
+
+    if payload["kind"] == "benchmark":
+        lines.extend(
+            [
+                "",
+                "## Benchmark Rows",
+                "",
+                (
+                    "| run_id | provider | operation | ok | errors | retries | avg_ms | "
+                    "delta_avg_ms | p95_ms | throughput/s | events |"
+                ),
+                "| --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
+            ]
+        )
+        lines.extend(
+            (
+                "| "
+                f"`{row['run_id']}` | {row['provider']} | {row['operation']} | "
+                f"{row['success_count']}/{row['iterations']} | {row['error_count']} | "
+                f"{row['retry_count']} | {_format_number(row['average_latency_ms'])} | "
+                f"{_format_number(row['delta_average_latency_ms'])} | "
+                f"{_format_number(row['p95_latency_ms'])} | "
+                f"{_format_number(row['throughput_per_second'])} | {row['event_count']} |"
+            )
+            for row in payload["rows"]
+        )
+    else:
+        lines.extend(
+            [
+                "",
+                "## Evaluation Rows",
+                "",
+                (
+                    "| run_id | provider | average_score | delta_average_score | "
+                    "passed | scenarios |"
+                ),
+                "| --- | --- | ---: | ---: | ---: | ---: |",
+            ]
+        )
+        lines.extend(
+            (
+                "| "
+                f"`{row['run_id']}` | {row['provider']} | "
+                f"{_format_number(row['average_score'])} | "
+                f"{_format_number(row['delta_average_score'])} | "
+                f"{row['passed_scenario_count']}/{row['scenario_count']} | "
+                f"{row['scenario_count']} |"
+            )
+            for row in payload["rows"]
+        )
+    return "\n".join(lines)
+
+
+def comparison_to_csv(payload: JSONDict) -> str:
+    """Render a comparison payload as stable CSV."""
+
+    buffer = io.StringIO()
+    if payload["kind"] == "benchmark":
+        fieldnames = [
+            "run_id",
+            "created_at",
+            "command",
+            "provider",
+            "operation",
+            "iterations",
+            "success_count",
+            "error_count",
+            "retry_count",
+            "average_latency_ms",
+            "delta_average_latency_ms",
+            "p95_latency_ms",
+            "throughput_per_second",
+            "event_count",
+            "artifact_refs_json",
+            "provenance_refs_json",
+        ]
+    else:
+        fieldnames = [
+            "run_id",
+            "created_at",
+            "command",
+            "provider",
+            "average_score",
+            "delta_average_score",
+            "scenario_count",
+            "passed_scenario_count",
+            "failed_scenario_count",
+            "artifact_refs_json",
+            "provenance_refs_json",
+        ]
+    run_lookup = {run["run_id"]: run for run in payload["runs"]}
+    writer = csv.DictWriter(buffer, fieldnames=fieldnames)
+    writer.writeheader()
+    for row in payload["rows"]:
+        run = run_lookup[row["run_id"]]
+        exported = {field: row.get(field, "") for field in fieldnames}
+        exported["created_at"] = run["created_at"]
+        exported["command"] = run["command"]
+        exported["artifact_refs_json"] = dump_json(run["artifact_refs"])
+        exported["provenance_refs_json"] = dump_json(run["provenance_refs"])
+        writer.writerow(exported)
+    return buffer.getvalue().strip()
+
+
+def comparison_artifact(payload: JSONDict, *, output_format: str) -> str:
+    """Render a comparison payload in one of the public export formats."""
+
+    if output_format == "json":
+        return json.dumps(payload, indent=2, sort_keys=True)
+    if output_format == "markdown":
+        return comparison_to_markdown(payload)
+    if output_format == "csv":
+        return comparison_to_csv(payload)
+    raise WorldForgeError("comparison format must be json, markdown, or csv.")
+
+
+def _read_json_object(path: Path, *, name: str) -> JSONDict:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise WorldForgeError(f"Failed to read {name} {path}: {exc}") from exc
+    except json.JSONDecodeError as exc:
+        raise WorldForgeError(f"{name.title()} {path} must contain valid JSON: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise WorldForgeError(f"{name.title()} {path} must be a JSON object.")
+    return dict(payload)
+
+
+def _report_path(run_path: Path) -> Path:
+    return run_path / "reports" / "report.json"
+
+
+def _validate_report_kind(kind: str, report: JSONDict, *, report_path: Path) -> None:
+    if kind == "benchmark" and not isinstance(report.get("results"), list):
+        raise WorldForgeError(f"Benchmark report {report_path} must contain a results list.")
+    if kind == "eval" and not isinstance(report.get("provider_summaries"), list):
+        raise WorldForgeError(f"Evaluation report {report_path} must contain provider_summaries.")
+
+
+def _run_summary(report: PreservedRunReport) -> JSONDict:
+    artifact_paths = report.manifest.get("artifact_paths", {})
+    artifact_refs = []
+    if isinstance(artifact_paths, dict):
+        artifact_refs = [
+            str(report.run_path / str(path))
+            for _, path in sorted(artifact_paths.items())
+            if isinstance(path, str)
+        ]
+    provenance_refs = _provenance_refs(report)
+    return {
+        "run_id": report.run_id,
+        "created_at": str(report.manifest.get("created_at", "")),
+        "status": str(report.manifest.get("status", "")),
+        "command": str(report.manifest.get("command", "")),
+        "provider": str(report.manifest.get("provider", "")),
+        "operation": str(report.manifest.get("operation", "")),
+        "path": str(report.run_path),
+        "report_path": str(report.report_path),
+        "artifact_refs": artifact_refs,
+        "provenance_refs": provenance_refs,
+        "event_count": int(report.manifest.get("event_count", 0) or 0),
+    }
+
+
+def _provenance_refs(report: PreservedRunReport) -> list[str]:
+    refs: list[str] = []
+    run_metadata = report.report.get("run_metadata", {})
+    if isinstance(run_metadata, dict):
+        for key in ("input_file", "budget_file"):
+            value = run_metadata.get(key)
+            if isinstance(value, dict) and isinstance(value.get("path"), str):
+                sha = value.get("sha256")
+                if isinstance(sha, str):
+                    refs.append(f"{key}:{value['path']}#{sha}")
+                else:
+                    refs.append(f"{key}:{value['path']}")
+    input_summary = report.manifest.get("input_summary", {})
+    if isinstance(input_summary, dict):
+        refs.extend(
+            f"{key}:{dump_json(input_summary[key])}"
+            for key in ("suite_id", "providers", "operations")
+            if key in input_summary
+        )
+    return refs
+
+
+def _benchmark_rows(reports: list[PreservedRunReport]) -> list[JSONDict]:
+    baseline: dict[tuple[str, str], float | None] = {}
+    rows: list[JSONDict] = []
+    for report_index, report in enumerate(reports):
+        for result in report.report.get("results", []):
+            if not isinstance(result, dict):
+                continue
+            key = (str(result.get("provider", "")), str(result.get("operation", "")))
+            avg = _optional_float(result.get("average_latency_ms"))
+            if report_index == 0:
+                baseline[key] = avg
+            baseline_avg = baseline.get(key)
+            event_count = _result_event_count(result)
+            row: JSONDict = {
+                "run_id": report.run_id,
+                "provider": key[0],
+                "operation": key[1],
+                "iterations": int(result.get("iterations", 0) or 0),
+                "success_count": int(result.get("success_count", 0) or 0),
+                "error_count": int(result.get("error_count", 0) or 0),
+                "retry_count": int(result.get("retry_count", 0) or 0),
+                "average_latency_ms": avg,
+                "delta_average_latency_ms": (
+                    None if avg is None or baseline_avg is None else avg - baseline_avg
+                ),
+                "p95_latency_ms": _optional_float(result.get("p95_latency_ms")),
+                "throughput_per_second": _optional_float(result.get("throughput_per_second")),
+                "event_count": event_count,
+            }
+            rows.append(row)
+    return rows
+
+
+def _evaluation_rows(reports: list[PreservedRunReport]) -> list[JSONDict]:
+    baseline: dict[str, float | None] = {}
+    rows: list[JSONDict] = []
+    for report_index, report in enumerate(reports):
+        for summary in report.report.get("provider_summaries", []):
+            if not isinstance(summary, dict):
+                continue
+            provider = str(summary.get("provider", ""))
+            avg = _optional_float(summary.get("average_score"))
+            if report_index == 0:
+                baseline[provider] = avg
+            baseline_avg = baseline.get(provider)
+            rows.append(
+                {
+                    "run_id": report.run_id,
+                    "provider": provider,
+                    "average_score": avg,
+                    "delta_average_score": (
+                        None if avg is None or baseline_avg is None else avg - baseline_avg
+                    ),
+                    "scenario_count": int(summary.get("scenario_count", 0) or 0),
+                    "passed_scenario_count": int(summary.get("passed_scenario_count", 0) or 0),
+                    "failed_scenario_count": int(summary.get("failed_scenario_count", 0) or 0),
+                }
+            )
+    return rows
+
+
+def _result_event_count(result: JSONDict) -> int:
+    metrics = result.get("operation_metrics", {})
+    if not isinstance(metrics, dict):
+        return 0
+    events = metrics.get("events", [])
+    if not isinstance(events, list):
+        return 0
+    total = 0
+    for event in events:
+        if isinstance(event, dict):
+            total += int(event.get("request_count", 0) or 0)
+    return total
+
+
+def _optional_float(value: object) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _format_number(value: object) -> str:
+    if value is None:
+        return ""
+    return f"{float(value):.4f}"
+
+
+def _markdown_join(values: object) -> str:
+    if not isinstance(values, list) or not values:
+        return ""
+    return "<br>".join(f"`{value}`" for value in values)

--- a/tests/test_harness_workspace.py
+++ b/tests/test_harness_workspace.py
@@ -14,6 +14,7 @@ from worldforge.harness.workspace import (
     list_run_workspaces,
     validate_run_id,
     workspace_root_for_state_dir,
+    write_run_manifest,
 )
 
 
@@ -208,6 +209,138 @@ def test_runs_cli_markdown_and_dry_run_cleanup(tmp_path, monkeypatch, capsys) ->
     assert len(list_run_workspaces(tmp_path)) == 2
 
 
+def test_runs_compare_exports_benchmark_artifacts(tmp_path, monkeypatch, capsys) -> None:
+    first = _preserved_benchmark_run(
+        tmp_path,
+        run_id="20260101T000000Z-00000001",
+        average_latency_ms=10.0,
+        throughput_per_second=5.0,
+    )
+    second = _preserved_benchmark_run(
+        tmp_path,
+        run_id="20260102T000000Z-00000002",
+        average_latency_ms=15.0,
+        throughput_per_second=4.0,
+    )
+    csv_path = tmp_path / "comparison.csv"
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "worldforge",
+            "runs",
+            "compare",
+            str(first.path),
+            str(second.manifest_path),
+            "--format",
+            "json",
+        ],
+    )
+    assert main() == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["kind"] == "benchmark"
+    assert payload["baseline_run_id"] == "20260101T000000Z-00000001"
+    assert payload["rows"][1]["delta_average_latency_ms"] == 5.0
+    assert "budget_file:/tmp/budget.json#abc123" in payload["runs"][0]["provenance_refs"]
+    assert str(first.path / "reports" / "report.json") in payload["runs"][0]["artifact_refs"]
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "worldforge",
+            "runs",
+            "compare",
+            str(first.path),
+            str(second.path),
+            "--format",
+            "csv",
+            "--output",
+            str(csv_path),
+        ],
+    )
+    assert main() == 0
+    assert "delta_average_latency_ms" in csv_path.read_text(encoding="utf-8")
+    assert capsys.readouterr().out == ""
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "worldforge",
+            "runs",
+            "compare",
+            str(first.path),
+            str(second.path),
+            "--format",
+            "markdown",
+        ],
+    )
+    assert main() == 0
+    markdown = capsys.readouterr().out
+    assert "# WorldForge Run Comparison" in markdown
+    assert "## Benchmark Rows" in markdown
+
+
+def test_runs_compare_exports_eval_summary(tmp_path, monkeypatch, capsys) -> None:
+    first = _preserved_eval_run(
+        tmp_path,
+        run_id="20260101T000000Z-00000001",
+        average_score=0.75,
+    )
+    second = _preserved_eval_run(
+        tmp_path,
+        run_id="20260102T000000Z-00000002",
+        average_score=0.5,
+    )
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "worldforge",
+            "runs",
+            "compare",
+            str(first.path / "reports" / "report.json"),
+            str(second.path),
+            "--format",
+            "json",
+        ],
+    )
+
+    assert main() == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["kind"] == "eval"
+    assert payload["rows"][1]["delta_average_score"] == -0.25
+    assert 'suite_id:"planning"' in payload["runs"][0]["provenance_refs"]
+
+
+def test_runs_compare_refuses_incompatible_report_types(tmp_path, monkeypatch, capsys) -> None:
+    benchmark = _preserved_benchmark_run(
+        tmp_path,
+        run_id="20260101T000000Z-00000001",
+        average_latency_ms=10.0,
+        throughput_per_second=5.0,
+    )
+    evaluation = _preserved_eval_run(
+        tmp_path,
+        run_id="20260102T000000Z-00000002",
+        average_score=0.5,
+    )
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["worldforge", "runs", "compare", str(benchmark.path), str(evaluation.path)],
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        main()
+    assert exc.value.code == 2
+    assert "Cannot compare incompatible report types" in capsys.readouterr().err
+
+
 def test_run_id_validation_rejects_non_sortable_names() -> None:
     with pytest.raises(ValueError, match="run_id must match"):
         validate_run_id("not safe")
@@ -232,3 +365,120 @@ def test_workspace_helpers_reject_escape_and_invalid_cleanup(tmp_path) -> None:
     bad_manifest.parent.mkdir(parents=True)
     bad_manifest.write_text("not-json", encoding="utf-8")
     assert [run["run_id"] for run in list_run_workspaces(tmp_path)] == ["20260101T000000Z-00000001"]
+
+
+def _preserved_benchmark_run(
+    workspace_dir: Path,
+    *,
+    run_id: str,
+    average_latency_ms: float,
+    throughput_per_second: float,
+):
+    workspace = create_run_workspace(
+        workspace_dir,
+        kind="benchmark",
+        command="worldforge benchmark --provider mock --operation predict",
+        provider="mock",
+        operation="predict",
+        run_id=run_id,
+        input_summary={"providers": ["mock"], "operations": ["predict"]},
+    )
+    report = {
+        "claim_boundary": "test",
+        "metric_semantics": "test",
+        "run_metadata": {
+            "budget_file": {
+                "path": "/tmp/budget.json",
+                "sha256": "abc123",
+                "metadata": {"profile": "ci"},
+            }
+        },
+        "results": [
+            {
+                "provider": "mock",
+                "operation": "predict",
+                "iterations": 2,
+                "concurrency": 1,
+                "success_count": 2,
+                "error_count": 0,
+                "retry_count": 1,
+                "total_time_ms": average_latency_ms * 2,
+                "average_latency_ms": average_latency_ms,
+                "min_latency_ms": average_latency_ms,
+                "max_latency_ms": average_latency_ms,
+                "p50_latency_ms": average_latency_ms,
+                "p95_latency_ms": average_latency_ms,
+                "throughput_per_second": throughput_per_second,
+                "operation_metrics": {"events": [{"request_count": 2}]},
+                "errors": [],
+            }
+        ],
+    }
+    workspace.write_json("reports/report.json", report)
+    workspace.write_text("reports/report.md", "# Benchmark Report")
+    workspace.write_text("reports/report.csv", "provider,operation\nmock,predict\n")
+    write_run_manifest(
+        workspace,
+        kind="benchmark",
+        command="worldforge benchmark --provider mock --operation predict",
+        provider="mock",
+        operation="predict",
+        status="completed",
+        input_summary={"providers": ["mock"], "operations": ["predict"]},
+        result_summary={"result_count": 1, "error_count": 0, "retry_count": 1},
+        artifact_paths={
+            "json": "reports/report.json",
+            "markdown": "reports/report.md",
+            "csv": "reports/report.csv",
+        },
+        event_count=2,
+    )
+    return workspace
+
+
+def _preserved_eval_run(workspace_dir: Path, *, run_id: str, average_score: float):
+    workspace = create_run_workspace(
+        workspace_dir,
+        kind="eval",
+        command="worldforge eval --suite planning --provider mock",
+        provider="mock",
+        operation="planning",
+        run_id=run_id,
+        input_summary={"suite_id": "planning", "providers": ["mock"]},
+    )
+    report = {
+        "suite_id": "planning",
+        "suite": "Planning Evaluation",
+        "claim_boundary": "test",
+        "metric_semantics": "test",
+        "provider_summaries": [
+            {
+                "provider": "mock",
+                "average_score": average_score,
+                "scenario_count": 2,
+                "passed_scenario_count": 1,
+                "failed_scenario_count": 1,
+                "pass_rate": 0.5,
+            }
+        ],
+        "results": [],
+    }
+    workspace.write_json("reports/report.json", report)
+    workspace.write_text("reports/report.md", "# Evaluation Report")
+    workspace.write_text("reports/report.csv", "provider,scenario\nmock,plan\n")
+    write_run_manifest(
+        workspace,
+        kind="eval",
+        command="worldforge eval --suite planning --provider mock",
+        provider="mock",
+        operation="planning",
+        status="completed",
+        input_summary={"suite_id": "planning", "providers": ["mock"]},
+        result_summary={"suite_id": "planning", "result_count": 2, "passed_count": 1},
+        artifact_paths={
+            "json": "reports/report.json",
+            "markdown": "reports/report.md",
+            "csv": "reports/report.csv",
+        },
+    )
+    return workspace


### PR DESCRIPTION
Closes #68.

## Summary
- add `worldforge runs compare` for preserved eval and benchmark run workspaces
- export stable Markdown, JSON, and CSV comparison summaries with commands, providers, operations, dates, artifacts, and input/budget provenance
- reject mixed report kinds with a clear error

## Validation
- `uv run ruff check src tests examples scripts`
- `uv run ruff format --check src tests examples scripts`
- `uv run pytest`
- `uv run pytest -m "not live"`
- `uv run --extra harness pytest --cov=src/worldforge --cov-report=term-missing --cov-fail-under=90`
- `uv run mkdocs build --strict`
- `bash scripts/test_package.sh`
- `uv lock --check`
- `uv run python scripts/generate_provider_docs.py --check`
- `UV_LOCKED=true uv export --all-groups --no-emit-project --no-hashes --output-file <tmp>/requirements.txt`
- `uvx --from pip-audit pip-audit -r <tmp>/requirements.txt`
