### PR TITLE
Add provider connector readiness workspace

### DIFF
--- a/docs/src/cli.md
+++ b/docs/src/cli.md
@@ -92,11 +92,14 @@ uv run --extra harness worldforge-harness --flow leworldmodel
 uv run --extra harness worldforge-harness --flow lerobot
 uv run --extra harness worldforge-harness --flow diagnostics
 uv run worldforge harness --list
+uv run worldforge harness --connectors --format json
 ```
 
 TheWorldHarness is optional and Textual-backed. It keeps Textual out of the base package while
 providing a visual workspace for checkout-safe flows, provider diagnostics, local worlds, evals, and
-benchmarks.
+benchmarks. The connector metadata command is checkout-safe and works without Textual; it reports
+provider readiness categories, missing env-var names, optional runtime dependencies, and first smoke
+commands without printing secret values.
 
 ## Packaged Demos
 

--- a/docs/src/theworldharness.md
+++ b/docs/src/theworldharness.md
@@ -26,6 +26,8 @@ uv run --extra harness worldforge-harness --flow eval
 uv run --extra harness worldforge-harness --flow benchmark
 uv run worldforge harness --list
 uv run worldforge harness --list --format json
+uv run worldforge harness --connectors
+uv run worldforge harness --connectors --format json
 ```
 
 Installed package:
@@ -40,6 +42,7 @@ Without the `harness` extra, metadata commands still work:
 ```bash
 uv run worldforge harness --list
 uv run worldforge harness --list --format json
+uv run worldforge harness --connectors --format json
 uv run worldforge provider workbench mock
 uv run worldforge provider workbench runway --format json
 ```
@@ -54,6 +57,16 @@ dependencies at package import time.
 | `leworldmodel` | `score` | Deterministic LeWorldModel-shaped cost runtime, candidate scoring, score planning, execution, persistence, reload, provider events. |
 | `lerobot` | `policy` plus score provider | Deterministic LeRobot-shaped policy, action translation, policy candidate ranking, execution, persistence, reload, provider events. |
 | `diagnostics` | provider catalog plus benchmark harness | `doctor()` provider scan, registered/unregistered provider status, mock benchmark matrix across predict/reason/generate/transfer/embed, latency/throughput comparison, provider events. |
+
+## Provider Connector Workspace
+
+The Providers screen and `worldforge harness --connectors --format json` use the same
+Textual-free readiness model. Each known provider is grouped as `configured`,
+`missing_credentials`, `missing_dependency`, `unhealthy`, or `scaffold`, with value-free required
+environment names, optional runtime dependency names, a first smoke command, and triage steps.
+
+This surface intentionally reports presence and status only. It does not print environment values,
+tokens, endpoints, checkpoint paths, or constructor-provided secrets.
 
 ## What The Interface Shows
 

--- a/src/worldforge/cli.py
+++ b/src/worldforge/cli.py
@@ -972,10 +972,15 @@ def _build_parser() -> argparse.ArgumentParser:
         help="List available harness flows without launching the TUI.",
     )
     harness.add_argument(
+        "--connectors",
+        action="store_true",
+        help="List provider connector readiness without launching the TUI.",
+    )
+    harness.add_argument(
         "--format",
         choices=("markdown", "json"),
         default="markdown",
-        help="Output format for --list.",
+        help="Output format for --list and --connectors.",
     )
     harness.add_argument("--no-animation", action="store_true", help="Disable step reveal delays.")
 
@@ -1026,6 +1031,7 @@ def _cmd_harness(args: argparse.Namespace) -> int:
         flow_id=args.flow,
         state_dir=args.state_dir,
         list_only=args.list,
+        connectors=args.connectors,
         output_format=args.format,
         animate=not args.no_animation,
     )

--- a/src/worldforge/harness/cli.py
+++ b/src/worldforge/harness/cli.py
@@ -7,6 +7,11 @@ import json
 import sys
 from pathlib import Path
 
+from worldforge.framework import WorldForge
+from worldforge.harness.connectors import (
+    provider_connector_summaries,
+    provider_connector_summary_markdown,
+)
 from worldforge.harness.flows import available_flows, flow_to_dicts
 
 
