### PR TITLE
Add robotics operator review host

### DIFF
--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -137,6 +137,27 @@ registered, credentials configured, optional runtime dependencies installed, and
 that match that provider's advertised capability. Keep scheduling, retry policy above the process,
 long-term artifact storage, and credential rotation outside the base package.
 
+## Robotics Operator Host
+
+| Example | Command | Runtime boundary |
+| --- | --- | --- |
+| `robotics-operator-host` | `uv run python examples/hosts/robotics-operator/app.py review --sample-translator` | Stdlib offline operator-review host; the lab application owns action translators, checklist policy, approval, controller integration, interlocks, and safety certification. |
+
+The default mode does not call robot controllers. It runs a deterministic LeRobot policy surface and
+score provider through an explicit sample PushT translator, then writes a preserved run workspace
+under `.worldforge/robotics-operator/runs/<run-id>/` with:
+
+- `results/action_chunks.json` for all candidate action chunks and the selected chunk.
+- `results/score_rationale.json` for score values, best index, and score metadata.
+- `logs/provider-events.jsonl` for the provider event stream.
+- `results/approval.json` for host-owned checklist and dry-run approval state.
+- `results/replay.json` for an offline replay artifact.
+
+Controller execution remains disabled unless the embedding host supplies an explicit controller
+hook in code, all checklist items are true, and dry-run approval is recorded. WorldForge only
+produces typed policy, score, event, replay, and run-manifest artifacts; it does not certify robot
+hardware, task safety, emergency stops, workspace readiness, or controller behavior.
+
 ## Optional Runtime Smoke
 
 | Example | Command | Runtime boundary |

--- a/docs/src/operations.md
+++ b/docs/src/operations.md
@@ -330,6 +330,25 @@ Expected success signal: `.worldforge/rerun/worldforge-rerun-showcase.rrd` exist
 prints a byte count, and the recording opens in the Rerun viewer. First triage step: run
 `uv run --extra rerun python -c "import rerun; print(rerun.__version__)"`.
 
+## Robotics Operator Review
+
+The checkout host at `examples/hosts/robotics-operator/app.py` is an offline review loop for
+policy-plus-score robotics runs:
+
+```bash
+uv run python examples/hosts/robotics-operator/app.py review --sample-translator
+```
+
+By default it does not talk to robot controllers. It requires an explicit action translator in the
+host process, records checklist and dry-run approval state, and preserves selected action chunks,
+score rationale, provider events, and a replay artifact under
+`.worldforge/robotics-operator/runs/<run-id>/`.
+
+WorldForge only certifies that its typed provider, event, replay, and manifest artifacts satisfy
+the framework contracts. The lab host remains responsible for embodiment translators, controller
+hooks, workspace safety, operator approval policy, emergency stops, hardware behavior, deployment
+readiness, and safety certification.
+
 ## Failure Modes
 
 - Invalid caller input raises `WorldForgeError`.

--- a/examples/README.md
+++ b/examples/README.md
@@ -70,6 +70,18 @@ The batch host uses only the base WorldForge package and Python stdlib. It write
 `.worldforge/batch-eval/runs/<run-id>/run_manifest.json`, report exports, and copied benchmark
 input or budget files. A benchmark budget violation exits `1` after preserving the failed run.
 
+## Robotics Operator Host
+
+| Example | Surface | Command |
+| --- | --- | --- |
+| `robotics-operator-host` | offline policy+score review, dry-run approval, replay artifacts | `uv run python examples/hosts/robotics-operator/app.py review --sample-translator` |
+
+The robotics operator host is non-mutating by default and never talks to robot controllers. It
+requires an explicit action translator, records host-owned checklist and dry-run approval state, and
+writes selected action chunks, score rationale, provider events, and a replay artifact under
+`.worldforge/robotics-operator/runs/<run-id>/`. Controller execution is only an application hook:
+WorldForge does not certify robot safety, controller semantics, interlocks, or deployment readiness.
+
 ## Optional Runtime Smoke
 
 | Example | Surface | Command |

