### PR TITLE
Add provider development workbench

### DIFF
--- a/docs/src/provider-authoring-guide.md
+++ b/docs/src/provider-authoring-guide.md
@@ -41,6 +41,22 @@ advertises no public capabilities, and raises `ProviderError` from generated met
 capabilities only after the adapter calls the real upstream runtime, validates inputs and outputs,
 and has fixture-driven tests for every documented failure mode.
 
+## Workbench Loop
+
+Before opening a provider PR, run the non-TUI workbench from a clean checkout:
+
+```bash
+uv run worldforge provider workbench mock
+uv run worldforge provider workbench <provider> --format json
+uv run python scripts/generate_provider_docs.py --check
+```
+
+The report lists the conformance helper required for every advertised capability, validates
+`tests/fixtures/providers/<provider>_*.json` playback files when they exist, links this guide, and
+prints a pasteable issue summary. It invokes only deterministic local providers by default. Use
+`--live` only on a prepared host when credentials, optional dependencies, injected runtimes, and
+runtime-owned artifacts are intentionally available.
+
 ## Adapter Decision Tree
 
 Start with the provider's real contract, not its label or category.

--- a/docs/src/providers/runway.md
+++ b/docs/src/providers/runway.md
@@ -2,6 +2,8 @@
 
 Capabilities: `generate`, `transfer`
 
+Maturity: `beta`
+
 Taxonomy category: remote video generation and transformation adapter
 
 `runway` is an HTTP adapter for Runway's image-to-video, text-to-video-compatible, video-to-video,

--- a/docs/src/theworldharness.md
+++ b/docs/src/theworldharness.md
@@ -40,6 +40,8 @@ Without the `harness` extra, metadata commands still work:
 ```bash
 uv run worldforge harness --list
 uv run worldforge harness --list --format json
+uv run worldforge provider workbench mock
+uv run worldforge provider workbench runway --format json
 ```
 
 Launching the TUI without Textual exits with an install hint instead of importing optional
@@ -73,9 +75,32 @@ The diagnostics, eval, and benchmark screens map directly to non-TUI commands:
 ```bash
 uv run worldforge doctor --registered-only
 uv run worldforge provider list
+uv run worldforge provider workbench mock
 uv run worldforge benchmark --provider mock --iterations 2 --format json
 uv run worldforge eval --suite planning --provider mock --format json
 ```
+
+## Provider Workbench
+
+`worldforge provider workbench <provider>` is the checkout-safe adapter author loop behind the
+harness provider development workflow. It does not import Textual and does not make live provider
+calls unless `--live` is passed explicitly. The default report is designed to paste into GitHub
+issues: provider profile, required capability conformance helpers, fixture JSON status, docs/catalog
+drift hints, redaction-safe provider event status, and exact follow-up commands.
+
+```bash
+uv run worldforge provider workbench mock
+uv run worldforge provider workbench runway --format json
+uv run worldforge provider workbench runway --live
+```
+
+For deterministic local providers such as `mock`, the workbench invokes the advertised capability
+helpers. For HTTP adapters it validates matching `tests/fixtures/providers/<provider>_*.json`
+playback files and lists the capability helpers that the provider test module must cover. For
+host-owned local runtimes such as LeRobot and LeWorldModel, the default path inspects profile,
+health, docs, and fixtures while leaving injected-runtime/live smoke execution to prepared hosts.
+Run `uv run python scripts/generate_provider_docs.py --check` before opening a provider PR so
+profile metadata and generated catalog tables stay in sync.
 
 Completed checkout-safe flows also preserve a sanitized run workspace:
 