@@ -36,10 +41,15 @@ def _parser() -> argparse.ArgumentParser:
         help="List available harness flows without launching the TUI.",
     )
     parser.add_argument(
+        "--connectors",
+        action="store_true",
+        help="List provider connector readiness without launching the TUI.",
+    )
+    parser.add_argument(
         "--format",
         choices=("markdown", "json"),
         default="markdown",
-        help="Output format for --list.",
+        help="Output format for --list and --connectors.",
     )
     parser.add_argument(
         "--no-animation",
@@ -62,6 +72,21 @@ def print_flow_index(*, output_format: str = "markdown") -> None:
     print("| --- | --- | --- | --- |")
     for flow in available_flows():
         print(f"| `{flow.id}` | {flow.focus} | {flow.provider} | `{flow.command}` |")
+
+
+def print_connector_index(
+    *,
+    state_dir: Path | None = None,
+    output_format: str = "markdown",
+) -> None:
+    """Print provider connector readiness metadata."""
+
+    forge = WorldForge(state_dir=state_dir, auto_register_remote=True)
+    rows = provider_connector_summaries(forge)
+    if output_format == "json":
+        print(json.dumps([row.to_dict() for row in rows], indent=2))
+        return
+    print(provider_connector_summary_markdown(rows))
 
 
 def launch_harness(
@@ -143,6 +168,7 @@ def run_from_args(
     flow_id: str | None,
     state_dir: Path | None,
     list_only: bool,
+    connectors: bool,
     output_format: str,
     animate: bool,
 ) -> int:
@@ -150,6 +176,9 @@ def run_from_args(
 
     if list_only:
         print_flow_index(output_format=output_format)
+        return 0
+    if connectors:
+        print_connector_index(state_dir=state_dir, output_format=output_format)
         return 0
     return launch_harness(flow_id=flow_id, state_dir=state_dir, animate=animate)
 
@@ -160,6 +189,7 @@ def main(argv: list[str] | None = None) -> int:
         flow_id=args.flow,
         state_dir=args.state_dir,
         list_only=args.list,
+        connectors=args.connectors,
         output_format=args.format,
         animate=not args.no_animation,
     )

--- a/src/worldforge/harness/connectors.py
+++ b/src/worldforge/harness/connectors.py
@@ -1,0 +1,184 @@
+"""Textual-free provider connector readiness summaries for TheWorldHarness."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+from worldforge.framework import WorldForge
+from worldforge.models import JSONDict, ProviderDoctorStatus
+from worldforge.providers.runtime_manifest import load_runtime_manifest
+
+ConnectorStatus = Literal[
+    "configured",
+    "missing_credentials",
+    "missing_dependency",
+    "unhealthy",
+    "scaffold",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderConnectorSummary:
+    """Operator-facing readiness row for one known provider."""
+
+    name: str
+    status: ConnectorStatus
+    registered: bool
+    health: str
+    capabilities: tuple[str, ...]
+    implementation_status: str
+    required_env_vars: tuple[str, ...]
+    missing_env_vars: tuple[str, ...]
+    optional_dependencies: tuple[str, ...]
+    smoke_command: str
+    triage_steps: tuple[str, ...]
+
+    def to_dict(self) -> JSONDict:
+        return {
+            "name": self.name,
+            "status": self.status,
+            "registered": self.registered,
+            "health": self.health,
+            "capabilities": list(self.capabilities),
+            "implementation_status": self.implementation_status,
+            "required_env_vars": list(self.required_env_vars),
+            "missing_env_vars": list(self.missing_env_vars),
+            "optional_dependencies": list(self.optional_dependencies),
+            "smoke_command": self.smoke_command,
+            "triage_steps": list(self.triage_steps),
+        }
+
+
+def provider_connector_summaries(forge: WorldForge) -> tuple[ProviderConnectorSummary, ...]:
+    """Return known provider readiness rows without importing Textual."""
+
+    doctor = forge.doctor(registered_only=False)
+    rows = [_summary_from_status(status, forge=forge) for status in doctor.providers]
+    return tuple(sorted(rows, key=lambda row: row.name))
+
+
+def provider_connector_summary_markdown(rows: tuple[ProviderConnectorSummary, ...]) -> str:
+    """Render connector readiness rows as a compact Markdown table."""
+
+    lines = [
+        "# Provider Connector Workspace",
+        "",
+        "| Provider | Status | Capabilities | Required env | Next command |",
+        "| --- | --- | --- | --- | --- |",
+    ]
+    for row in rows:
+        capabilities = ", ".join(f"`{name}`" for name in row.capabilities) or "none"
+        required = ", ".join(f"`{name}`" for name in row.required_env_vars) or "none"
+        lines.append(
+            "| "
+            f"`{row.name}` | "
+            f"`{row.status}` | "
+            f"{capabilities} | "
+            f"{required} | "
+            f"`{row.smoke_command}` |"
+        )
+    return "\n".join(lines)
+
+
+def _summary_from_status(
+    status: ProviderDoctorStatus,
+    *,
+    forge: WorldForge,
+) -> ProviderConnectorSummary:
+    profile = status.profile
+    manifest = _runtime_manifest(profile.name)
+    config = forge.provider_config_summary(profile.name)
+    missing_env_vars = tuple(
+        str(field["name"])
+        for field in config.to_dict()["fields"]
+        if field.get("required") and not field.get("present")
+    )
+    optional_dependencies = manifest.optional_dependencies if manifest is not None else ()
+    health_detail = status.health.details
+    connector_status = _connector_status(
+        implementation_status=profile.implementation_status,
+        configured=config.configured,
+        healthy=status.health.healthy,
+        health_detail=health_detail,
+    )
+    smoke_command = (
+        manifest.minimum_smoke_command
+        if manifest is not None
+        else f"uv run worldforge provider info {profile.name} --format json"
+    )
+    triage_steps = _triage_steps(
+        name=profile.name,
+        status=connector_status,
+        missing_env_vars=missing_env_vars,
+        smoke_command=smoke_command,
+    )
+    return ProviderConnectorSummary(
+        name=profile.name,
+        status=connector_status,
+        registered=status.registered,
+        health=health_detail,
+        capabilities=tuple(profile.capabilities.enabled_names()),
+        implementation_status=profile.implementation_status,
+        required_env_vars=tuple(profile.required_env_vars),
+        missing_env_vars=missing_env_vars,
+        optional_dependencies=optional_dependencies,
+        smoke_command=smoke_command,
+        triage_steps=triage_steps,
+    )
+
+
+def _connector_status(
+    *,
+    implementation_status: str,
+    configured: bool,
+    healthy: bool,
+    health_detail: str,
+) -> ConnectorStatus:
+    if implementation_status == "scaffold":
+        return "scaffold"
+    if healthy:
+        return "configured"
+    if not configured:
+        return "missing_credentials"
+    if "missing optional dependency" in health_detail.lower():
+        return "missing_dependency"
+    return "unhealthy"
+
+
+def _triage_steps(
+    *,
+    name: str,
+    status: ConnectorStatus,
+    missing_env_vars: tuple[str, ...],
+    smoke_command: str,
+) -> tuple[str, ...]:
+    if status == "configured":
+        return (smoke_command,)
+    if status == "missing_credentials":
+        missing = ", ".join(missing_env_vars) or "required provider environment"
+        return (
+            f"Configure {missing}.",
+            f"uv run worldforge provider info {name} --format json",
+        )
+    if status == "missing_dependency":
+        return (
+            "Install the provider runtime in the host environment.",
+            smoke_command,
+        )
+    if status == "scaffold":
+        return (
+            "Treat this provider as a fail-closed scaffold.",
+            f"uv run worldforge provider info {name} --format json",
+        )
+    return (
+        f"uv run worldforge provider health {name} --format json",
+        smoke_command,
+    )
+
+
+def _runtime_manifest(provider: str):
+    try:
+        return load_runtime_manifest(provider)
+    except Exception:
+        return None

--- a/src/worldforge/harness/tui.py
+++ b/src/worldforge/harness/tui.py
@@ -57,6 +57,10 @@ from worldforge import (
     list_eval_suites,
 )
 from worldforge.benchmark import BENCHMARKABLE_OPERATIONS
+from worldforge.harness.connectors import (
+    ProviderConnectorSummary,
+    provider_connector_summaries,
+)
 from worldforge.harness.flows import (
     available_flows,
     benchmark_run_artifacts,
@@ -2357,6 +2361,7 @@ class ProvidersScreen(Screen):  # pragma: no cover - exercised by Pilot tests.
         super().__init__()
         self._forge = forge
         self._provider_names: list[str] = []
+        self._provider_rows: dict[str, ProviderConnectorSummary] = {}
         self._last_call_summary: dict[str, dict[str, Any]] = {}
 
     def compose(self) -> ComposeResult:
@@ -2403,24 +2408,27 @@ class ProvidersScreen(Screen):  # pragma: no cover - exercised by Pilot tests.
         if table is None:
             return
         table.clear(columns=True)
-        table.add_columns("provider", *CAPABILITY_NAMES)
-        infos = self._forge.list_providers()
-        self._provider_names = [info.name for info in infos]
-        for info in infos:
-            profile = self._forge.provider_profile(info.name)
+        table.add_columns("provider", "status", "credentials", "runtime", *CAPABILITY_NAMES)
+        rows = provider_connector_summaries(self._forge)
+        self._provider_rows = {row.name: row for row in rows}
+        self._provider_names = [row.name for row in rows]
+        for row in rows:
             cells = [
-                self._capability_cell(
-                    info.capabilities.supports(name), profile.implementation_status
-                )
+                self._capability_cell(name in row.capabilities, row.implementation_status)
                 for name in CAPABILITY_NAMES
             ]
-            table.add_row(info.name, *cells, key=info.name)
-        if infos:
+            credentials = "missing" if row.missing_env_vars else "ok"
+            runtime = "deps" if row.status == "missing_dependency" else "ok"
+            if row.status == "scaffold":
+                credentials = "n/a"
+                runtime = "scaffold"
+            table.add_row(row.name, row.status, credentials, runtime, *cells, key=row.name)
+        if rows:
             table.remove_class("hidden")
             if empty is not None:
                 empty.add_class("hidden")
             table.focus()
-            self.current_row_provider = infos[0].name
+            self.current_row_provider = rows[0].name
         else:
             table.add_class("hidden")
             if empty is not None:
@@ -2451,10 +2459,14 @@ class ProvidersScreen(Screen):  # pragma: no cover - exercised by Pilot tests.
         if provider is None:
             detail.update("No provider selected.")
             return
-        profile = self._forge.provider_profile(provider)
-        health = self._forge.provider_health(provider)
+        row = self._provider_rows.get(provider)
+        if row is None:
+            detail.update("No provider selected.")
+            return
         summary = self._last_call_summary.get(provider, {})
-        env_vars = ", ".join(profile.required_env_vars) if profile.required_env_vars else "none"
+        env_vars = ", ".join(row.required_env_vars) if row.required_env_vars else "none"
+        missing = ", ".join(row.missing_env_vars) if row.missing_env_vars else "none"
+        dependencies = ", ".join(row.optional_dependencies) if row.optional_dependencies else "none"
         last = (
             f"{summary.get('phase')} "
             f"{float(summary.get('latency_ms') or 0.0):.2f} ms "
@@ -2466,11 +2478,14 @@ class ProvidersScreen(Screen):  # pragma: no cover - exercised by Pilot tests.
             "\n".join(
                 [
                     f"Provider: {provider}",
-                    f"Status: {profile.implementation_status}",
-                    f"Capabilities: {', '.join(profile.supported_tasks) or 'none'}",
-                    f"Health: {'healthy' if health.healthy else 'unhealthy'} ({health.details})",
-                    f"Latency: {health.latency_ms:.2f} ms",
+                    f"Status: {row.status} ({row.implementation_status})",
+                    f"Capabilities: {', '.join(row.capabilities) or 'none'}",
+                    f"Health: {row.health}",
                     f"Required env vars: {env_vars}",
+                    f"Missing env vars: {missing}",
+                    f"Optional deps: {dependencies}",
+                    f"Next command: {row.smoke_command}",
+                    "Triage: " + " | ".join(row.triage_steps),
                     f"Last call: {last}",
                 ]
             )

--- a/tests/test_cli_help_snapshots.py
+++ b/tests/test_cli_help_snapshots.py
@@ -80,7 +80,7 @@ options:
 """,
     ("harness", "--help"): """\
 usage: worldforge harness [-h] [--flow {leworldmodel,lerobot,diagnostics}]
-                          [--state-dir STATE_DIR] [--list]
+                          [--state-dir STATE_DIR] [--list] [--connectors]
                           [--format {markdown,json}] [--no-animation]
 
 options:
@@ -92,8 +92,10 @@ options:
                         temporary directory.
   --list                List available harness flows without launching the
                         TUI.
+  --connectors          List provider connector readiness without launching
+                        the TUI.
   --format {markdown,json}
-                        Output format for --list.
+                        Output format for --list and --connectors.
   --no-animation        Disable step reveal delays.
 """,
     ("predict", "--help"): """\

--- a/tests/test_harness_cli.py
+++ b/tests/test_harness_cli.py
@@ -39,6 +39,57 @@ def test_worldforge_harness_console_entry_lists_flows(capsys) -> None:
     assert "TheWorldHarness Flows" in capsys.readouterr().out
 
 
+def test_worldforge_harness_lists_connector_readiness_without_textual(monkeypatch, capsys) -> None:
+    for name in (
+        "COSMOS_BASE_URL",
+        "RUNWAYML_API_SECRET",
+        "RUNWAY_API_SECRET",
+        "LEWORLDMODEL_POLICY",
+        "LEWM_POLICY",
+        "GROOT_POLICY_HOST",
+        "LEROBOT_POLICY_PATH",
+        "LEROBOT_POLICY",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["worldforge", "harness", "--connectors", "--format", "json"],
+    )
+
+    assert worldforge_main() == 0
+    payload = {row["name"]: row for row in json.loads(capsys.readouterr().out)}
+
+    assert set(payload) >= {
+        "mock",
+        "cosmos",
+        "runway",
+        "leworldmodel",
+        "gr00t",
+        "lerobot",
+        "jepa",
+        "genie",
+    }
+    assert payload["mock"]["status"] == "configured"
+    assert payload["cosmos"]["status"] == "missing_credentials"
+    assert payload["runway"]["missing_env_vars"] == ["RUNWAYML_API_SECRET"]
+    assert payload["jepa"]["status"] == "scaffold"
+    assert payload["genie"]["status"] == "scaffold"
+    assert "--provider-profile runway" in payload["runway"]["smoke_command"]
+
+
+def test_connector_readiness_distinguishes_missing_dependency(monkeypatch, tmp_path) -> None:
+    from worldforge import WorldForge
+    from worldforge.harness.connectors import provider_connector_summaries
+
+    monkeypatch.setenv("LEWORLDMODEL_POLICY", "demo/pusht")
+    rows = {row.name: row for row in provider_connector_summaries(WorldForge(state_dir=tmp_path))}
+
+    assert rows["leworldmodel"].status == "missing_dependency"
+    assert "stable_worldmodel" in rows["leworldmodel"].optional_dependencies
+    assert rows["leworldmodel"].missing_env_vars == ()
+
+
 def test_launch_harness_passes_home_when_no_flow(monkeypatch) -> None:
     """No --flow → initial_screen='home', resolved_flow_id falls back to leworldmodel."""
     pytest.importorskip("rich")

--- a/tests/test_harness_tui.py
+++ b/tests/test_harness_tui.py
@@ -1169,8 +1169,8 @@ def test_providers_screen_runs_real_mock_predict(tmp_path) -> None:
             await pilot.pause()
             assert isinstance(app.screen, ProvidersScreen)
             table = app.screen.query_one("#providers-table", DataTable)
-            assert table.row_count == 1
-            assert len(table.columns) == len(CAPABILITY_NAMES) + 1
+            assert table.row_count >= 8
+            assert len(table.columns) == len(CAPABILITY_NAMES) + 4
             await pilot.press("p")
             for _ in range(8):
                 await pilot.pause()
@@ -1203,7 +1203,7 @@ def test_providers_register_modal_adds_mock_variant(tmp_path) -> None:
                 await pilot.pause()
             assert isinstance(app.screen, ProvidersScreen)
             table = app.screen.query_one("#providers-table", DataTable)
-            assert table.row_count == 2
+            assert table.row_count >= 9
             assert app.current_provider == "mock-alt"
 
     asyncio.run(scenario())


### PR DESCRIPTION
Closes #67.

## Summary
- add a Textual-free provider connector readiness model shared by CLI and the Providers screen
- expose `worldforge harness --connectors` with Markdown/JSON output for readiness automation
- show configured, missing credentials, missing optional dependency, unhealthy, and scaffold states with value-free env/dependency metadata and next smoke commands

## Validation
- `uv run ruff check src tests examples scripts`
- `uv run ruff format --check src tests examples scripts`
- `uv run pytest`
- `uv run pytest -m "not live"`
- `uv run --extra harness pytest --cov=src/worldforge --cov-report=term-missing --cov-fail-under=90`
- `uv run mkdocs build --strict`
- `bash scripts/test_package.sh`
- `uv lock --check`
- `uv run python scripts/generate_provider_docs.py --check`
- `UV_LOCKED=true uv export --all-groups --no-emit-project --no-hashes --output-file <tmp> && uvx --from pip-audit pip-audit -r <tmp>`
