### PR TITLE
Replace JEPA scaffold with score adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,15 +362,14 @@ observe state
 | [`leworldmodel`](https://abdelstark.github.io/worldforge/providers/leworldmodel/) | `stable` | `score` | `LEWORLDMODEL_POLICY` or `LEWM_POLICY` | host installs the official LeWM loading path (`stable_worldmodel.policy.AutoCostModel`), torch, and compatible checkpoints |
 | [`gr00t`](https://abdelstark.github.io/worldforge/providers/gr00t/) | `beta` | `policy` | `GROOT_POLICY_HOST` | host runs or reaches an Isaac GR00T policy server |
 | [`lerobot`](https://abdelstark.github.io/worldforge/providers/lerobot/) | `stable` | `policy` | `LEROBOT_POLICY_PATH` or `LEROBOT_POLICY` | host installs LeRobot and compatible policy checkpoints |
-| `jepa` | `scaffold` | scaffold | `JEPA_MODEL_PATH` | capability-fail-closed reservation, not a real JEPA runtime |
+| [`jepa`](https://abdelstark.github.io/worldforge/providers/jepa/) | `experimental` | `score` | `JEPA_MODEL_NAME` | host supplies torch, facebookresearch/jepa-wms runtime dependencies, and task preprocessing |
 | [`genie`](https://abdelstark.github.io/worldforge/providers/genie/) | `scaffold` | scaffold | `GENIE_API_KEY` | capability-fail-closed reservation; Project Genie has no supported automation API contract |
 <!-- provider-catalog-readme:end -->
 
-`jepa` and `genie` are capability-closed reservations. Executable scaffold candidates stay outside
+`jepa` is a score-only adapter for host-owned `facebookresearch/jepa-wms` torch-hub runtimes.
+`genie` remains a capability-closed reservation. Executable scaffold candidates stay outside
 package exports and auto-registration until they have a validated runtime path, typed parser
-coverage, request limits, and docs. The active candidate is
-[`jepa-wms`](https://abdelstark.github.io/worldforge/providers/jepa-wms/), a direct-construction scaffold targeting future
-`facebookresearch/jepa-wms` score-provider work.
+coverage, request limits, and docs.
 
 ## Architecture
 
@@ -508,8 +507,9 @@ needs to tighten.
 
 **Known limits**
 
-- `jepa` and `genie` are capability-fail-closed scaffold adapters
-- `jepa-wms` is a direct-construction candidate, not exported or auto-registered
+- `jepa` requires host-owned PyTorch, JEPA-WMS dependencies, checkpoints, and task preprocessing
+- `genie` is a capability-fail-closed scaffold adapter
+- `jepa-wms` remains a direct-construction candidate for host experiments
 - local JSON persistence is single-writer only
 - evaluation scores are contract signals, not physical-fidelity or safety claims
 - optional runtimes, checkpoints, trace export, dashboards, and production telemetry stay

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -17,6 +17,7 @@
   - [Cosmos](./providers/cosmos.md)
   - [Genie](./providers/genie.md)
   - [GR00T](./providers/gr00t.md)
+  - [JEPA](./providers/jepa.md)
   - [JEPA-WMS](./providers/jepa-wms.md)
   - [LeWorldModel](./providers/leworldmodel.md)
   - [LeRobot](./providers/lerobot.md)

--- a/docs/src/architecture.md
+++ b/docs/src/architecture.md
@@ -274,7 +274,7 @@ WorldForge(auto_register_remote=True)
   |-- runway            if RUNWAYML_API_SECRET or RUNWAY_API_SECRET is set
   |-- leworldmodel      if LEWORLDMODEL_POLICY or LEWM_POLICY is set
   |-- gr00t             if GROOT_POLICY_HOST is set
-  |-- jepa              if JEPA_MODEL_PATH is set
+  |-- jepa              if JEPA_MODEL_NAME is set
   `-- genie             if GENIE_API_KEY is set
 ```
 
@@ -557,7 +557,7 @@ In-repo provider mapping:
 | `lerobot` | optional runtime adapter | policy | host-owned LeRobot policy checkpoint |
 | `cosmos` | HTTP adapter | generate | remote physical-AI video foundation model API |
 | `runway` | HTTP adapter | generate, transfer | remote video generation API |
-| `jepa` | scaffold | capability-fail-closed | reservation for future JEPA provider work |
+| `jepa` | optional runtime adapter | score | host-owned `facebookresearch/jepa-wms` torch-hub runtime |
 | `genie` | scaffold | capability-fail-closed | reservation for future interactive simulator work |
 
 `src/worldforge/providers/catalog.py` owns the in-repo provider factory list and auto-registration

--- a/docs/src/operations.md
+++ b/docs/src/operations.md
@@ -82,9 +82,12 @@ Configuration comes from constructor arguments and environment variables documen
 - `LEROBOT_POLICY_PATH` or `LEROBOT_POLICY` enables the optional LeRobot embodied-policy adapter.
 - `LEROBOT_POLICY_TYPE`, `LEROBOT_DEVICE`, `LEROBOT_CACHE_DIR`, and `LEROBOT_EMBODIMENT_TAG` are
   optional LeRobot settings.
-- `JEPA_MODEL_PATH` and `GENIE_API_KEY` only register capability-closed scaffold reservations.
+- `JEPA_MODEL_NAME` enables the experimental score-only JEPA adapter backed by the upstream
+  `facebookresearch/jepa-wms` torch-hub path.
+- `JEPA_MODEL_PATH` is legacy scaffold metadata only; it does not make the provider runnable.
+- `GENIE_API_KEY` only registers a capability-closed scaffold reservation.
 - `WORLDFORGE_ENABLE_SCAFFOLD_SURROGATES=1` is for local scaffold adapter tests only; it does not
-  make JEPA or Genie real provider integrations.
+  make Genie a real provider integration.
 
 Validate configuration when the host process starts:
 

--- a/docs/src/provider-authoring-guide.md
+++ b/docs/src/provider-authoring-guide.md
@@ -212,7 +212,7 @@ Current classifications:
 | `leworldmodel` | `stable` | Recommended score adapter for the official LeWM loading path; prepared hosts own torch, `stable_worldmodel`, checkpoints, and task preprocessing. |
 | `gr00t` | `beta` | Real remote PolicyClient boundary with fixture-backed failure coverage; prepared hosts own the reachable server, credentials, translator, and robot runtime. |
 | `lerobot` | `stable` | Recommended embodied policy adapter for the LeRobot `PreTrainedPolicy` path; prepared hosts own LeRobot, checkpoints, translators, and robot runtime. |
-| `jepa` | `scaffold` | Fail-closed reservation until a real upstream JEPA runtime and single capability are selected. |
+| `jepa` | `experimental` | Score-only adapter for host-owned `facebookresearch/jepa-wms` torch-hub runtimes. |
 | `genie` | `scaffold` | Fail-closed reservation until a concrete upstream runtime/API contract exists. |
 | `jepa-wms` | `scaffold` | Direct-construction candidate only; not exported or auto-registered until runtime limits and smoke evidence are credible. |
 

--- a/docs/src/provider-platform-roadmap.md
+++ b/docs/src/provider-platform-roadmap.md
@@ -57,7 +57,7 @@ Non-negotiable quality bar:
 | Area | Current state | Constraint |
 | --- | --- | --- |
 | Base package | `httpx` runtime dependency, Python 3.13 only, hatchling/uv packaging | Keep provider and host extras optional. |
-| Provider catalog | `mock`, `cosmos`, `runway`, `leworldmodel`, `gr00t`, `lerobot`, plus scaffold `jepa` and `genie` | Do not advertise scaffold providers as real integrations. |
+| Provider catalog | `mock`, `cosmos`, `runway`, `leworldmodel`, `gr00t`, `lerobot`, experimental score-only `jepa`, plus scaffold `genie` | Do not advertise scaffold providers as real integrations. |
 | Candidate provider | `jepa-wms` direct-construction score candidate, not exported or auto-registered | Promote only after real upstream limits and runtime behavior are validated. |
 | Planning | `World.plan(...)` composes `predict`, `score`, `policy`, and `policy+score` flows | Do not treat `plan` as a provider badge unless a provider implements planning directly. |
 | Harness | Optional Textual app with worlds, providers, eval, benchmark, run inspector, and robotics report surfaces | Textual remains isolated to `worldforge.harness.tui`. |
@@ -932,7 +932,7 @@ Scope:
 
 Acceptance criteria:
 
-- [ ] `mock`, `cosmos`, `runway`, `leworldmodel`, `gr00t`, `lerobot`, scaffold `jepa`, and scaffold
+- [ ] `mock`, `cosmos`, `runway`, `leworldmodel`, `gr00t`, `lerobot`, experimental `jepa`, and scaffold
       `genie` render with distinct status.
 - [ ] Missing credentials and missing optional dependencies are visibly different.
 - [ ] Textual remains isolated to `worldforge.harness.tui`.

--- a/docs/src/provider-selection-rfc.md
+++ b/docs/src/provider-selection-rfc.md
@@ -48,6 +48,27 @@ Validation path:
 Why now: it extends the JEPA-centered planning path without adding another media generator or
 generic provider name.
 
+### JEPA Public Adapter Addendum
+
+Decision date: 2026-05-01.
+
+Capability: `score`.
+
+Selected upstream: [`facebookresearch/jepa-wms`](https://github.com/facebookresearch/jepa-wms)
+through `torch.hub.load("facebookresearch/jepa-wms", model_name)`.
+
+Decision: promote the public `jepa` catalog entry from a fail-closed reservation to an
+experimental score-only adapter that reuses the JEPA-WMS runtime contract. The adapter requires
+`JEPA_MODEL_NAME`, keeps PyTorch and checkpoints host-owned, and does not expose `predict`,
+`embed`, generation, transfer, or reasoning.
+
+Migration: `JEPA_MODEL_PATH` was the old scaffold reservation variable. It is retained only as
+value-free diagnostic metadata; hosts must set `JEPA_MODEL_NAME` to load a real upstream model.
+
+Why this does not promote every JEPA surface: upstream action-conditioned JEPA-WM planning maps
+cleanly to candidate-action scoring. Latent rollout and embedding APIs need separate contracts
+before WorldForge can advertise `predict` or `embed`.
+
 ### Genie Issue Outline
 
 Capability: `generate`.

--- a/docs/src/providers/README.md
+++ b/docs/src/providers/README.md
@@ -18,7 +18,7 @@ Keep this page and the provider pages aligned with that catalog.
 | [`leworldmodel`](./leworldmodel.md) | `stable` | `score` | `LEWORLDMODEL_POLICY` or `LEWM_POLICY` | host installs the official LeWM loading path (`stable_worldmodel.policy.AutoCostModel`), torch, and compatible checkpoints |
 | [`gr00t`](./gr00t.md) | `beta` | `policy` | `GROOT_POLICY_HOST` | host runs or reaches an Isaac GR00T policy server |
 | [`lerobot`](./lerobot.md) | `stable` | `policy` | `LEROBOT_POLICY_PATH` or `LEROBOT_POLICY` | host installs LeRobot and compatible policy checkpoints |
-| `jepa` | `scaffold` | scaffold | `JEPA_MODEL_PATH` | capability-fail-closed reservation, not a real JEPA runtime |
+| [`jepa`](./jepa.md) | `experimental` | `score` | `JEPA_MODEL_NAME` | host supplies torch, facebookresearch/jepa-wms runtime dependencies, and task preprocessing |
 | [`genie`](./genie.md) | `scaffold` | scaffold | `GENIE_API_KEY` | capability-fail-closed reservation; Project Genie has no supported automation API contract |
 <!-- provider-catalog:end -->
 

--- a/docs/src/providers/jepa.md
+++ b/docs/src/providers/jepa.md
@@ -1,0 +1,119 @@
+# JEPA Provider
+
+Capability: `score`
+
+Taxonomy category: JEPA latent predictive world model
+
+`jepa` is the public, score-only JEPA adapter. The first runtime surface is intentionally narrow:
+it scores candidate action tensors with upstream JEPA-WM models and returns `ActionScoreResult`.
+It does not expose `predict`, `embed`, `generate`, `transfer`, or `reason`.
+
+## Provider Selection RFC
+
+Decision: use [`facebookresearch/jepa-wms`](https://github.com/facebookresearch/jepa-wms) as the
+first public JEPA runtime path, via `torch.hub.load("facebookresearch/jepa-wms", model_name)`.
+
+Why this surface:
+
+- the upstream repository publishes JEPA-WM checkpoints and torch-hub model entry points;
+- the upstream planning interface is naturally a candidate-action cost model, so `score` is the
+honest WorldForge capability;
+- WorldForge already has score-planning contracts and run evidence through the `jepa-wms`
+direct-construction candidate;
+- `predict` and `embed` would require a separate latent rollout or representation contract that is
+not stable enough to expose by default.
+
+Initial model names documented by upstream include `jepa_wm_pusht`, `jepa_wm_droid`,
+`jepa_wm_metaworld`, `jepa_wm_pointmaze`, and `jepa_wm_wall`. Use `jepa_wm_pusht` for the
+smallest public smoke path unless your host has validated another task family.
+
+## Runtime Ownership
+
+WorldForge owns:
+
+- provider registration and score capability declaration;
+- input shape validation before runtime calls;
+- score-result validation, best-index selection, and provider events;
+- score-planning integration and contract tests.
+
+The host owns:
+
+- installing PyTorch and upstream JEPA-WMS dependencies;
+- downloading compatible checkpoints and any optional encoder assets;
+- selecting `JEPA_MODEL_NAME`;
+- converting observations, goals, action history, and action candidates into task-shaped tensors;
+- preserving live smoke evidence for the selected model, checkpoint, and task.
+
+WorldForge does not add PyTorch, JEPA-WMS, datasets, checkpoints, simulators, or robot
+preprocessing dependencies to its base package.
+
+## Configuration
+
+Required:
+
+- `JEPA_MODEL_NAME`: upstream torch-hub model name, for example `jepa_wm_pusht`.
+
+Optional:
+
+- `JEPA_DEVICE`: runtime device passed to the torch-hub runtime, for example `cpu` or `cuda`.
+- `JEPA_MODEL_PATH`: legacy scaffold variable. It is retained only as value-free diagnostic
+  metadata for users who previously configured the fail-closed scaffold. It does not make the
+  provider runnable; set `JEPA_MODEL_NAME` instead.
+
+## Runtime Contract
+
+The adapter lazily loads:
+
+```python
+model, preprocessor = torch.hub.load(
+    "facebookresearch/jepa-wms",
+    "jepa_wm_pusht",
+)
+```
+
+It first delegates to model-native scoring methods such as `score_actions(...)`. If the loaded
+model does not expose a scoring method, it uses the same latent-distance fallback documented for
+the [`jepa-wms`](./jepa-wms.md) candidate.
+
+Required score inputs:
+
+- `info["observation"]`: tensor-like object or rectangular nested finite numeric sequence with at
+  least two dimensions;
+- `info["goal"]`: tensor-like object or rectangular nested finite numeric sequence with at least
+  two dimensions;
+- `info["action_history"]`: optional tensor-like object or rectangular nested finite numeric
+  sequence with at least two dimensions;
+- `action_candidates`: tensor-like object or rectangular nested finite numeric sequence shaped as
+  `(batch, samples, horizon, action_dim)`.
+
+The public adapter supports exactly one batch and returns one score per candidate sample. Scores
+default to costs: lower values are better.
+
+## Migration From The Scaffold
+
+Before this adapter, `jepa` was a capability-closed reservation gated by `JEPA_MODEL_PATH`.
+That deterministic surrogate path is no longer part of the public `jepa` provider. Tests or host
+experiments that need the old candidate shell should construct `JEPAWMSProvider` directly from
+`worldforge.providers.jepa_wms`.
+
+Migration checklist:
+
+- replace `JEPA_MODEL_PATH=/path/to/old/scaffold` with `JEPA_MODEL_NAME=jepa_wm_pusht` or another
+  validated upstream torch-hub model name;
+- keep checkpoint paths and task assets in host-owned configuration, not in issue-safe diagnostic
+  payloads;
+- use `worldforge-smoke-jepa-wms` to preserve live runtime evidence until a dedicated `jepa` smoke
+  command is needed.
+
+## Tests
+
+```bash
+uv run pytest tests/test_jepa_provider.py tests/test_provider_catalog_docs.py
+uv run python scripts/generate_provider_docs.py --check
+uv run mkdocs build --strict
+```
+
+## Primary References
+
+- [facebookresearch/jepa-wms](https://github.com/facebookresearch/jepa-wms)
+- [facebook/jepa-wms Hugging Face model repository](https://huggingface.co/facebook/jepa-wms)

--- a/docs/src/world-model-taxonomy.md
+++ b/docs/src/world-model-taxonomy.md
@@ -164,9 +164,9 @@ pretraining, then action-conditioned post-training for robotic planning with ima
 because it contains code, data, weights, training loops, shared planning components, and simulation
 planning evaluations for joint-embedding predictive world models.
 
-WorldForge's `jepa` provider is a scaffold. A real JEPA provider should follow the
-LeWorldModel pattern: do not advertise generation or reasoning unless implemented; expose score,
-latent rollout, or prediction capabilities explicitly; document tensor shapes and task contracts.
+WorldForge's public `jepa` provider now follows the LeWorldModel pattern as a score-only adapter:
+it does not advertise generation, reasoning, prediction, or embedding, and it documents tensor
+shapes and host-owned task preprocessing before runtime calls.
 WorldForge also carries a [`jepa-wms` provider candidate scaffold](./providers/jepa-wms.md) with
 injected-runtime and host-owned torch-hub contract tests for future work against
 `facebookresearch/jepa-wms`; it is intentionally not exported or registered.
@@ -314,7 +314,7 @@ flowchart TD
     WF --> Cosmos[cosmos\nvideo generation adapter]
     WF --> Groot[gr00t\nembodied policy adapter]
     WF --> Runway[runway\nvideo generation/transfer adapter]
-    WF --> JEPA[jepa\nscaffold]
+    WF --> JEPA[jepa\nscore adapter]
     WF --> Genie[genie\nscaffold]
 
     LeWM --> Score[score_actions -> ActionScoreResult]

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -57,6 +57,7 @@ nav:
       - Cosmos: providers/cosmos.md
       - Genie: providers/genie.md
       - GR00T: providers/gr00t.md
+      - JEPA: providers/jepa.md
       - JEPA-WMS: providers/jepa-wms.md
       - LeWorldModel: providers/leworldmodel.md
       - LeRobot: providers/lerobot.md

--- a/src/worldforge/providers/catalog.py
+++ b/src/worldforge/providers/catalog.py
@@ -144,7 +144,11 @@ PROVIDER_CATALOG: tuple[ProviderCatalogEntry, ...] = (
     ProviderCatalogEntry(
         "jepa",
         _jepa,
-        runtime_ownership="capability-fail-closed reservation, not a real JEPA runtime",
+        docs_page="jepa.md",
+        runtime_ownership=(
+            "host supplies torch, facebookresearch/jepa-wms runtime dependencies, and task "
+            "preprocessing"
+        ),
     ),
     ProviderCatalogEntry(
         "genie",

--- a/src/worldforge/providers/remote.py
+++ b/src/worldforge/providers/remote.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 import os
 from collections.abc import Callable
+from time import perf_counter
 
 from worldforge.models import (
     Action,
+    ActionScoreResult,
     EmbeddingResult,
     GenerationOptions,
     JSONDict,
@@ -14,9 +16,18 @@ from worldforge.models import (
     ProviderEvent,
     ReasoningResult,
     VideoClip,
+    WorldForgeError,
 )
 
+from ._config import (
+    ProviderConfigSummary,
+    config_field_summary,
+    config_source,
+    env_value,
+    optional_non_empty,
+)
 from .base import PredictionPayload, ProviderError, ProviderProfileSpec, RemoteProvider
+from .jepa_wms import JEPAWMSProvider, TorchHubJEPAWMSRuntime
 from .mock import MockProvider
 
 SCAFFOLD_SURROGATE_ENV_VAR = "WORLDFORGE_ENABLE_SCAFFOLD_SURROGATES"
@@ -105,35 +116,163 @@ class StubRemoteProvider(RemoteProvider):
         return self._surrogate.embed(text=text)
 
 
-class JepaProvider(StubRemoteProvider):
-    """Python adapter placeholder for JEPA-family models."""
+JEPA_MODEL_NAME_ENV_VAR = "JEPA_MODEL_NAME"
+JEPA_MODEL_PATH_ENV_VAR = "JEPA_MODEL_PATH"
+JEPA_DEVICE_ENV_VAR = "JEPA_DEVICE"
+DEFAULT_JEPA_HUB_REPO = "facebookresearch/jepa-wms"
 
-    env_var = "JEPA_MODEL_PATH"
+
+class JepaProvider(JEPAWMSProvider):
+    """Score-only JEPA adapter backed by the upstream JEPA-WMS torch-hub API."""
+
+    env_var = None
 
     def __init__(
         self,
         name: str = "jepa",
         *,
+        model_name: str | None = None,
+        model_path: str | None = None,
+        hub_repo: str = DEFAULT_JEPA_HUB_REPO,
+        device: str | None = None,
+        pretrained: bool = True,
+        trust_repo: bool | None = None,
+        hub_loader: Callable[..., object] | None = None,
+        torch_module: object | None = None,
         event_handler: Callable[[ProviderEvent], None] | None = None,
     ) -> None:
+        self.model_name = optional_non_empty(
+            model_name if model_name is not None else env_value(JEPA_MODEL_NAME_ENV_VAR),
+            name="JEPA model_name",
+        )
+        self.legacy_model_path = optional_non_empty(
+            model_path if model_path is not None else env_value(JEPA_MODEL_PATH_ENV_VAR),
+            name="JEPA model_path",
+        )
+        self.device = optional_non_empty(
+            device if device is not None else env_value(JEPA_DEVICE_ENV_VAR),
+            name="JEPA device",
+        )
+        self.hub_repo = optional_non_empty(hub_repo, name="JEPA hub_repo")
+        if self.hub_repo is None:
+            raise WorldForgeError("JEPA hub_repo must be provided.")
+        runtime = None
+        if self.model_name is not None:
+            runtime = TorchHubJEPAWMSRuntime(
+                model_name=self.model_name,
+                hub_repo=self.hub_repo,
+                device=self.device,
+                pretrained=pretrained,
+                trust_repo=trust_repo,
+                hub_loader=hub_loader,
+                torch_module=torch_module,
+            )
         super().__init__(
             name=name,
-            capabilities=ProviderCapabilities(),
-            profile=ProviderProfileSpec(
-                description="Python adapter surface for JEPA-family models.",
-                implementation_status="scaffold",
-                supported_modalities=("world_state", "text"),
-                artifact_types=(),
-                notes=(
-                    "Capability-fail-closed scaffold adapter; it is not a real JEPA runtime.",
-                    "A deterministic local surrogate exists only behind "
-                    f"{SCAFFOLD_SURROGATE_ENV_VAR}=1 for adapter testing.",
-                ),
-                default_model="jepa-scaffold-v1",
-                supported_models=("jepa-scaffold-v1",),
-            ),
+            model_path=self.model_name or self.legacy_model_path,
+            runtime=runtime,
             event_handler=event_handler,
         )
+        self.capabilities = ProviderCapabilities(score=True)
+        profile = ProviderProfileSpec(
+            is_local=True,
+            description=(
+                "Score-only JEPA adapter backed by facebookresearch/jepa-wms torch-hub models."
+            ),
+            package="worldforge + host-supplied torch + facebookresearch/jepa-wms",
+            implementation_status="experimental",
+            deterministic=True,
+            requires_credentials=False,
+            required_env_vars=(JEPA_MODEL_NAME_ENV_VAR,),
+            supported_modalities=("observations", "goals", "actions"),
+            artifact_types=("action_scores",),
+            notes=(
+                "Selected upstream: facebookresearch/jepa-wms via torch.hub.load(...).",
+                "The public jepa adapter exposes only score; it does not expose predict, "
+                "embed, generation, or reasoning.",
+                f"{JEPA_MODEL_PATH_ENV_VAR} was the old scaffold reservation variable. It is "
+                f"accepted only as legacy model-path metadata; set {JEPA_MODEL_NAME_ENV_VAR} "
+                "to load a real upstream model such as jepa_wm_pusht.",
+                "PyTorch, upstream dependencies, checkpoints, and task preprocessing remain "
+                "host-owned.",
+            ),
+            default_model=self.model_name or self.legacy_model_path,
+            supported_models=(self.model_name,) if self.model_name else (),
+        )
+        self.is_local = profile.is_local
+        self.description = profile.description
+        self.package = profile.package
+        self.implementation_status = profile.implementation_status
+        self.deterministic = profile.deterministic
+        self.requires_credentials = profile.requires_credentials
+        self.required_env_vars = list(profile.required_env_vars)
+        self.supported_modalities = list(profile.supported_modalities)
+        self.artifact_types = list(profile.artifact_types)
+        self.notes = list(profile.notes)
+        self.default_model = profile.default_model
+        self.supported_models = list(profile.supported_models)
+
+    def configured(self) -> bool:
+        return self.model_name is not None
+
+    def config_summary(self) -> ProviderConfigSummary:
+        return ProviderConfigSummary(
+            provider=self.name,
+            configured=self.configured(),
+            fields=(
+                config_field_summary(
+                    JEPA_MODEL_NAME_ENV_VAR,
+                    required=True,
+                    source=config_source(
+                        JEPA_MODEL_NAME_ENV_VAR,
+                        direct=self.model_name is not None
+                        and env_value(JEPA_MODEL_NAME_ENV_VAR) is None,
+                    ),
+                    present=self.model_name is not None,
+                ),
+                config_field_summary(
+                    JEPA_MODEL_PATH_ENV_VAR,
+                    required=False,
+                    source=config_source(
+                        JEPA_MODEL_PATH_ENV_VAR,
+                        direct=self.legacy_model_path is not None
+                        and env_value(JEPA_MODEL_PATH_ENV_VAR) is None,
+                    ),
+                    present=self.legacy_model_path is not None,
+                    detail="legacy scaffold variable; set JEPA_MODEL_NAME for runtime loading"
+                    if self.legacy_model_path is not None and self.model_name is None
+                    else "",
+                ),
+                config_field_summary(
+                    JEPA_DEVICE_ENV_VAR,
+                    required=False,
+                    source=config_source(
+                        JEPA_DEVICE_ENV_VAR,
+                        direct=self.device is not None and env_value(JEPA_DEVICE_ENV_VAR) is None,
+                    ),
+                    present=self.device is not None,
+                ),
+            ),
+        )
+
+    def health(self):
+        if self.model_name is None:
+            started = perf_counter()
+            detail = f"missing {JEPA_MODEL_NAME_ENV_VAR}"
+            if self.legacy_model_path is not None:
+                detail += f"; {JEPA_MODEL_PATH_ENV_VAR} is legacy scaffold metadata only"
+            return self._health(started, detail, healthy=False)
+        return super().health()
+
+    def score_actions(self, *, info: JSONDict, action_candidates: object) -> ActionScoreResult:
+        result = super().score_actions(info=info, action_candidates=action_candidates)
+        result.metadata.setdefault("runtime", "torchhub")
+        if self.model_name is not None:
+            result.metadata.setdefault("model_name", self.model_name)
+        result.metadata.setdefault("hub_repo", self.hub_repo)
+        if self.device is not None:
+            result.metadata.setdefault("device", self.device)
+        return result
 
 
 class GenieProvider(StubRemoteProvider):

--- a/src/worldforge/providers/runtime_manifests/jepa.json
+++ b/src/worldforge/providers/runtime_manifests/jepa.json
@@ -1,0 +1,19 @@
+{
+  "schema_version": 1,
+  "provider": "jepa",
+  "capabilities": ["score"],
+  "optional_dependencies": ["torch"],
+  "required_env_vars": ["JEPA_MODEL_NAME"],
+  "optional_env_vars": ["JEPA_DEVICE", "JEPA_MODEL_PATH"],
+  "default_model": "jepa_wm_pusht",
+  "device_support": ["cpu", "cuda", "mps"],
+  "host_owned_artifacts": [
+    "JEPA-WMS checkpoint",
+    "torch-hub cache",
+    "task-shaped observation, goal, and action tensors"
+  ],
+  "minimum_smoke_command": "uv run --with torch worldforge-smoke-jepa-wms --model-name jepa_wm_pusht --device cpu",
+  "expected_success_signal": "score_actions() returns finite lower-is-better candidate costs and a sanitized run manifest",
+  "setup_hint": "install torch and the upstream facebookresearch/jepa-wms runtime in the host environment",
+  "docs_path": "docs/src/providers/jepa.md"
+}

--- a/tests/test_harness_cli.py
+++ b/tests/test_harness_cli.py
@@ -49,6 +49,9 @@ def test_worldforge_harness_lists_connector_readiness_without_textual(monkeypatc
         "GROOT_POLICY_HOST",
         "LEROBOT_POLICY_PATH",
         "LEROBOT_POLICY",
+        "JEPA_MODEL_NAME",
+        "JEPA_MODEL_PATH",
+        "JEPA_DEVICE",
     ):
         monkeypatch.delenv(name, raising=False)
     monkeypatch.setattr(
@@ -73,7 +76,9 @@ def test_worldforge_harness_lists_connector_readiness_without_textual(monkeypatc
     assert payload["mock"]["status"] == "configured"
     assert payload["cosmos"]["status"] == "missing_credentials"
     assert payload["runway"]["missing_env_vars"] == ["RUNWAYML_API_SECRET"]
-    assert payload["jepa"]["status"] == "scaffold"
+    assert payload["jepa"]["status"] == "missing_credentials"
+    assert payload["jepa"]["capabilities"] == ["score"]
+    assert payload["jepa"]["missing_env_vars"] == ["JEPA_MODEL_NAME"]
     assert payload["genie"]["status"] == "scaffold"
     assert "worldforge-smoke-runway" in payload["runway"]["smoke_command"]
 

--- a/tests/test_jepa_provider.py
+++ b/tests/test_jepa_provider.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from worldforge import Action, WorldForge
+from worldforge.providers import JepaProvider, ProviderError
+from worldforge.testing import assert_provider_contract, assert_score_conformance
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures" / "providers"
+
+
+def _fixture(name: str) -> dict[str, Any]:
+    return json.loads((FIXTURE_DIR / name).read_text(encoding="utf-8"))
+
+
+class FakeHubScoringModel:
+    def __init__(self, response: object) -> None:
+        self.response = response
+        self.device: str | None = None
+        self.eval_called = False
+        self.calls: list[dict[str, Any]] = []
+
+    def to(self, device: str) -> FakeHubScoringModel:
+        self.device = device
+        return self
+
+    def eval(self) -> FakeHubScoringModel:
+        self.eval_called = True
+        return self
+
+    def score_actions(
+        self,
+        *,
+        model_path: str,
+        info: dict[str, Any],
+        action_candidates: object,
+    ) -> object:
+        self.calls.append(
+            {
+                "model_path": model_path,
+                "info": info,
+                "action_candidates": action_candidates,
+            }
+        )
+        return self.response
+
+
+def test_jepa_profile_is_real_score_only_adapter(monkeypatch) -> None:
+    monkeypatch.delenv("JEPA_MODEL_NAME", raising=False)
+    monkeypatch.delenv("JEPA_MODEL_PATH", raising=False)
+
+    provider = JepaProvider()
+    profile = provider.profile()
+
+    assert profile.implementation_status == "experimental"
+    assert profile.capabilities.enabled_names() == ["score"]
+    assert profile.required_env_vars == ["JEPA_MODEL_NAME"]
+    assert provider.configured() is False
+    assert provider.health().healthy is False
+    assert "JEPA_MODEL_NAME" in provider.health().details
+
+
+def test_jepa_legacy_scaffold_env_is_metadata_not_runtime(monkeypatch) -> None:
+    monkeypatch.delenv("JEPA_MODEL_NAME", raising=False)
+    monkeypatch.setenv("JEPA_MODEL_PATH", "/tmp/old-scaffold-path")
+
+    provider = JepaProvider()
+    summary = provider.config_summary().to_dict()
+
+    assert provider.configured() is False
+    assert provider.health().healthy is False
+    assert "legacy scaffold metadata" in provider.health().details
+    assert summary["fields"][0]["name"] == "JEPA_MODEL_NAME"
+    assert summary["fields"][0]["present"] is False
+    assert summary["fields"][1]["name"] == "JEPA_MODEL_PATH"
+    assert summary["fields"][1]["present"] is True
+    assert "old-scaffold-path" not in json.dumps(summary)
+
+
+def test_jepa_scores_through_upstream_torch_hub_contract(tmp_path) -> None:
+    payload = _fixture("jepa_wms_success.json")
+    model = FakeHubScoringModel(payload["runtime_response"])
+    loader_calls: list[dict[str, Any]] = []
+
+    def load_from_hub(hub_repo: str, model_name: str, **kwargs: object) -> object:
+        loader_calls.append(
+            {
+                "hub_repo": hub_repo,
+                "model_name": model_name,
+                "kwargs": kwargs,
+            }
+        )
+        return model, object()
+
+    provider = JepaProvider(
+        model_name="jepa_wm_pusht",
+        device="cpu",
+        hub_loader=load_from_hub,
+        torch_module=object(),
+    )
+    result = provider.score_actions(
+        info=payload["info"],
+        action_candidates=payload["action_candidates"],
+    )
+
+    assert result.provider == "jepa"
+    assert result.best_index == 1
+    assert result.metadata["model_name"] == "jepa_wm_pusht"
+    assert result.metadata["hub_repo"] == "facebookresearch/jepa-wms"
+    assert loader_calls == [
+        {
+            "hub_repo": "facebookresearch/jepa-wms",
+            "model_name": "jepa_wm_pusht",
+            "kwargs": {"pretrained": True, "device": "cpu"},
+        }
+    ]
+    assert model.calls[-1]["model_path"] == "jepa_wm_pusht"
+    assert model.device == "cpu"
+    assert model.eval_called is True
+
+    forge = WorldForge(state_dir=tmp_path, auto_register_remote=False)
+    forge.register_provider(provider)
+    world = forge.create_world_from_prompt("tabletop Push-T scene", provider="mock")
+    candidate_plans = [
+        [Action.move_to(0.1, 0.5, 0.0)],
+        [Action.move_to(0.4, 0.5, 0.0)],
+        [Action.move_to(0.7, 0.5, 0.0)],
+    ]
+    plan = world.plan(
+        goal="choose the lowest JEPA latent cost",
+        provider="jepa",
+        planner="jepa-mpc",
+        candidate_actions=candidate_plans,
+        score_info=payload["info"],
+        score_action_candidates=payload["action_candidates"],
+        execution_provider="mock",
+    )
+
+    assert plan.provider == "jepa"
+    assert plan.actions == candidate_plans[1]
+    assert plan.metadata["planning_mode"] == "score"
+
+
+def test_jepa_contract_helpers_cover_configured_score_provider() -> None:
+    payload = _fixture("jepa_wms_success.json")
+    provider = JepaProvider(
+        model_name="jepa_wm_pusht",
+        hub_loader=lambda *_args, **_kwargs: FakeHubScoringModel(payload["runtime_response"]),
+        torch_module=object(),
+    )
+
+    assert provider.configured() is True
+    assert_score_conformance(
+        provider,
+        info=payload["info"],
+        action_candidates=payload["action_candidates"],
+    )
+    report = assert_provider_contract(
+        provider,
+        score_info=payload["info"],
+        score_action_candidates=payload["action_candidates"],
+    )
+    assert report.exercised_operations == ["score"]
+
+
+def test_jepa_rejects_unsupported_scaffold_surrogate_call() -> None:
+    provider = JepaProvider(model_name="jepa_wm_pusht")
+
+    with pytest.raises(ProviderError, match="does not implement embed"):
+        provider.embed(text="cube")

--- a/tests/test_provider_catalog.py
+++ b/tests/test_provider_catalog.py
@@ -35,8 +35,8 @@ def test_provider_catalog_instantiates_known_provider_profiles() -> None:
     assert profiles["leworldmodel"].capabilities.score is True
     assert profiles["gr00t"].capabilities.policy is True
     assert profiles["lerobot"].capabilities.policy is True
-    assert profiles["jepa"].implementation_status == "scaffold"
-    assert profiles["jepa"].capabilities.enabled_names() == []
+    assert profiles["jepa"].implementation_status == "experimental"
+    assert profiles["jepa"].capabilities.enabled_names() == ["score"]
     assert profiles["genie"].implementation_status == "scaffold"
     assert profiles["genie"].capabilities.enabled_names() == []
 
@@ -57,7 +57,7 @@ def test_provider_catalog_statuses_match_promotion_gate() -> None:
         "leworldmodel": "stable",
         "gr00t": "beta",
         "lerobot": "stable",
-        "jepa": "scaffold",
+        "jepa": "experimental",
         "genie": "scaffold",
     }
     for profile in profiles.values():

--- a/tests/test_provider_config.py
+++ b/tests/test_provider_config.py
@@ -18,6 +18,7 @@ SECRET_VALUES = (
     "gr00t-secret",
     "signed-query-secret",
     "password-secret",
+    "legacy-jepa-secret",
 )
 
 
@@ -35,6 +36,8 @@ def test_provider_config_summaries_are_value_free_json(monkeypatch) -> None:
     monkeypatch.setenv("GROOT_POLICY_API_TOKEN", "gr00t-secret")
     monkeypatch.setenv("LEROBOT_POLICY_PATH", "lerobot/checkpoint")
     monkeypatch.setenv("LEWORLDMODEL_POLICY", "pusht/lewm")
+    monkeypatch.setenv("JEPA_MODEL_NAME", "jepa_wm_pusht")
+    monkeypatch.setenv("JEPA_MODEL_PATH", "legacy-jepa-secret")
 
     summaries = [provider.config_summary().to_dict() for provider in create_known_providers()]
 
@@ -63,6 +66,12 @@ def test_provider_config_summaries_are_value_free_json(monkeypatch) -> None:
             }
             assert "value" not in field
     _assert_no_secret_values(summaries)
+    jepa_summary = next(summary for summary in summaries if summary["provider"] == "jepa")
+    assert [field["name"] for field in jepa_summary["fields"]] == [
+        "JEPA_MODEL_NAME",
+        "JEPA_MODEL_PATH",
+        "JEPA_DEVICE",
+    ]
 
 
 def test_provider_config_summary_reports_alias_source_without_value(monkeypatch) -> None:

--- a/tests/test_provider_contracts.py
+++ b/tests/test_provider_contracts.py
@@ -177,22 +177,21 @@ def test_scaffold_provider_reports_clear_unconfigured_contract(monkeypatch) -> N
 
 
 def test_configured_scaffold_remote_providers_stay_fail_closed(monkeypatch) -> None:
-    monkeypatch.setenv("JEPA_MODEL_PATH", "/tmp/jepa-model")
     monkeypatch.setenv("GENIE_API_KEY", "genie-test-key")
     monkeypatch.delenv("WORLDFORGE_ENABLE_SCAFFOLD_SURROGATES", raising=False)
-
-    jepa_report = assert_provider_contract(JepaProvider())
-    assert jepa_report.configured is True
-    assert jepa_report.exercised_operations == []
 
     genie_report = assert_provider_contract(GenieProvider())
     assert genie_report.configured is True
     assert genie_report.exercised_operations == []
 
 
-def test_scaffold_surrogate_requires_explicit_local_opt_in(monkeypatch) -> None:
+def test_jepa_no_longer_exposes_scaffold_surrogate(monkeypatch) -> None:
     monkeypatch.setenv("JEPA_MODEL_PATH", "/tmp/jepa-model")
     monkeypatch.delenv("WORLDFORGE_ENABLE_SCAFFOLD_SURROGATES", raising=False)
 
-    with pytest.raises(ProviderError, match="WORLDFORGE_ENABLE_SCAFFOLD_SURROGATES"):
+    provider = JepaProvider()
+    assert provider.configured() is False
+    assert provider.profile().capabilities.enabled_names() == ["score"]
+
+    with pytest.raises(ProviderError, match="does not implement embed"):
         JepaProvider().embed(text="cube")

--- a/tests/test_provider_events.py
+++ b/tests/test_provider_events.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from worldforge import Action, ProviderEvent, VideoClip, WorldForge
-from worldforge.providers import GenieProvider, JepaProvider, MockProvider
+from worldforge.providers import GenieProvider, MockProvider
 
 
 def test_worldforge_event_handler_propagates_to_builtin_and_manual_providers(tmp_path) -> None:
@@ -30,16 +30,16 @@ def test_worldforge_event_handler_propagates_to_builtin_and_manual_providers(tmp
 
 
 def test_stub_remote_provider_forwards_mock_events(monkeypatch) -> None:
-    monkeypatch.setenv("JEPA_MODEL_PATH", "/tmp/jepa-model")
+    monkeypatch.setenv("GENIE_API_KEY", "genie-test-key")
     monkeypatch.setenv("WORLDFORGE_ENABLE_SCAFFOLD_SURROGATES", "1")
     events: list[ProviderEvent] = []
-    provider = JepaProvider(event_handler=events.append)
+    provider = GenieProvider(event_handler=events.append)
 
     payload = provider.predict(
         {
             "id": "world-test",
             "name": "test",
-            "provider": "jepa",
+            "provider": "genie",
             "step": 0,
             "scene": {"objects": {}},
             "metadata": {},
@@ -50,7 +50,7 @@ def test_stub_remote_provider_forwards_mock_events(monkeypatch) -> None:
 
     assert payload.metadata["mode"] == "stub-remote-adapter"
     assert [(event.provider, event.operation, event.phase) for event in events] == [
-        ("jepa", "predict", "success")
+        ("genie", "predict", "success")
     ]
 
 

--- a/tests/test_provider_profiles.py
+++ b/tests/test_provider_profiles.py
@@ -27,7 +27,9 @@ def test_provider_profiles_and_doctor_report_include_known_scaffolds(tmp_path, m
         "LEROBOT_DEVICE",
         "LEROBOT_CACHE_DIR",
         "LEROBOT_EMBODIMENT_TAG",
+        "JEPA_MODEL_NAME",
         "JEPA_MODEL_PATH",
+        "JEPA_DEVICE",
         "GENIE_API_KEY",
     ):
         monkeypatch.delenv(env_var, raising=False)
@@ -80,7 +82,9 @@ def test_provider_profiles_and_doctor_report_include_known_scaffolds(tmp_path, m
         "LEROBOT_POLICY_PATH",
         "LEROBOT_POLICY",
     ]
-    assert builtin_profiles["jepa"].capabilities.enabled_names() == []
+    assert builtin_profiles["jepa"].implementation_status == "experimental"
+    assert builtin_profiles["jepa"].capabilities.enabled_names() == ["score"]
+    assert builtin_profiles["jepa"].required_env_vars == ["JEPA_MODEL_NAME"]
     assert builtin_profiles["genie"].capabilities.enabled_names() == []
 
     report = forge.doctor()

--- a/tests/test_provider_runtime_manifests.py
+++ b/tests/test_provider_runtime_manifests.py
@@ -17,7 +17,7 @@ from worldforge.providers.runtime_manifest import (
     missing_optional_dependency_detail,
 )
 
-EXPECTED_MANIFEST_PROVIDERS = ("cosmos", "gr00t", "lerobot", "leworldmodel", "runway")
+EXPECTED_MANIFEST_PROVIDERS = ("cosmos", "gr00t", "jepa", "lerobot", "leworldmodel", "runway")
 
 
 def test_runtime_manifests_cover_real_optional_providers() -> None:


### PR DESCRIPTION
Closes #59.

## Summary
- replace the public `jepa` scaffold with an experimental score-only adapter backed by `facebookresearch/jepa-wms` torch-hub models
- require `JEPA_MODEL_NAME` for runtime loading and keep `JEPA_MODEL_PATH` as legacy diagnostic metadata only
- add JEPA provider docs, provider-selection addendum, runtime manifest, catalog/docs updates, and focused score-contract tests

## Validation
- `uv run ruff check src tests examples scripts`
- `uv run ruff format --check src tests examples scripts`
- `uv run pytest -m "not live"`
- `uv run python scripts/generate_provider_docs.py --check`
- `uv run mkdocs build --strict`
- `bash scripts/test_package.sh`
