### PR TITLE
Add LeWorldModel task bridge registry

### DIFF
--- a/docs/src/providers/leworldmodel.md
+++ b/docs/src/providers/leworldmodel.md
@@ -119,6 +119,30 @@ The selected `Plan.actions` come from `candidate_actions[best_index]`. `Plan.pre
 stays empty because a score provider ranks candidate futures without returning a WorldForge state
 rollout. Use `execute_plan(...)` with an execution provider that supports `predict`.
 
+## Task Bridges
+
+WorldForge ships a small bridge registry for smoke commands, not a generic tensor preprocessor.
+The first registered bridge is `pusht`; it wires:
+
+- `build_observation()` for the LeRobot PushT policy input
+- `build_score_info()` for LeWorldModel `pixels`, `goal`, and `action`
+- `translate_candidates_contract` for WorldForge replay actions
+- `build_action_candidates()` for `1 x 3 x 4 x 10` PushT score tensors
+
+Use it from the lower-level runner with:
+
+```bash
+scripts/lewm-lerobot-real \
+  --policy-path lerobot/diffusion_pusht \
+  --checkpoint ~/.stable-wm/pusht/lewm_object.ckpt \
+  --bridge pusht
+```
+
+The bridge registry records expected policy, score, and candidate tensor shapes. Run manifests copy
+that shape summary plus the observed score tensor shapes so issue evidence can show whether a host
+used the intended task contract. WorldForge validates shape consistency and fails on mismatched
+action dimensions before planning; the host still owns task preprocessing and any non-PushT bridge.
+
 ## Runtime Checks
 
 Checkout-safe provider/planner demo:

--- a/docs/src/robotics-showcase-deep-dive.md
+++ b/docs/src/robotics-showcase-deep-dive.md
@@ -272,6 +272,11 @@ The packaged PushT bridge builds them from two deterministic PushT resets:
 | `goal` | `1 x 1 x 3 x 3 x 224 x 224` | Goal PushT RGB frame repeated across the same history window. |
 | `action` | `1 x 1 x 3 x 10` | Zero action history for the 3-step history window and 10-dimensional PushT action block. |
 
+The smoke commands resolve this through the checkout-safe `--bridge pusht` registry entry. That
+entry names the observation factory, score-info factory, translator, candidate builder, expected
+horizon, expected score action dimension, and static shape summary. The registry does not infer
+task tensors for other robots; a host bringing another task must provide an equivalent bridge.
+
 The score provider also receives action candidates. The default `build_action_candidates(...)`
 bridge converts the LeRobot raw action into:
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -126,10 +126,19 @@ scripts/lewm-lerobot-real \
   --checkpoint ~/.stable-wm/pusht/lewm_object.ckpt \
   --device cpu \
   --mode select_action \
-  --observation-module /path/to/pusht_obs.py:build_observation \
+  --bridge pusht
+```
+
+For non-PushT tasks, pass explicit host-owned hooks instead of the packaged bridge:
+
+```bash
+scripts/lewm-lerobot-real \
+  --policy-path /path/to/task-policy \
+  --checkpoint /path/to/task/lewm_object.ckpt \
+  --observation-module /path/to/task_obs.py:build_observation \
   --score-info-npz /path/to/lewm_score_tensors.npz \
-  --translator worldforge.smoke.lerobot_leworldmodel:translate_pusht_xy_actions \
-  --candidate-builder /path/to/pusht_lewm_bridge.py:build_action_candidates
+  --translator /path/to/task_translator.py:translate_actions \
+  --candidate-builder /path/to/task_lewm_bridge.py:build_action_candidates
 ```
 
 Use custom hooks only with task-aligned inputs: the LeRobot policy, observation, LeWorldModel score

--- a/src/worldforge/smoke/lerobot_leworldmodel.py
+++ b/src/worldforge/smoke/lerobot_leworldmodel.py
@@ -27,6 +27,7 @@ from worldforge import Action, BBox, Position, SceneObject, StructuredGoal, Worl
 from worldforge.models import ProviderEvent
 from worldforge.providers import LeRobotPolicyProvider, LeWorldModelProvider
 from worldforge.providers._config import env_value as _env_value
