### PR TITLE
docs: define persistence adapter boundary

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -10,6 +10,8 @@
 - [Rerun Integration](./rerun.md)
 - [World Model Taxonomy](./world-model-taxonomy.md)
 - [Architecture](./architecture.md)
+- Decisions
+  - [Persistence Adapter Boundary](./adr/0001-persistence-adapter-boundary.md)
 - [User And Operator Playbooks](./playbooks.md)
 - [Providers](./providers/README.md)
   - [Cosmos](./providers/cosmos.md)

--- a/docs/src/adr/0001-persistence-adapter-boundary.md
+++ b/docs/src/adr/0001-persistence-adapter-boundary.md
@@ -1,0 +1,113 @@
+# ADR 0001: Persistence Adapter Boundary
+
+Status: Accepted
+
+Date: 2026-04-30
+
+## Context
+
+WorldForge persists worlds today as validated local JSON files. That store is intentionally
+single-writer and is useful for tests, examples, local harness workflows, and checkout-safe issue
+evidence. Host applications that run services, batch workers, or robot labs can need multi-writer
+durability, locking, backup/restore, retention policy, and schema migrations.
+
+Adding a database directly to core would blur the line between WorldForge's framework contract and
+host-owned deployment responsibilities. A durable store also needs operational decisions that
+WorldForge cannot infer from a library call: transaction isolation, lease ownership, backup cadence,
+retention windows, migration rollout, and incident recovery.
+
+## Decision
+
+WorldForge keeps local JSON as the default persistence behavior. Durable multi-writer persistence
+must enter through an explicit `WorldPersistenceAdapter` boundary before any implementation is
+accepted into core, an optional extra, or a reference host.
+
+The adapter boundary is:
+
+```text
+WorldPersistenceAdapter
+  save(world) -> None
+  load(world_id) -> World
+  list() -> list[WorldSummary]
+  delete(world_id) -> None
+  export(world_id) -> dict
+  import(payload, *, new_id: str | None = None) -> World
+  health() -> PersistenceHealth
+```
+
+Every implementation must preserve the current local JSON invariants:
+
+- validate world IDs before addressing storage;
+- validate serialized world payloads before writes and after reads;
+- fail loudly on malformed state, missing worlds, failed writes, and unsafe identifiers;
+- keep provider secrets, signed URLs, host paths, and private payloads out of exported issue
+  evidence;
+- emit enough typed error context for operators without requiring database-specific exceptions.
+
+The first durable implementation, if accepted later, should be an optional adapter or reference
+host integration. It must not add a database dependency to the base package.
+
+## Required Adapter Design
+
+A future implementation PR must include:
+
+- **Locking:** define single-writer, optimistic concurrency, advisory locks, lease ownership, and
+  stale-lock recovery.
+- **Migrations:** define schema version storage, forward migration ordering, rollback policy, and
+  how old WorldForge clients fail.
+- **Backup and restore:** document which payloads are sufficient to restore worlds, how integrity is
+  checked, and what the recovery drill looks like.
+- **Retention:** separate world state retention from run-workspace evidence retention and document
+  deletion guarantees.
+- **Schema versioning:** store an adapter schema version separately from the WorldForge package
+  version and validate it before reads or writes.
+- **Failure recovery:** specify retryable versus terminal failures, partial-write cleanup, and
+  operator-facing diagnostics.
+
+## Rejected Alternatives
+
+### Replace Local JSON With SQLite
+
+SQLite is attractive for local workflows, but replacing JSON would change the default persistence
+surface, add migration complexity to simple examples, and still not solve distributed multi-writer
+coordination for service hosts.
+
+### Add Lock Files Around The Current Store
+
+Lock files would make local JSON look safer than it is. They do not define backup, migration,
+retention, or cross-host recovery, and their behavior varies by filesystem.
+
+### Add A Generic Database URL Setting
+
+A connection string alone does not define the storage contract. Without an adapter design,
+WorldForge would be responsible for unknown locking, transaction, migration, backup, and recovery
+semantics.
+
+### Move Persistence Entirely Out Of WorldForge
+
+WorldForge still needs local JSON for deterministic tests, examples, harness workflows, and issue
+reproduction. Removing it would make the checkout experience worse and push basic state validation
+into every host.
+
+## Consequences
+
+- Current local JSON behavior remains authoritative and unchanged.
+- Host applications remain responsible for production databases, backups, retention, and
+  multi-writer coordination.
+- WorldForge can still document a future durable adapter without adding a base dependency.
+- Any future persistence adapter has a named boundary and acceptance bar before implementation.
+
+## Validation
+
+The default persistence contract remains covered by existing local JSON and CLI tests:
+
+```bash
+uv run pytest tests/test_persistence*.py tests/test_cli_worlds.py
+```
+
+The ADR and linked documentation are validated by:
+
+```bash
+uv run pytest tests/test_docs_site.py
+uv run mkdocs build --strict
+```