--- a/examples/hosts/robotics-operator/app.py
+++ b/examples/hosts/robotics-operator/app.py
@@ -1,0 +1,411 @@
+"""Stdlib robotics operator-review host for offline policy+score runs."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Callable, Sequence
+from pathlib import Path
+from typing import Any
+
+from worldforge import Action, WorldForge, WorldForgeError
+from worldforge.demos import BLUE_CUBE_GOAL, blue_cube_goal, make_blue_cube, make_candidate_plans
+from worldforge.demos.lerobot_e2e import (
+    DemoDistanceScoreProvider,
+    DemoLeRobotPolicy,
+)
+from worldforge.harness.workspace import create_run_workspace, write_run_manifest
+from worldforge.models import JSONDict, ProviderEvent, require_json_dict
+from worldforge.observability import RunJsonLogSink, compose_event_handlers
+from worldforge.providers import LeRobotPolicyProvider
+
+JSON = dict[str, Any]
+ActionTranslator = Callable[
+    [object, JSONDict, JSONDict],
+    Sequence[Action] | Sequence[Sequence[Action]],
+]
+ControllerExecutionHook = Callable[[Sequence[Action], JSONDict], JSONDict]
+DEFAULT_WORKSPACE = Path(".worldforge/robotics-operator")
+DEFAULT_STATE_DIR = Path(".worldforge/robotics-operator/worlds")
+REQUIRED_CHECKS = (
+    "workspace_clear",
+    "emergency_stop_available",
+    "operator_present",
+    "controller_isolated",
+)
+
+
+def sample_pusht_translator(
+    _raw_actions: object,
+    info: JSONDict,
+    _provider_info: JSONDict,
+) -> list[list[Action]]:
+    """Translate sample PushT policy outputs into WorldForge action chunks."""
+
+    cube_id = str(info.get("object_id") or "").strip()
+    if not cube_id:
+        raise WorldForgeError("sample translator requires policy info.object_id.")
+    return make_candidate_plans(cube_id)
+
+
+def sample_policy_info(*, cube_id: str) -> JSONDict:
+    """Return deterministic PushT-shaped sample policy inputs for checkout review."""
+
+    return {
+        "observation": {
+            "observation.state": [[0.0, 0.5, 0.0]],
+            "observation.images.top": [[[[0, 0, 0]]]],
+            "task": "move the blue cube near the marked target",
+        },
+        "embodiment_tag": "pusht",
+        "action_horizon": 2,
+        "object_id": cube_id,
+    }
+
+
+def sample_candidate_tensors() -> list[list[list[float]]]:
+    """Return sample raw policy tensors that the explicit translator maps to action chunks."""
+
+    return [
+        [[0.20, 0.50, 0.00], [0.35, 0.50, 0.00]],
+        [[0.30, 0.50, 0.00], [0.55, 0.50, 0.00]],
+        [[0.70, 0.50, 0.00], [0.95, 0.50, 0.00]],
+    ]
+
+
+def run_operator_review(
+    *,
+    workspace_dir: Path,
+    state_dir: Path,
+    action_translator: ActionTranslator | None,
+    safety_checklist: JSONDict,
+    dry_run_approved: bool,
+    controller_hook: ControllerExecutionHook | None = None,
+    execute_controller: bool = False,
+) -> JSON:
+    """Run an offline operator review and preserve issue-safe artifacts."""
+
+    if action_translator is None:
+        raise WorldForgeError("robotics operator host requires an explicit action translator.")
+    checklist = validate_safety_checklist(safety_checklist)
+    dry_run_approved = _require_bool(dry_run_approved, name="dry_run_approved")
+    if execute_controller and controller_hook is None:
+        raise WorldForgeError(
+            "controller execution is disabled until the host supplies controller_hook."
+        )
+    if execute_controller and not dry_run_approved:
+        raise WorldForgeError("controller execution requires recorded dry-run approval.")
+    if execute_controller and not all(checklist.values()):
+        raise WorldForgeError("controller execution requires every safety checklist item.")
+
+    command = _command_string(
+        [
+            "--workspace",
+            str(workspace_dir),
+            "--state-dir",
+            str(state_dir),
+            "review",
+        ]
+    )
+    workspace = create_run_workspace(
+        workspace_dir,
+        kind="robotics_operator_review",
+        command=command,
+        provider="lerobot",
+        operation="policy+score",
+        input_summary={
+            "mode": "offline_operator_review",
+            "controller_execution_requested": execute_controller,
+            "dry_run_approved": dry_run_approved,
+            "required_check_count": len(REQUIRED_CHECKS),
+        },
+    )
+
+    events: list[ProviderEvent] = []
+    event_sink = compose_event_handlers(
+        events.append,
+        RunJsonLogSink(
+            workspace.logs_dir / "provider-events.jsonl",
+            workspace.run_id,
+            extra_fields={"host": "robotics-operator"},
+        ),
+    )
+
+    try:
+        forge = WorldForge(
+            state_dir=state_dir,
+            auto_register_remote=False,
+            event_handler=event_sink,
+        )
+        world = forge.create_world("robotics-operator-review", provider="mock")
+        cube = make_blue_cube(world)
+        goal = blue_cube_goal(cube)
+
+        policy_info = sample_policy_info(cube_id=cube.id)
+        score_info: JSONDict = {
+            "goal": [BLUE_CUBE_GOAL.x, BLUE_CUBE_GOAL.y, BLUE_CUBE_GOAL.z],
+            "review_mode": "operator_dry_run",
+        }
+        policy = DemoLeRobotPolicy(sample_candidate_tensors())
+
+        def loader(
+            _policy_path: str,
+            _policy_type: str | None,
+            _device: str | None,
+            _cache_dir: str | None,
+        ) -> DemoLeRobotPolicy:
+            return policy
+
+        forge.register_provider(
+            LeRobotPolicyProvider(
+                policy_path="host/sample-pusht-policy",
+                policy_type="diffusion",
+                embodiment_tag="pusht",
+                device="cpu",
+                policy_loader=loader,
+                action_translator=action_translator,
+                event_handler=event_sink,
+            )
+        )
+        forge.register_provider(DemoDistanceScoreProvider())
+
+        policy_result = forge.select_actions("lerobot", info=policy_info)
+        score_result = forge.score_actions(
+            "demo-distance-score",
+            info=score_info,
+            action_candidates=[
+                [action.to_dict() for action in candidate]
+                for candidate in policy_result.action_candidates
+            ],
+        )
+        selected_actions = list(policy_result.action_candidates[score_result.best_index])
+        action_chunks = [
+            {
+                "index": index,
+                "selected": index == score_result.best_index,
+                "actions": [action.to_dict() for action in candidate],
+                "score": score_result.scores[index],
+            }
+            for index, candidate in enumerate(policy_result.action_candidates)
+        ]
+        approval = {
+            "dry_run_approved": dry_run_approved,
+            "safety_checklist": checklist,
+            "controller_execution_requested": execute_controller,
+            "controller_hook_supplied": controller_hook is not None,
+            "worldforge_certifies_robot_safety": False,
+        }
+        replay = _replay_payload(
+            selected_actions,
+            goal=goal.to_dict(),
+            selected_candidate_index=score_result.best_index,
+            dry_run_approved=dry_run_approved,
+        )
+        controller_result = None
+        if execute_controller and controller_hook is not None:
+            controller_result = require_json_dict(
+                controller_hook(selected_actions, approval),
+                name="controller hook result",
+            )
+
+        artifacts: JSON = {
+            "action_chunks": action_chunks,
+            "approval": approval,
+            "controller_result": controller_result,
+            "events": [event.to_dict() for event in events],
+            "policy": policy_result.to_dict(),
+            "replay": replay,
+            "score_rationale": {
+                "provider": score_result.provider,
+                "score_type": score_result.metadata.get("score_type"),
+                "scores": score_result.scores,
+                "lower_is_better": score_result.lower_is_better,
+                "best_index": score_result.best_index,
+                "best_score": score_result.best_score,
+                "metadata": score_result.metadata,
+            },
+        }
+        workspace.write_json("results/action_chunks.json", artifacts["action_chunks"])
+        workspace.write_json("results/approval.json", artifacts["approval"])
+        workspace.write_json("results/score_rationale.json", artifacts["score_rationale"])
+        workspace.write_json("results/replay.json", artifacts["replay"])
+        workspace.write_json("results/operator_review.json", artifacts)
+        workspace.write_text("reports/operator_review.md", _review_markdown(artifacts))
+
+        artifact_paths = {
+            "action_chunks": "results/action_chunks.json",
+            "approval": "results/approval.json",
+            "operator_review": "results/operator_review.json",
+            "provider_events": "logs/provider-events.jsonl",
+            "replay": "results/replay.json",
+            "report": "reports/operator_review.md",
+            "score_rationale": "results/score_rationale.json",
+        }
+        result_summary = {
+            "selected_candidate_index": score_result.best_index,
+            "selected_action_count": len(selected_actions),
+            "best_score": score_result.best_score,
+            "dry_run_approved": dry_run_approved,
+            "controller_execution_requested": execute_controller,
+            "controller_executed": controller_result is not None,
+        }
+        write_run_manifest(
+            workspace,
+            kind="robotics_operator_review",
+            command=command,
+            provider="lerobot",
+            operation="policy+score",
+            status="completed",
+            input_summary={
+                "mode": "offline_operator_review",
+                "controller_execution_requested": execute_controller,
+                "dry_run_approved": dry_run_approved,
+                "required_check_count": len(REQUIRED_CHECKS),
+            },
+            result_summary=result_summary,
+            artifact_paths=artifact_paths,
+            event_count=len(events),
+        )
+        return {
+            "status": "passed",
+            "exit_code": 0,
+            "run_id": workspace.run_id,
+            "run_workspace": str(workspace.path),
+            "run_manifest": str(workspace.manifest_path),
+            "artifact_paths": artifact_paths,
+            "summary": result_summary,
+        }
+    except Exception:
+        write_run_manifest(
+            workspace,
+            kind="robotics_operator_review",
+            command=command,
+            provider="lerobot",
+            operation="policy+score",
+            status="failed",
+            input_summary={
+                "mode": "offline_operator_review",
+                "controller_execution_requested": execute_controller,
+                "dry_run_approved": dry_run_approved,
+                "required_check_count": len(REQUIRED_CHECKS),
+            },
+            result_summary={"error": "operator review failed"},
+            artifact_paths={"provider_events": "logs/provider-events.jsonl"},
+            event_count=len(events),
+        )
+        raise
+
+
+def validate_safety_checklist(payload: JSONDict) -> dict[str, bool]:
+    """Return the required host-owned safety checklist with boolean values."""
+
+    checklist = require_json_dict(payload, name="safety checklist")
+    missing = [key for key in REQUIRED_CHECKS if key not in checklist]
+    if missing:
+        raise WorldForgeError(f"safety checklist is missing required items: {', '.join(missing)}.")
+    normalized: dict[str, bool] = {}
+    for key in REQUIRED_CHECKS:
+        normalized[key] = _require_bool(checklist[key], name=f"safety checklist {key}")
+    return normalized
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--workspace", type=Path, default=DEFAULT_WORKSPACE)
+    parser.add_argument("--state-dir", type=Path, default=DEFAULT_STATE_DIR)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    review = subparsers.add_parser("review", help="Run an offline robotics operator review.")
+    review.add_argument(
+        "--sample-translator",
+        action="store_true",
+        help="Use the checkout sample PushT translator for the dry-run review.",
+    )
+    review.add_argument(
+        "--approve-dry-run",
+        action="store_true",
+        help="Record operator approval for the dry-run artifact.",
+    )
+    review.add_argument(
+        "--check",
+        action="append",
+        choices=REQUIRED_CHECKS,
+        default=[],
+        help="Mark one required host-owned safety checklist item true. Can be repeated.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    checklist = {key: key in args.check for key in REQUIRED_CHECKS}
+    translator = sample_pusht_translator if args.sample_translator else None
+    try:
+        result = run_operator_review(
+            workspace_dir=args.workspace,
+            state_dir=args.state_dir,
+            action_translator=translator,
+            safety_checklist=checklist,
+            dry_run_approved=args.approve_dry_run,
+        )
+    except WorldForgeError as exc:
+        print(json.dumps({"error": {"type": "validation_error", "message": str(exc)}}))
+        return 2
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return int(result["exit_code"])
+
+
+def _replay_payload(
+    actions: Sequence[Action],
+    *,
+    goal: JSONDict,
+    selected_candidate_index: int,
+    dry_run_approved: bool,
+) -> JSON:
+    return {
+        "mode": "dry_run_replay",
+        "selected_candidate_index": selected_candidate_index,
+        "dry_run_approved": dry_run_approved,
+        "controller_calls": 0,
+        "steps": [
+            {
+                "step": index,
+                "action": action.to_dict(),
+                "operator_prompt": "review_only",
+            }
+            for index, action in enumerate(actions, start=1)
+        ],
+        "goal": goal,
+    }
+
+
+def _review_markdown(artifacts: JSON) -> str:
+    score = artifacts["score_rationale"]
+    approval = artifacts["approval"]
+    lines = [
+        "# Robotics Operator Review",
+        "",
+        f"- selected_candidate_index: {score['best_index']}",
+        f"- best_score: {score['best_score']}",
+        f"- dry_run_approved: {approval['dry_run_approved']}",
+        f"- controller_execution_requested: {approval['controller_execution_requested']}",
+        f"- controller_hook_supplied: {approval['controller_hook_supplied']}",
+        "",
+        "WorldForge produced offline policy, score, replay, and event artifacts. The host owns "
+        "robot controller integration and safety certification.",
+    ]
+    return "\n".join(lines)
+
+
+def _command_string(args: list[str]) -> str:
+    return "python examples/hosts/robotics-operator/app.py " + " ".join(args)
+
+
+def _require_bool(value: object, *, name: str) -> bool:
+    if not isinstance(value, bool):
+        raise WorldForgeError(f"{name} must be a boolean.")
+    return value
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/worldforge/cli.py
+++ b/src/worldforge/cli.py
@@ -124,6 +124,19 @@ EXAMPLE_COMMANDS: tuple[dict[str, str], ...] = (
         ),
     },
     {
+        "task": "Robotics operator host",
+        "name": "robotics-operator-host",
+        "surface": "offline policy+score review, dry-run approval, replay artifacts",
+        "requires": "base WorldForge package; checkout examples directory",
+        "command": (
+            "uv run python examples/hosts/robotics-operator/app.py review --sample-translator"
+        ),
+        "description": (
+            "Run a non-mutating robotics operator review that preserves selected action chunks, "
+            "score rationale, provider events, dry-run approval, and replay artifacts."
+        ),
+    },
+    {
         "task": "Optional runtime smoke",
         "name": "leworldmodel-real-checkpoint-smoke",
         "surface": "optional runtime smoke",

--- a/tests/test_examples_index.py
+++ b/tests/test_examples_index.py
@@ -18,6 +18,7 @@ def test_example_index_metadata_is_task_grouped() -> None:
         "Policy plus score planning",
         "Visual harness",
         "Batch evaluation host",
+        "Robotics operator host",
         "Optional runtime smoke",
         "Real robotics showcase",
     ]

--- a/tests/test_robotics_operator_host.py
+++ b/tests/test_robotics_operator_host.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from worldforge import WorldForgeError
+
+ROOT = Path(__file__).resolve().parents[1]
+OPERATOR_APP = ROOT / "examples" / "hosts" / "robotics-operator" / "app.py"
+
+
+def _load_operator_app():
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(
+        "worldforge_robotics_operator_host_example",
+        OPERATOR_APP,
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _checklist(app) -> dict[str, bool]:
+    return dict.fromkeys(app.REQUIRED_CHECKS, True)
+
+
+def test_robotics_operator_host_preserves_offline_review_artifacts(tmp_path) -> None:
+    app = _load_operator_app()
+
+    result = app.run_operator_review(
+        workspace_dir=tmp_path / "workspace",
+        state_dir=tmp_path / "worlds",
+        action_translator=app.sample_pusht_translator,
+        safety_checklist=_checklist(app),
+        dry_run_approved=True,
+    )
+
+    assert result["status"] == "passed"
+    assert result["exit_code"] == 0
+    run_workspace = Path(result["run_workspace"])
+    manifest = json.loads(Path(result["run_manifest"]).read_text(encoding="utf-8"))
+    review = json.loads((run_workspace / "results" / "operator_review.json").read_text())
+    approval = json.loads((run_workspace / "results" / "approval.json").read_text())
+    replay = json.loads((run_workspace / "results" / "replay.json").read_text())
+
+    assert manifest["kind"] == "robotics_operator_review"
+    assert manifest["operation"] == "policy+score"
+    assert manifest["status"] == "completed"
+    assert manifest["result_summary"]["selected_candidate_index"] == 1
+    assert manifest["result_summary"]["controller_executed"] is False
+    assert manifest["artifact_paths"]["provider_events"] == "logs/provider-events.jsonl"
+    assert (run_workspace / "logs" / "provider-events.jsonl").exists()
+    assert (run_workspace / "reports" / "operator_review.md").exists()
+    assert approval["dry_run_approved"] is True
+    assert approval["controller_execution_requested"] is False
+    assert approval["worldforge_certifies_robot_safety"] is False
+    assert replay["mode"] == "dry_run_replay"
+    assert replay["controller_calls"] == 0
+    assert len(review["action_chunks"]) == 3
+    assert review["action_chunks"][1]["selected"] is True
+    assert review["score_rationale"]["lower_is_better"] is True
+    assert review["events"]
+
+
+def test_robotics_operator_host_requires_explicit_translator(tmp_path) -> None:
+    app = _load_operator_app()
+
+    with pytest.raises(WorldForgeError, match="explicit action translator"):
+        app.run_operator_review(
+            workspace_dir=tmp_path / "workspace",
+            state_dir=tmp_path / "worlds",
+            action_translator=None,
+            safety_checklist=_checklist(app),
+            dry_run_approved=True,
+        )
+
+
+def test_robotics_operator_host_blocks_controller_without_hook(tmp_path) -> None:
+    app = _load_operator_app()
+
+    with pytest.raises(WorldForgeError, match="controller execution is disabled"):
+        app.run_operator_review(
+            workspace_dir=tmp_path / "workspace",
+            state_dir=tmp_path / "worlds",
+            action_translator=app.sample_pusht_translator,
+            safety_checklist=_checklist(app),
+            dry_run_approved=True,
+            execute_controller=True,
+        )
+
+
+def test_robotics_operator_host_records_host_supplied_controller_hook(tmp_path) -> None:
+    app = _load_operator_app()
+    calls = []
+
+    def hook(actions, approval):
+        calls.append((actions, approval))
+        return {"status": "dry_run_dispatched", "action_count": len(actions)}
+
+    result = app.run_operator_review(
+        workspace_dir=tmp_path / "workspace",
+        state_dir=tmp_path / "worlds",
+        action_translator=app.sample_pusht_translator,
+        safety_checklist=_checklist(app),
+        dry_run_approved=True,
+        execute_controller=True,
+        controller_hook=hook,
+    )
+
+    review = json.loads(
+        (Path(result["run_workspace"]) / "results" / "operator_review.json").read_text()
+    )
+    manifest = json.loads(Path(result["run_manifest"]).read_text(encoding="utf-8"))
+
+    assert len(calls) == 1
+    assert calls[0][1]["controller_hook_supplied"] is True
+    assert manifest["result_summary"]["controller_executed"] is True
+    assert review["controller_result"] == {"status": "dry_run_dispatched", "action_count": 2}
+
+
+def test_robotics_operator_host_cli_defaults_to_safe_validation_error(tmp_path, capsys) -> None:
+    app = _load_operator_app()
+
+    exit_code = app.main(
+        [
+            "--workspace",
+            str(tmp_path / "workspace"),
+            "--state-dir",
+            str(tmp_path / "worlds"),
+            "review",
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 2
+    assert payload["error"]["type"] == "validation_error"
+    assert "explicit action translator" in payload["error"]["message"]


### PR DESCRIPTION
Closes #74.

## Summary
- add a stdlib robotics operator-review host for offline policy+score runs
- preserve action chunks, score rationale, provider events, approval, replay, and run manifest artifacts
- keep controller execution disabled unless the embedding host supplies an explicit hook, checklist, and dry-run approval
- document the WorldForge vs lab-host safety boundary

## Validation
- `uv run pytest tests/test_robotics_operator_host.py tests/test_robotics_showcase.py -q`
- `uv run ruff check src tests examples scripts`
- `uv run ruff format --check src tests examples scripts`
- `uv run mkdocs build --strict`
- `uv run pytest -q`
- `uv run --extra harness pytest --cov=src/worldforge --cov-report=term-missing --cov-fail-under=90`
- `bash scripts/test_package.sh`
- `UV_LOCKED=true uv export --all-groups --no-emit-project --no-hashes ...` + `pip-audit`
