### PR TITLE
Document Genie runtime defer decision

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,7 +363,7 @@ observe state
 | [`gr00t`](https://abdelstark.github.io/worldforge/providers/gr00t/) | `beta` | `policy` | `GROOT_POLICY_HOST` | host runs or reaches an Isaac GR00T policy server |
 | [`lerobot`](https://abdelstark.github.io/worldforge/providers/lerobot/) | `stable` | `policy` | `LEROBOT_POLICY_PATH` or `LEROBOT_POLICY` | host installs LeRobot and compatible policy checkpoints |
 | `jepa` | `scaffold` | scaffold | `JEPA_MODEL_PATH` | capability-fail-closed reservation, not a real JEPA runtime |
-| `genie` | `scaffold` | scaffold | `GENIE_API_KEY` | capability-fail-closed reservation, not a real Genie runtime |
+| [`genie`](https://abdelstark.github.io/worldforge/providers/genie/) | `scaffold` | scaffold | `GENIE_API_KEY` | capability-fail-closed reservation; Project Genie has no supported automation API contract |
 <!-- provider-catalog-readme:end -->
 
 `jepa` and `genie` are capability-closed reservations. Executable scaffold candidates stay outside

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -15,6 +15,7 @@
 - [User And Operator Playbooks](./playbooks.md)
 - [Providers](./providers/README.md)
   - [Cosmos](./providers/cosmos.md)
+  - [Genie](./providers/genie.md)
   - [GR00T](./providers/gr00t.md)
   - [JEPA-WMS](./providers/jepa-wms.md)
   - [LeWorldModel](./providers/leworldmodel.md)

--- a/docs/src/providers/README.md
+++ b/docs/src/providers/README.md
@@ -19,7 +19,7 @@ Keep this page and the provider pages aligned with that catalog.
 | [`gr00t`](./gr00t.md) | `beta` | `policy` | `GROOT_POLICY_HOST` | host runs or reaches an Isaac GR00T policy server |
 | [`lerobot`](./lerobot.md) | `stable` | `policy` | `LEROBOT_POLICY_PATH` or `LEROBOT_POLICY` | host installs LeRobot and compatible policy checkpoints |
 | `jepa` | `scaffold` | scaffold | `JEPA_MODEL_PATH` | capability-fail-closed reservation, not a real JEPA runtime |
-| `genie` | `scaffold` | scaffold | `GENIE_API_KEY` | capability-fail-closed reservation, not a real Genie runtime |
+| [`genie`](./genie.md) | `scaffold` | scaffold | `GENIE_API_KEY` | capability-fail-closed reservation; Project Genie has no supported automation API contract |
 <!-- provider-catalog:end -->
 
 ## Candidate Scaffolds

--- a/docs/src/providers/genie.md
+++ b/docs/src/providers/genie.md
@@ -1,0 +1,60 @@
+# Genie Provider
+
+Status: scaffold.
+
+WorldForge keeps `genie` as a fail-closed provider reservation. It does not advertise `generate`,
+`predict`, or any scene/world capability, and it is not a real Google DeepMind Genie or Project
+Genie integration.
+
+## Defer Decision
+
+Decision date: 2026-05-01.
+
+The first real Genie-facing surface should be `generate` only after there is a supported upstream
+runtime or API contract that automation can call and test. Google DeepMind describes Genie 3 as a
+general-purpose world model for real-time interactive environments, and the January 2026 Project
+Genie announcement describes Project Genie as an experimental research prototype web app for U.S.
+Google AI Ultra subscribers. Those sources describe an interactive product experience, not a supported automation API, SDK, artifact schema, authentication contract, or smoke-testable runtime
+boundary.
+
+Until those boundaries exist, WorldForge must not present deterministic local surrogate behavior as
+a Genie implementation. Keeping the provider as `scaffold` is the accurate production behavior.
+
+References:
+
+- [Genie 3 - Google DeepMind](https://deepmind.google/models/genie/)
+- [Project Genie announcement - Google Blog](https://blog.google/innovation-and-ai/models-and-research/google-deepmind/project-genie/)
+
+## Current Contract
+
+| Field | Value |
+| --- | --- |
+| Provider name | `genie` |
+| Maturity | `scaffold` |
+| Public capabilities | none |
+| Auto-registration signal | `GENIE_API_KEY` |
+| Runtime ownership | none yet; future runtime/API must be host-owned |
+| Artifact types | none |
+
+Setting `GENIE_API_KEY` only makes the reservation visible to diagnostics and readiness surfaces. It
+does not make `genie.generate(...)` callable. All capability methods remain fail-closed unless
+`WORLDFORGE_ENABLE_SCAFFOLD_SURROGATES=1` is set for local adapter tests.
+
+The surrogate opt-in exists only to exercise shared provider plumbing. It must not be used for
+benchmarks, demos, release evidence, or issue evidence that claims Genie runtime behavior.
+
+## Promotion Requirements
+
+Replace this scaffold only when a PR can name and validate one concrete upstream contract:
+
+- supported API, SDK, or local runtime entrypoint;
+- authentication and configuration fields with redacted `config_summary()` output;
+- exact input contract for prompts, optional image/state inputs, duration, and controls;
+- returned artifact schema, MIME/type hints, expiration behavior, and retention expectations;
+- typed failure modes for auth errors, validation errors, unavailable capacity, timeouts, and
+  unsupported artifacts;
+- fixture-backed parser tests for success and failure payloads;
+- optional prepared-host smoke command that writes a sanitized `run_manifest.json`.
+
+If the upstream surface remains an interactive web prototype without a supported automation
+contract, this provider should stay `scaffold`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -55,6 +55,7 @@ nav:
   - Providers:
       - Overview: providers/README.md
       - Cosmos: providers/cosmos.md
+      - Genie: providers/genie.md
       - GR00T: providers/gr00t.md
       - JEPA-WMS: providers/jepa-wms.md
       - LeWorldModel: providers/leworldmodel.md

--- a/src/worldforge/providers/catalog.py
+++ b/src/worldforge/providers/catalog.py
@@ -149,7 +149,11 @@ PROVIDER_CATALOG: tuple[ProviderCatalogEntry, ...] = (
     ProviderCatalogEntry(
         "genie",
         _genie,
-        runtime_ownership="capability-fail-closed reservation, not a real Genie runtime",
+        docs_page="genie.md",
+        runtime_ownership=(
+            "capability-fail-closed reservation; Project Genie has no supported "
+            "automation API contract"
+        ),
     ),
 )
 

--- a/src/worldforge/providers/remote.py
+++ b/src/worldforge/providers/remote.py
@@ -157,6 +157,8 @@ class GenieProvider(StubRemoteProvider):
                 artifact_types=(),
                 notes=(
                     "Capability-fail-closed scaffold adapter; it is not a real Genie runtime.",
+                    "Project Genie is currently documented as an experimental web prototype, "
+                    "not a supported automation API.",
                     "A deterministic local surrogate exists only behind "
                     f"{SCAFFOLD_SURROGATE_ENV_VAR}=1 for adapter testing.",
                 ),

--- a/tests/test_docs_site.py
+++ b/tests/test_docs_site.py
@@ -119,3 +119,19 @@ def test_persistence_adapter_adr_documents_host_owned_boundary() -> None:
 
     for doc in (operations, architecture, playbooks):
         assert "0001-persistence-adapter-boundary.md" in doc
+
+
+def test_genie_scaffold_docs_record_runtime_contract_defer_decision() -> None:
+    provider_page = (ROOT / "docs/src/providers/genie.md").read_text(encoding="utf-8")
+    provider_index = (ROOT / "docs/src/providers/README.md").read_text(encoding="utf-8")
+    summary = (ROOT / "docs/src/SUMMARY.md").read_text(encoding="utf-8")
+
+    assert "Status: scaffold" in provider_page
+    assert "Decision date: 2026-05-01" in provider_page
+    assert "Project Genie announcement" in provider_page
+    assert "not a supported automation API" in provider_page
+    assert "must not present deterministic local surrogate behavior" in provider_page
+    assert "fixture-backed parser tests" in provider_page
+    assert "sanitized `run_manifest.json`" in provider_page
+    assert "| [`genie`](./genie.md) | `scaffold` | scaffold | `GENIE_API_KEY` |" in provider_index
+    assert "[Genie](./providers/genie.md)" in summary


### PR DESCRIPTION
Closes #54.

## Summary
- keep `genie` as a fail-closed scaffold because Project Genie is documented as an experimental web prototype, not a supported automation API contract
- add a dedicated Genie provider page with the defer decision, current scaffold contract, references, and promotion requirements
- link the page from generated provider catalogs and docs navigation

## Validation
- `uv run ruff check src tests scripts`
- `uv run ruff format --check src tests scripts`
- `uv run pytest tests/test_provider_catalog.py tests/test_provider_catalog_docs.py tests/test_provider_contracts.py tests/test_docs_site.py -q`
- `uv run python scripts/generate_provider_docs.py --check`
- `uv run mkdocs build --strict`
- `uv run pytest -m "not live"`
