### PR TITLE
Promote LeWorldModel score provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,7 +359,7 @@ observe state
 | `mock` | `stable` | `predict`, `generate`, `transfer`, `reason`, `embed` | always registered | in-repo deterministic local provider |
 | [`cosmos`](https://abdelstark.github.io/worldforge/providers/cosmos/) | `beta` | `generate` | `COSMOS_BASE_URL` | host supplies a reachable Cosmos deployment and optional `NVIDIA_API_KEY` |
 | [`runway`](https://abdelstark.github.io/worldforge/providers/runway/) | `beta` | `generate`, `transfer` | `RUNWAYML_API_SECRET` or `RUNWAY_API_SECRET` | host supplies Runway credentials and persists returned artifacts |
-| [`leworldmodel`](https://abdelstark.github.io/worldforge/providers/leworldmodel/) | `beta` | `score` | `LEWORLDMODEL_POLICY` or `LEWM_POLICY` | host installs the official LeWM loading path (`stable_worldmodel.policy.AutoCostModel`), torch, and compatible checkpoints |
+| [`leworldmodel`](https://abdelstark.github.io/worldforge/providers/leworldmodel/) | `stable` | `score` | `LEWORLDMODEL_POLICY` or `LEWM_POLICY` | host installs the official LeWM loading path (`stable_worldmodel.policy.AutoCostModel`), torch, and compatible checkpoints |
 | [`gr00t`](https://abdelstark.github.io/worldforge/providers/gr00t/) | `experimental` | `policy` | `GROOT_POLICY_HOST` | host runs or reaches an Isaac GR00T policy server |
 | [`lerobot`](https://abdelstark.github.io/worldforge/providers/lerobot/) | `beta` | `policy` | `LEROBOT_POLICY_PATH` or `LEROBOT_POLICY` | host installs LeRobot and compatible policy checkpoints |
 | `jepa` | `scaffold` | scaffold | `JEPA_MODEL_PATH` | capability-fail-closed reservation, not a real JEPA runtime |

--- a/docs/src/provider-authoring-guide.md
+++ b/docs/src/provider-authoring-guide.md
@@ -209,7 +209,7 @@ Current classifications:
 | `mock` | `stable` | Deterministic in-repo provider with no optional runtime and broad checkout-safe test coverage. |
 | `cosmos` | `beta` | Real remote generate adapter with fixture coverage and runtime manifest; prepared hosts own the Cosmos deployment. |
 | `runway` | `beta` | Real remote generate/transfer adapter with parser and artifact checks; prepared hosts own credentials and artifact retention. |
-| `leworldmodel` | `beta` | Real score adapter for the official LeWM loading path; prepared hosts own torch, `stable_worldmodel`, and checkpoints. |
+| `leworldmodel` | `stable` | Recommended score adapter for the official LeWM loading path; prepared hosts own torch, `stable_worldmodel`, checkpoints, and task preprocessing. |
 | `gr00t` | `experimental` | Real PolicyClient boundary exists, but prepared-host operation and failure coverage still need beta hardening. |
 | `lerobot` | `beta` | Real policy adapter with host-owned LeRobot/checkpoint runtime and documented translator boundary. |
 | `jepa` | `scaffold` | Fail-closed reservation until a real upstream JEPA runtime and single capability are selected. |

--- a/docs/src/providers/README.md
+++ b/docs/src/providers/README.md
@@ -15,7 +15,7 @@ Keep this page and the provider pages aligned with that catalog.
 | `mock` | `stable` | `predict`, `generate`, `transfer`, `reason`, `embed` | always registered | in-repo deterministic local provider |
 | [`cosmos`](./cosmos.md) | `beta` | `generate` | `COSMOS_BASE_URL` | host supplies a reachable Cosmos deployment and optional `NVIDIA_API_KEY` |
 | [`runway`](./runway.md) | `beta` | `generate`, `transfer` | `RUNWAYML_API_SECRET` or `RUNWAY_API_SECRET` | host supplies Runway credentials and persists returned artifacts |
-| [`leworldmodel`](./leworldmodel.md) | `beta` | `score` | `LEWORLDMODEL_POLICY` or `LEWM_POLICY` | host installs the official LeWM loading path (`stable_worldmodel.policy.AutoCostModel`), torch, and compatible checkpoints |
+| [`leworldmodel`](./leworldmodel.md) | `stable` | `score` | `LEWORLDMODEL_POLICY` or `LEWM_POLICY` | host installs the official LeWM loading path (`stable_worldmodel.policy.AutoCostModel`), torch, and compatible checkpoints |
 | [`gr00t`](./gr00t.md) | `experimental` | `policy` | `GROOT_POLICY_HOST` | host runs or reaches an Isaac GR00T policy server |
 | [`lerobot`](./lerobot.md) | `beta` | `policy` | `LEROBOT_POLICY_PATH` or `LEROBOT_POLICY` | host installs LeRobot and compatible policy checkpoints |
 | `jepa` | `scaffold` | scaffold | `JEPA_MODEL_PATH` | capability-fail-closed reservation, not a real JEPA runtime |

--- a/docs/src/providers/leworldmodel.md
+++ b/docs/src/providers/leworldmodel.md
@@ -4,6 +4,8 @@ Capability: `score`
 
 Taxonomy category: JEPA latent predictive world model
 
+Maturity: `stable`
+
 `leworldmodel` wraps LeWorldModel's `stable_worldmodel.policy.AutoCostModel` surface. It ranks
 candidate action sequences from task-shaped observations, goals, and actions. WorldForge models it
 as an action scorer because the upstream runtime returns costs; it does not generate video, answer
@@ -40,7 +42,8 @@ WorldForge does not add LeWorldModel, torch, checkpoint archives, or datasets to
 Runtime manifest:
 `src/worldforge/providers/runtime_manifests/leworldmodel.json` records the policy aliases,
 optional checkpoint/device settings, host-owned checkpoint artifacts, minimum real-checkpoint smoke
-command, and expected finite-cost signal.
+command, the pinned upstream import boundary
+`stable_worldmodel.policy.AutoCostModel`, and expected finite-cost signal.
 
 Programmatic construction can inject a loader and tensor module for tests or host-owned runtimes:
 
@@ -79,6 +82,9 @@ Validation rules:
 - `action_candidates` must be a tensor or rectangular nested numeric array shaped as
   `(batch, samples, horizon, action_dim)`.
 - Returned costs must flatten to finite numeric scores.
+- Returned score tensor shape must contain exactly one score per candidate action sample. Shapes
+  such as `(samples,)`, `(1, samples)`, or `(samples, 1)` are accepted; ambiguous non-singleton
+  dimensions fail before `ActionScoreResult` is returned.
 - The number of returned scores must match the scored candidate set.
 
 Scores are costs: lower values are better. WorldForge sets `best_index` to the lowest-cost
@@ -128,12 +134,18 @@ path without loading an upstream checkpoint.
 Real-checkpoint smoke:
 
 ```bash
-scripts/lewm-real --checkpoint ~/.stable-wm/pusht/lewm_object.ckpt --device cpu
+scripts/lewm-real --checkpoint ~/.stable-wm/pusht/lewm_object.ckpt --device cpu \
+  --json-output /tmp/lewm-real-summary.json \
+  --run-manifest .worldforge/runs/lewm-real/run_manifest.json
 ```
 
 This loads the host-owned upstream runtime and object checkpoint, then scores synthetic
 PushT-shaped candidate tensors through `LeWorldModelProvider`. It is real checkpoint scoring, not
 task-specific preprocessing or robot execution.
+
+The JSON summary and optional run manifest include the score payload summary, input tensor shape
+summary, provider event count, runtime API, and sanitized artifact links. They do not include
+checkpoint bytes or host credentials.
 
 The upstream dependency shown by the wrapper is `stable-worldmodel` because the official
 `lucas-maes/le-wm` repository documents `stable_worldmodel.policy.AutoCostModel("pusht/lewm")` as
@@ -155,10 +167,15 @@ and [Robotics Replay Showcase](../robotics-showcase.md).
 - Missing `LEWORLDMODEL_POLICY` and `LEWM_POLICY` leaves the provider unregistered.
 - Missing `torch` or `stable_worldmodel.policy.AutoCostModel` is reported by `health()`.
 - Checkpoint loading failures are wrapped in `ProviderError`.
+- If no device is configured, the provider prepares the runtime on `cpu`; pass
+  `LEWORLDMODEL_DEVICE` or `device=` for a host-owned accelerator.
 - Missing required `pixels`, `goal`, or `action` fields fail before model invocation.
 - Ragged nested arrays, non-finite values, or low-rank tensors fail before model invocation.
 - Non-four-dimensional action candidates fail before model invocation.
 - Non-finite model outputs fail before `ActionScoreResult` is returned.
+- Score tensor shapes with more than one non-singleton dimension fail before
+  `ActionScoreResult` is returned.
+- Returned score count must match the candidate sample count.
 - Score planning fails if the score result cannot identify an in-range candidate.
 
 ## Tests

--- a/src/worldforge/providers/leworldmodel.py
+++ b/src/worldforge/providers/leworldmodel.py
@@ -115,7 +115,7 @@ class LeWorldModelProvider(BaseProvider):
                     "action, and goal tensors."
                 ),
                 package="worldforge + stable_worldmodel AutoCostModel",
-                implementation_status="beta",
+                implementation_status="stable",
                 deterministic=True,
                 requires_credentials=False,
                 required_env_vars=tuple(LEWORLDMODEL_POLICY_ENV_ALIASES),
@@ -128,6 +128,8 @@ class LeWorldModelProvider(BaseProvider):
                     "Runs real AutoCostModel.get_cost(...) inference when the host supplies the "
                     "optional runtime and checkpoint.",
                     "Set LEWORLDMODEL_POLICY to the checkpoint run name relative to STABLEWM_HOME.",
+                    "Defaults smoke/runtime execution to CPU unless LEWORLDMODEL_DEVICE or a "
+                    "direct device override is supplied.",
                     "Input tensors or nested numeric arrays must already match the checkpoint "
                     "task.",
                     "Scores are costs: lower values are better and best_index is the argmin.",
@@ -250,6 +252,9 @@ class LeWorldModelProvider(BaseProvider):
                 + ")."
             ) from exc
 
+    def _effective_device(self) -> str:
+        return self.device or "cpu"
+
     def _load_model(self) -> Any:
         if not self.configured():
             raise ProviderError(
@@ -273,7 +278,7 @@ class LeWorldModelProvider(BaseProvider):
                 f"Failed to load LeWorldModel policy '{self.policy}': {exc}"
             ) from exc
 
-        model = prepare_model(model, device=self.device)
+        model = prepare_model(model, device=self._effective_device())
         if hasattr(model, "interpolate_pos_encoding"):
             model.interpolate_pos_encoding = True
         self._model = model
@@ -381,6 +386,47 @@ class LeWorldModelProvider(BaseProvider):
             raise ProviderError("LeWorldModel action_candidates sample dimension must be positive.")
         return samples
 
+    def _score_output_shape(self, raw_scores: object) -> tuple[int, ...]:
+        try:
+            shape = _shape(raw_scores, name="LeWorldModel scores")
+            if any(dimension < 0 for dimension in shape):
+                tolist = getattr(raw_scores, "tolist", None)
+                if callable(tolist):
+                    return _shape(tolist(), name="LeWorldModel scores")
+            return shape
+        except ProviderError:
+            try:
+                require_finite_number(raw_scores, name="LeWorldModel scores")  # type: ignore[arg-type]
+            except WorldForgeError as exc:
+                raise ProviderError(
+                    "LeWorldModel scores must contain only finite score values."
+                ) from exc
+            return ()
+
+    def _json_shape(self, value: object, *, name: str) -> list[int]:
+        shape = _shape(value, name=name)
+        if any(dimension < 0 for dimension in shape):
+            tolist = getattr(value, "tolist", None)
+            if callable(tolist):
+                shape = _shape(tolist(), name=name)
+        return list(shape)
+
+    def _validate_score_output_shape(self, shape: tuple[int, ...], *, candidate_count: int) -> None:
+        if shape == ():
+            if candidate_count == 1:
+                return
+            raise ProviderError(
+                "LeWorldModel score output must contain one finite score per candidate action "
+                f"sample; got scalar output for {candidate_count} candidates."
+            )
+        non_singleton_dimensions = [dimension for dimension in shape if dimension != 1]
+        if non_singleton_dimensions not in ([candidate_count], []):
+            raise ProviderError(
+                "LeWorldModel score output shape must expose only the candidate sample "
+                f"dimension plus optional singleton dimensions; got {shape} for "
+                f"{candidate_count} candidates."
+            )
+
     def _tensor_to_scores(self, raw_scores: object) -> list[float]:
         value = raw_scores
         for method_name in ("detach", "cpu"):
@@ -419,6 +465,15 @@ class LeWorldModelProvider(BaseProvider):
             tensor_info = self._tensorize_info(torch, info)
             candidate_count = self._candidate_sample_count(action_candidates)
             action_tensor = self._tensorize_action_candidates(torch, action_candidates)
+            input_shapes = {
+                "pixels": self._json_shape(tensor_info["pixels"], name="LeWorldModel info.pixels"),
+                "goal": self._json_shape(tensor_info["goal"], name="LeWorldModel info.goal"),
+                "action": self._json_shape(tensor_info["action"], name="LeWorldModel info.action"),
+                "action_candidates": self._json_shape(
+                    action_tensor,
+                    name="LeWorldModel action_candidates",
+                ),
+            }
             with no_grad_context(torch):
                 raw_scores = model.get_cost(tensor_info, action_tensor)
             scores = self._tensor_to_scores(raw_scores)
@@ -427,6 +482,8 @@ class LeWorldModelProvider(BaseProvider):
                     f"LeWorldModel returned {len(scores)} score(s) for "
                     f"{candidate_count} candidate action sample(s)."
                 )
+            score_shape = self._score_output_shape(raw_scores)
+            self._validate_score_output_shape(score_shape, candidate_count=candidate_count)
             best_index = min(range(len(scores)), key=scores.__getitem__)
             duration_ms = max(0.1, (perf_counter() - started) * 1000)
             result = ActionScoreResult(
@@ -437,13 +494,17 @@ class LeWorldModelProvider(BaseProvider):
                 metadata={
                     "policy": self.policy,
                     "cache_dir": self.cache_dir,
-                    "device": self.device,
+                    "device": self._effective_device(),
+                    "requested_device": self.device,
                     "score_type": "cost",
+                    "score_direction": "lower_is_better",
                     "model_family": "LeWorldModel (LeWM)",
                     "official_code": LEWORLDMODEL_OFFICIAL_REPO_URL,
                     "runtime_api": LEWORLDMODEL_RUNTIME_API,
                     "checkpoint_format": "<policy>_object.ckpt",
                     "candidate_count": candidate_count,
+                    "input_shapes": input_shapes,
+                    "score_shape": list(score_shape),
                 },
             )
             self._emit_operation_event(
@@ -454,6 +515,7 @@ class LeWorldModelProvider(BaseProvider):
                     "policy": self.policy,
                     "candidate_count": candidate_count,
                     "best_index": best_index,
+                    "score_shape": list(score_shape),
                 },
             )
             return result

--- a/src/worldforge/providers/runtime_manifests/leworldmodel.json
+++ b/src/worldforge/providers/runtime_manifests/leworldmodel.json
@@ -1,7 +1,9 @@
 {
   "schema_version": 1,
   "provider": "leworldmodel",
+  "implementation_status": "stable",
   "capabilities": ["score"],
+  "runtime_api": "stable_worldmodel.policy.AutoCostModel",
   "optional_dependencies": ["torch", "stable_worldmodel"],
   "required_env_vars": ["LEWORLDMODEL_POLICY", "LEWM_POLICY"],
   "optional_env_vars": ["STABLEWM_HOME", "LEWORLDMODEL_CACHE_DIR", "LEWORLDMODEL_DEVICE"],
@@ -9,7 +11,8 @@
   "device_support": ["cpu", "cuda", "mps"],
   "host_owned_artifacts": ["LeWorldModel checkpoint", "checkpoint cache", "task-shaped tensors"],
   "minimum_smoke_command": "scripts/lewm-real --checkpoint ~/.stable-wm/pusht/lewm_object.ckpt --device cpu",
-  "expected_success_signal": "AutoCostModel.get_cost(...) returns finite candidate costs",
+  "score_contract": "AutoCostModel.get_cost(info, action_candidates) returns one finite lower-is-better cost per candidate sample",
+  "expected_success_signal": "AutoCostModel.get_cost(...) returns finite candidate costs and a score payload summary",
   "setup_hint": "install torch plus the official stable_worldmodel loading path in the host runtime",
   "docs_path": "docs/src/providers/leworldmodel.md"
 }

--- a/src/worldforge/smoke/leworldmodel.py
+++ b/src/worldforge/smoke/leworldmodel.py
@@ -231,6 +231,21 @@ def _score_stats(result: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def _score_payload_summary(result: dict[str, Any]) -> dict[str, Any]:
+    metadata = result.get("metadata") if isinstance(result.get("metadata"), dict) else {}
+    scores = result.get("scores") if isinstance(result.get("scores"), list) else []
+    return {
+        "candidate_count": metadata.get("candidate_count", len(scores)),
+        "best_index": result.get("best_index"),
+        "best_score": result.get("best_score"),
+        "lower_is_better": result.get("lower_is_better"),
+        "score_direction": metadata.get("score_direction", "lower_is_better"),
+        "score_shape": metadata.get("score_shape"),
+        "input_shapes": metadata.get("input_shapes"),
+        "runtime_api": metadata.get("runtime_api"),
+    }
+
+
 def _score_chart(result: dict[str, Any], *, color: bool = False) -> list[str]:
     scores = [float(score) for score in result.get("scores", [])]
     if not scores:
@@ -613,6 +628,7 @@ def main() -> int:
     score_latency_ms = (perf_counter() - started) * 1000
     result_payload = result.to_dict()
     score_stats = _score_stats(result_payload)
+    score_payload_summary = _score_payload_summary(result_payload)
     total_latency_ms = (perf_counter() - total_started) * 1000
     metrics = {
         "resolve_latency_ms": resolve_latency_ms,
@@ -640,6 +656,7 @@ def main() -> int:
         "metrics": metrics,
         "provider_events": provider_events,
         "result": result_payload,
+        "score_payload_summary": score_payload_summary,
     }
     if args.json_output is not None:
         json_output_path = _write_json_output(args.json_output, payload)

--- a/tests/test_leworldmodel_provider.py
+++ b/tests/test_leworldmodel_provider.py
@@ -134,9 +134,15 @@ def test_leworldmodel_provider_scores_fixture_payload_and_routes_through_forge(t
     assert result.best_score == 0.15
     assert result.lower_is_better is True
     assert result.metadata["score_type"] == "cost"
+    assert result.metadata["score_direction"] == "lower_is_better"
     assert result.metadata["model_family"] == "LeWorldModel (LeWM)"
     assert result.metadata["official_code"] == "https://github.com/lucas-maes/le-wm"
     assert result.metadata["runtime_api"] == "stable_worldmodel.policy.AutoCostModel"
+    assert result.metadata["device"] == "cpu"
+    assert result.metadata["requested_device"] == "cpu"
+    assert result.metadata["candidate_count"] == 3
+    assert result.metadata["input_shapes"]["action_candidates"] == [1, 3, 3, 1]
+    assert result.metadata["score_shape"] == [3]
     assert result.to_dict()["best_score"] == 0.15
     assert loaded == [("pusht/lewm", "/tmp/stablewm")]
     assert model.device == "cpu"
@@ -160,6 +166,40 @@ def test_leworldmodel_provider_rejects_score_count_mismatch() -> None:
             info=payload["info"],
             action_candidates=payload["action_candidates"],
         )
+
+
+def test_leworldmodel_provider_rejects_ambiguous_score_tensor_shape() -> None:
+    payload = _fixture("leworldmodel_score_request.json")
+    provider = LeWorldModelProvider(
+        policy="pusht/lewm",
+        model_loader=lambda _policy, _cache_dir: FakeLeWorldModel([[0.1, 0.2], [0.3, 0.4]]),
+        tensor_module=FakeTorch(),
+    )
+
+    with pytest.raises(ProviderError, match="score output shape"):
+        provider.score_actions(
+            info=payload["info"],
+            action_candidates=[[[[0.1, 0.2]], [[0.3, 0.4]], [[0.5, 0.6]], [[0.7, 0.8]]]],
+        )
+
+
+def test_leworldmodel_provider_defaults_runtime_device_to_cpu() -> None:
+    payload = _fixture("leworldmodel_score_request.json")
+    model = FakeLeWorldModel([0.7, 0.15, 0.4])
+    provider = LeWorldModelProvider(
+        policy="pusht/lewm",
+        model_loader=lambda _policy, _cache_dir: model,
+        tensor_module=FakeTorch(),
+    )
+
+    result = provider.score_actions(
+        info=payload["info"],
+        action_candidates=payload["action_candidates"],
+    )
+
+    assert model.device == "cpu"
+    assert result.metadata["device"] == "cpu"
+    assert result.metadata["requested_device"] is None
 
 
 def test_leworldmodel_score_planning_selects_best_candidate_and_execution_provider(
@@ -246,7 +286,7 @@ def test_leworldmodel_provider_reports_profile_health_and_auto_registration(
     assert provider.configured() is True
     assert profile.capabilities.score is True
     assert profile.capabilities.predict is False
-    assert profile.implementation_status == "beta"
+    assert profile.implementation_status == "stable"
     assert profile.requires_credentials is False
     assert profile.default_model == "cube/lewm"
     assert "LEWORLDMODEL_POLICY" in profile.required_env_vars

--- a/tests/test_leworldmodel_smoke_script.py
+++ b/tests/test_leworldmodel_smoke_script.py
@@ -534,6 +534,8 @@ def test_smoke_main_prints_provider_result(
     assert output["checkpoint"] == str(tmp_path / "pusht/lewm_object.ckpt")
     assert output["health"] == {"healthy": True, "name": "leworldmodel"}
     assert output["result"] == {"best_index": 0, "scores": [0.1]}
+    assert output["score_payload_summary"]["candidate_count"] == 1
+    assert output["score_payload_summary"]["score_direction"] == "lower_is_better"
     assert output["inputs"]["seed"] == 7
     assert output["inputs"]["total_tensor_elements"] == 0
     assert output["metrics"]["score_latency_ms"] >= 0.0
@@ -651,6 +653,8 @@ def test_smoke_main_prints_visual_pipeline_by_default(
     payload = json.loads(json_output.read_text(encoding="utf-8"))
     assert payload["inputs"]["seed"] == 7
     assert payload["inputs"]["total_tensor_elements"] == 903198
+    assert payload["score_payload_summary"]["candidate_count"] == 2
+    assert payload["score_payload_summary"]["best_index"] == 1
     assert payload["metrics"]["gap_to_runner_up"] == pytest.approx(0.2)
     assert payload["provider_events"][0]["phase"] == "success"
 

--- a/tests/test_provider_catalog.py
+++ b/tests/test_provider_catalog.py
@@ -54,7 +54,7 @@ def test_provider_catalog_statuses_match_promotion_gate() -> None:
         "mock": "stable",
         "cosmos": "beta",
         "runway": "beta",
-        "leworldmodel": "beta",
+        "leworldmodel": "stable",
         "gr00t": "experimental",
         "lerobot": "beta",
         "jepa": "scaffold",

--- a/tests/test_provider_profiles.py
+++ b/tests/test_provider_profiles.py
@@ -62,7 +62,7 @@ def test_provider_profiles_and_doctor_report_include_known_scaffolds(tmp_path, m
     ]
     assert builtin_profiles["runway"].request_policy is not None
     assert builtin_profiles["runway"].request_policy.download.retry.max_attempts == 3
-    assert builtin_profiles["leworldmodel"].implementation_status == "beta"
+    assert builtin_profiles["leworldmodel"].implementation_status == "stable"
     assert builtin_profiles["leworldmodel"].capabilities.score is True
     assert builtin_profiles["leworldmodel"].capabilities.predict is False
     assert builtin_profiles["leworldmodel"].required_env_vars == [


### PR DESCRIPTION
Closes #63.

## Summary
- promote `leworldmodel` to stable in provider profile, catalog docs, and runtime manifest
- add explicit CPU fallback, score direction metadata, input shape summaries, and score output shape validation
- include score payload summaries in real-checkpoint smoke JSON/run manifest evidence
- document the pinned `stable_worldmodel.policy.AutoCostModel` boundary and failure matrix

## Validation
- `uv run ruff check src tests examples scripts`
- `uv run ruff format --check src tests examples scripts`
- `uv run pytest tests/test_leworldmodel_provider.py tests/test_provider_contracts.py -q`
- `uv run pytest tests/test_leworldmodel_smoke_script.py tests/test_leworldmodel_provider.py -q`
- `uv run python scripts/generate_provider_docs.py --check`
- `uv run mkdocs build --strict`
- `uv run --extra harness pytest --cov=src/worldforge --cov-report=term-missing --cov-fail-under=90` (`600 passed, 2 skipped`, coverage `90.11%`)
- `uv lock --check`
- `bash scripts/test_package.sh` (`523 passed, 79 skipped`)
- `UV_LOCKED=true uv export --all-groups --no-emit-project --no-hashes -o /tmp/worldforge-requirements-ci.txt && uvx --from pip-audit pip-audit -r /tmp/worldforge-requirements-ci.txt`
