### PR TITLE
Add live run inspector artifacts

### DIFF
--- a/docs/src/theworldharness.md
+++ b/docs/src/theworldharness.md
@@ -77,11 +77,19 @@ The harness now exposes the main WorldForge surfaces directly:
 - Providers: registered-provider capability matrix, health details, and cancellable `mock.predict`.
 - Eval: built-in deterministic suites with capability errors surfaced as hard toasts.
 - Benchmark: provider-operation latency, retry, and throughput runs with live samples.
-- Run Inspector: timeline, metrics, transcript, and export preview for flows and reports.
+- Run Inspector: timeline, metrics, sanitized provider-event table, validation errors, transcript,
+  and export preview for flows and reports.
 
 Flow and report views are rendered from the same structured `HarnessRun` object used in tests.
 The provider, eval, and benchmark screens call the same Python APIs as the CLI; report artifacts
 use the canonical JSON / Markdown / CSV renderers.
+
+Every harness flow preserves the final inspector state under
+`.worldforge/runs/<run-id>/results/inspector.json`, writes sanitized provider events to
+`logs/provider-events.jsonl`, and links both artifacts from `run_manifest.json`. If a flow fails
+before provider work completes, the manifest status is `failed` rather than left as `running`; the
+inspector still records the command, redacted validation error, and failure event needed to
+reproduce the run.
 
 The diagnostics, eval, and benchmark screens map directly to non-TUI commands:
 

--- a/src/worldforge/demos/lerobot_e2e.py
+++ b/src/worldforge/demos/lerobot_e2e.py
@@ -247,6 +247,7 @@ def run_demo(*, state_dir: Path | None = None, emit: bool = True) -> JSONDict:
         "saved_world_id": saved_world_id,
         "saved_worlds": forge.list_worlds(),
         "event_phases": [event.phase for event in events],
+        "provider_events": [event.to_dict() for event in events],
         "policy_reset_calls": policy.reset_calls,
         "policy_eval_called": policy.eval_called,
         "policy_requires_grad_disabled": policy.requires_grad_disabled,

--- a/src/worldforge/demos/leworldmodel_e2e.py
+++ b/src/worldforge/demos/leworldmodel_e2e.py
@@ -214,6 +214,7 @@ def run_demo(
         "saved_world_id": saved_world_id,
         "saved_worlds": forge.list_worlds(),
         "event_phases": [event.phase for event in events],
+        "provider_events": [event.to_dict() for event in events],
         "runtime_eval_called": runtime.eval_called,
         "runtime_grad_disabled": runtime.requires_grad_disabled,
     }

--- a/src/worldforge/harness/flows.py
+++ b/src/worldforge/harness/flows.py
@@ -19,7 +19,7 @@ from worldforge.harness.workspace import (
     workspace_root_for_state_dir,
     write_run_manifest,
 )
-from worldforge.models import JSONDict
+from worldforge.models import JSONDict, ProviderEvent
 
 FlowRunner = Callable[..., JSONDict]
 
@@ -184,7 +184,23 @@ def run_flow(flow_id: str, *, state_dir: Path | None = None) -> HarnessRun:
         provider=flow.provider,
         operation=flow.id,
     )
-    summary = _RUNNERS[flow_id](state_dir=resolved_state_dir, emit=False)
+    try:
+        summary = _RUNNERS[flow_id](state_dir=resolved_state_dir, emit=False)
+    except Exception as exc:
+        summary = _failed_flow_summary(flow_id, resolved_state_dir, exc)
+        run = HarnessRun(
+            flow=flow,
+            state_dir=resolved_state_dir,
+            summary=summary,
+            steps=_steps_for(flow_id, summary),
+            metrics=_metrics_for(flow_id, summary),
+            transcript=_transcript_for(flow_id, summary),
+            workspace_path=workspace.path,
+            provider_events=_provider_events_for(flow_id, summary),
+            validation_errors=tuple(str(error) for error in summary.get("validation_errors", [])),
+        )
+        _write_flow_workspace(workspace, run)
+        return run
     run = HarnessRun(
         flow=flow,
         state_dir=resolved_state_dir,
@@ -193,9 +209,27 @@ def run_flow(flow_id: str, *, state_dir: Path | None = None) -> HarnessRun:
         metrics=_metrics_for(flow_id, summary),
         transcript=_transcript_for(flow_id, summary),
         workspace_path=workspace.path,
+        provider_events=_provider_events_for(flow_id, summary),
     )
     _write_flow_workspace(workspace, run)
     return run