--- a/src/worldforge/cli.py
+++ b/src/worldforge/cli.py
@@ -48,6 +48,7 @@ CLI_EPILOG = """Common commands:
   worldforge provider list
   worldforge provider docs
   worldforge provider info mock
+  worldforge provider workbench mock
   worldforge harness --list
   worldforge predict kitchen --provider mock --x 0.3 --y 0.8 --z 0.0 --steps 2
   worldforge eval --suite planning --provider mock --format json
@@ -515,6 +516,29 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Output format for provider docs metadata.",
     )
 
+    provider_workbench = provider_subparsers.add_parser(
+        "workbench",
+        help="Run provider authoring checks without launching the TUI.",
+    )
+    provider_workbench.add_argument("name", help="Provider name.")
+    provider_workbench.add_argument(
+        "--format",
+        choices=("markdown", "json"),
+        default="markdown",
+        help="Output format for the workbench report.",
+    )
+    provider_workbench.add_argument(
+        "--live",
+        action="store_true",
+        help="Allow live provider calls on a prepared host.",
+    )
+    provider_workbench.add_argument(
+        "--fixtures-dir",
+        type=Path,
+        default=Path("tests/fixtures/providers"),
+        help="Directory containing provider fixture JSON files.",
+    )
+
     world = subparsers.add_parser("world", help="Manage persisted local JSON worlds.")
     world_subparsers = world.add_subparsers(
         dest="world_command",
@@ -975,6 +999,24 @@ def _cmd_provider_docs(args: argparse.Namespace, parser: argparse.ArgumentParser
     else:
         _print_provider_docs_markdown(entries)
     return 0
+
+
+def _cmd_provider_workbench(args: argparse.Namespace) -> int:
+    from worldforge.harness.workbench import (
+        provider_workbench_markdown,
+        provider_workbench_report,
+    )
+
+    report = provider_workbench_report(
+        args.name,
+        live=args.live,
+        fixtures_dir=args.fixtures_dir,
+    )
+    if args.format == "json":
+        _print_json(report)
+    else:
+        print(provider_workbench_markdown(report))
+    return 0 if report["status"] == "passed" else 1
 
 
 def _cmd_harness(args: argparse.Namespace) -> int:
@@ -1569,6 +1611,12 @@ def main() -> int:
 
     if args.command == "provider" and args.provider_command == "docs":
         return _cmd_provider_docs(args, parser)
+
+    if args.command == "provider" and args.provider_command == "workbench":
+        try:
+            return _cmd_provider_workbench(args)
+        except (ProviderError, WorldForgeError, ValueError) as exc:
+            parser.exit(2, f"{exc}\n")
 
     if args.command == "harness":
         return _cmd_harness(args)

--- a/src/worldforge/harness/workbench.py
+++ b/src/worldforge/harness/workbench.py
@@ -1,0 +1,294 @@
+"""Provider development workbench checks."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from pathlib import Path
+from time import perf_counter
+
+from worldforge.models import JSONDict, ProviderEvent, WorldForgeError
+from worldforge.providers import BaseProvider, ProviderError
+from worldforge.providers.catalog import DOC_CAPABILITY_ORDER, PROVIDER_CATALOG
+from worldforge.testing import (
+    assert_embed_conformance,
+    assert_generate_conformance,
+    assert_predict_conformance,
+    assert_provider_events_conform,
+    assert_reason_conformance,
+    assert_transfer_conformance,
+)
+
+AUTHORING_DOC = "docs/src/provider-authoring-guide.md"
+CATALOG_CHECK_COMMAND = "uv run python scripts/generate_provider_docs.py --check"
+FIXTURE_DOC = "tests/fixtures/providers/<provider>_*.json"
+
+_CONFORMANCE_HELPERS: dict[str, str] = {
+    "predict": "assert_predict_conformance",
+    "generate": "assert_generate_conformance",
+    "transfer": "assert_transfer_conformance",
+    "reason": "assert_reason_conformance",
+    "embed": "assert_embed_conformance",
+    "score": "assert_score_conformance",
+    "policy": "assert_policy_conformance",
+}
+
+
+def provider_workbench_report(
+    provider_name: str,
+    *,
+    live: bool = False,
+    fixtures_dir: Path | None = None,
+    docs_root: Path | None = None,
+) -> JSONDict:
+    """Return an issue-ready provider workbench report.
+
+    Default execution is checkout-safe: only deterministic local providers are
+    invoked. Optional runtimes and credentialed providers are inspected but not
+    called unless ``live=True`` is explicit.
+    """
+
+    events: list[ProviderEvent] = []
+    provider = _create_catalog_provider(provider_name, events.append)
+    profile = provider.profile()
+    docs_base = docs_root or Path.cwd()
+    started = perf_counter()
+
+    required_tests = _required_tests(provider)
+    health_report = _health_report(provider)
+    invocation = _run_safe_conformance(provider, live=live)
+    fixture_report = _fixture_report(provider.name, fixtures_dir=fixtures_dir)
+    docs_report = _docs_report(provider, docs_root=docs_base)
+    event_report = _event_report(events, provider=provider.name)
+
+    checks = [
+        _status_check(
+            "profile",
+            "passed",
+            f"{provider.name} advertises {', '.join(required_tests) or 'no'} capability tests.",
+        ),
+        health_report,
+        invocation,
+        fixture_report,
+        docs_report,
+        event_report,
+    ]
+    status = (
+        "passed" if all(check["status"] in {"passed", "skipped"} for check in checks) else "failed"
+    )
+    return {
+        "provider": provider.name,
+        "status": status,
+        "live": live,
+        "duration_ms": round((perf_counter() - started) * 1000, 3),
+        "profile": profile.to_dict(),
+        "required_tests": required_tests,
+        "checks": checks,
+        "docs": {
+            "authoring_guide": AUTHORING_DOC,
+            "catalog_check": CATALOG_CHECK_COMMAND,
+            "fixture_pattern": FIXTURE_DOC,
+        },
+        "issue_summary": _issue_summary(provider.name, checks),
+    }
+
+
+def provider_workbench_markdown(report: JSONDict) -> str:
+    """Render a provider workbench report as pasteable Markdown."""
+
+    lines = [
+        f"# Provider Workbench: `{report['provider']}`",
+        "",
+        f"- status: `{report['status']}`",
+        f"- live calls: `{str(report['live']).lower()}`",
+        f"- duration_ms: `{report['duration_ms']}`",
+        "",
+        "## Required Capability Tests",
+        "",
+    ]
+    required_tests = report["required_tests"]
+    if isinstance(required_tests, list) and required_tests:
+        lines.extend(f"- `{test}`" for test in required_tests)
+    else:
+        lines.append("- none advertised")
+    lines.extend(["", "## Checks", ""])
+    lines.extend(
+        f"- `{check['status']}` `{check['name']}`: {check['detail']}" for check in report["checks"]
+    )
+    docs = report["docs"]
+    lines.extend(
+        [
+            "",
+            "## Author Links",
+            "",
+            f"- authoring guide: `{docs['authoring_guide']}`",
+            f"- generated catalog check: `{docs['catalog_check']}`",
+            f"- fixture pattern: `{docs['fixture_pattern']}`",
+            "",
+            "## Issue Summary",
+            "",
+            str(report["issue_summary"]),
+        ]
+    )
+    return "\n".join(lines)
+
+
+def _create_catalog_provider(
+    provider_name: str,
+    event_handler: Callable[[ProviderEvent], None],
+) -> BaseProvider:
+    for entry in PROVIDER_CATALOG:
+        if entry.name == provider_name:
+            return entry.create(event_handler=event_handler)
+    valid = ", ".join(entry.name for entry in PROVIDER_CATALOG)
+    raise ProviderError(f"Provider '{provider_name}' is unknown. Valid providers: {valid}.")
+
+
+def _required_tests(provider: BaseProvider) -> list[str]:
+    profile = provider.profile()
+    return [
+        _CONFORMANCE_HELPERS[capability]
+        for capability in DOC_CAPABILITY_ORDER
+        if profile.capabilities.supports(capability) and capability in _CONFORMANCE_HELPERS
+    ]
+
+
+def _run_safe_conformance(provider: BaseProvider, *, live: bool) -> JSONDict:
+    profile = provider.profile()
+    can_invoke = live or (profile.is_local and profile.deterministic and provider.configured())
+    if not can_invoke:
+        return _status_check(
+            "conformance",
+            "skipped",
+            "live provider calls were not selected; rerun with --live on a prepared host.",
+        )
+
+    generated = None
+    exercised: list[str] = []
+    try:
+        if profile.capabilities.predict:
+            assert_predict_conformance(provider)
+            exercised.append("predict")
+        if profile.capabilities.reason:
+            assert_reason_conformance(provider)
+            exercised.append("reason")
+        if profile.capabilities.embed:
+            assert_embed_conformance(provider)
+            exercised.append("embed")
+        if profile.capabilities.generate:
+            generated = assert_generate_conformance(provider)
+            exercised.append("generate")
+        if profile.capabilities.transfer:
+            assert_transfer_conformance(provider, clip=generated)
+            exercised.append("transfer")
+    except (AssertionError, ProviderError, WorldForgeError) as exc:
+        return _status_check("conformance", "failed", str(exc))
+
+    return _status_check(
+        "conformance",
+        "passed",
+        f"exercised {', '.join(exercised) if exercised else 'metadata-only'} safely.",
+    )
+
+
+def _health_report(provider: BaseProvider) -> JSONDict:
+    health = provider.health()
+    configured = provider.configured()
+    if health.healthy and not configured:
+        return _status_check(
+            "health",
+            "failed",
+            "provider reports healthy while configured() is false.",
+        )
+    state = "healthy" if health.healthy else "unhealthy"
+    config = "configured" if configured else "unconfigured"
+    return {
+        **_status_check("health", "passed", f"{state}; {config}; {health.details}"),
+        "health": health.to_dict(),
+        "configured": configured,
+    }
+
+
+def _fixture_report(provider: str, *, fixtures_dir: Path | None) -> JSONDict:
+    resolved_dir = fixtures_dir or Path("tests/fixtures/providers")
+    if not resolved_dir.exists():
+        return _status_check("fixtures", "skipped", f"{resolved_dir} does not exist.")
+
+    fixture_paths = sorted(resolved_dir.glob(f"{provider}_*.json"))
+    if not fixture_paths:
+        return _status_check(
+            "fixtures",
+            "skipped",
+            f"no fixture playback files matched {resolved_dir}/{provider}_*.json.",
+        )
+
+    try:
+        for path in fixture_paths:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+            if not isinstance(payload, dict):
+                raise WorldForgeError(f"{path} must contain a JSON object.")
+    except (OSError, json.JSONDecodeError, WorldForgeError) as exc:
+        return _status_check("fixtures", "failed", str(exc))
+
+    return {
+        **_status_check(
+            "fixtures",
+            "passed",
+            f"validated {len(fixture_paths)} provider fixture JSON file(s).",
+        ),
+        "paths": [str(path) for path in fixture_paths],
+    }
+
+
+def _docs_report(provider: BaseProvider, *, docs_root: Path) -> JSONDict:
+    profile = provider.profile()
+    docs_paths = [
+        docs_root / f"docs/src/providers/{provider.name}.md",
+        docs_root / "docs/src/providers/README.md",
+    ]
+    docs_path = next((path for path in docs_paths if path.exists()), None)
+    if docs_path is None:
+        return _status_check(
+            "docs",
+            "failed",
+            "provider docs page is missing; update docs/src/providers/ and generated catalog.",
+        )
+
+    text = docs_path.read_text(encoding="utf-8").lower()
+    missing_terms = [
+        term
+        for term in (profile.implementation_status, *profile.supported_tasks)
+        if term and term.lower() not in text
+    ]
+    if missing_terms:
+        return _status_check(
+            "docs",
+            "failed",
+            f"{docs_path} does not mention profile metadata: {', '.join(missing_terms)}.",
+        )
+
+    return _status_check(
+        "docs",
+        "passed",
+        f"{docs_path} covers profile metadata; run `{CATALOG_CHECK_COMMAND}` before PR.",
+    )
+
+
+def _event_report(events: list[ProviderEvent], *, provider: str) -> JSONDict:
+    try:
+        assert_provider_events_conform(events, provider=provider)
+    except AssertionError as exc:
+        return _status_check("events", "failed", str(exc))
+    return _status_check("events", "passed", f"{len(events)} provider event(s) are issue-safe.")
+
+
+def _status_check(name: str, status: str, detail: str) -> JSONDict:
+    return {"name": name, "status": status, "detail": detail}
+
+
+def _issue_summary(provider: str, checks: list[JSONDict]) -> str:
+    failures = [check for check in checks if check["status"] == "failed"]
+    if not failures:
+        return f"`{provider}` workbench passed with no failing checks."
+    rendered = "; ".join(f"{check['name']}: {check['detail']}" for check in failures)
+    return f"`{provider}` workbench failures: {rendered}"

