### PR TITLE
Add batch evaluation host example

### DIFF
--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -106,6 +106,37 @@ with that request id so host logs can correlate HTTP requests with provider call
 use typed JSON payloads and redact obvious secret-shaped values, but production services still own
 credential storage, request authentication, dashboards, alert routing, and provider SLA policy.
 
+## Batch Evaluation Host
+
+| Example | Command | Runtime boundary |
+| --- | --- | --- |
+| `batch-eval-host` | `uv run python examples/hosts/batch-eval/app.py benchmark --provider mock` | Stdlib job reference host; the embedding batch system owns scheduling, durable storage, credentials, and provider-specific runtime setup. |
+
+Run deterministic mock evaluation and benchmark jobs in a clean checkout:
+
+```bash
+uv run python examples/hosts/batch-eval/app.py \
+  --workspace .worldforge/batch-eval \
+  eval --suite planning --provider mock
+
+uv run python examples/hosts/batch-eval/app.py \
+  --workspace .worldforge/batch-eval \
+  benchmark --provider mock --operation generate --iterations 1 \
+  --input-file examples/benchmark-inputs.json \
+  --budget-file examples/benchmark-budget.json
+```
+
+Each job writes a shared run workspace under `.worldforge/batch-eval/runs/<run-id>/` with
+`run_manifest.json`, JSON/Markdown/CSV reports, copied input and budget files for benchmark jobs,
+and a JSON stdout summary that points to the manifest. Benchmark budget violations return exit
+code `1` after preserving the failed run, which lets CI or a scheduler fail the job while still
+keeping issue-safe artifacts.
+
+To swap in a real provider, run the same command on a prepared host that has the provider
+registered, credentials configured, optional runtime dependencies installed, and benchmark inputs
+that match that provider's advertised capability. Keep scheduling, retry policy above the process,
+long-term artifact storage, and credential rotation outside the base package.
+
 ## Optional Runtime Smoke
 
 | Example | Command | Runtime boundary |

--- a/examples/README.md
+++ b/examples/README.md
@@ -60,6 +60,16 @@ reference for embedding WorldForge in a host process, not a WorldForge deploymen
 production services still own authentication, alerting, telemetry export, upstream SLA handling,
 and artifact retention.
 
+## Batch Evaluation Host
+
+| Example | Surface | Command |
+| --- | --- | --- |
+| `batch-eval-host` | eval/benchmark jobs, run manifests, budget exits | `uv run python examples/hosts/batch-eval/app.py benchmark --provider mock` |
+
+The batch host uses only the base WorldForge package and Python stdlib. It writes
+`.worldforge/batch-eval/runs/<run-id>/run_manifest.json`, report exports, and copied benchmark
+input or budget files. A benchmark budget violation exits `1` after preserving the failed run.
+
 ## Optional Runtime Smoke
 
 | Example | Surface | Command |

