### PR TITLE
Add LeRobot embodiment translator contract

### DIFF
--- a/docs/src/providers/lerobot.md
+++ b/docs/src/providers/lerobot.md
@@ -132,6 +132,39 @@ The translator may return:
 
 Multiple candidates are useful for policy-plus-score planning.
 
+Use `EmbodimentTranslatorContract` and `EmbodimentActionTranslator` when a translator has a known
+robot or task boundary:
+
+```python
+from worldforge import Action
+from worldforge.providers import EmbodimentActionTranslator, EmbodimentTranslatorContract
+
+contract = EmbodimentTranslatorContract(
+    embodiment_tag="aloha",
+    action_dim=3,
+    action_horizon=16,
+    metadata={"controller": "host-owned", "units": "meters"},
+)
+
+def translate_actions(raw_actions, info, provider_info):
+    tensor = raw_actions.tolist() if hasattr(raw_actions, "tolist") else raw_actions
+    return [Action.move_to(float(x), float(y), float(z)) for (x, y, z) in tensor]
+
+translator = EmbodimentActionTranslator(contract, translate_actions)
+```
+
+The contract validates the incoming `embodiment_tag`, rectangular numeric raw actions, finite
+values, optional action dimension, optional horizon, JSON-native metadata, and returned candidate
+cardinality. It fails before planning on unknown embodiment tags or shape mismatches instead of
+padding, projecting, or silently dropping policy outputs. The provider stores a
+`translator_contract` summary in `ActionPolicyResult.metadata` so run artifacts can cite the
+validated translation boundary without including robot credentials or controller state.
+
+The packaged PushT robotics showcase uses this wrapper for its visual `x, y` translator while the
+separate LeWorldModel candidate builder owns the checkpoint-native 10-dimensional score tensor.
+Hosts should follow the same split: WorldForge validates the boundary and preserves provenance;
+host code owns preprocessing, controller semantics, safety interlocks, and any hardware execution.
+
 ## Planning
 
 Policy-only planning:
@@ -203,6 +236,8 @@ showcase. Full runnable context lives in [CLI Reference](../cli.md),
 - Missing `lerobot` or `PreTrainedPolicy` is reported by `health()`.
 - Policy class resolution or checkpoint loading failures are wrapped in `ProviderError`.
 - Missing `action_translator` fails with `ProviderError`.
+- Contracted translators fail on unknown embodiment tags, non-finite raw action values, raw action
+  shape mismatches, and candidate cardinality mismatches.
 - Malformed observations, options, or modes fail before invoking the policy.
 - Requesting `mode="predict_chunk"` against a policy without `predict_action_chunk` fails
   explicitly.
@@ -213,7 +248,8 @@ showcase. Full runnable context lives in [CLI Reference](../cli.md),
 
 - `tests/test_lerobot_provider.py` covers injected-policy contract checks, event emission, malformed
   inputs, missing translator, unconfigured health, env configuration, lazy import,
-  select/predict_chunk modes, reset delegation, auto-registration, and policy-plus-score planning.
+  select/predict_chunk modes, reset delegation, auto-registration, translator contracts, and
+  policy-plus-score planning.
 - `tests/test_lerobot_e2e_demo.py` covers the full checkout-safe demo.
 - `tests/test_lerobot_smoke_script.py` covers smoke-script input loading, callable resolution, and
   validation without requiring LeRobot or a GPU.