--- a/tests/test_provider_workbench.py
+++ b/tests/test_provider_workbench.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import json
+import sys
+
+from worldforge.cli import main as worldforge_main
+from worldforge.harness.workbench import provider_workbench_markdown, provider_workbench_report
+
+
+def test_provider_workbench_runs_mock_in_clean_checkout() -> None:
+    report = provider_workbench_report("mock")
+
+    assert report["status"] == "passed"
+    assert report["live"] is False
+    assert report["required_tests"] == [
+        "assert_predict_conformance",
+        "assert_generate_conformance",
+        "assert_transfer_conformance",
+        "assert_reason_conformance",
+        "assert_embed_conformance",
+    ]
+    checks = {check["name"]: check for check in report["checks"]}
+    assert checks["health"]["status"] == "passed"
+    assert checks["health"]["configured"] is True
+    assert checks["conformance"]["status"] == "passed"
+    assert "exercised predict" in checks["conformance"]["detail"]
+    assert checks["events"]["status"] == "passed"
+    assert report["docs"]["authoring_guide"] == "docs/src/provider-authoring-guide.md"
+    assert (
+        report["docs"]["catalog_check"] == "uv run python scripts/generate_provider_docs.py --check"
+    )
+
+
+def test_provider_workbench_skips_live_runway_but_validates_fixtures() -> None:
+    report = provider_workbench_report("runway")
+
+    assert report["status"] == "passed"
+    assert report["required_tests"] == [
+        "assert_generate_conformance",
+        "assert_transfer_conformance",
+    ]
+    checks = {check["name"]: check for check in report["checks"]}
+    assert checks["health"]["status"] == "passed"
+    assert checks["health"]["configured"] is False
+    assert checks["conformance"]["status"] == "skipped"
+    assert "--live" in checks["conformance"]["detail"]
+    assert checks["fixtures"]["status"] == "passed"
+    assert checks["fixtures"]["paths"]
+
+
+def test_provider_workbench_markdown_is_issue_ready() -> None:
+    markdown = provider_workbench_markdown(provider_workbench_report("mock"))
+
+    assert markdown.startswith("# Provider Workbench: `mock`")
+    assert "`passed` `conformance`" in markdown
+    assert "generated catalog check" in markdown
+    assert "Issue Summary" in markdown
+
+
+def test_provider_workbench_cli_outputs_json(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["worldforge", "provider", "workbench", "mock", "--format", "json"],
+    )
+
+    assert worldforge_main() == 0
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload["provider"] == "mock"
+    assert payload["status"] == "passed"


### PR DESCRIPTION
Closes #69

## Summary
- add `worldforge provider workbench <provider>` for checkout-safe provider authoring checks
- report required capability conformance helpers, health/config status, fixture JSON validation, docs/catalog drift hints, and redaction-safe events
- document the workbench loop and mark Runway maturity on its provider page

## Validation
- `uv run pytest tests/test_provider_workbench.py -q`
- `uv run pytest tests/test_provider_contracts.py tests/test_harness_flows.py tests/test_harness_cli.py -q`
- `uv run --extra harness pytest tests/test_harness_tui.py -q`
- `uv run ruff check src tests examples scripts`
- `uv run ruff format --check src tests examples scripts`
- `uv run python scripts/generate_provider_docs.py --check`
- `uv run mkdocs build --strict`
- `uv run pytest`
- `bash scripts/test_package.sh`
- `uv lock --check`
- `uv run --extra harness pytest --cov=src/worldforge --cov-report=term-missing --cov-fail-under=90`
- `UV_LOCKED=true uv export --all-groups --no-emit-project --no-hashes --output-file <tmp>` + `uvx --from pip-audit pip-audit -r <tmp>`