+
+
+def _failed_flow_summary(flow_id: str, state_dir: Path, exc: Exception) -> JSONDict:
+    event = ProviderEvent(
+        provider=flow_index()[flow_id].provider,
+        operation=flow_id,
+        phase="failure",
+        message=str(exc),
+    )
+    return {
+        "demo_kind": "harness_flow",
+        "state_dir": str(state_dir),
+        "status": "failed",
+        "event_phases": [event.phase],
+        "provider_events": [event.to_dict()],
+        "validation_errors": [event.message],
+    }
 
 
 def eval_run_artifacts(
@@ -540,30 +574,23 @@ def _write_flow_workspace(workspace: RunWorkspace, run: HarnessRun) -> None:
         [metric.to_dict() for metric in run.metrics],
     )
     transcript_path = workspace.write_text("logs/transcript.txt", "\n".join(run.transcript))
-    event_count = 0
-    event_phases = run.summary.get("event_phases")
-    if isinstance(event_phases, list):
-        event_count = len(event_phases)
+    inspector_path = workspace.write_json(
+        "results/inspector.json",
+        _inspector_payload(run),
+    )
+    provider_events = run.provider_events
+    event_count = len(provider_events)
+    if provider_events:
         workspace.write_text(
             "logs/provider-events.jsonl",
-            "\n".join(
-                json.dumps(
-                    {
-                        "event_type": "provider_event_summary",
-                        "provider": run.flow.provider,
-                        "operation": run.flow.id,
-                        "phase": str(phase),
-                    },
-                    sort_keys=True,
-                )
-                for phase in event_phases
-            ),
+            "\n".join(json.dumps(event, sort_keys=True) for event in provider_events),
         )
     artifact_paths = {
         "summary": str(summary_path.relative_to(workspace.path)),
         "steps": str(steps_path.relative_to(workspace.path)),
         "metrics": str(metrics_path.relative_to(workspace.path)),
         "transcript": str(transcript_path.relative_to(workspace.path)),
+        "inspector": str(inspector_path.relative_to(workspace.path)),
     }
     write_run_manifest(
         workspace,
@@ -571,16 +598,29 @@ def _write_flow_workspace(workspace: RunWorkspace, run: HarnessRun) -> None:
         command=run.flow.command,
         provider=run.flow.provider,
         operation=run.flow.id,
-        status="completed",
+        status="failed" if run.validation_errors else "completed",
         input_summary={"flow_id": run.flow.id, "state_dir": str(run.state_dir)},
         result_summary={
             "step_count": len(run.steps),
             "metric_count": len(run.metrics),
             "summary_keys": sorted(run.summary),
+            "validation_error_count": len(run.validation_errors),
         },
         artifact_paths=artifact_paths,
         event_count=event_count,
     )
+
+
+def _inspector_payload(run: HarnessRun) -> JSONDict:
+    return {
+        "flow": run.flow.to_dict(),
+        "status": "failed" if run.validation_errors else "completed",
+        "metrics": [metric.to_dict() for metric in run.metrics],
+        "steps": [step.to_dict() for step in run.steps],
+        "provider_events": [dict(event) for event in run.provider_events],
+        "validation_errors": list(run.validation_errors),
+        "workspace_path": str(run.workspace_path) if run.workspace_path is not None else None,
+    }
 
 
 def _write_report_artifacts(workspace: RunWorkspace, artifacts: dict[str, str]) -> dict[str, str]:
@@ -593,6 +633,22 @@ def _write_report_artifacts(workspace: RunWorkspace, artifacts: dict[str, str]) 
 
 
 def _steps_for(flow_id: str, summary: JSONDict) -> tuple[HarnessStep, ...]:
+    validation_errors = summary.get("validation_errors")
+    if isinstance(validation_errors, list) and validation_errors:
+        return (
+            HarnessStep(
+                "Start flow",
+                "Create a run workspace and record the command before invoking providers.",
+                "Run workspace preserved.",
+                f"state_dir={Path(str(summary.get('state_dir', ''))).name}",
+            ),
+            HarnessStep(
+                "Capture failure",
+                "Persist sanitized provider events and validation errors for triage.",
+                str(validation_errors[0]),
+                "artifact=run_manifest.json results/inspector.json",
+            ),
+        )
     if flow_id == "leworldmodel":
         return (
             HarnessStep(
@@ -741,6 +797,13 @@ def _steps_for(flow_id: str, summary: JSONDict) -> tuple[HarnessStep, ...]:
 
 
 def _metrics_for(flow_id: str, summary: JSONDict) -> tuple[HarnessMetric, ...]:
+    validation_errors = summary.get("validation_errors")
+    if isinstance(validation_errors, list) and validation_errors:
+        return (
+            HarnessMetric("Status", "failed", "run manifest preserved for reproduction"),
+            HarnessMetric("Events", str(len(summary.get("event_phases", []))), "failure"),
+            HarnessMetric("Errors", str(len(validation_errors)), str(validation_errors[0])),
+        )
     if flow_id == "diagnostics":
         return (
             HarnessMetric(
@@ -787,6 +850,15 @@ def _metrics_for(flow_id: str, summary: JSONDict) -> tuple[HarnessMetric, ...]:
 
 
 def _transcript_for(flow_id: str, summary: JSONDict) -> tuple[str, ...]:
+    validation_errors = summary.get("validation_errors")
+    if isinstance(validation_errors, list) and validation_errors:
+        return (
+            f"flow: {flow_id}",
+            "status: failed",
+            f"state_dir: {summary.get('state_dir', '')}",
+            f"validation_errors: {' | '.join(str(error) for error in validation_errors)}",
+            f"events: {', '.join(str(phase) for phase in summary.get('event_phases', []))}",
+        )
     if flow_id == "diagnostics":
         return (
             "flow: diagnostics",
@@ -843,6 +915,55 @@ def _final_position_result(summary: JSONDict) -> str:
 
 def _event_result(summary: JSONDict) -> str:
     return f"Provider phases: {', '.join(summary['event_phases'])}."
+
+
+def _provider_events_for(flow_id: str, summary: JSONDict) -> tuple[JSONDict, ...]:
+    events = summary.get("provider_events")
+    if isinstance(events, list):
+        return tuple(dict(event) for event in events if isinstance(event, dict))
+    benchmark_results = summary.get("benchmark_results")
+    if isinstance(benchmark_results, list):
+        synthesized: list[JSONDict] = []
+        for result in benchmark_results:
+            if not isinstance(result, dict):
+                continue
+            metrics = result.get("operation_metrics")
+            if not isinstance(metrics, dict):
+                continue
+            for metric_event in metrics.get("events", []):
+                if not isinstance(metric_event, dict):
+                    continue
+                request_count = int(metric_event.get("request_count", 0) or 0)
+                retry_count = int(metric_event.get("retry_count", 0) or 0)
+                error_count = int(metric_event.get("error_count", 0) or 0)
+                phase = "failure" if error_count else "retry" if retry_count else "success"
+                synthesized.append(
+                    ProviderEvent(
+                        provider=str(metric_event.get("provider", result.get("provider", "mock"))),
+                        operation=str(
+                            metric_event.get("operation", result.get("operation", flow_id))
+                        ),
+                        phase=phase,
+                        metadata={
+                            "request_count": request_count,
+                            "retry_count": retry_count,
+                            "error_count": error_count,
+                        },
+                    ).to_dict()
+                )
+        return tuple(synthesized)
+    phases = summary.get("event_phases")
+    if not isinstance(phases, list):
+        return ()
+    flow = flow_index()[flow_id]
+    return tuple(
+        ProviderEvent(
+            provider=flow.provider,
+            operation=flow.id,
+            phase=str(phase),
+        ).to_dict()
+        for phase in phases
+    )
 
 
 def _position(summary: JSONDict) -> str:

--- a/src/worldforge/harness/models.py
+++ b/src/worldforge/harness/models.py
@@ -85,6 +85,8 @@ class HarnessRun:
     report_path: Path | None = None
     workspace_path: Path | None = None
     artifacts: dict[str, str] | None = None
+    provider_events: tuple[JSONDict, ...] = ()
+    validation_errors: tuple[str, ...] = ()
 
     def to_dict(self) -> JSONDict:
         return {
@@ -98,6 +100,8 @@ class HarnessRun:
             "report_path": str(self.report_path) if self.report_path is not None else None,
             "workspace_path": str(self.workspace_path) if self.workspace_path is not None else None,
             "artifacts": dict(self.artifacts or {}),
+            "provider_events": [dict(event) for event in self.provider_events],
+            "validation_errors": list(self.validation_errors),
         }
 
     @property

--- a/src/worldforge/harness/tui.py
+++ b/src/worldforge/harness/tui.py
@@ -330,6 +330,8 @@ class InspectorPane(Static, _ThemedRenderer):
     def render_run(self, run: HarnessRun) -> None:
         accent = self._color("accent")
         success = self._color("success")
+        warning = self._color("warning")
+        error = self._color("error")
         table = Table.grid(expand=True)
         table.add_column(justify="left", ratio=1)
         table.add_column(justify="right", ratio=1)
@@ -339,6 +341,36 @@ class InspectorPane(Static, _ThemedRenderer):
             )
             if metric.detail:
                 table.add_row("", Text(metric.detail, style=success))
+        if run.provider_events:
+            table.add_row(Text(""), Text(""))
+            table.add_row(Text("Provider events", style="dim"), Text(str(len(run.provider_events))))
+            for provider_event in run.provider_events[:6]:
+                phase = str(provider_event.get("phase", "event"))
+                phase_style = {
+                    "success": success,
+                    "retry": warning,
+                    "failure": error,
+                    "cancelled": warning,
+                    "budget_exceeded": error,
+                }.get(phase, accent)
+                provider = str(provider_event.get("provider", "provider"))
+                operation = str(provider_event.get("operation", "operation"))
+                attempt = provider_event.get("attempt")
+                duration = provider_event.get("duration_ms")
+                suffix = []
+                if attempt is not None:
+                    suffix.append(f"attempt={attempt}")
+                if duration is not None:
+                    suffix.append(f"{float(duration):.1f} ms")
+                table.add_row(
+                    Text(phase, style=f"bold {phase_style}"),
+                    Text(f"{provider}.{operation} {' '.join(suffix)}".strip()),
+                )
+        if run.validation_errors:
+            table.add_row(Text(""), Text(""))
+            table.add_row(Text("Validation errors", style=f"bold {error}"), Text(""))
+            for validation_error in run.validation_errors[:3]:
+                table.add_row("", Text(validation_error, style=error))
         self.update(Panel(table, title="Inspector", border_style=accent))
 
 

--- a/src/worldforge/models.py
+++ b/src/worldforge/models.py
@@ -54,12 +54,12 @@ _SENSITIVE_FIELD_PATTERN = re.compile(
     re.IGNORECASE,
 )
 _SENSITIVE_ASSIGNMENT_PATTERN = re.compile(
-    r"\b(api[_-]?key|authorization|credential|password|secret|signature|signed[_-]?url|token)=([^&\s,;]+)",
+    r"\b([A-Za-z0-9_-]*(?:api[_-]?key|authorization|credential|password|secret|signature|signed[_-]?url|token)[A-Za-z0-9_-]*)=([^&\s,;]+)",
     re.IGNORECASE,
 )
 _SENSITIVE_COLON_PATTERN = re.compile(
     r"(?P<key_quote>[\"']?)"
-    r"(?P<key>api[_-]?key|authorization|bearer|credential|password|secret|signature|signed[_-]?url|token)"
+    r"(?P<key>[A-Za-z0-9_-]*(?:api[_-]?key|authorization|bearer|credential|password|secret|signature|signed[_-]?url|token)[A-Za-z0-9_-]*)"
     r"(?P=key_quote)\s*:\s*"
     r"(?P<value>\"[^\"]*\"|'[^']*'|[^,\s;}]+)",
     re.IGNORECASE,

--- a/tests/test_harness_flows.py
+++ b/tests/test_harness_flows.py
@@ -37,7 +37,14 @@ def test_harness_runs_leworldmodel_flow(tmp_path) -> None:
     assert run.summary["selected_candidate_index"] == 1
     assert run.summary["saved_worlds"] == [run.summary["saved_world_id"]]
     assert run.summary["event_phases"] == ["success", "success"]
+    assert [event["phase"] for event in run.provider_events] == ["success", "success"]
     assert "final_position: (0.55, 0.50, 0.00)" in run.transcript
+    assert run.workspace_path is not None
+    event_log = run.workspace_path / "logs" / "provider-events.jsonl"
+    events = [json.loads(line) for line in event_log.read_text(encoding="utf-8").splitlines()]
+    assert [event["phase"] for event in events] == ["success", "success"]
+    inspector = json.loads((run.workspace_path / "results" / "inspector.json").read_text())
+    assert inspector["provider_events"] == events
 
 
 def test_harness_runs_lerobot_flow(tmp_path) -> None:
@@ -49,6 +56,32 @@ def test_harness_runs_lerobot_flow(tmp_path) -> None:
     assert run.summary["selected_candidate_index"] == 1
     assert run.summary["policy_select_calls"] == 2
     assert "policy_select_calls: 2" in run.transcript
+
+
+def test_harness_failed_flow_preserves_manifest_and_inspector(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from worldforge.harness import flows
+
+    def broken_runner(**_kwargs) -> dict[str, object]:
+        raise RuntimeError("api_key=secret-value failed")
+
+    monkeypatch.setitem(flows._RUNNERS, "leworldmodel", broken_runner)
+
+    run = flows.run_flow("leworldmodel", state_dir=tmp_path)
+
+    assert run.validation_errors == ("api_key=[redacted] failed",)
+    assert run.provider_events[0]["phase"] == "failure"
+    assert run.provider_events[0]["message"] == "api_key=[redacted] failed"
+    assert run.workspace_path is not None
+    manifest = json.loads((run.workspace_path / "run_manifest.json").read_text())
+    assert manifest["status"] == "failed"
+    assert manifest["event_count"] == 1
+    assert manifest["artifact_paths"]["inspector"] == "results/inspector.json"
+    inspector = json.loads((run.workspace_path / "results" / "inspector.json").read_text())
+    assert inspector["status"] == "failed"
+    assert inspector["validation_errors"] == ["api_key=[redacted] failed"]
 
 
 def test_harness_runs_diagnostics_flow(tmp_path) -> None:

--- a/tests/test_harness_tui.py
+++ b/tests/test_harness_tui.py
@@ -420,6 +420,41 @@ def test_the_world_harness_app_switches_to_diagnostics_flow(tmp_path) -> None:
     asyncio.run(scenario())
 
 
+def test_run_inspector_renders_failed_flow_without_credentials(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pytest.importorskip("textual")
+
+    from worldforge.harness import flows
+    from worldforge.harness.tui import RunInspectorScreen, TheWorldHarnessApp
+
+    def broken_runner(**_kwargs) -> dict[str, object]:
+        raise RuntimeError("RUNWAYML_API_SECRET=secret-value unavailable")
+
+    monkeypatch.setitem(flows._RUNNERS, "leworldmodel", broken_runner)
+
+    async def scenario() -> None:
+        app = TheWorldHarnessApp(
+            initial_flow_id="leworldmodel",
+            initial_screen="run-inspector",
+            state_dir=tmp_path,
+            step_delay=0.0,
+        )
+        async with app.run_test(size=(130, 42)) as pilot:
+            await pilot.press("r")
+            await pilot.pause()
+            screen = app.screen
+            assert isinstance(screen, RunInspectorScreen)
+            assert screen.last_run is not None
+            assert screen.last_run.validation_errors == (
+                "RUNWAYML_API_SECRET=[redacted] unavailable",
+            )
+            assert screen.last_run.provider_events[0]["phase"] == "failure"
+
+    asyncio.run(scenario())
+
+
 # ---------------------------------------------------------------------------
 # M1 — Screen architecture tests
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #73.

## Summary
- preserve live run inspector state in each harness run workspace
- write sanitized provider event JSONL and failed-flow inspector payloads
- render provider-event and validation-error details in the Run Inspector
- broaden observable text redaction for environment-style secret assignments

## Validation
- `uv run ruff check src tests examples scripts`
- `uv run ruff format --check src tests examples scripts`
- `uv run pytest`
- `uv run pytest -m "not live"`
- `uv run --extra harness pytest --cov=src/worldforge --cov-report=term-missing --cov-fail-under=90`
- `uv run mkdocs build --strict`
- `uv lock --check`
- `uv run python scripts/generate_provider_docs.py --check`
- `bash scripts/test_package.sh`
- `UV_LOCKED=true uv export --all-groups --no-emit-project --no-hashes --output-file <tmp>`
- `uvx --from pip-audit pip-audit -r <tmp>`