--- a/src/worldforge/__init__.py
+++ b/src/worldforge/__init__.py
@@ -68,6 +68,8 @@ _EXPORTS: dict[str, str] = {  # pragma: no cover - initialized before pytest-cov
     "list_eval_suites": "worldforge.framework",
     "run_eval": "worldforge.framework",
     "ProviderBudgetExceededError": "worldforge.providers",
+    "EmbodimentActionTranslator": "worldforge.providers",
+    "EmbodimentTranslatorContract": "worldforge.providers",
     "CAPABILITY_NAMES": "worldforge.models",
     "Action": "worldforge.models",
     "ActionPolicyResult": "worldforge.models",

--- a/src/worldforge/providers/__init__.py
+++ b/src/worldforge/providers/__init__.py
@@ -20,6 +20,7 @@ from .base import (
 )
 from .catalog import PROVIDER_CATALOG, ProviderCatalogEntry, create_known_providers
 from .cosmos import CosmosProvider
+from .embodiment import EmbodimentActionTranslator, EmbodimentTranslatorContract
 from .gr00t import GrootPolicyClientProvider
 from .lerobot import LeRobotPolicyProvider
 from .leworldmodel import LeWorldModelProvider
@@ -32,6 +33,8 @@ __all__ = [
     "BaseProvider",
     "ConfigFieldSummary",
     "CosmosProvider",
+    "EmbodimentActionTranslator",
+    "EmbodimentTranslatorContract",
     "GenieProvider",
     "GrootPolicyClientProvider",
     "JepaProvider",

--- a/src/worldforge/providers/embodiment.py
+++ b/src/worldforge/providers/embodiment.py
@@ -1,0 +1,175 @@
+"""Embodiment action translator contracts for policy providers."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass, field
+
+from worldforge.models import Action, JSONDict
+
+from ._policy import json_object, normalize_policy_action_candidates
+from .base import ProviderError
+
+ActionTranslatorCallable = Callable[
+    [object, JSONDict, JSONDict],
+    Sequence[Action] | Sequence[Sequence[Action]],
+]
+
+
+def _materialize(value: object) -> object:
+    current = value
+    for method_name in ("detach", "cpu"):
+        method = getattr(current, method_name, None)
+        if callable(method):
+            current = method()
+    tolist = getattr(current, "tolist", None)
+    if callable(tolist):
+        return tolist()
+    if isinstance(current, tuple):
+        return [_materialize(item) for item in current]
+    return current
+
+
+def _numeric_leaf(value: object, *, name: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        raise ProviderError(f"{name} must contain only numeric action values.")
+    number = float(value)
+    if not math.isfinite(number):
+        raise ProviderError(f"{name} must contain only finite action values.")
+    return number
+
+
+def _nested_shape(value: object, *, name: str) -> tuple[int, ...]:
+    if isinstance(value, Sequence) and not isinstance(value, str | bytes | bytearray):
+        if not value:
+            raise ProviderError(f"{name} must not contain empty action dimensions.")
+        child_shapes = [_nested_shape(child, name=name) for child in value]
+        first = child_shapes[0]
+        if any(shape != first for shape in child_shapes):
+            raise ProviderError(f"{name} must be rectangular.")
+        return (len(value), *first)
+    _numeric_leaf(value, name=name)
+    return ()
+
+
+def _action_shape(value: object, *, name: str) -> tuple[int, ...]:
+    shape = getattr(value, "shape", None)
+    if shape is not None:
+        try:
+            return tuple(int(part) for part in tuple(shape))
+        except (TypeError, ValueError):
+            pass
+    materialized = _materialize(value)
+    return _nested_shape(materialized, name=name)
+
+
+@dataclass(frozen=True)
+class EmbodimentTranslatorContract:
+    """Validation metadata for a host-owned action translator.
+
+    The contract is intentionally about the boundary, not robot execution. It
+    proves the raw policy output belongs to the expected embodiment and has the
+    expected tensor shape before a host translator converts it to WorldForge
+    ``Action`` objects.
+    """
+
+    embodiment_tag: str
+    action_dim: int | None = None
+    action_horizon: int | None = None
+    metadata: JSONDict = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        tag = self.embodiment_tag.strip()
+        if not tag:
+            raise ProviderError("embodiment_tag must be a non-empty string.")
+        object.__setattr__(self, "embodiment_tag", tag)
+        for field_name in ("action_dim", "action_horizon"):
+            value = getattr(self, field_name)
+            if value is not None and (isinstance(value, bool) or value <= 0):
+                raise ProviderError(f"{field_name} must be an integer greater than 0.")
+        normalized_metadata = json_object(self.metadata, name="translator metadata")
+        object.__setattr__(self, "metadata", normalized_metadata)
+
+    def validate_raw_actions(
+        self,
+        raw_actions: object,
+        info: JSONDict,
+        provider_info: JSONDict,
+        *,
+        name: str = "raw policy actions",
+    ) -> tuple[int, ...]:
+        """Validate the embodiment tag and raw action tensor shape."""
+
+        raw_tag = info.get("embodiment_tag") or provider_info.get("embodiment_tag")
+        if raw_tag is not None and str(raw_tag).strip() != self.embodiment_tag:
+            raise ProviderError(
+                f"Embodiment translator for '{self.embodiment_tag}' cannot translate "
+                f"actions tagged '{str(raw_tag).strip()}'."
+            )
+        shape = _action_shape(raw_actions, name=name)
+        if self.action_dim is not None and (not shape or shape[-1] != self.action_dim):
+            actual = shape[-1] if shape else "scalar"
+            raise ProviderError(
+                f"Embodiment translator expected action_dim={self.action_dim}, got {actual}."
+            )
+        if self.action_horizon is not None and (len(shape) < 2 or shape[-2] != self.action_horizon):
+            actual = shape[-2] if len(shape) >= 2 else "scalar"
+            raise ProviderError(
+                "Embodiment translator expected "
+                f"action_horizon={self.action_horizon}, got {actual}."
+            )
+        return shape
+
+    def validate_candidates(self, candidates: Sequence[Sequence[Action]]) -> None:
+        if self.action_horizon is None:
+            return
+        for index, actions in enumerate(candidates):
+            if len(actions) != self.action_horizon:
+                raise ProviderError(
+                    f"Embodiment translator candidate {index} returned {len(actions)} "
+                    f"WorldForge action(s), expected {self.action_horizon}."
+                )
+
+    def preview_summary(self, *, raw_shape: tuple[int, ...] | None = None) -> JSONDict:
+        return {
+            "embodiment_tag": self.embodiment_tag,
+            "action_dim": self.action_dim,
+            "action_horizon": self.action_horizon,
+            "raw_action_shape": list(raw_shape) if raw_shape is not None else None,
+            "metadata": dict(self.metadata),
+        }
+
+
+class EmbodimentActionTranslator:
+    """Callable wrapper that enforces an ``EmbodimentTranslatorContract``."""
+
+    def __init__(
+        self,
+        contract: EmbodimentTranslatorContract,
+        translate: ActionTranslatorCallable,
+    ) -> None:
+        if not callable(translate):
+            raise ProviderError("translate must be callable.")
+        self.contract = contract
+        self._translate = translate
+        self.last_raw_shape: tuple[int, ...] | None = None
+
+    def __call__(
+        self,
+        raw_actions: object,
+        info: JSONDict,
+        provider_info: JSONDict,
+    ) -> list[list[Action]]:
+        raw_shape = self.contract.validate_raw_actions(raw_actions, info, provider_info)
+        translated = self._translate(raw_actions, info, provider_info)
+        candidates = normalize_policy_action_candidates(
+            translated,
+            provider_label=f"{self.contract.embodiment_tag} embodiment",
+        )
+        self.contract.validate_candidates(candidates)
+        self.last_raw_shape = raw_shape
+        return candidates
+
+    def contract_summary(self) -> JSONDict:
+        return self.contract.preview_summary(raw_shape=self.last_raw_shape)

--- a/src/worldforge/providers/lerobot.py
+++ b/src/worldforge/providers/lerobot.py
@@ -481,6 +481,13 @@ class LeRobotPolicyProvider(BaseProvider):
                 info=info,
                 provider_info=normalized_provider_info,
             )
+            translator_contract = None
+            contract_summary = getattr(self._action_translator, "contract_summary", None)
+            if callable(contract_summary):
+                translator_contract = json_object(
+                    contract_summary(),
+                    name="LeRobot translator_contract",
+                )
             action_horizon_value = info.get("action_horizon")
             if action_horizon_value is None:
                 action_horizon = len(candidate_plans[0])
@@ -510,6 +517,7 @@ class LeRobotPolicyProvider(BaseProvider):
                     "mode": mode,
                     "provider_info": normalized_provider_info,
                     "candidate_count": len(candidate_plans),
+                    "translator_contract": translator_contract,
                 },
                 action_candidates=candidate_plans,
             )

--- a/src/worldforge/smoke/pusht_showcase_inputs.py
+++ b/src/worldforge/smoke/pusht_showcase_inputs.py
@@ -21,6 +21,23 @@ DEFAULT_ACTION_DIM = 10
 DEFAULT_ACTION_BLOCK = 5
 
 
+def pusht_translator_contract() -> object:
+    """Return the checkout-safe PushT translator contract without importing optional runtimes."""
+
+    from worldforge.providers import EmbodimentTranslatorContract
+
+    return EmbodimentTranslatorContract(
+        embodiment_tag="pusht",
+        action_dim=2,
+        metadata={
+            "task": "pusht",
+            "raw_policy_space": "xy",
+            "worldforge_action": "move_to",
+            "score_action_dim": DEFAULT_ACTION_DIM,
+        },
+    )
+
+
 def _materialize(value: object) -> object:
     current = value
     for method_name in ("detach", "cpu"):
@@ -145,3 +162,14 @@ def translate_candidates(
         y = 0.5 + float(xy[1]) * 0.25
         plans.append([Action.move_to(x, y, 0.0, object_id=object_id)])
     return plans
+
+
+def translate_candidates_with_contract() -> object:
+    """Return a PushT translator callable that validates embodiment and raw shape."""
+
+    from worldforge.providers import EmbodimentActionTranslator
+
+    return EmbodimentActionTranslator(pusht_translator_contract(), translate_candidates)
+
+
+translate_candidates_contract = translate_candidates_with_contract()

--- a/src/worldforge/smoke/robotics_showcase.py
+++ b/src/worldforge/smoke/robotics_showcase.py
@@ -229,7 +229,7 @@ def _forward_args(args: argparse.Namespace) -> list[str]:
         "--score-info-module",
         f"{PUSHT_INPUT_MODULE}:build_score_info",
         "--translator",
-        f"{PUSHT_INPUT_MODULE}:translate_candidates",
+        f"{PUSHT_INPUT_MODULE}:translate_candidates_contract",
         "--candidate-builder",
         f"{PUSHT_INPUT_MODULE}:build_action_candidates",
         "--expected-action-dim",

--- a/tests/test_lerobot_provider.py
+++ b/tests/test_lerobot_provider.py
@@ -12,6 +12,8 @@ from worldforge import Action, ActionPolicyResult, ActionScoreResult, WorldForge
 from worldforge.models import JSONDict, ProviderCapabilities, ProviderEvent, ProviderHealth
 from worldforge.providers import (
     BaseProvider,
+    EmbodimentActionTranslator,
+    EmbodimentTranslatorContract,
     LeRobotPolicyProvider,
     MockProvider,
     ProviderError,
@@ -185,6 +187,91 @@ def test_lerobot_policy_provider_passes_contract_and_emits_events() -> None:
     assert policy.select_action_calls[-1] == _policy_info()["observation"]
     assert events[-1].operation == "policy"
     assert events[-1].phase == "success"
+
+
+def test_lerobot_contract_translator_records_safe_metadata() -> None:
+    contract = EmbodimentTranslatorContract(
+        embodiment_tag="aloha",
+        action_dim=3,
+        action_horizon=2,
+        metadata={"controller": "sim", "preview": {"units": "meters"}},
+    )
+
+    translator = EmbodimentActionTranslator(
+        contract,
+        lambda *_args: [
+            Action.move_to(0.1, 0.5, 0.0),
+            Action.move_to(0.2, 0.5, 0.0),
+        ],
+    )
+    provider = LeRobotPolicyProvider(
+        policy=FakeLeRobotPolicy(response=FakeTensor([[0.1, 0.5, 0.0], [0.2, 0.5, 0.0]])),
+        embodiment_tag="aloha",
+        action_translator=translator,
+    )
+
+    result = provider.select_actions(info=_policy_info())
+
+    summary = result.metadata["translator_contract"]
+    assert summary == {
+        "embodiment_tag": "aloha",
+        "action_dim": 3,
+        "action_horizon": 2,
+        "raw_action_shape": [2, 3],
+        "metadata": {"controller": "sim", "preview": {"units": "meters"}},
+    }
+    assert contract.preview_summary(raw_shape=(2, 3)) == summary
+
+
+def test_lerobot_contract_translator_rejects_wrong_embodiment_tag() -> None:
+    translator = EmbodimentActionTranslator(
+        EmbodimentTranslatorContract(embodiment_tag="aloha", action_dim=3),
+        lambda *_args: [Action.move_to(0.1, 0.5, 0.0)],
+    )
+    provider = LeRobotPolicyProvider(
+        policy=FakeLeRobotPolicy(response=FakeTensor([[0.1, 0.5, 0.0]])),
+        action_translator=translator,
+    )
+
+    with pytest.raises(ProviderError, match="cannot translate actions tagged 'so100'"):
+        provider.select_actions(info={**_policy_info(), "embodiment_tag": "so100"})
+
+
+def test_lerobot_contract_translator_rejects_shape_and_cardinality_mismatches() -> None:
+    wrong_dim = EmbodimentActionTranslator(
+        EmbodimentTranslatorContract(embodiment_tag="aloha", action_dim=3),
+        lambda *_args: [Action.move_to(0.1, 0.5, 0.0)],
+    )
+    provider = LeRobotPolicyProvider(
+        policy=FakeLeRobotPolicy(response=FakeTensor([[0.1, 0.5]])),
+        action_translator=wrong_dim,
+    )
+    with pytest.raises(ProviderError, match="action_dim=3"):
+        provider.select_actions(info=_policy_info())
+
+    wrong_count = EmbodimentActionTranslator(
+        EmbodimentTranslatorContract(embodiment_tag="aloha", action_dim=3, action_horizon=2),
+        lambda *_args: [Action.move_to(0.1, 0.5, 0.0)],
+    )
+    provider = LeRobotPolicyProvider(
+        policy=FakeLeRobotPolicy(response=FakeTensor([[0.1, 0.5, 0.0], [0.2, 0.5, 0.0]])),
+        action_translator=wrong_count,
+    )
+    with pytest.raises(ProviderError, match="expected 2"):
+        provider.select_actions(info=_policy_info())
+
+
+def test_lerobot_contract_translator_rejects_nonfinite_values_and_metadata() -> None:
+    contract = EmbodimentTranslatorContract(embodiment_tag="aloha", action_dim=3)
+    with pytest.raises(ProviderError, match="finite action values"):
+        contract.validate_raw_actions(
+            [[math.inf, 0.5, 0.0]],
+            {"embodiment_tag": "aloha"},
+            {},
+        )
+
+    with pytest.raises(ProviderError, match="translator metadata"):
+        EmbodimentTranslatorContract(embodiment_tag="aloha", metadata={"bad": object()})
 
 
 def test_lerobot_provider_supports_predict_action_chunk_mode() -> None:

--- a/tests/test_robotics_showcase.py
+++ b/tests/test_robotics_showcase.py
@@ -235,7 +235,7 @@ def test_robotics_showcase_forwards_packaged_pusht_defaults(
     )
     assert (
         forwarded[forwarded.index("--translator") + 1]
-        == "worldforge.smoke.pusht_showcase_inputs:translate_candidates"
+        == "worldforge.smoke.pusht_showcase_inputs:translate_candidates_contract"
     )
     assert (
         forwarded[forwarded.index("--candidate-builder") + 1]
@@ -264,6 +264,25 @@ def test_packaged_pusht_bridge_builds_candidates_without_optional_import_at_modu
     assert len(plans) == 3
     assert plans[0][0].parameters["object_id"] == "block-1"
     assert plans[0][0].parameters["target"] == {"x": 0.7, "y": 0.25, "z": 0.0}
+
+    contracted = pusht_showcase_inputs.translate_candidates_contract(
+        [0.8, -2.0],
+        {"embodiment_tag": "pusht", "score_bridge": {"object_id": "block-1"}},
+        {},
+    )
+    assert len(contracted) == 3
+    assert pusht_showcase_inputs.translate_candidates_contract.contract_summary() == {
+        "embodiment_tag": "pusht",
+        "action_dim": 2,
+        "action_horizon": None,
+        "raw_action_shape": [2],
+        "metadata": {
+            "task": "pusht",
+            "raw_policy_space": "xy",
+            "worldforge_action": "move_to",
+            "score_action_dim": 10,
+        },
+    }
 
 
 def test_robotics_showcase_uses_tmp_json_output_by_default(monkeypatch) -> None:


### PR DESCRIPTION
Closes #61.

## Summary
- add a reusable `EmbodimentTranslatorContract` and callable `EmbodimentActionTranslator`
- record translator contract summaries in LeRobot policy results
- wire the packaged PushT showcase through the contracted translator while keeping its public CLI behavior
- document the host-owned translator boundary and failure modes

## Validation
- `uv run ruff check src tests examples scripts`
- `uv run ruff format --check src tests examples scripts`
- `uv run pytest tests/test_lerobot_provider.py tests/test_robotics_showcase.py tests/test_lerobot_leworldmodel_smoke_script.py -q`
- `uv run pytest`
- `uv run pytest -m "not live"`
- `uv run --extra harness pytest --cov=src/worldforge --cov-report=term-missing --cov-fail-under=90`
- `uv run mkdocs build --strict`
- `bash scripts/test_package.sh`
- `UV_LOCKED=true uv export --all-groups --no-emit-project --no-hashes --output-file /tmp/worldforge-audit/requirements.txt && uvx --from pip-audit pip-audit -r /tmp/worldforge-audit/requirements.txt`
- `uv lock --check && uv run python scripts/generate_provider_docs.py --check`
