### PR TITLE
Promote LeRobot policy provider to stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,7 +361,7 @@ observe state
 | [`runway`](https://abdelstark.github.io/worldforge/providers/runway/) | `beta` | `generate`, `transfer` | `RUNWAYML_API_SECRET` or `RUNWAY_API_SECRET` | host supplies Runway credentials and persists returned artifacts |
 | [`leworldmodel`](https://abdelstark.github.io/worldforge/providers/leworldmodel/) | `stable` | `score` | `LEWORLDMODEL_POLICY` or `LEWM_POLICY` | host installs the official LeWM loading path (`stable_worldmodel.policy.AutoCostModel`), torch, and compatible checkpoints |
 | [`gr00t`](https://abdelstark.github.io/worldforge/providers/gr00t/) | `beta` | `policy` | `GROOT_POLICY_HOST` | host runs or reaches an Isaac GR00T policy server |
-| [`lerobot`](https://abdelstark.github.io/worldforge/providers/lerobot/) | `beta` | `policy` | `LEROBOT_POLICY_PATH` or `LEROBOT_POLICY` | host installs LeRobot and compatible policy checkpoints |
+| [`lerobot`](https://abdelstark.github.io/worldforge/providers/lerobot/) | `stable` | `policy` | `LEROBOT_POLICY_PATH` or `LEROBOT_POLICY` | host installs LeRobot and compatible policy checkpoints |
 | `jepa` | `scaffold` | scaffold | `JEPA_MODEL_PATH` | capability-fail-closed reservation, not a real JEPA runtime |
 | `genie` | `scaffold` | scaffold | `GENIE_API_KEY` | capability-fail-closed reservation, not a real Genie runtime |
 <!-- provider-catalog-readme:end -->

--- a/docs/src/provider-authoring-guide.md
+++ b/docs/src/provider-authoring-guide.md
@@ -211,7 +211,7 @@ Current classifications:
 | `runway` | `beta` | Real remote generate/transfer adapter with parser and artifact checks; prepared hosts own credentials and artifact retention. |
 | `leworldmodel` | `stable` | Recommended score adapter for the official LeWM loading path; prepared hosts own torch, `stable_worldmodel`, checkpoints, and task preprocessing. |
 | `gr00t` | `beta` | Real remote PolicyClient boundary with fixture-backed failure coverage; prepared hosts own the reachable server, credentials, translator, and robot runtime. |
-| `lerobot` | `beta` | Real policy adapter with host-owned LeRobot/checkpoint runtime and documented translator boundary. |
+| `lerobot` | `stable` | Recommended embodied policy adapter for the LeRobot `PreTrainedPolicy` path; prepared hosts own LeRobot, checkpoints, translators, and robot runtime. |
 | `jepa` | `scaffold` | Fail-closed reservation until a real upstream JEPA runtime and single capability are selected. |
 | `genie` | `scaffold` | Fail-closed reservation until a concrete upstream runtime/API contract exists. |
 | `jepa-wms` | `scaffold` | Direct-construction candidate only; not exported or auto-registered until runtime limits and smoke evidence are credible. |

--- a/docs/src/providers/README.md
+++ b/docs/src/providers/README.md
@@ -17,7 +17,7 @@ Keep this page and the provider pages aligned with that catalog.
 | [`runway`](./runway.md) | `beta` | `generate`, `transfer` | `RUNWAYML_API_SECRET` or `RUNWAY_API_SECRET` | host supplies Runway credentials and persists returned artifacts |
 | [`leworldmodel`](./leworldmodel.md) | `stable` | `score` | `LEWORLDMODEL_POLICY` or `LEWM_POLICY` | host installs the official LeWM loading path (`stable_worldmodel.policy.AutoCostModel`), torch, and compatible checkpoints |
 | [`gr00t`](./gr00t.md) | `beta` | `policy` | `GROOT_POLICY_HOST` | host runs or reaches an Isaac GR00T policy server |
-| [`lerobot`](./lerobot.md) | `beta` | `policy` | `LEROBOT_POLICY_PATH` or `LEROBOT_POLICY` | host installs LeRobot and compatible policy checkpoints |
+| [`lerobot`](./lerobot.md) | `stable` | `policy` | `LEROBOT_POLICY_PATH` or `LEROBOT_POLICY` | host installs LeRobot and compatible policy checkpoints |
 | `jepa` | `scaffold` | scaffold | `JEPA_MODEL_PATH` | capability-fail-closed reservation, not a real JEPA runtime |
 | `genie` | `scaffold` | scaffold | `GENIE_API_KEY` | capability-fail-closed reservation, not a real Genie runtime |
 <!-- provider-catalog:end -->

--- a/docs/src/providers/lerobot.md
+++ b/docs/src/providers/lerobot.md
@@ -38,7 +38,7 @@ WorldForge never drives hardware directly.
   `lerobot/act_aloha_sim_transfer_cube_human`.
 - `LEROBOT_POLICY_TYPE`: optional policy class hint. Supported values include `act`, `diffusion`,
   `tdmpc`, `vqbet`, `pi0`, `pi0fast`, `sac`, and `smolvla`.
-- `LEROBOT_DEVICE`: optional device string passed to `policy.to(...)`.
+- `LEROBOT_DEVICE`: optional device string passed to `policy.to(...)`. Defaults to `cpu`.
 - `LEROBOT_CACHE_DIR`: optional Hugging Face cache directory.
 - `LEROBOT_EMBODIMENT_TAG`: optional metadata for the robot embodiment.
 
@@ -72,12 +72,21 @@ policy.predict_action_chunk(observation) -> action_chunk_tensor # optional
 policy.reset()                                                  # optional
 ```
 
+Supported loading modes are explicit:
+
+- injected `policy=...` for tests or host-managed runtimes
+- injected `policy_loader=...` for host-owned custom loading
+- `PreTrainedPolicy.from_pretrained(...)` for the configured path
+- typed policy-class loading when `LEROBOT_POLICY_TYPE` is set
+
 Without an injected policy, WorldForge lazily imports `PreTrainedPolicy` and loads the configured
 checkpoint. If `LEROBOT_POLICY_TYPE` is set, it resolves the specific policy class before calling
 `from_pretrained(...)`.
 
 After loading, the adapter calls `policy.to(device)`, `policy.eval()`,
-`policy.requires_grad_(False)`, and `policy.reset()` when those methods exist.
+`policy.requires_grad_(False)`, and `policy.reset()` when those methods exist. The default device is
+`cpu`; hosts must opt into `cuda`, `mps`, or another runtime-specific device with `LEROBOT_DEVICE`
+or `device=`.
 
 ## Input Contract
 
@@ -108,6 +117,8 @@ Validation rules:
 - `predict_chunk` requires a policy that implements `predict_action_chunk`.
 - Tensor-like values with `tolist()` are normalized for metadata and raw-action preservation.
 - A host-supplied `action_translator` is required before `ActionPolicyResult` can be returned.
+- Result metadata includes `loader_mode` and a bounded `raw_action_summary` with type, rectangular
+  shape when available, and a small preview suitable for run reports.
 
 ## Action Translation
 
@@ -234,6 +245,8 @@ showcase. Full runnable context lives in [CLI Reference](../cli.md),
 
 - Missing `LEROBOT_POLICY_PATH` and `LEROBOT_POLICY` leaves the provider unregistered.
 - Missing `lerobot` or `PreTrainedPolicy` is reported by `health()`.
+- Local-looking checkpoint paths that do not exist are reported by `health()` before runtime import.
+- Unsupported `LEROBOT_POLICY_TYPE` values fail during provider construction.
 - Policy class resolution or checkpoint loading failures are wrapped in `ProviderError`.
 - Missing `action_translator` fails with `ProviderError`.
 - Contracted translators fail on unknown embodiment tags, non-finite raw action values, raw action

--- a/src/worldforge/providers/lerobot.py
+++ b/src/worldforge/providers/lerobot.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import importlib
 from collections.abc import Callable, Sequence
+from pathlib import Path
 from time import perf_counter
 from typing import Any
 
@@ -53,6 +54,7 @@ LEROBOT_POLICY_TYPE_ENV_VAR = "LEROBOT_POLICY_TYPE"
 LEROBOT_DEVICE_ENV_VAR = "LEROBOT_DEVICE"
 LEROBOT_CACHE_DIR_ENV_VAR = "LEROBOT_CACHE_DIR"
 LEROBOT_EMBODIMENT_TAG_ENV_VAR = "LEROBOT_EMBODIMENT_TAG"
+LEROBOT_DEFAULT_DEVICE = "cpu"
 
 SUPPORTED_POLICY_TYPES: tuple[str, ...] = (
     "act",
@@ -108,6 +110,63 @@ def _import_pretrained_policy_module() -> tuple[Any | None, str | None]:
     return None, "LeRobot PreTrainedPolicy import unavailable (" + "; ".join(failures) + ")"
 
 
+def _looks_like_local_checkpoint(path: str) -> bool:
+    return path.startswith((".", "~")) or Path(path).is_absolute() or Path(path).exists()
+
+
+def _checkpoint_missing_detail(path: str) -> str | None:
+    if not _looks_like_local_checkpoint(path):
+        return None
+    if Path(path).expanduser().exists():
+        return None
+    return "LeRobot local checkpoint path does not exist."
+
+
+def _json_shape(value: object) -> list[int] | None:
+    if not isinstance(value, list):
+        return []
+    length = len(value)
+    if length == 0:
+        return [0]
+    child_shapes = [_json_shape(child) for child in value]
+    if any(shape is None for shape in child_shapes):
+        return None
+    first_shape = child_shapes[0]
+    if any(shape != first_shape for shape in child_shapes[1:]):
+        return None
+    return [length, *(first_shape or [])]
+
+
+def _json_preview(value: object, *, max_items: int = 3, depth: int = 0) -> object:
+    if depth >= 3:
+        return "..."
+    if isinstance(value, list):
+        preview = [
+            _json_preview(child, max_items=max_items, depth=depth + 1)
+            for child in value[:max_items]
+        ]
+        if len(value) > max_items:
+            preview.append("...")
+        return preview
+    if isinstance(value, dict):
+        items = list(value.items())[:max_items]
+        preview = {
+            key: _json_preview(child, max_items=max_items, depth=depth + 1) for key, child in items
+        }
+        if len(value) > max_items:
+            preview["..."] = "..."
+        return preview
+    return value
+
+
+def _raw_action_summary(actions: object) -> JSONDict:
+    return {
+        "type": type(actions).__name__,
+        "shape": _json_shape(actions),
+        "preview": _json_preview(actions),
+    }
+
+
 class LeRobotPolicyProvider(BaseProvider):
     """Adapter for Hugging Face LeRobot pretrained policies.
 
@@ -131,6 +190,10 @@ class LeRobotPolicyProvider(BaseProvider):
         action_translator: ActionTranslator | None = None,
         event_handler: Callable[[ProviderEvent], None] | None = None,
     ) -> None:
+        if policy_loader is not None and not callable(policy_loader):
+            raise WorldForgeError("LeRobot policy_loader must be callable when provided.")
+        if action_translator is not None and not callable(action_translator):
+            raise WorldForgeError("LeRobot action_translator must be callable when provided.")
         self.policy_path = optional_non_empty(
             policy_path
             if policy_path is not None
@@ -141,8 +204,11 @@ class LeRobotPolicyProvider(BaseProvider):
             policy_type if policy_type is not None else env_value(LEROBOT_POLICY_TYPE_ENV_VAR),
             name="LeRobot policy_type",
         )
+        self._device_direct = device is not None
+        configured_device = device if device is not None else env_value(LEROBOT_DEVICE_ENV_VAR)
+        self._device_configured = configured_device is not None
         self.device = optional_non_empty(
-            device if device is not None else env_value(LEROBOT_DEVICE_ENV_VAR),
+            device if device is not None else configured_device or LEROBOT_DEFAULT_DEVICE,
             name="LeRobot device",
         )
         self.cache_dir = optional_non_empty(
@@ -178,13 +244,14 @@ class LeRobotPolicyProvider(BaseProvider):
                     "Hugging Face LeRobot pretrained-policy adapter for embodied action selection."
                 ),
                 package="worldforge + lerobot",
-                implementation_status="beta",
+                implementation_status="stable",
                 requires_credentials=False,
                 required_env_vars=tuple(LEROBOT_POLICY_PATH_ENV_ALIASES),
                 supported_modalities=("state", "images", "language", "actions"),
                 artifact_types=("action_policy",),
                 notes=(
                     "Loads policies with lerobot.policies.PreTrainedPolicy.from_pretrained.",
+                    "Defaults to CPU unless LEROBOT_DEVICE or device= selects another runtime.",
                     "Supports ACT, Diffusion, TDMPC, VQBet, Pi0, Pi0Fast, SAC, SmolVLA policies.",
                     "Set LEROBOT_POLICY_PATH to a Hugging Face repo id or local checkpoint "
                     "directory.",
@@ -234,8 +301,13 @@ class LeRobotPolicyProvider(BaseProvider):
                 _field_summary(
                     LEROBOT_DEVICE_ENV_VAR,
                     required=False,
-                    source=config_source(LEROBOT_DEVICE_ENV_VAR, direct=self.device is not None),
+                    source=config_source(
+                        LEROBOT_DEVICE_ENV_VAR,
+                        direct=self._device_direct,
+                        default=not self._device_configured,
+                    ),
                     present=self.device is not None,
+                    detail="defaults to cpu" if self.device == LEROBOT_DEFAULT_DEVICE else "",
                 ),
                 _field_summary(
                     LEROBOT_CACHE_DIR_ENV_VAR,
@@ -267,13 +339,30 @@ class LeRobotPolicyProvider(BaseProvider):
                 healthy=False,
             )
         if self._policy is None:
+            if self.policy_path is not None:
+                checkpoint_error = _checkpoint_missing_detail(self.policy_path)
+                if checkpoint_error is not None:
+                    return self._health(started, checkpoint_error, healthy=False)
             dependency_error = self._runtime_dependency_error()
             if dependency_error is not None:
                 return self._health(started, dependency_error, healthy=False)
         detail_source = "injected policy"
         if self._policy is None:
             detail_source = self.policy_path or detail_source
-        return self._health(started, f"configured for {detail_source}", healthy=True)
+        return self._health(
+            started,
+            f"configured for {detail_source}; loader={self._loader_mode()}; device={self.device}",
+            healthy=True,
+        )
+
+    def _loader_mode(self) -> str:
+        if self._policy is not None:
+            return "injected_policy"
+        if self._policy_loader is not None:
+            return "policy_loader"
+        if self.policy_type is not None:
+            return "typed_from_pretrained"
+        return "pretrained_policy"
 
     def _runtime_dependency_error(self) -> str | None:
         if self._policy_loader is not None:
@@ -511,11 +600,15 @@ class LeRobotPolicyProvider(BaseProvider):
                 embodiment_tag=embodiment_tag or None,
                 metadata={
                     "runtime": "lerobot",
+                    "loader_mode": self._loader_mode(),
                     "policy_path": self.policy_path,
                     "policy_type": self.policy_type,
                     "device": self.device,
                     "mode": mode,
                     "provider_info": normalized_provider_info,
+                    "raw_action_summary": _raw_action_summary(
+                        normalized_raw_actions["actions"],
+                    ),
                     "candidate_count": len(candidate_plans),
                     "translator_contract": translator_contract,
                 },
@@ -528,6 +621,7 @@ class LeRobotPolicyProvider(BaseProvider):
                 metadata={
                     "policy_path": self.policy_path,
                     "policy_type": self.policy_type,
+                    "loader_mode": self._loader_mode(),
                     "candidate_count": len(result.action_candidates),
                     "action_horizon": result.action_horizon,
                     "embodiment_tag": result.embodiment_tag,

--- a/tests/test_lerobot_provider.py
+++ b/tests/test_lerobot_provider.py
@@ -184,9 +184,17 @@ def test_lerobot_policy_provider_passes_contract_and_emits_events() -> None:
     assert result.raw_actions == {"actions": [[0.1, 0.5, 0.0]]}
     assert result.metadata["runtime"] == "lerobot"
     assert result.metadata["mode"] == "select_action"
+    assert result.metadata["device"] == "cpu"
+    assert result.metadata["loader_mode"] == "injected_policy"
+    assert result.metadata["raw_action_summary"] == {
+        "type": "list",
+        "shape": [1, 3],
+        "preview": [[0.1, 0.5, 0.0]],
+    }
     assert policy.select_action_calls[-1] == _policy_info()["observation"]
     assert events[-1].operation == "policy"
     assert events[-1].phase == "success"
+    assert events[-1].metadata["loader_mode"] == "injected_policy"
 
 
 def test_lerobot_contract_translator_records_safe_metadata() -> None:
@@ -419,6 +427,20 @@ def test_lerobot_provider_reports_unconfigured_and_missing_dependency(monkeypatc
     assert "lerobot" in unhealthy.health().details
 
 
+def test_lerobot_provider_reports_missing_local_checkpoint(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr(
+        lerobot_module,
+        "_import_pretrained_policy_module",
+        lambda: pytest.fail("missing local checkpoints should fail before runtime imports"),
+    )
+    provider = LeRobotPolicyProvider(policy_path=str(tmp_path / "missing-checkpoint"))
+
+    health = provider.health()
+
+    assert health.healthy is False
+    assert "checkpoint path does not exist" in health.details
+
+
 def test_lerobot_provider_health_reports_optional_import_crash(monkeypatch) -> None:
     real_import = importlib.import_module
 
@@ -458,6 +480,19 @@ def test_lerobot_provider_reads_env_configuration(monkeypatch) -> None:
     assert provider.embodiment_tag == "pusht"
     assert provider.profile().default_model == "lerobot/diffusion_pusht"
     assert provider.configured() is True
+
+
+def test_lerobot_provider_defaults_device_to_cpu(monkeypatch) -> None:
+    monkeypatch.delenv("LEROBOT_DEVICE", raising=False)
+
+    provider = LeRobotPolicyProvider(policy=FakeLeRobotPolicy(response=FakeTensor([[0.0]])))
+    summary = provider.config_summary().to_dict()
+    device = next(field for field in summary["fields"] if field["name"] == "LEROBOT_DEVICE")
+
+    assert provider.device == "cpu"
+    assert device["source"] == "default"
+    assert device["detail"] == "defaults to cpu"
+    assert "device=cpu" in provider.health().details
 
 
 def test_lerobot_provider_lazily_loads_via_loader_and_applies_device() -> None:
@@ -544,6 +579,8 @@ def test_lerobot_provider_lazily_imports_pretrained_policy(monkeypatch) -> None:
         ({"device": " "}, "device"),
         ({"cache_dir": " "}, "cache_dir"),
         ({"embodiment_tag": " "}, "embodiment_tag"),
+        ({"policy_loader": object()}, "policy_loader"),
+        ({"action_translator": object()}, "action_translator"),
     ],
 )
 def test_lerobot_provider_rejects_invalid_configuration(

--- a/tests/test_provider_catalog.py
+++ b/tests/test_provider_catalog.py
@@ -56,7 +56,7 @@ def test_provider_catalog_statuses_match_promotion_gate() -> None:
         "runway": "beta",
         "leworldmodel": "stable",
         "gr00t": "beta",
-        "lerobot": "beta",
+        "lerobot": "stable",
         "jepa": "scaffold",
         "genie": "scaffold",
     }

--- a/tests/test_provider_profiles.py
+++ b/tests/test_provider_profiles.py
@@ -73,7 +73,7 @@ def test_provider_profiles_and_doctor_report_include_known_scaffolds(tmp_path, m
     assert builtin_profiles["gr00t"].capabilities.policy is True
     assert builtin_profiles["gr00t"].capabilities.predict is False
     assert builtin_profiles["gr00t"].required_env_vars == ["GROOT_POLICY_HOST"]
-    assert builtin_profiles["lerobot"].implementation_status == "beta"
+    assert builtin_profiles["lerobot"].implementation_status == "stable"
     assert builtin_profiles["lerobot"].capabilities.policy is True
     assert builtin_profiles["lerobot"].capabilities.predict is False
     assert builtin_profiles["lerobot"].required_env_vars == [


### PR DESCRIPTION
Closes #60.

## Summary
- promote `lerobot` to stable and document the supported loader modes
- default LeRobot policy loading to CPU unless the host selects another device
- add loader/translator validation, local checkpoint health detail, and bounded raw-action summaries
- refresh provider catalog docs and profile assertions

## Validation
- `uv run ruff check src tests examples scripts`
- `uv run ruff format --check src tests examples scripts`
- `uv run pytest tests/test_lerobot_provider.py tests/test_provider_contracts.py tests/test_provider_catalog_docs.py -q`
- `uv run pytest -m "not live"`
- `uv run mkdocs build --strict`
- `uv run python scripts/generate_provider_docs.py --check`
- `bash scripts/test_package.sh`
- `uv run --extra harness pytest --cov=src/worldforge --cov-report=term-missing --cov-fail-under=90`
