### PR TITLE
Promote GR00T policy provider to beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,7 +360,7 @@ observe state
 | [`cosmos`](https://abdelstark.github.io/worldforge/providers/cosmos/) | `beta` | `generate` | `COSMOS_BASE_URL` | host supplies a reachable Cosmos deployment and optional `NVIDIA_API_KEY` |
 | [`runway`](https://abdelstark.github.io/worldforge/providers/runway/) | `beta` | `generate`, `transfer` | `RUNWAYML_API_SECRET` or `RUNWAY_API_SECRET` | host supplies Runway credentials and persists returned artifacts |
 | [`leworldmodel`](https://abdelstark.github.io/worldforge/providers/leworldmodel/) | `stable` | `score` | `LEWORLDMODEL_POLICY` or `LEWM_POLICY` | host installs the official LeWM loading path (`stable_worldmodel.policy.AutoCostModel`), torch, and compatible checkpoints |
-| [`gr00t`](https://abdelstark.github.io/worldforge/providers/gr00t/) | `experimental` | `policy` | `GROOT_POLICY_HOST` | host runs or reaches an Isaac GR00T policy server |
+| [`gr00t`](https://abdelstark.github.io/worldforge/providers/gr00t/) | `beta` | `policy` | `GROOT_POLICY_HOST` | host runs or reaches an Isaac GR00T policy server |
 | [`lerobot`](https://abdelstark.github.io/worldforge/providers/lerobot/) | `beta` | `policy` | `LEROBOT_POLICY_PATH` or `LEROBOT_POLICY` | host installs LeRobot and compatible policy checkpoints |
 | `jepa` | `scaffold` | scaffold | `JEPA_MODEL_PATH` | capability-fail-closed reservation, not a real JEPA runtime |
 | `genie` | `scaffold` | scaffold | `GENIE_API_KEY` | capability-fail-closed reservation, not a real Genie runtime |

--- a/docs/src/provider-authoring-guide.md
+++ b/docs/src/provider-authoring-guide.md
@@ -210,7 +210,7 @@ Current classifications:
 | `cosmos` | `beta` | Real remote generate adapter with fixture coverage and runtime manifest; prepared hosts own the Cosmos deployment. |
 | `runway` | `beta` | Real remote generate/transfer adapter with parser and artifact checks; prepared hosts own credentials and artifact retention. |
 | `leworldmodel` | `stable` | Recommended score adapter for the official LeWM loading path; prepared hosts own torch, `stable_worldmodel`, checkpoints, and task preprocessing. |
-| `gr00t` | `experimental` | Real PolicyClient boundary exists, but prepared-host operation and failure coverage still need beta hardening. |
+| `gr00t` | `beta` | Real remote PolicyClient boundary with fixture-backed failure coverage; prepared hosts own the reachable server, credentials, translator, and robot runtime. |
 | `lerobot` | `beta` | Real policy adapter with host-owned LeRobot/checkpoint runtime and documented translator boundary. |
 | `jepa` | `scaffold` | Fail-closed reservation until a real upstream JEPA runtime and single capability are selected. |
 | `genie` | `scaffold` | Fail-closed reservation until a concrete upstream runtime/API contract exists. |

--- a/docs/src/providers/README.md
+++ b/docs/src/providers/README.md
@@ -16,7 +16,7 @@ Keep this page and the provider pages aligned with that catalog.
 | [`cosmos`](./cosmos.md) | `beta` | `generate` | `COSMOS_BASE_URL` | host supplies a reachable Cosmos deployment and optional `NVIDIA_API_KEY` |
 | [`runway`](./runway.md) | `beta` | `generate`, `transfer` | `RUNWAYML_API_SECRET` or `RUNWAY_API_SECRET` | host supplies Runway credentials and persists returned artifacts |
 | [`leworldmodel`](./leworldmodel.md) | `stable` | `score` | `LEWORLDMODEL_POLICY` or `LEWM_POLICY` | host installs the official LeWM loading path (`stable_worldmodel.policy.AutoCostModel`), torch, and compatible checkpoints |
-| [`gr00t`](./gr00t.md) | `experimental` | `policy` | `GROOT_POLICY_HOST` | host runs or reaches an Isaac GR00T policy server |
+| [`gr00t`](./gr00t.md) | `beta` | `policy` | `GROOT_POLICY_HOST` | host runs or reaches an Isaac GR00T policy server |
 | [`lerobot`](./lerobot.md) | `beta` | `policy` | `LEROBOT_POLICY_PATH` or `LEROBOT_POLICY` | host installs LeRobot and compatible policy checkpoints |
 | `jepa` | `scaffold` | scaffold | `JEPA_MODEL_PATH` | capability-fail-closed reservation, not a real JEPA runtime |
 | `genie` | `scaffold` | scaffold | `GENIE_API_KEY` | capability-fail-closed reservation, not a real Genie runtime |

--- a/docs/src/providers/gr00t.md
+++ b/docs/src/providers/gr00t.md
@@ -52,6 +52,10 @@ expected policy-client health signal.
 
 ## Runtime Contract
 
+Maturity: `beta`. Prepared hosts can use the remote PolicyClient path for policy selection when
+they provide a reachable server, optional auth token, observation envelope, and action translator.
+WorldForge does not start or supervise local GR00T runtime services by default.
+
 Direct construction with an injected test client or host-owned client:
 
 ```python
@@ -103,6 +107,11 @@ Validation rules:
 - `options`, when supplied, must be a JSON object.
 - Tensor-like values with `tolist()` are normalized for metadata and raw-action preservation.
 - A host-supplied `action_translator` is required before `ActionPolicyResult` can be returned.
+
+Provider events emitted by `select_actions()` include operation `policy`, attempt `1`, max attempts
+`1`, method `POLICYCLIENT.GET_ACTION`, a sanitized target, elapsed duration, timeout settings, and
+the strict-mode flag. Token-like values in messages, targets, or metadata are redacted before they
+reach logs or run manifests.
 
 ## Action Translation
 
@@ -187,6 +196,7 @@ dependencies. On unsupported hosts, connect WorldForge to an already running rem
 
 - Missing `GROOT_POLICY_HOST` leaves the provider unregistered.
 - Missing `gr00t.policy.server_client.PolicyClient` is reported by `health()`.
+- Unreachable policy servers or ping failures are reported by `health()` without leaking tokens.
 - Missing `action_translator` fails with `ProviderError`.
 - Malformed observations fail before invoking the policy client.
 - Non-JSON-compatible raw actions or provider info fail before returning `ActionPolicyResult`.

--- a/src/worldforge/providers/gr00t.py
+++ b/src/worldforge/providers/gr00t.py
@@ -121,7 +121,7 @@ class GrootPolicyClientProvider(BaseProvider):
                     "NVIDIA Isaac GR00T policy-client adapter for selecting embodied action chunks."
                 ),
                 package="worldforge + host-supplied Isaac-GR00T runtime",
-                implementation_status="experimental",
+                implementation_status="beta",
                 requires_credentials=self.api_token is not None,
                 required_env_vars=(GROOT_POLICY_HOST_ENV_VAR,),
                 supported_modalities=("video", "state", "language", "actions"),
@@ -227,10 +227,49 @@ class GrootPolicyClientProvider(BaseProvider):
                 return self._health(started, "policy server ping failed", healthy=False)
         except ProviderError as exc:
             return self._health(started, str(exc), healthy=False)
+        except Exception as exc:
+            return self._health(
+                started,
+                f"GR00T policy server health check failed: {exc}",
+                healthy=False,
+            )
         return self._health(
             started,
             f"configured for {self.host or 'injected policy client'}:{self.port}",
             healthy=True,
+        )
+
+    def _event_target(self) -> str:
+        if self.host is None:
+            return "injected-policy-client"
+        return f"{self.host}:{self.port}"
+
+    def _emit_policy_event(
+        self,
+        *,
+        phase: str,
+        duration_ms: float,
+        message: str = "",
+        metadata: JSONDict | None = None,
+    ) -> None:
+        self._emit_event(
+            ProviderEvent(
+                provider=self.name,
+                operation="policy",
+                phase=phase,
+                attempt=1,
+                max_attempts=1,
+                method="POLICYCLIENT.GET_ACTION",
+                target=self._event_target(),
+                duration_ms=duration_ms,
+                message=message,
+                metadata={
+                    "timeout_ms": self.timeout_ms,
+                    "strict": self.strict,
+                    "embodiment_tag": self.embodiment_tag,
+                    **dict(metadata or {}),
+                },
+            )
         )
 
     def _runtime_dependency_error(self) -> str | None:
@@ -366,8 +405,7 @@ class GrootPolicyClientProvider(BaseProvider):
                 },
                 action_candidates=candidate_plans,
             )
-            self._emit_operation_event(
-                "policy",
+            self._emit_policy_event(
                 phase="success",
                 duration_ms=max(0.1, (perf_counter() - started) * 1000),
                 metadata={
@@ -378,8 +416,7 @@ class GrootPolicyClientProvider(BaseProvider):
             )
             return result
         except ProviderError as exc:
-            self._emit_operation_event(
-                "policy",
+            self._emit_policy_event(
                 phase="failure",
                 duration_ms=max(0.1, (perf_counter() - started) * 1000),
                 message=str(exc),
@@ -387,8 +424,7 @@ class GrootPolicyClientProvider(BaseProvider):
             raise
         except Exception as exc:
             error = ProviderError(f"GR00T policy selection failed: {exc}")
-            self._emit_operation_event(
-                "policy",
+            self._emit_policy_event(
                 phase="failure",
                 duration_ms=max(0.1, (perf_counter() - started) * 1000),
                 message=str(error),

--- a/tests/test_gr00t_provider.py
+++ b/tests/test_gr00t_provider.py
@@ -52,6 +52,11 @@ class FakeGrootClient:
         return self.response
 
 
+class FailingPingGrootClient(FakeGrootClient):
+    def ping(self) -> bool:
+        raise RuntimeError("server unreachable api_token=secret")
+
+
 class FakeArray:
     def __init__(self, value: object) -> None:
         self.value = value
@@ -155,6 +160,12 @@ def test_gr00t_policy_client_provider_passes_contract_and_emits_events() -> None
     assert client.get_action_calls[-1]["observation"] == _policy_info()["observation"]
     assert events[-1].operation == "policy"
     assert events[-1].phase == "success"
+    assert events[-1].attempt == 1
+    assert events[-1].max_attempts == 1
+    assert events[-1].method == "POLICYCLIENT.GET_ACTION"
+    assert events[-1].target == "injected-policy-client"
+    assert events[-1].metadata["timeout_ms"] == 15000
+    assert events[-1].metadata["strict"] is False
 
 
 @pytest.mark.parametrize(
@@ -332,6 +343,20 @@ def test_gr00t_provider_health_reports_native_import_failures(monkeypatch) -> No
     assert "native loader failed" in health.details
 
 
+def test_gr00t_provider_health_reports_unreachable_policy_server() -> None:
+    provider = GrootPolicyClientProvider(
+        policy_client=FailingPingGrootClient(({"arm": [[[0.0]]]}, {})),
+        action_translator=lambda *_args: [Action("noop")],
+    )
+
+    health = provider.health()
+
+    assert health.healthy is False
+    assert "policy server health check failed" in health.details
+    assert "api_token=[redacted]" in health.details
+    assert "secret" not in health.details
+
+
 def test_gr00t_provider_lazily_constructs_policy_client_from_import(monkeypatch) -> None:
     created: list[dict[str, object]] = []
 
@@ -367,6 +392,43 @@ def test_gr00t_provider_lazily_constructs_policy_client_from_import(monkeypatch)
         }
     ]
     assert result.raw_actions == {"arm": [[[0.2, 0.5, 0.0]]]}
+
+
+def test_gr00t_policy_events_include_sanitized_remote_target_and_redacted_failures() -> None:
+    events: list[ProviderEvent] = []
+    client = FakeGrootClient(({"arm": [[[0.0]]]}, {}))
+
+    def fail_get_action(_observation: object) -> object:
+        raise RuntimeError("server refused bearer secret-token")
+
+    client.get_action = fail_get_action  # type: ignore[method-assign]
+    provider = GrootPolicyClientProvider(
+        host="https://policy.example.test:8443/path?api_token=secret",
+        port=5555,
+        timeout_ms=2500,
+        strict=True,
+        api_token="provider-token",
+        policy_client=client,
+        action_translator=lambda *_args: [Action("noop")],
+        event_handler=events.append,
+    )
+
+    with pytest.raises(ProviderError, match="server refused"):
+        provider.select_actions(info=_policy_info())
+
+    event = events[-1]
+    payload = event.to_dict()
+    assert payload["phase"] == "failure"
+    assert payload["operation"] == "policy"
+    assert payload["attempt"] == 1
+    assert payload["max_attempts"] == 1
+    assert payload["method"] == "POLICYCLIENT.GET_ACTION"
+    assert payload["target"] == "https://policy.example.test:8443/path"
+    assert payload["metadata"]["timeout_ms"] == 2500
+    assert payload["metadata"]["strict"] is True
+    assert "provider-token" not in str(payload)
+    assert "secret-token" not in payload["message"]
+    assert "Bearer [redacted]" in payload["message"]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_provider_catalog.py
+++ b/tests/test_provider_catalog.py
@@ -55,7 +55,7 @@ def test_provider_catalog_statuses_match_promotion_gate() -> None:
         "cosmos": "beta",
         "runway": "beta",
         "leworldmodel": "stable",
-        "gr00t": "experimental",
+        "gr00t": "beta",
         "lerobot": "beta",
         "jepa": "scaffold",
         "genie": "scaffold",

--- a/tests/test_provider_profiles.py
+++ b/tests/test_provider_profiles.py
@@ -69,7 +69,7 @@ def test_provider_profiles_and_doctor_report_include_known_scaffolds(tmp_path, m
         "LEWORLDMODEL_POLICY",
         "LEWM_POLICY",
     ]
-    assert builtin_profiles["gr00t"].implementation_status == "experimental"
+    assert builtin_profiles["gr00t"].implementation_status == "beta"
     assert builtin_profiles["gr00t"].capabilities.policy is True
     assert builtin_profiles["gr00t"].capabilities.predict is False
     assert builtin_profiles["gr00t"].required_env_vars == ["GROOT_POLICY_HOST"]


### PR DESCRIPTION
Closes #62.

## Summary
- promote `gr00t` to beta for the documented remote PolicyClient path
- make GR00T health checks report unreachable policy servers without leaking token-like values
- emit sanitized policy events with operation, attempt, target, duration, timeout, and strict-mode metadata
- update provider docs/catalog expectations and tests

## Validation
- `uv run ruff check src tests examples scripts`
- `uv run ruff format --check src tests examples scripts`
- `uv run python scripts/generate_provider_docs.py --check`
- `uv run mkdocs build --strict`
- `uv run pytest -m "not live" -q`
- `bash scripts/test_package.sh`
- `uv run --extra harness pytest --cov=src/worldforge --cov-report=term-missing --cov-fail-under=90`