+from worldforge.smoke.leworldmodel_bridges import bridge_names, get_bridge
 from worldforge.smoke.run_manifest import build_run_manifest, write_run_manifest
 
 from .leworldmodel import (
@@ -46,6 +47,7 @@ DEFAULT_LEROBOT_POLICY = "lerobot/diffusion_pusht"
 DEFAULT_LEWORLDMODEL_POLICY = "pusht/lewm"
 DEFAULT_DEVICE = "cpu"
 DEFAULT_MODE = "select_action"
+DEFAULT_TRANSLATOR = "worldforge.smoke.lerobot_leworldmodel:translate_pusht_xy_actions"
 DEFAULT_TASK = (
     "PushT tabletop manipulation: use a LeRobot policy to propose an action chunk, "
     "then rank policy-compatible candidates with a LeWorldModel cost checkpoint."
@@ -830,11 +832,44 @@ def _runtime_command(*, checkpoint: Path, policy_path: str, device: str) -> str:
         f"  --checkpoint {checkpoint_text} \\\n"
         f"  --device {device} \\\n"
         "  --mode select_action \\\n"
-        "  --observation-module /path/to/pusht_obs.py:build_observation \\\n"
-        "  --score-info-npz /path/to/lewm_score_tensors.npz \\\n"
-        "  --translator worldforge.smoke.lerobot_leworldmodel:translate_pusht_xy_actions \\\n"
-        "  --candidate-builder /path/to/pusht_lewm_bridge.py:build_action_candidates"
+        "  --bridge pusht"
     )
+
+
+def _apply_bridge_defaults(args: argparse.Namespace) -> dict[str, Any] | None:
+    if args.bridge is None:
+        return None
+    try:
+        bridge = get_bridge(args.bridge)
+    except ValueError as exc:
+        raise SystemExit(str(exc)) from exc
+    if (
+        args.observation_module is None
+        and args.observation_json is None
+        and args.policy_info_json is None
+    ):
+        args.observation_module = bridge.observation_module
+    if (
+        args.score_info_module is None
+        and args.score_info_json is None
+        and args.score_info_npz is None
+    ):
+        args.score_info_module = bridge.score_info_module
+    if (
+        args.candidate_builder is None
+        and args.action_candidates_json is None
+        and args.action_candidates_npz is None
+    ):
+        args.candidate_builder = bridge.candidate_builder
+    if args.translator == DEFAULT_TRANSLATOR:
+        args.translator = bridge.translator
+    if args.expected_action_dim is None:
+        args.expected_action_dim = bridge.expected_action_dim
+    if args.expected_horizon is None:
+        args.expected_horizon = bridge.expected_horizon
+    if args.task == DEFAULT_TASK:
+        args.task = bridge.task
+    return bridge.to_dict()
 
 
 def _parser() -> argparse.ArgumentParser:
@@ -898,6 +933,15 @@ def _parser() -> argparse.ArgumentParser:
     parser.add_argument("--lerobot-cache-dir", default=_env_value("LEROBOT_CACHE_DIR"))
     parser.add_argument("--embodiment-tag", default=_env_value("LEROBOT_EMBODIMENT_TAG") or "pusht")
     parser.add_argument("--mode", choices=("select_action", "predict_chunk"), default=DEFAULT_MODE)
+    parser.add_argument(
+        "--bridge",
+        choices=bridge_names(),
+        default=None,
+        help=(
+            "Use a registered task bridge for observation, score tensors, translator, "
+            "candidate builder, and expected LeWorldModel tensor dimensions."
+        ),
+    )
     parser.add_argument("--action-horizon", type=int, default=None)
     parser.add_argument("--expected-action-dim", type=int, default=None)
     parser.add_argument("--expected-horizon", type=int, default=None)
@@ -992,7 +1036,7 @@ def _parser() -> argparse.ArgumentParser:
     parser.add_argument("--action-candidates-key", default="action_candidates")
     parser.add_argument(
         "--translator",
-        default="worldforge.smoke.lerobot_leworldmodel:translate_pusht_xy_actions",
+        default=DEFAULT_TRANSLATOR,
         help=(
             "Callable module_or_file:function receiving (raw_actions, info, provider_info) "
             "and returning WorldForge Action candidates."
@@ -1004,6 +1048,7 @@ def _parser() -> argparse.ArgumentParser:
 def main(argv: Sequence[str] | None = None) -> int:
     parser = _parser()
     args = parser.parse_args(argv)
+    bridge_summary = _apply_bridge_defaults(args)
     if not args.policy_path:
         parser.error(
             "real LeRobot+LeWorldModel flow requires --policy-path or LEROBOT_POLICY_PATH."
@@ -1153,6 +1198,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     if args.health_only or not preflight_ok:
         payload = {
             "mode": "real_lerobot_policy_plus_real_leworldmodel_score",
+            "bridge": bridge_summary,
             "checkpoint": str(object_path),
             "checkpoint_display": _display_path(object_path),
             "checkpoint_exists": checkpoint_exists,
@@ -1192,6 +1238,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                         "STABLEWM_HOME",
                     ),
                     event_count=len(provider_events),
+                    input_summary={"bridge": bridge_summary} if bridge_summary is not None else {},
                     result=payload,
                     artifact_paths=json_artifacts,
                 ),
@@ -1372,6 +1419,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     payload = {
         "mode": "real_lerobot_policy_plus_real_leworldmodel_score",
         "task": args.task,
+        "bridge": bridge_summary,
         "checkpoint": str(object_path),
         "checkpoint_display": _display_path(object_path),
         "state_dir": str(state_dir),
@@ -1443,6 +1491,13 @@ def main(argv: Sequence[str] | None = None) -> int:
                     "STABLEWM_HOME",
                 ),
                 event_count=len(event_payload),
+                input_summary={
+                    "bridge": bridge_summary,
+                    "score_shapes": score_shape_payload,
+                    "score_action_candidates_shape": list(
+                        _shape_tuple(score_action_candidates) or []
+                    ),
+                },
                 input_fixture=input_fixture,
                 result=payload,
                 artifact_paths=artifact_paths,

--- a/src/worldforge/smoke/leworldmodel_bridges.py
+++ b/src/worldforge/smoke/leworldmodel_bridges.py
@@ -1,0 +1,92 @@
+"""Checkout-safe LeWorldModel task bridge registry."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from .pusht_showcase_inputs import (
+    DEFAULT_ACTION_DIM,
+    DEFAULT_HISTORY,
+    DEFAULT_HORIZON,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class LeWorldModelTaskBridge:
+    """Static metadata for a host-owned LeWorldModel task bridge."""
+
+    name: str
+    task: str
+    observation_module: str
+    score_info_module: str
+    translator: str
+    candidate_builder: str
+    expected_action_dim: int
+    expected_horizon: int
+    shape_summary: dict[str, Any]
+    description: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "task": self.task,
+            "observation_module": self.observation_module,
+            "score_info_module": self.score_info_module,
+            "translator": self.translator,
+            "candidate_builder": self.candidate_builder,
+            "expected_action_dim": self.expected_action_dim,
+            "expected_horizon": self.expected_horizon,
+            "shape_summary": dict(self.shape_summary),
+            "description": self.description,
+        }
+
+
+PUSHT_BRIDGE = LeWorldModelTaskBridge(
+    name="pusht",
+    task="PushT tabletop manipulation",
+    observation_module="worldforge.smoke.pusht_showcase_inputs:build_observation",
+    score_info_module="worldforge.smoke.pusht_showcase_inputs:build_score_info",
+    translator="worldforge.smoke.pusht_showcase_inputs:translate_candidates_contract",
+    candidate_builder="worldforge.smoke.pusht_showcase_inputs:build_action_candidates",
+    expected_action_dim=DEFAULT_ACTION_DIM,
+    expected_horizon=DEFAULT_HORIZON,
+    shape_summary={
+        "policy_observation": {
+            "observation.image": [1, 3, 96, 96],
+            "observation.state": [1, 2],
+        },
+        "score_info": {
+            "pixels": [1, 1, DEFAULT_HISTORY, 3, 224, 224],
+            "goal": [1, 1, DEFAULT_HISTORY, 3, 224, 224],
+            "action": [1, 1, DEFAULT_HISTORY, DEFAULT_ACTION_DIM],
+        },
+        "action_candidates": [1, 3, DEFAULT_HORIZON, DEFAULT_ACTION_DIM],
+        "raw_policy_action": [2],
+    },
+    description=(
+        "Packaged PushT bridge for the LeRobot diffusion PushT policy and the "
+        "LeWorldModel PushT object checkpoint. Hosts own the environment reset, "
+        "image preprocessing, and the 2D policy action to 10D score tensor mapping."
+    ),
+)
+
+BRIDGES = {PUSHT_BRIDGE.name: PUSHT_BRIDGE}
+
+
+def bridge_names() -> tuple[str, ...]:
+    """Return registered task bridge names."""
+
+    return tuple(sorted(BRIDGES))
+
+
+def get_bridge(name: str) -> LeWorldModelTaskBridge:
+    """Return a registered bridge or raise a user-facing ValueError."""
+
+    try:
+        return BRIDGES[name]
+    except KeyError as exc:
+        raise ValueError(
+            f"Unknown LeWorldModel task bridge '{name}'. Available bridges: "
+            f"{', '.join(bridge_names())}."
+        ) from exc

--- a/src/worldforge/smoke/robotics_showcase.py
+++ b/src/worldforge/smoke/robotics_showcase.py
@@ -22,11 +22,11 @@ from .lerobot_leworldmodel import (
     DEFAULT_MODE,
 )
 from .leworldmodel import DEFAULT_STABLEWM_HOME, _checkpoint_path
-from .pusht_showcase_inputs import DEFAULT_ACTION_DIM, DEFAULT_HORIZON
+from .leworldmodel_bridges import get_bridge
 
 DEFAULT_JSON_OUTPUT = Path("/tmp/worldforge-robotics-showcase/real-run.json")
 DEFAULT_RERUN_OUTPUT = Path("/tmp/worldforge-robotics-showcase/real-run.rrd")
-PUSHT_INPUT_MODULE = "worldforge.smoke.pusht_showcase_inputs"
+DEFAULT_BRIDGE = "pusht"
 
 
 def _parser() -> argparse.ArgumentParser:
@@ -224,20 +224,10 @@ def _forward_args(args: argparse.Namespace) -> list[str]:
         args.device,
         "--mode",
         args.mode,
-        "--observation-module",
-        f"{PUSHT_INPUT_MODULE}:build_observation",
-        "--score-info-module",
-        f"{PUSHT_INPUT_MODULE}:build_score_info",
-        "--translator",
-        f"{PUSHT_INPUT_MODULE}:translate_candidates_contract",
-        "--candidate-builder",
-        f"{PUSHT_INPUT_MODULE}:build_action_candidates",
-        "--expected-action-dim",
-        str(DEFAULT_ACTION_DIM),
-        "--expected-horizon",
-        str(DEFAULT_HORIZON),
+        "--bridge",
+        DEFAULT_BRIDGE,
         "--task",
-        "PushT real LeRobot policy plus LeWorldModel score planning",
+        get_bridge(DEFAULT_BRIDGE).task,
         "--goal",
         "rank PushT policy action candidates with a LeWorldModel checkpoint",
         "--color",

--- a/src/worldforge/smoke/run_manifest.py
+++ b/src/worldforge/smoke/run_manifest.py
@@ -38,6 +38,7 @@ class LiveSmokeRunManifest:
     env_summary: tuple[JSONDict, ...]
     artifact_paths: Mapping[str, str] = field(default_factory=dict)
     event_count: int = 0
+    input_summary: Mapping[str, Any] = field(default_factory=dict)
     input_fixture_digest: str | None = None
     result_digest: str | None = None
     runtime_manifest_id: str | None = None
@@ -71,6 +72,7 @@ class LiveSmokeRunManifest:
             "status": self.status,
             "runtime_manifest_id": self.runtime_manifest_id,
             "env_summary": [dict(item) for item in self.env_summary],
+            "input_summary": _json_native(dict(self.input_summary)),
             "input_fixture_digest": self.input_fixture_digest,
             "event_count": self.event_count,
             "result_digest": self.result_digest,
@@ -89,6 +91,7 @@ def build_run_manifest(
     artifact_paths: Mapping[str, Path | str] | None = None,
     command_argv: Sequence[str] | None = None,
     event_count: int = 0,
+    input_summary: Mapping[str, Any] | None = None,
     input_fixture: Path | str | None = None,
     result: Mapping[str, Any] | None = None,
     result_digest: str | None = None,
@@ -118,6 +121,7 @@ def build_run_manifest(
         status=status,
         runtime_manifest_id=runtime_manifest_id,
         env_summary=tuple(env_summary(env_vars, environ=environ)),
+        input_summary=input_summary or {},
         input_fixture_digest=digest_file(input_fixture) if input_fixture is not None else None,
         event_count=event_count,
         result_digest=resolved_result_digest,
@@ -205,6 +209,9 @@ def validate_run_manifest(payload: Mapping[str, Any]) -> JSONDict:
         raise WorldForgeError("Run manifest env_summary must be a list.")
     if not isinstance(manifest.get("artifact_paths"), dict):
         raise WorldForgeError("Run manifest artifact_paths must be an object.")
+    manifest.setdefault("input_summary", {})
+    if not isinstance(manifest.get("input_summary"), dict):
+        raise WorldForgeError("Run manifest input_summary must be an object.")
     _reject_secret_like_values(manifest)
     _reject_unsafe_strings(manifest)
     return manifest

--- a/tests/test_lerobot_leworldmodel_smoke_script.py
+++ b/tests/test_lerobot_leworldmodel_smoke_script.py
@@ -11,6 +11,7 @@ import pytest
 
 from worldforge.providers import LeRobotPolicyProvider, LeWorldModelProvider
 from worldforge.smoke import lerobot_leworldmodel
+from worldforge.smoke.leworldmodel_bridges import get_bridge
 
 
 class FakeTensor:
@@ -226,6 +227,46 @@ def test_builtin_pusht_translator_returns_worldforge_actions() -> None:
             {},
             {},
         )
+
+
+def test_leworldmodel_bridge_registry_exposes_checkout_safe_pusht_metadata() -> None:
+    bridge = get_bridge("pusht")
+
+    assert bridge.observation_module == "worldforge.smoke.pusht_showcase_inputs:build_observation"
+    assert bridge.score_info_module == "worldforge.smoke.pusht_showcase_inputs:build_score_info"
+    assert bridge.expected_action_dim == 10
+    assert bridge.expected_horizon == 4
+    assert bridge.shape_summary["action_candidates"] == [1, 3, 4, 10]
+
+    with pytest.raises(ValueError, match="Unknown LeWorldModel task bridge"):
+        get_bridge("unknown")
+
+
+def test_bridge_defaults_fill_smoke_inputs_without_optional_imports() -> None:
+    args = _args(
+        bridge="pusht",
+        score_info_json=None,
+        score_info_npz=None,
+        score_info_module=None,
+        action_candidates_json=None,
+        action_candidates_npz=None,
+        candidate_builder=None,
+        translator=lerobot_leworldmodel.DEFAULT_TRANSLATOR,
+        task=lerobot_leworldmodel.DEFAULT_TASK,
+    )
+
+    summary = lerobot_leworldmodel._apply_bridge_defaults(args)
+
+    assert summary is not None
+    assert summary["name"] == "pusht"
+    assert args.observation_module == "worldforge.smoke.pusht_showcase_inputs:build_observation"
+    assert args.score_info_module == "worldforge.smoke.pusht_showcase_inputs:build_score_info"
+    assert (
+        args.candidate_builder == "worldforge.smoke.pusht_showcase_inputs:build_action_candidates"
+    )
+    assert args.translator == "worldforge.smoke.pusht_showcase_inputs:translate_candidates_contract"
+    assert args.expected_action_dim == 10
+    assert args.expected_horizon == 4
 
 
 def test_helper_loaders_and_error_paths(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
@@ -471,6 +512,7 @@ def test_main_runs_policy_score_plan_with_fake_real_runtimes(
     assert manifest["status"] == "passed"
     assert manifest["event_count"] == len(payload["provider_events"])
     assert manifest["input_fixture_digest"].startswith("sha256:")
+    assert manifest["input_summary"]["score_shapes"]["action_candidates"] == [1, 2, 2, 2]
     assert set(manifest["artifact_paths"]) == {"worldforge_state"}
 
 

--- a/tests/test_robotics_showcase.py
+++ b/tests/test_robotics_showcase.py
@@ -224,25 +224,13 @@ def test_robotics_showcase_forwards_packaged_pusht_defaults(
 
     forwarded = captured["argv"]
     assert forwarded[:2] == ["--policy-path", "lerobot/diffusion_pusht"]
-    assert "--observation-module" in forwarded
-    assert (
-        forwarded[forwarded.index("--observation-module") + 1]
-        == "worldforge.smoke.pusht_showcase_inputs:build_observation"
-    )
-    assert (
-        forwarded[forwarded.index("--score-info-module") + 1]
-        == "worldforge.smoke.pusht_showcase_inputs:build_score_info"
-    )
-    assert (
-        forwarded[forwarded.index("--translator") + 1]
-        == "worldforge.smoke.pusht_showcase_inputs:translate_candidates_contract"
-    )
-    assert (
-        forwarded[forwarded.index("--candidate-builder") + 1]
-        == "worldforge.smoke.pusht_showcase_inputs:build_action_candidates"
-    )
-    assert forwarded[forwarded.index("--expected-action-dim") + 1] == "10"
-    assert forwarded[forwarded.index("--expected-horizon") + 1] == "4"
+    assert forwarded[forwarded.index("--bridge") + 1] == "pusht"
+    assert "--observation-module" not in forwarded
+    assert "--score-info-module" not in forwarded
+    assert "--translator" not in forwarded
+    assert "--candidate-builder" not in forwarded
+    assert "--expected-action-dim" not in forwarded
+    assert "--expected-horizon" not in forwarded
     assert "--json-output" not in forwarded
 
 

--- a/tests/test_smoke_run_manifest.py
+++ b/tests/test_smoke_run_manifest.py
@@ -78,6 +78,26 @@ def test_write_run_manifest_validates_before_writing(tmp_path: Path) -> None:
     assert json.loads(path.read_text(encoding="utf-8"))["provider_profile"] == "cosmos"
 
 
+def test_run_manifest_preserves_safe_input_summary() -> None:
+    manifest = build_run_manifest(
+        run_id="run-1",
+        provider_profile="leworldmodel",
+        capability="score",
+        status="passed",
+        env_vars=("LEWORLDMODEL_POLICY",),
+        command_argv=("lewm-real",),
+        input_summary={
+            "bridge": "pusht",
+            "score_shapes": {"action_candidates": [1, 3, 4, 10]},
+        },
+    ).to_dict()
+
+    assert manifest["input_summary"] == {
+        "bridge": "pusht",
+        "score_shapes": {"action_candidates": [1, 3, 4, 10]},
+    }
+
+
 def test_run_manifest_rejects_secret_like_values_and_signed_urls(tmp_path: Path) -> None:
     manifest = build_run_manifest(
         run_id="run-1",


### PR DESCRIPTION
Closes #71.

## Summary
- add a checkout-safe LeWorldModel task bridge registry with the packaged PushT bridge
- let `scripts/robotics-showcase` and the lower-level runner resolve `--bridge pusht`
- include bridge and score shape summaries in sanitized live run manifests
- document WorldForge validation vs host-owned task preprocessing

## Validation
- `uv run ruff check src tests examples scripts`
- `uv run ruff format --check src tests examples scripts`
- `uv run pytest -m "not live"`
- `uv run mkdocs build --strict`
- `uv run python scripts/generate_provider_docs.py --check`
