### PR TITLE
Document real provider roadmap completion

### DIFF
--- a/docs/src/provider-platform-roadmap.md
+++ b/docs/src/provider-platform-roadmap.md
@@ -509,6 +509,32 @@ uv run mkdocs build --strict
 
 ## Workstream B: Real Provider Implementations
 
+Track status: complete for [#48](https://github.com/AbdelStark/worldforge/issues/48).
+
+Completion signals:
+
+- `leworldmodel` is a stable score provider over `stable_worldmodel.policy.AutoCostModel`, with
+  CPU fallback, score direction metadata, runtime manifests, real-checkpoint smoke commands, and
+  the PushT bridge registry preserving shape summaries in run manifests.
+- `lerobot` is a stable policy provider with explicit loader validation, bounded raw-action
+  previews, translator-contract evidence, and host-owned checkpoint, runtime, and controller
+  boundaries.
+- `gr00t` is a beta remote PolicyClient provider with sanitized target metadata, timeout/auth
+  handling, unreachable-server health signals, and docs that keep CUDA, TensorRT, Isaac-GR00T,
+  and policy-server operation host-owned.
+- `cosmos` and `runway` keep remote media generation/transfer production-shaped through parser
+  fixtures, retry/timeout event metadata, optional live smoke manifests, benchmark inputs, and
+  artifact-retention guidance that excludes signed URL query strings from observable records.
+- `jepa` now advertises only the selected experimental `score` surface through the
+  `facebookresearch/jepa-wms` torch-hub contract, while `jepa-wms` remains a direct-construction
+  candidate with prepared-host smoke evidence rather than auto-registration.
+- `genie` remains a fail-closed scaffold with a documented defer decision until a credible
+  upstream automation API or runtime contract exists.
+- [Provider docs](./providers/README.md), [provider-selection records](./provider-selection-rfc.md),
+  [robotics showcase docs](./robotics-showcase.md), runtime manifests, fixtures, and conformance
+  tests now agree on which provider capabilities are executable and which runtime responsibilities
+  remain with hosts.
+
 ### WF-LWM-001: LeWorldModel Stable Score Provider
 
 Type: provider promotion  

--- a/tests/test_docs_site.py
+++ b/tests/test_docs_site.py
@@ -239,6 +239,81 @@ def test_production_harness_roadmap_tracker_records_completion() -> None:
         assert signal in harness
 
 
+def test_real_provider_roadmap_tracker_records_completion() -> None:
+    roadmap = (ROOT / "docs/src/provider-platform-roadmap.md").read_text(encoding="utf-8")
+    provider_index = (ROOT / "docs/src/providers/README.md").read_text(encoding="utf-8")
+    selection = (ROOT / "docs/src/provider-selection-rfc.md").read_text(encoding="utf-8")
+    showcase = (ROOT / "docs/src/robotics-showcase.md").read_text(encoding="utf-8")
+
+    provider_pages = {
+        name: (ROOT / f"docs/src/providers/{name}.md").read_text(encoding="utf-8")
+        for name in (
+            "leworldmodel",
+            "lerobot",
+            "gr00t",
+            "cosmos",
+            "runway",
+            "jepa",
+            "jepa-wms",
+            "genie",
+        )
+    }
+    runtime_manifests = {
+        path.stem for path in (ROOT / "src/worldforge/providers/runtime_manifests").glob("*.json")
+    }
+
+    assert "Track status: complete for [#48]" in roadmap
+    for child in (
+        "WF-LWM-001",
+        "WF-LWM-002",
+        "WF-LEROBOT-001",
+        "WF-LEROBOT-002",
+        "WF-GROOT-001",
+        "WF-COSMOS-001",
+        "WF-RUNWAY-001",
+        "WF-JEPAWMS-001",
+        "WF-JEPA-001",
+        "WF-GENIE-001",
+        "WF-PROVIDER-SELECT-001",
+    ):
+        assert child in roadmap
+
+    for status_row in (
+        "| [`leworldmodel`](./leworldmodel.md) | `stable` | `score` |",
+        "| [`lerobot`](./lerobot.md) | `stable` | `policy` |",
+        "| [`gr00t`](./gr00t.md) | `beta` | `policy` |",
+        "| [`jepa`](./jepa.md) | `experimental` | `score` |",
+        "| [`genie`](./genie.md) | `scaffold` | scaffold |",
+    ):
+        assert status_row in provider_index
+
+    assert {"leworldmodel", "lerobot", "gr00t", "cosmos", "runway", "jepa"} <= runtime_manifests
+
+    for signal in (
+        "stable_worldmodel.policy.AutoCostModel",
+        "CPU fallback",
+        "score direction",
+        "PushT",
+        "translator_contract",
+        "remote PolicyClient",
+        "unreachable policy server",
+        "failed tasks",
+        "signed URL",
+        "facebookresearch/jepa-wms",
+        "Status: scaffold",
+        "Decision date: 2026-05-01",
+    ):
+        assert signal in roadmap or any(signal in page for page in provider_pages.values())
+
+    for provider_name in provider_pages:
+        assert f"[`{provider_name}`]" in provider_index
+
+    assert 'torch.hub.load("facebookresearch/jepa-wms", model_name)' in selection
+    assert "Genie Issue Outline" in selection
+    assert "worldforge.smoke.pusht_showcase_inputs" in showcase
+    assert "host must provide" in showcase
+
+
 def test_genie_scaffold_docs_record_runtime_contract_defer_decision() -> None:
     provider_page = (ROOT / "docs/src/providers/genie.md").read_text(encoding="utf-8")
     provider_index = (ROOT / "docs/src/providers/README.md").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

- record the real provider implementations roadmap tracker as complete for #48
- summarize the completed provider signals across LeWorldModel, LeRobot, GR00T, Cosmos, Runway, JEPA, JEPA-WMS, and Genie
- add docs coverage tying the completion record to provider docs, runtime manifests, selection records, and robotics showcase evidence

## Validation

- `uv run pytest tests/test_docs_site.py -q`
- `uv run mkdocs build --strict`
- `uv run ruff check docs tests/test_docs_site.py`
- `uv run ruff format --check docs tests/test_docs_site.py`
- `uv run python scripts/generate_provider_docs.py --check`
- `uv run pytest -m "not live"`