--- a/docs/src/architecture.md
+++ b/docs/src/architecture.md
@@ -744,6 +744,10 @@ This keeps the library small and makes persistence ownership explicit. A future 
 adapter must preserve the same state validation invariants before it becomes a supported runtime
 surface.
 
+ADR 0001, [Persistence Adapter Boundary](./adr/0001-persistence-adapter-boundary.md), names the
+future `WorldPersistenceAdapter` interface and rejects replacing local JSON with an implicit
+database backend.
+
 ## Design Implications
 
 - Capability reporting is part of correctness. A provider that only scores must not be presented

--- a/docs/src/operations.md
+++ b/docs/src/operations.md
@@ -123,6 +123,9 @@ clarity: host applications own deployment topology, durability, locking semantic
 and retention requirements. WorldForge should not imply production durability guarantees that a
 local JSON store cannot enforce.
 
+ADR 0001, [Persistence Adapter Boundary](./adr/0001-persistence-adapter-boundary.md), records the
+future `WorldPersistenceAdapter` boundary and the acceptance bar for any durable store.
+
 Supported persistence invariants:
 
 - World IDs are validated as file-safe local storage identifiers before any read or write. Path

--- a/docs/src/playbooks.md
+++ b/docs/src/playbooks.md
@@ -232,8 +232,8 @@ Recovery guidance:
 - if local JSON is corrupted, restore from the host application's backup of exported world JSON.
 - if multiple workers need writes, move persistence into host-owned storage with locking,
   migrations, backups, and recovery drills.
-- do not add a lock file, SQLite store, or service adapter to WorldForge without a separate
-  persistence design.
+- do not add a lock file, SQLite store, or service adapter to WorldForge without the
+  [persistence adapter ADR](./adr/0001-persistence-adapter-boundary.md).
 
 ### 5a. Manage Worlds From TheWorldHarness
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,6 +49,8 @@ nav:
   - Rerun Integration: rerun.md
   - World Model Taxonomy: world-model-taxonomy.md
   - Architecture: architecture.md
+  - Decisions:
+      - Persistence Adapter Boundary: adr/0001-persistence-adapter-boundary.md
   - User And Operator Playbooks: playbooks.md
   - Providers:
       - Overview: providers/README.md

--- a/tests/test_docs_site.py
+++ b/tests/test_docs_site.py
@@ -86,3 +86,36 @@ def test_health_readiness_runbook_documents_required_operational_signals() -> No
 
     assert "WorldForge does not own upstream SLA" in playbooks
     assert "Alert routing, paging policy" in playbooks
+
+
+def test_persistence_adapter_adr_documents_host_owned_boundary() -> None:
+    adr = (ROOT / "docs/src/adr/0001-persistence-adapter-boundary.md").read_text(encoding="utf-8")
+    operations = (ROOT / "docs/src/operations.md").read_text(encoding="utf-8")
+    architecture = (ROOT / "docs/src/architecture.md").read_text(encoding="utf-8")
+    playbooks = (ROOT / "docs/src/playbooks.md").read_text(encoding="utf-8")
+
+    assert "Status: Accepted" in adr
+    assert "WorldPersistenceAdapter" in adr
+    assert "must not add a database dependency to the base package" in adr
+    assert "Current local JSON behavior remains authoritative and unchanged" in adr
+
+    for required_topic in (
+        "Locking",
+        "Migrations",
+        "Backup and restore",
+        "Retention",
+        "Schema versioning",
+        "Failure recovery",
+    ):
+        assert f"**{required_topic}:**" in adr
+
+    for rejected in (
+        "Replace Local JSON With SQLite",
+        "Add Lock Files Around The Current Store",
+        "Add A Generic Database URL Setting",
+        "Move Persistence Entirely Out Of WorldForge",
+    ):
+        assert rejected in adr
+
+    for doc in (operations, architecture, playbooks):
+        assert "0001-persistence-adapter-boundary.md" in doc


### PR DESCRIPTION
Closes #81.

## Summary
- add ADR 0001 defining the future `WorldPersistenceAdapter` boundary
- document locking, migrations, backup/restore, retention, schema versioning, and recovery requirements
- link the decision from operations, architecture, playbooks, and docs navigation
- add docs coverage so the host-owned persistence boundary stays explicit

## Validation
- `uv run pytest tests/test_docs_site.py tests/test_cli_doctor.py tests/test_world_lifecycle.py -q`
- `uv run ruff check src tests examples scripts`
- `uv run ruff format --check src tests examples scripts`
- `uv run mkdocs build --strict`
- `uv run pytest`
- `bash scripts/test_package.sh`
- `uv lock --check`
- `uv run python scripts/generate_provider_docs.py --check`
- `uv run --extra harness pytest --cov=src/worldforge --cov-report=term-missing --cov-fail-under=90`