--- a/examples/hosts/batch-eval/app.py
+++ b/examples/hosts/batch-eval/app.py
@@ -1,0 +1,332 @@
+"""Stdlib batch evaluation host for WorldForge eval and benchmark jobs."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+from hashlib import sha256
+from pathlib import Path
+from typing import Any
+
+from worldforge import WorldForge, WorldForgeError
+from worldforge.benchmark import (
+    ProviderBenchmarkHarness,
+    load_benchmark_budgets,
+    load_benchmark_inputs,
+)
+from worldforge.evaluation import EvaluationSuite
+from worldforge.harness.flows import (
+    preserve_benchmark_run_workspace,
+    preserve_eval_run_workspace,
+)
+
+JSON = dict[str, Any]
+DEFAULT_WORKSPACE = Path(".worldforge/batch-eval")
+DEFAULT_STATE_DIR = Path(".worldforge/batch-eval/worlds")
+
+
+def run_eval_job(
+    *,
+    suite: str,
+    providers: list[str],
+    workspace_dir: Path,
+    state_dir: Path,
+) -> JSON:
+    """Run a deterministic evaluation job and preserve its artifacts."""
+
+    forge = WorldForge(state_dir=state_dir)
+    report = EvaluationSuite.from_builtin(suite).run_report(providers, forge=forge)
+    command = _command_string(
+        [
+            "eval",
+            "--suite",
+            suite,
+            *_repeat_args("--provider", providers),
+            "--workspace",
+            str(workspace_dir),
+        ]
+    )
+    workspace = preserve_eval_run_workspace(
+        workspace_dir,
+        suite_id=suite,
+        providers=providers,
+        artifacts=report.artifacts(),
+        report=report,
+        command=command,
+    )
+    manifest = _manifest_payload(workspace.manifest_path)
+    return {
+        "kind": "eval",
+        "status": "passed",
+        "exit_code": 0,
+        "run_id": workspace.run_id,
+        "run_workspace": str(workspace.path),
+        "run_manifest": str(workspace.manifest_path),
+        "report_paths": manifest["artifact_paths"],
+        "summary": manifest["result_summary"],
+    }
+
+
+def run_benchmark_job(
+    *,
+    providers: list[str],
+    operations: list[str] | None,
+    iterations: int,
+    concurrency: int,
+    workspace_dir: Path,
+    state_dir: Path,
+    input_file: Path | None = None,
+    budget_file: Path | None = None,
+) -> JSON:
+    """Run a benchmark job, preserve artifacts, and return a budget-aware summary."""
+
+    forge = WorldForge(state_dir=state_dir)
+    inputs = None
+    input_metadata = None
+    if input_file is not None:
+        input_metadata, input_payload = _load_json_file(input_file, label="benchmark input file")
+        inputs = load_benchmark_inputs(input_payload, base_path=input_file.expanduser().parent)
+
+    report = ProviderBenchmarkHarness(forge=forge).run(
+        providers,
+        operations=operations,
+        iterations=iterations,
+        concurrency=concurrency,
+        inputs=inputs,
+    )
+    if input_metadata is not None:
+        report.run_metadata["input_file"] = input_metadata
+
+    gate_report = None
+    budget_metadata = None
+    if budget_file is not None:
+        budget_metadata, budget_payload = _load_json_file(
+            budget_file,
+            label="benchmark budget file",
+        )
+        report.run_metadata["budget_file"] = budget_metadata
+        gate_report = report.evaluate_budgets(load_benchmark_budgets(budget_payload))
+
+    command = _command_string(
+        [
+            "benchmark",
+            *_repeat_args("--provider", providers),
+            *_repeat_args("--operation", operations or []),
+            "--iterations",
+            str(iterations),
+            "--concurrency",
+            str(concurrency),
+            "--workspace",
+            str(workspace_dir),
+        ]
+    )
+    workspace = preserve_benchmark_run_workspace(
+        workspace_dir,
+        providers=providers,
+        operations=operations,
+        artifacts=report.artifacts(),
+        report=report,
+        command=command,
+        budget_passed=None if gate_report is None else gate_report.passed,
+    )
+    attached_inputs = _copy_input_artifacts(
+        workspace.path,
+        input_file=input_file,
+        budget_file=budget_file,
+    )
+    if attached_inputs:
+        _patch_manifest_artifacts(workspace.manifest_path, attached_inputs)
+    manifest = _manifest_payload(workspace.manifest_path)
+    budget_passed = None if gate_report is None else gate_report.passed
+    status = "passed" if budget_passed is not False else "failed"
+    return {
+        "kind": "benchmark",
+        "status": status,
+        "exit_code": 0 if status == "passed" else 1,
+        "run_id": workspace.run_id,
+        "run_workspace": str(workspace.path),
+        "run_manifest": str(workspace.manifest_path),
+        "report_paths": manifest["artifact_paths"],
+        "summary": manifest["result_summary"],
+        "budget": None if gate_report is None else gate_report.to_dict(),
+        "input_file": input_metadata,
+        "budget_file": budget_metadata,
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the batch host CLI parser."""
+
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run WorldForge evaluation and benchmark jobs with preserved run-workspace artifacts."
+        )
+    )
+    parser.add_argument(
+        "--workspace",
+        type=Path,
+        default=DEFAULT_WORKSPACE,
+        help="Workspace root that will receive runs/<run-id>/ artifacts.",
+    )
+    parser.add_argument(
+        "--state-dir",
+        type=Path,
+        default=DEFAULT_STATE_DIR,
+        help="WorldForge state directory for temporary job worlds.",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    eval_parser = subparsers.add_parser("eval", help="Run a built-in evaluation suite.")
+    eval_parser.add_argument(
+        "--suite",
+        choices=EvaluationSuite.builtin_names(),
+        default="planning",
+        help="Built-in evaluation suite.",
+    )
+    eval_parser.add_argument(
+        "--provider",
+        dest="providers",
+        action="append",
+        default=None,
+        help="Provider name. Can be repeated.",
+    )
+
+    benchmark_parser = subparsers.add_parser("benchmark", help="Run provider benchmarks.")
+    benchmark_parser.add_argument(
+        "--provider",
+        dest="providers",
+        action="append",
+        default=None,
+        help="Provider name. Can be repeated.",
+    )
+    benchmark_parser.add_argument(
+        "--operation",
+        dest="operations",
+        action="append",
+        default=None,
+        choices=ProviderBenchmarkHarness.benchmarkable_operations,
+        help="Operation to benchmark. Can be repeated.",
+    )
+    benchmark_parser.add_argument("--iterations", type=int, default=2)
+    benchmark_parser.add_argument("--concurrency", type=int, default=1)
+    benchmark_parser.add_argument(
+        "--input-file",
+        type=Path,
+        help="Optional deterministic benchmark input JSON file.",
+    )
+    benchmark_parser.add_argument(
+        "--budget-file",
+        type=Path,
+        help="Optional benchmark budget JSON file. Failing gates exit non-zero.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the batch evaluation host CLI."""
+
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        if args.command == "eval":
+            result = run_eval_job(
+                suite=args.suite,
+                providers=args.providers or ["mock"],
+                workspace_dir=args.workspace,
+                state_dir=args.state_dir,
+            )
+        else:
+            result = run_benchmark_job(
+                providers=args.providers or ["mock"],
+                operations=args.operations,
+                iterations=args.iterations,
+                concurrency=args.concurrency,
+                workspace_dir=args.workspace,
+                state_dir=args.state_dir,
+                input_file=args.input_file,
+                budget_file=args.budget_file,
+            )
+    except WorldForgeError as exc:
+        print(json.dumps({"error": {"type": "validation_error", "message": str(exc)}}))
+        return 2
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return int(result["exit_code"])
+
+
+def _repeat_args(flag: str, values: list[str]) -> list[str]:
+    args: list[str] = []
+    for value in values:
+        args.extend([flag, value])
+    return args
+
+
+def _command_string(args: list[str]) -> str:
+    return "python examples/hosts/batch-eval/app.py " + " ".join(args)
+
+
+def _load_json_file(path: Path, *, label: str) -> tuple[JSON, object]:
+    resolved = path.expanduser()
+    try:
+        text = resolved.read_text(encoding="utf-8")
+        payload = json.loads(text)
+    except OSError as exc:
+        raise WorldForgeError(f"Failed to read {label} {path}: {exc}") from exc
+    except json.JSONDecodeError as exc:
+        raise WorldForgeError(f"{label} must contain valid JSON: {exc}") from exc
+    metadata = (
+        payload.get("metadata")
+        if isinstance(payload, dict) and isinstance(payload.get("metadata"), dict)
+        else {}
+    )
+    return (
+        {
+            "path": str(resolved.resolve()),
+            "sha256": sha256(text.encode("utf-8")).hexdigest(),
+            "metadata": metadata,
+        },
+        payload,
+    )
+
+
+def _copy_input_artifacts(
+    run_workspace: Path,
+    *,
+    input_file: Path | None,
+    budget_file: Path | None,
+) -> dict[str, str]:
+    copied: dict[str, str] = {}
+    inputs_dir = run_workspace / "inputs"
+    if input_file is not None:
+        target = inputs_dir / "benchmark-inputs.json"
+        shutil.copy2(input_file.expanduser(), target)
+        copied["input_file"] = "inputs/benchmark-inputs.json"
+    if budget_file is not None:
+        target = inputs_dir / "benchmark-budget.json"
+        shutil.copy2(budget_file.expanduser(), target)
+        copied["budget_file"] = "inputs/benchmark-budget.json"
+    return copied
+
+
+def _patch_manifest_artifacts(manifest_path: Path, artifact_paths: dict[str, str]) -> None:
+    manifest = _manifest_payload(manifest_path)
+    paths = manifest.get("artifact_paths")
+    if not isinstance(paths, dict):
+        paths = {}
+    paths.update(artifact_paths)
+    manifest["artifact_paths"] = paths
+    manifest_path.write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _manifest_payload(manifest_path: Path) -> JSON:
+    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise WorldForgeError(f"run manifest at {manifest_path} must contain a JSON object.")
+    return payload
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/worldforge/cli.py
+++ b/src/worldforge/cli.py
@@ -112,6 +112,17 @@ EXAMPLE_COMMANDS: tuple[dict[str, str], ...] = (
         ),
     },
     {
+        "task": "Batch evaluation host",
+        "name": "batch-eval-host",
+        "surface": "evaluation, benchmarking, run workspaces, budget gates",
+        "requires": "base WorldForge package; checkout examples directory",
+        "command": "uv run python examples/hosts/batch-eval/app.py benchmark --provider mock",
+        "description": (
+            "Run mock provider eval or benchmark jobs as a production-shaped batch process with "
+            "preserved run manifests, report exports, and non-zero budget-gate failures."
+        ),
+    },
+    {
         "task": "Optional runtime smoke",
         "name": "leworldmodel-real-checkpoint-smoke",
         "surface": "optional runtime smoke",

--- a/tests/test_batch_eval_host.py
+++ b/tests/test_batch_eval_host.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+BATCH_APP = ROOT / "examples" / "hosts" / "batch-eval" / "app.py"
+
+
+def _load_batch_app():
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("worldforge_batch_eval_host_example", BATCH_APP)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_batch_eval_host_runs_mock_eval_job(tmp_path) -> None:
+    app = _load_batch_app()
+    result = app.run_eval_job(
+        suite="planning",
+        providers=["mock"],
+        workspace_dir=tmp_path / "workspace",
+        state_dir=tmp_path / "worlds",
+    )
+
+    assert result["status"] == "passed"
+    assert result["exit_code"] == 0
+    run_workspace = Path(result["run_workspace"])
+    manifest = json.loads(Path(result["run_manifest"]).read_text(encoding="utf-8"))
+
+    assert manifest["kind"] == "eval"
+    assert manifest["operation"] == "planning"
+    assert manifest["status"] == "completed"
+    assert manifest["artifact_paths"]["json"] == "reports/report.json"
+    assert (run_workspace / "reports" / "report.json").exists()
+    assert (run_workspace / "reports" / "report.md").exists()
+    assert (run_workspace / "reports" / "report.csv").exists()
+
+
+def test_batch_eval_host_runs_mock_benchmark_with_inputs_and_budget(tmp_path) -> None:
+    app = _load_batch_app()
+    result = app.run_benchmark_job(
+        providers=["mock"],
+        operations=["generate"],
+        iterations=1,
+        concurrency=1,
+        workspace_dir=tmp_path / "workspace",
+        state_dir=tmp_path / "worlds",
+        input_file=ROOT / "examples" / "benchmark-inputs.json",
+        budget_file=ROOT / "examples" / "benchmark-budget.json",
+    )
+
+    assert result["status"] == "passed"
+    assert result["exit_code"] == 0
+    assert result["budget"]["passed"] is True
+    run_workspace = Path(result["run_workspace"])
+    manifest = json.loads(Path(result["run_manifest"]).read_text(encoding="utf-8"))
+
+    assert manifest["kind"] == "benchmark"
+    assert manifest["status"] == "completed"
+    assert manifest["artifact_paths"]["input_file"] == "inputs/benchmark-inputs.json"
+    assert manifest["artifact_paths"]["budget_file"] == "inputs/benchmark-budget.json"
+    assert (run_workspace / "inputs" / "benchmark-inputs.json").exists()
+    assert (run_workspace / "inputs" / "benchmark-budget.json").exists()
+    assert (run_workspace / "reports" / "report.json").exists()
+    assert "sha256" in result["input_file"]
+    assert "sha256" in result["budget_file"]
+
+
+def test_batch_eval_host_exits_nonzero_on_budget_violation(tmp_path, capsys) -> None:
+    app = _load_batch_app()
+    budget_file = tmp_path / "budget.json"
+    budget_file.write_text(
+        json.dumps(
+            {
+                "budgets": [
+                    {
+                        "provider": "mock",
+                        "operation": "predict",
+                        "max_average_latency_ms": 0.0,
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    exit_code = app.main(
+        [
+            "--workspace",
+            str(tmp_path / "workspace"),
+            "--state-dir",
+            str(tmp_path / "worlds"),
+            "benchmark",
+            "--provider",
+            "mock",
+            "--operation",
+            "predict",
+            "--iterations",
+            "1",
+            "--budget-file",
+            str(budget_file),
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 1
+    assert payload["status"] == "failed"
+    assert payload["budget"]["passed"] is False
+    manifest = json.loads(Path(payload["run_manifest"]).read_text(encoding="utf-8"))
+    assert manifest["status"] == "failed"
+    assert manifest["result_summary"]["budget_passed"] is False

--- a/tests/test_examples_index.py
+++ b/tests/test_examples_index.py
@@ -17,6 +17,7 @@ def test_example_index_metadata_is_task_grouped() -> None:
         "Score planning",
         "Policy plus score planning",
         "Visual harness",
+        "Batch evaluation host",
         "Optional runtime smoke",
         "Real robotics showcase",
     ]


### PR DESCRIPTION
Closes #70.

## Summary
- add a stdlib-only batch eval host under `examples/hosts/batch-eval/`
- preserve eval and benchmark runs under `.worldforge/batch-eval/runs/<run-id>/`
- copy benchmark input/budget files into the run workspace and exit non-zero on failed budget gates
- document mock commands and the prepared-host boundary for real providers

## Validation
- `uv run pytest tests/test_batch_eval_host.py`
- `bash scripts/test_package.sh`
- `uv run mkdocs build --strict`
- `uv run ruff check src tests examples scripts`
- `uv run ruff format --check src tests examples scripts`
- `uv run pytest`
- `uv run --extra harness pytest --cov=src/worldforge --cov-report=term-missing --cov-fail-under=90`
- `uv lock --check`
- `uv run python scripts/generate_provider_docs.py --check`
- `UV_LOCKED=true uv export --all-groups --no-emit-project --no-hashes --output-file <tmp> && uvx --from pip-audit pip-audit -r <tmp>`
