### PR TITLE
Harden LeWorldModel checkpoint config loading

### DIFF
--- a/docs/src/operations.md
+++ b/docs/src/operations.md
@@ -419,14 +419,16 @@ readiness, and safety certification.
     --with "imageio" \
     worldforge-build-leworldmodel-checkpoint \
       --stablewm-home ~/.stable-wm \
-      --policy pusht/lewm
+      --policy pusht/lewm \
+      --revision 22b330c28c27ead4bfd1888615af1340e3fe9052
   ```
 
   `hydra-core`, `omegaconf`, and `transformers` are required to instantiate the official LeWM
   PushT config. Before Hydra is allowed to instantiate anything, the builder validates the
   downloaded config against the known official PushT LeWM target allowlist and rejects nested or
-  interpolated `_target_` values outside that allowlist. Pass `--revision <tag-or-commit>` or set
-  `LEWORLDMODEL_REVISION` when the run must be pinned to a specific Hugging Face revision.
+  interpolated `_target_` values outside that allowlist. The default revision is the pinned commit
+  `22b330c28c27ead4bfd1888615af1340e3fe9052`; pass `--revision <40-char-commit-sha>` or set
+  `LEWORLDMODEL_REVISION` to another audited immutable Hugging Face commit.
   The builder loads downloaded `weights.pt` with `torch.load(..., weights_only=True)` by default;
   `--allow-unsafe-pickle` exists only for trusted legacy weights and older torch environments. The
   builder downloads assets to `~/.cache/worldforge/leworldmodel` by default and writes the object

--- a/docs/src/operations.md
+++ b/docs/src/operations.md
@@ -425,8 +425,9 @@ readiness, and safety certification.
 
   `hydra-core`, `omegaconf`, and `transformers` are required to instantiate the official LeWM
   PushT config. Before Hydra is allowed to instantiate anything, the builder validates the
-  downloaded config against the known official PushT LeWM target allowlist and rejects nested or
-  interpolated `_target_` values outside that allowlist. The default revision is the pinned commit
+  downloaded config against the known official PushT LeWM target allowlist, rejects any
+  interpolated `_target_` value, and rejects nested targets outside that allowlist. The default
+  revision is the pinned commit
   `22b330c28c27ead4bfd1888615af1340e3fe9052`; pass `--revision <40-char-commit-sha>` or set
   `LEWORLDMODEL_REVISION` to another audited immutable Hugging Face commit.
   The builder loads downloaded `weights.pt` with `torch.load(..., weights_only=True)` by default;

--- a/docs/src/operations.md
+++ b/docs/src/operations.md
@@ -423,8 +423,10 @@ readiness, and safety certification.
   ```
 
   `hydra-core`, `omegaconf`, and `transformers` are required to instantiate the official LeWM
-  PushT config. Pass `--revision <tag-or-commit>` or set `LEWORLDMODEL_REVISION` when the run
-  must be pinned to a specific Hugging Face revision.
+  PushT config. Before Hydra is allowed to instantiate anything, the builder validates the
+  downloaded config against the known official PushT LeWM target allowlist and rejects nested or
+  interpolated `_target_` values outside that allowlist. Pass `--revision <tag-or-commit>` or set
+  `LEWORLDMODEL_REVISION` when the run must be pinned to a specific Hugging Face revision.
   The builder loads downloaded `weights.pt` with `torch.load(..., weights_only=True)` by default;
   `--allow-unsafe-pickle` exists only for trusted legacy weights and older torch environments. The
   builder downloads assets to `~/.cache/worldforge/leworldmodel` by default and writes the object

--- a/docs/src/robotics-showcase-deep-dive.md
+++ b/docs/src/robotics-showcase-deep-dive.md
@@ -416,8 +416,9 @@ For the default policy, that is:
 ```
 
 If the default checkpoint is missing, the polished runner builds it from Hugging Face assets using
-`worldforge.smoke.leworldmodel_checkpoint`. That builder downloads `config.json` and `weights.pt`
-from `quentinll/lewm-pusht`, instantiates the upstream model, loads the weights, freezes the
+`worldforge.smoke.leworldmodel_checkpoint`. That builder downloads `config.json` from
+`quentinll/lewm-pusht`, validates every Hydra `_target_` against the known official PushT LeWM
+allowlist, downloads `weights.pt`, instantiates the upstream model, loads the weights, freezes the
 module, and saves the object checkpoint where `AutoCostModel` expects it.
 
 This auto-build step runs only for normal showcase execution. With `--health-only`, the runner

--- a/docs/src/robotics-showcase-deep-dive.md
+++ b/docs/src/robotics-showcase-deep-dive.md
@@ -417,18 +417,20 @@ For the default policy, that is:
 
 If the default checkpoint is missing, the polished runner builds it from Hugging Face assets using
 `worldforge.smoke.leworldmodel_checkpoint`. That builder downloads `config.json` from
-`quentinll/lewm-pusht`, validates every Hydra `_target_` against the known official PushT LeWM
-allowlist, downloads `weights.pt`, instantiates the upstream model, loads the weights, freezes the
-module, and saves the object checkpoint where `AutoCostModel` expects it.
+`quentinll/lewm-pusht` at the pinned commit
+`22b330c28c27ead4bfd1888615af1340e3fe9052`, validates every Hydra `_target_` and the known PushT
+ViT backbone parameters against the audited allowlist, downloads `weights.pt`, instantiates the
+upstream model from the sanitized config, loads the weights, freezes the module, and saves the
+object checkpoint where `AutoCostModel` expects it.
 
 This auto-build step runs only for normal showcase execution. With `--health-only`, the runner
 reports whether the checkpoint path exists and exits without downloading assets or writing to the
 cache.
 
-For reproducible artifact resolution, pass `--lewm-revision <tag-or-commit>` or set
-`LEWORLDMODEL_REVISION`; the same revision is passed to both Hugging Face downloads. The builder
-loads the downloaded `weights.pt` with `torch.load(..., weights_only=True)` by default. The
-`--allow-unsafe-pickle` flag is intentionally explicit and should be limited to trusted legacy
+For a different reproducible artifact, pass `--lewm-revision <40-char-commit-sha>` or set
+`LEWORLDMODEL_REVISION`; the same immutable revision is passed to both Hugging Face downloads. The
+builder loads the downloaded `weights.pt` with `torch.load(..., weights_only=True)` by default.
+The `--allow-unsafe-pickle` flag is intentionally explicit and should be limited to trusted legacy
 weights or older torch environments that cannot perform safe weights-only deserialization.
 
 ### 3. The Runner Forwards Packaged PushT Hooks

--- a/docs/src/robotics-showcase.md
+++ b/docs/src/robotics-showcase.md
@@ -275,10 +275,11 @@ For non-PushT tasks, the host must provide:
 
 When the default LeWorldModel object checkpoint is missing, the polished command can build it from
 Hugging Face assets. Use `--lewm-revision <tag-or-commit>` or `LEWORLDMODEL_REVISION` for a pinned
-asset revision. The builder loads `weights.pt` with `torch.load(..., weights_only=True)` by default;
-the `--allow-unsafe-pickle` flag is an explicit trusted-artifact escape hatch for legacy weights.
-This auto-build path is skipped for `--health-only`, which only reports whether the checkpoint is
-present.
+asset revision. The builder validates the downloaded Hydra config against the official PushT LeWM
+target allowlist before instantiating the model or downloading weights. It then loads `weights.pt`
+with `torch.load(..., weights_only=True)` by default; the `--allow-unsafe-pickle` flag is an
+explicit trusted-artifact escape hatch for legacy weights. This auto-build path is skipped for
+`--health-only`, which only reports whether the checkpoint is present.
 
 WorldForge fails instead of padding, projecting, or silently reinterpreting mismatched action
 spaces.

--- a/docs/src/robotics-showcase.md
+++ b/docs/src/robotics-showcase.md
@@ -60,7 +60,7 @@ scripts/robotics-showcase --no-rerun          # skip the default Rerun .rrd arti
 scripts/robotics-showcase --rerun-output /tmp/pusht.rrd
 scripts/robotics-showcase --tui-stage-delay 0.1
 scripts/robotics-showcase --no-tui-animation
-scripts/robotics-showcase --lewm-revision <tag-or-commit>
+scripts/robotics-showcase --lewm-revision 22b330c28c27ead4bfd1888615af1340e3fe9052
 ```
 
 Open the Rerun artifact from the TUI with `o`, or from the shell with:
@@ -274,12 +274,14 @@ For non-PushT tasks, the host must provide:
 - a candidate builder that preserves the model's expected action dimension and horizon.
 
 When the default LeWorldModel object checkpoint is missing, the polished command can build it from
-Hugging Face assets. Use `--lewm-revision <tag-or-commit>` or `LEWORLDMODEL_REVISION` for a pinned
+Hugging Face assets. By default it uses the pinned Hugging Face commit
+`22b330c28c27ead4bfd1888615af1340e3fe9052`; use
+`--lewm-revision <40-char-commit-sha>` or `LEWORLDMODEL_REVISION` for a different audited immutable
 asset revision. The builder validates the downloaded Hydra config against the official PushT LeWM
-target allowlist before instantiating the model or downloading weights. It then loads `weights.pt`
-with `torch.load(..., weights_only=True)` by default; the `--allow-unsafe-pickle` flag is an
-explicit trusted-artifact escape hatch for legacy weights. This auto-build path is skipped for
-`--health-only`, which only reports whether the checkpoint is present.
+target and parameter allowlist before instantiating the model or downloading weights. It then loads
+`weights.pt` with `torch.load(..., weights_only=True)` by default; the `--allow-unsafe-pickle` flag
+is an explicit trusted-artifact escape hatch for legacy weights. This auto-build path is skipped
+for `--health-only`, which only reports whether the checkpoint is present.
 
 WorldForge fails instead of padding, projecting, or silently reinterpreting mismatched action
 spaces.

--- a/src/worldforge/smoke/leworldmodel_checkpoint.py
+++ b/src/worldforge/smoke/leworldmodel_checkpoint.py
@@ -6,9 +6,10 @@ Run with the same upstream runtime used by the real smoke:
       --with huggingface_hub --with hydra-core --with omegaconf --with transformers
       --with "opencv-python" --with "imageio" worldforge-build-leworldmodel-checkpoint
 
-The command downloads ``config.json`` and ``weights.pt`` from the model repo,
-instantiates the LeWM module, loads the weights, and saves the object checkpoint
-where ``stable_worldmodel.policy.AutoCostModel`` expects it.
+The command downloads ``config.json`` from the model repo, validates that every
+Hydra target is one of the known official PushT LeWM constructors, downloads
+``weights.pt``, instantiates the LeWM module, loads the weights, and saves the
+object checkpoint where ``stable_worldmodel.policy.AutoCostModel`` expects it.
 """
 
 from __future__ import annotations
@@ -18,6 +19,7 @@ import importlib
 import json
 import os
 import sys
+from collections.abc import Mapping, Sequence
 from pathlib import Path
 from types import ModuleType
 from typing import Any
@@ -27,8 +29,19 @@ from worldforge.smoke.leworldmodel import DEFAULT_STABLEWM_HOME, _checkpoint_pat
 DEFAULT_REPO_ID = "quentinll/lewm-pusht"
 LEWORLDMODEL_OFFICIAL_REPO_URL = "https://github.com/lucas-maes/le-wm"
 LEWORLDMODEL_RUNTIME_API = "stable_worldmodel.policy.AutoCostModel"
-LEWORLDMODEL_HF_CONFIG_TARGET = "stable_worldmodel.wm.lewm"
+LEWORLDMODEL_HF_CONFIG_TARGET = "stable_worldmodel.wm.lewm.LeWM"
 LEWORLDMODEL_HF_BACKBONE_TARGET = "stable_pretraining.backbone.utils.vit_hf"
+# Hydra instantiates nested `_target_` values recursively, so this list must stay exact and narrow.
+LEWORLDMODEL_HF_ALLOWED_CONFIG_TARGETS = frozenset(
+    {
+        LEWORLDMODEL_HF_CONFIG_TARGET,
+        LEWORLDMODEL_HF_BACKBONE_TARGET,
+        "stable_worldmodel.wm.lewm.module.Embedder",
+        "stable_worldmodel.wm.lewm.module.MLP",
+        "stable_worldmodel.wm.lewm.module.Predictor",
+        "torch.nn.BatchNorm1d",
+    }
+)
 
 
 def _vit_hf_backbone(
@@ -175,19 +188,74 @@ def _load_weights(torch: object, weights_path: Path, *, allow_unsafe_pickle: boo
 
 
 def _config_target(config: object) -> str:
-    getter = getattr(config, "get", None)
-    target = getter("_target_") if callable(getter) else None
+    if not isinstance(config, Mapping):
+        raise SystemExit("LeWorldModel config.json must contain a JSON object.")
+    target = config.get("_target_")
     if not isinstance(target, str) or not target.strip():
         raise SystemExit("LeWorldModel config.json must contain a non-empty _target_ field.")
     return target.strip()
 
 
 def _ensure_leworldmodel_target(target: str) -> None:
-    normalized = target.lower()
-    if "lewm" not in normalized and "jepa" not in normalized:
+    if target != LEWORLDMODEL_HF_CONFIG_TARGET:
         raise SystemExit(
-            f"LeWorldModel config.json did not describe a LeWM/JEPA model target: {target!r}."
+            "LeWorldModel config.json root _target_ must be "
+            f"{LEWORLDMODEL_HF_CONFIG_TARGET!r}; got {target!r}."
         )
+
+
+def _config_to_container(omega_conf: object, config: object) -> object:
+    to_container = getattr(omega_conf, "to_container", None)
+    if callable(to_container):
+        return to_container(config, resolve=False)
+    return config
+
+
+def _target_path(path: str) -> str:
+    return f"{path}._target_" if path != "$" else "$._target_"
+
+
+def _child_path(path: str, key: object) -> str:
+    if isinstance(key, int):
+        return f"{path}[{key}]"
+    key_text = str(key)
+    return key_text if path == "$" else f"{path}.{key_text}"
+
+
+def _ensure_allowed_hydra_target(target: object, path: str) -> str:
+    target_path = _target_path(path)
+    if not isinstance(target, str) or not target.strip():
+        raise SystemExit(f"LeWorldModel config {target_path} must be a non-empty string.")
+    normalized = target.strip()
+    if "${" in normalized:
+        raise SystemExit(f"LeWorldModel config {target_path} must not use interpolation.")
+    if normalized not in LEWORLDMODEL_HF_ALLOWED_CONFIG_TARGETS:
+        allowed = ", ".join(sorted(LEWORLDMODEL_HF_ALLOWED_CONFIG_TARGETS))
+        raise SystemExit(
+            "LeWorldModel config contains disallowed Hydra _target_ "
+            f"at {target_path}: {normalized!r}. Allowed targets: {allowed}."
+        )
+    return normalized
+
+
+def _walk_hydra_targets(node: object, path: str = "$") -> None:
+    if isinstance(node, Mapping):
+        if "_target_" in node:
+            _ensure_allowed_hydra_target(node["_target_"], path)
+        for key, value in node.items():
+            _walk_hydra_targets(value, _child_path(path, key))
+        return
+    if isinstance(node, Sequence) and not isinstance(node, str | bytes | bytearray):
+        for index, value in enumerate(node):
+            _walk_hydra_targets(value, _child_path(path, index))
+
+
+def _validate_leworldmodel_config(omega_conf: object, config: object) -> str:
+    plain_config = _config_to_container(omega_conf, config)
+    target = _config_target(plain_config)
+    _walk_hydra_targets(plain_config)
+    _ensure_leworldmodel_target(target)
+    return target
 
 
 def _checkpoint_provenance() -> dict[str, object]:
@@ -231,6 +299,9 @@ def build_checkpoint(
             revision=revision,
         )
     )
+
+    config = omega_conf.load(config_path)
+    target = _validate_leworldmodel_config(omega_conf, config)
     weights_path = Path(
         hf_hub_download(
             repo_id=repo_id,
@@ -239,10 +310,6 @@ def build_checkpoint(
             revision=revision,
         )
     )
-
-    config = omega_conf.load(config_path)
-    target = _config_target(config)
-    _ensure_leworldmodel_target(target)
     model = instantiate(config)
     weights = _load_weights(torch, weights_path, allow_unsafe_pickle=allow_unsafe_pickle)
     incompatible = model.load_state_dict(weights, strict=False)

--- a/src/worldforge/smoke/leworldmodel_checkpoint.py
+++ b/src/worldforge/smoke/leworldmodel_checkpoint.py
@@ -17,16 +17,20 @@ from __future__ import annotations
 import argparse
 import importlib
 import json
+import math
 import os
+import re
 import sys
 from collections.abc import Mapping, Sequence
 from pathlib import Path
 from types import ModuleType
 from typing import Any
 
+from worldforge.models import WorldStateError
 from worldforge.smoke.leworldmodel import DEFAULT_STABLEWM_HOME, _checkpoint_path
 
 DEFAULT_REPO_ID = "quentinll/lewm-pusht"
+LEWORLDMODEL_HF_DEFAULT_REVISION = "22b330c28c27ead4bfd1888615af1340e3fe9052"
 LEWORLDMODEL_OFFICIAL_REPO_URL = "https://github.com/lucas-maes/le-wm"
 LEWORLDMODEL_RUNTIME_API = "stable_worldmodel.policy.AutoCostModel"
 LEWORLDMODEL_HF_CONFIG_TARGET = "stable_worldmodel.wm.lewm.LeWM"
@@ -46,7 +50,7 @@ LEWORLDMODEL_HF_ALLOWED_CONFIG_TARGETS = frozenset(
 
 def _vit_hf_backbone(
     size: str = "tiny",
-    patch_size: int = 16,
+    patch_size: int = 14,
     image_size: int = 224,
     pretrained: bool = False,
     use_mask_token: bool = True,
@@ -56,36 +60,29 @@ def _vit_hf_backbone(
 
     from transformers import ViTConfig, ViTModel
 
-    size_configs: dict[str, dict[str, int]] = {
-        "tiny": {"hidden_size": 192, "num_hidden_layers": 12, "num_attention_heads": 3},
-        "small": {"hidden_size": 384, "num_hidden_layers": 12, "num_attention_heads": 6},
-        "base": {"hidden_size": 768, "num_hidden_layers": 12, "num_attention_heads": 12},
-        "large": {"hidden_size": 1024, "num_hidden_layers": 24, "num_attention_heads": 16},
-        "huge": {"hidden_size": 1280, "num_hidden_layers": 32, "num_attention_heads": 16},
-    }
-    if size not in size_configs:
-        raise ValueError(f"Invalid ViT size {size!r}; expected one of {sorted(size_configs)}.")
+    if kwargs:
+        unsupported = ", ".join(sorted(kwargs))
+        raise ValueError(f"Unsupported LeWM PushT ViT parameters: {unsupported}.")
+    if pretrained is not False:
+        raise ValueError("LeWM PushT ViT checkpoint builder requires pretrained=False.")
+    if size != "tiny" or patch_size != 14 or image_size != 224:
+        raise ValueError(
+            "LeWM PushT ViT checkpoint builder only supports "
+            "size='tiny', patch_size=14, image_size=224."
+        )
 
+    size_config = {"hidden_size": 192, "num_hidden_layers": 12, "num_attention_heads": 3}
     config_params = {
-        **size_configs[size],
-        "intermediate_size": size_configs[size]["hidden_size"] * 4,
+        **size_config,
+        "intermediate_size": size_config["hidden_size"] * 4,
         "image_size": image_size,
         "patch_size": patch_size,
-        **kwargs,
     }
-    if pretrained:
-        model_name = f"google/vit-{size}-patch{patch_size}-{image_size}"
-        model = ViTModel.from_pretrained(
-            model_name,
-            add_pooling_layer=False,
-            use_mask_token=use_mask_token,
-        )
-    else:
-        model = ViTModel(
-            ViTConfig(**config_params),
-            add_pooling_layer=False,
-            use_mask_token=use_mask_token,
-        )
+    model = ViTModel(
+        ViTConfig(**config_params),
+        add_pooling_layer=False,
+        use_mask_token=use_mask_token,
+    )
     model.config.interpolate_pos_encoding = True
     return model
 
@@ -189,16 +186,16 @@ def _load_weights(torch: object, weights_path: Path, *, allow_unsafe_pickle: boo
 
 def _config_target(config: object) -> str:
     if not isinstance(config, Mapping):
-        raise SystemExit("LeWorldModel config.json must contain a JSON object.")
+        raise WorldStateError("LeWorldModel config.json must contain a JSON object.")
     target = config.get("_target_")
     if not isinstance(target, str) or not target.strip():
-        raise SystemExit("LeWorldModel config.json must contain a non-empty _target_ field.")
+        raise WorldStateError("LeWorldModel config.json must contain a non-empty _target_ field.")
     return target.strip()
 
 
 def _ensure_leworldmodel_target(target: str) -> None:
     if target != LEWORLDMODEL_HF_CONFIG_TARGET:
-        raise SystemExit(
+        raise WorldStateError(
             "LeWorldModel config.json root _target_ must be "
             f"{LEWORLDMODEL_HF_CONFIG_TARGET!r}; got {target!r}."
         )
@@ -225,13 +222,13 @@ def _child_path(path: str, key: object) -> str:
 def _ensure_allowed_hydra_target(target: object, path: str) -> str:
     target_path = _target_path(path)
     if not isinstance(target, str) or not target.strip():
-        raise SystemExit(f"LeWorldModel config {target_path} must be a non-empty string.")
+        raise WorldStateError(f"LeWorldModel config {target_path} must be a non-empty string.")
     normalized = target.strip()
     if "${" in normalized:
-        raise SystemExit(f"LeWorldModel config {target_path} must not use interpolation.")
+        raise WorldStateError(f"LeWorldModel config {target_path} must not use interpolation.")
     if normalized not in LEWORLDMODEL_HF_ALLOWED_CONFIG_TARGETS:
         allowed = ", ".join(sorted(LEWORLDMODEL_HF_ALLOWED_CONFIG_TARGETS))
-        raise SystemExit(
+        raise WorldStateError(
             "LeWorldModel config contains disallowed Hydra _target_ "
             f"at {target_path}: {normalized!r}. Allowed targets: {allowed}."
         )
@@ -250,12 +247,94 @@ def _walk_hydra_targets(node: object, path: str = "$") -> None:
             _walk_hydra_targets(value, _child_path(path, index))
 
 
-def _validate_leworldmodel_config(omega_conf: object, config: object) -> str:
+def _walk_safe_config_values(node: object, path: str = "$") -> None:
+    if isinstance(node, Mapping):
+        for key, value in node.items():
+            if not isinstance(key, str) or not key:
+                raise WorldStateError(f"LeWorldModel config {path} contains an invalid key.")
+            _walk_safe_config_values(value, _child_path(path, key))
+        return
+    if isinstance(node, Sequence) and not isinstance(node, str | bytes | bytearray):
+        for index, value in enumerate(node):
+            _walk_safe_config_values(value, _child_path(path, index))
+        return
+    if isinstance(node, str):
+        if "${" in node:
+            raise WorldStateError(f"LeWorldModel config {path} must not use interpolation.")
+        return
+    if isinstance(node, bool) or node is None or isinstance(node, int):
+        return
+    if isinstance(node, float) and math.isfinite(node):
+        return
+    raise WorldStateError(
+        f"LeWorldModel config {path} must contain only JSON-native finite values."
+    )
+
+
+def _require_mapping_field(config: Mapping[str, object], key: str) -> Mapping[str, object]:
+    value = config.get(key)
+    if not isinstance(value, Mapping):
+        raise WorldStateError(f"LeWorldModel config field {key!r} must be a JSON object.")
+    return value
+
+
+def _require_exact_mapping(
+    mapping: Mapping[str, object],
+    *,
+    path: str,
+    expected: Mapping[str, object],
+) -> None:
+    extra = sorted(set(mapping) - set(expected))
+    missing = sorted(set(expected) - set(mapping))
+    if extra or missing:
+        raise WorldStateError(
+            f"LeWorldModel config {path} does not match the audited PushT shape: "
+            f"missing={missing}, extra={extra}."
+        )
+    for key, expected_value in expected.items():
+        if mapping.get(key) != expected_value:
+            raise WorldStateError(
+                f"LeWorldModel config {path}.{key} must be {expected_value!r}; "
+                f"got {mapping.get(key)!r}."
+            )
+
+
+def _validate_known_pusht_parameters(config: Mapping[str, object]) -> None:
+    encoder = _require_mapping_field(config, "encoder")
+    _require_exact_mapping(
+        encoder,
+        path="$.encoder",
+        expected={
+            "_target_": LEWORLDMODEL_HF_BACKBONE_TARGET,
+            "size": "tiny",
+            "patch_size": 14,
+            "image_size": 224,
+            "pretrained": False,
+            "use_mask_token": False,
+        },
+    )
+
+
+def _validate_leworldmodel_config(
+    omega_conf: object, config: object
+) -> tuple[str, Mapping[str, object]]:
     plain_config = _config_to_container(omega_conf, config)
     target = _config_target(plain_config)
     _walk_hydra_targets(plain_config)
+    _walk_safe_config_values(plain_config)
     _ensure_leworldmodel_target(target)
-    return target
+    _validate_known_pusht_parameters(plain_config)
+    return target, plain_config
+
+
+def _resolve_hf_revision(revision: str | None) -> str:
+    resolved = (revision or LEWORLDMODEL_HF_DEFAULT_REVISION).strip()
+    if not re.fullmatch(r"[0-9a-f]{40}", resolved):
+        raise WorldStateError(
+            "LeWorldModel Hugging Face revision must be a pinned 40-character "
+            f"commit SHA; got {revision!r}."
+        )
+    return resolved
 
 
 def _checkpoint_provenance() -> dict[str, object]:
@@ -289,6 +368,7 @@ def build_checkpoint(
             **_checkpoint_provenance(),
         }
 
+    resolved_revision = _resolve_hf_revision(revision)
     torch, hf_hub_download, instantiate, omega_conf = _load_optional_build_dependencies()
     asset_dir = (cache_dir or _repo_cache_dir(repo_id)).expanduser()
     config_path = Path(
@@ -296,21 +376,21 @@ def build_checkpoint(
             repo_id=repo_id,
             filename="config.json",
             local_dir=str(asset_dir),
-            revision=revision,
+            revision=resolved_revision,
         )
     )
 
     config = omega_conf.load(config_path)
-    target = _validate_leworldmodel_config(omega_conf, config)
+    target, safe_config = _validate_leworldmodel_config(omega_conf, config)
     weights_path = Path(
         hf_hub_download(
             repo_id=repo_id,
             filename="weights.pt",
             local_dir=str(asset_dir),
-            revision=revision,
+            revision=resolved_revision,
         )
     )
-    model = instantiate(config)
+    model = instantiate(safe_config)
     weights = _load_weights(torch, weights_path, allow_unsafe_pickle=allow_unsafe_pickle)
     incompatible = model.load_state_dict(weights, strict=False)
     missing, unexpected = _incompatible_keys(incompatible)
@@ -332,12 +412,11 @@ def build_checkpoint(
         "output": str(output_path),
         "policy": policy,
         "repo_id": repo_id,
+        "revision": resolved_revision,
         "weights": str(weights_path),
         "config_target": target,
         **_checkpoint_provenance(),
     }
-    if revision is not None:
-        summary["revision"] = revision
     return summary
 
 
@@ -349,8 +428,11 @@ def _parser() -> argparse.ArgumentParser:
     parser.add_argument("--repo-id", default=DEFAULT_REPO_ID)
     parser.add_argument(
         "--revision",
-        default=os.environ.get("LEWORLDMODEL_REVISION"),
-        help="Optional Hugging Face git revision, tag, or commit for config.json and weights.pt.",
+        default=os.environ.get("LEWORLDMODEL_REVISION") or LEWORLDMODEL_HF_DEFAULT_REVISION,
+        help=(
+            "Pinned Hugging Face commit SHA for config.json and weights.pt. Defaults to the "
+            f"audited PushT LeWM revision {LEWORLDMODEL_HF_DEFAULT_REVISION}."
+        ),
     )
     parser.add_argument("--policy", default=os.environ.get("LEWORLDMODEL_POLICY", "pusht/lewm"))
     parser.add_argument(
@@ -384,15 +466,18 @@ def _parser() -> argparse.ArgumentParser:
 
 def main() -> int:
     args = _parser().parse_args()
-    summary = build_checkpoint(
-        repo_id=args.repo_id,
-        policy=args.policy,
-        stablewm_home=args.stablewm_home,
-        cache_dir=args.asset_cache_dir.expanduser() if args.asset_cache_dir else None,
-        revision=args.revision,
-        allow_unsafe_pickle=args.allow_unsafe_pickle,
-        force=args.force,
-    )
+    try:
+        summary = build_checkpoint(
+            repo_id=args.repo_id,
+            policy=args.policy,
+            stablewm_home=args.stablewm_home,
+            cache_dir=args.asset_cache_dir.expanduser() if args.asset_cache_dir else None,
+            revision=args.revision,
+            allow_unsafe_pickle=args.allow_unsafe_pickle,
+            force=args.force,
+        )
+    except WorldStateError as exc:
+        raise SystemExit(str(exc)) from exc
     print(json.dumps(summary, indent=2, sort_keys=True))
     return 0
 

--- a/src/worldforge/smoke/robotics_showcase.py
+++ b/src/worldforge/smoke/robotics_showcase.py
@@ -12,6 +12,7 @@ from collections.abc import Sequence
 from pathlib import Path
 from typing import Any
 
+from worldforge.models import WorldStateError
 from worldforge.providers._config import env_value as _env_value
 
 from . import lerobot_leworldmodel, leworldmodel_checkpoint
@@ -82,7 +83,10 @@ def _parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--lewm-revision",
         default=os.environ.get("LEWORLDMODEL_REVISION"),
-        help="Optional Hugging Face revision, tag, or commit for auto-built LeWorldModel assets.",
+        help=(
+            "Optional pinned 40-character Hugging Face commit SHA for auto-built "
+            "LeWorldModel assets."
+        ),
     )
     parser.add_argument("--device", default=DEFAULT_DEVICE)
     parser.add_argument("--lerobot-device", default=_env_value("LEROBOT_DEVICE"))
@@ -201,13 +205,16 @@ def _ensure_checkpoint(args: argparse.Namespace) -> None:
         file=sys.stderr,
         flush=True,
     )
-    leworldmodel_checkpoint.build_checkpoint(
-        repo_id=leworldmodel_checkpoint.DEFAULT_REPO_ID,
-        policy=args.lewm_policy,
-        stablewm_home=cache_dir,
-        revision=args.lewm_revision,
-        allow_unsafe_pickle=args.allow_unsafe_pickle,
-    )
+    try:
+        leworldmodel_checkpoint.build_checkpoint(
+            repo_id=leworldmodel_checkpoint.DEFAULT_REPO_ID,
+            policy=args.lewm_policy,
+            stablewm_home=cache_dir,
+            revision=args.lewm_revision,
+            allow_unsafe_pickle=args.allow_unsafe_pickle,
+        )
+    except WorldStateError as exc:
+        raise SystemExit(str(exc)) from exc
 
 
 def _forward_args(args: argparse.Namespace) -> list[str]:

--- a/tests/test_leworldmodel_smoke_script.py
+++ b/tests/test_leworldmodel_smoke_script.py
@@ -207,9 +207,47 @@ def test_build_checkpoint_saves_object_checkpoint_with_injected_runtime(
 
     class FakeOmegaConf:
         @staticmethod
-        def load(path: Path) -> dict[str, str]:
+        def load(path: Path) -> dict[str, object]:
             assert path.name == "config.json"
-            return {"_target_": "stable_worldmodel.wm.lewm.LeWM"}
+            return {
+                "_target_": "stable_worldmodel.wm.lewm.LeWM",
+                "encoder": {
+                    "_target_": "stable_pretraining.backbone.utils.vit_hf",
+                    "size": "tiny",
+                    "patch_size": 14,
+                    "image_size": 224,
+                    "pretrained": False,
+                    "use_mask_token": False,
+                },
+                "predictor": {
+                    "_target_": "stable_worldmodel.wm.lewm.module.Predictor",
+                    "num_frames": 3,
+                    "input_dim": 192,
+                    "hidden_dim": 192,
+                    "output_dim": 192,
+                    "depth": 6,
+                    "heads": 16,
+                    "mlp_dim": 2048,
+                    "dim_head": 64,
+                    "dropout": 0.1,
+                    "emb_dropout": 0.0,
+                },
+                "action_encoder": {
+                    "_target_": "stable_worldmodel.wm.lewm.module.Embedder",
+                    "input_dim": 10,
+                    "emb_dim": 192,
+                },
+                "projector": {
+                    "_target_": "stable_worldmodel.wm.lewm.module.MLP",
+                    "input_dim": 192,
+                    "output_dim": 192,
+                    "hidden_dim": 2048,
+                    "norm_fn": {
+                        "_target_": "torch.nn.BatchNorm1d",
+                        "_partial_": True,
+                    },
+                },
+            }
 
     model = FakeModel()
     torch = FakeTorch()
@@ -259,6 +297,137 @@ def test_build_checkpoint_saves_object_checkpoint_with_injected_runtime(
     assert model.evaluated is True
     assert model.parameter.requires_grad is False
     assert (tmp_path / "stablewm/pusht/lewm_object.ckpt").read_text() == "saved"
+
+
+def test_build_checkpoint_rejects_nested_disallowed_config_target_before_instantiate(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    class FakeOmegaConf:
+        @staticmethod
+        def load(path: Path) -> dict[str, object]:
+            return {
+                "_target_": "stable_worldmodel.wm.lewm.LeWM",
+                "encoder": {
+                    "_target_": "stable_pretraining.backbone.utils.vit_hf",
+                    "size": "tiny",
+                },
+                "callbacks": [
+                    {
+                        "_target_": "os.system",
+                        "command": "touch /tmp/worldforge-should-not-execute",
+                    }
+                ],
+            }
+
+    downloaded: list[str] = []
+
+    class NoWeightsTorch:
+        @staticmethod
+        def load(path: Path, *, map_location: str, weights_only: bool = False) -> object:
+            pytest.fail("weights should not load for rejected config")
+
+    def hf_hub_download(
+        *,
+        repo_id: str,
+        filename: str,
+        local_dir: str,
+        revision: str | None,
+    ) -> str:
+        downloaded.append(filename)
+        path = Path(local_dir) / filename
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(filename)
+        return str(path)
+
+    monkeypatch.setattr(
+        leworldmodel_checkpoint,
+        "_load_optional_build_dependencies",
+        lambda: (
+            NoWeightsTorch,
+            hf_hub_download,
+            lambda _config: pytest.fail("unsafe config must not be instantiated"),
+            FakeOmegaConf,
+        ),
+    )
+
+    with pytest.raises(SystemExit, match="disallowed Hydra _target_"):
+        leworldmodel_checkpoint.build_checkpoint(
+            repo_id="quentinll/lewm-pusht",
+            policy="pusht/lewm",
+            stablewm_home=tmp_path / "stablewm",
+            cache_dir=tmp_path / "assets",
+        )
+
+    assert downloaded == ["config.json"]
+
+
+def test_build_checkpoint_rejects_interpolated_config_target_before_instantiate(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    class FakeOmegaConf:
+        @staticmethod
+        def load(path: Path) -> dict[str, object]:
+            return {
+                "_target_": "stable_worldmodel.wm.lewm.LeWM",
+                "encoder": {
+                    "_target_": "${encoder_target}",
+                    "encoder_target": "os.system",
+                },
+            }
+
+    def hf_hub_download(
+        *,
+        repo_id: str,
+        filename: str,
+        local_dir: str,
+        revision: str | None,
+    ) -> str:
+        path = Path(local_dir) / filename
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(filename)
+        return str(path)
+
+    class NoWeightsTorch:
+        @staticmethod
+        def load(path: Path, *, map_location: str, weights_only: bool = False) -> object:
+            pytest.fail("weights should not load for rejected config")
+
+    monkeypatch.setattr(
+        leworldmodel_checkpoint,
+        "_load_optional_build_dependencies",
+        lambda: (
+            NoWeightsTorch,
+            hf_hub_download,
+            lambda _config: pytest.fail("unsafe config must not be instantiated"),
+            FakeOmegaConf,
+        ),
+    )
+
+    with pytest.raises(SystemExit, match="must not use interpolation"):
+        leworldmodel_checkpoint.build_checkpoint(
+            repo_id="quentinll/lewm-pusht",
+            policy="pusht/lewm",
+            stablewm_home=tmp_path / "stablewm",
+            cache_dir=tmp_path / "assets",
+        )
+
+
+def test_leworldmodel_config_validation_uses_unresolved_omegaconf_container() -> None:
+    class FakeOmegaConf:
+        @staticmethod
+        def to_container(config: object, *, resolve: bool) -> dict[str, object]:
+            assert resolve is False
+            return {
+                "_target_": "stable_worldmodel.wm.lewm.LeWM",
+                "encoder": {"_target_": "stable_pretraining.backbone.utils.vit_hf"},
+            }
+
+    assert (
+        leworldmodel_checkpoint._validate_leworldmodel_config(FakeOmegaConf, object())
+        == "stable_worldmodel.wm.lewm.LeWM"
+    )
 
 
 def test_build_checkpoint_rejects_incompatible_weights(
@@ -320,7 +489,7 @@ def test_build_checkpoint_rejects_non_leworldmodel_config_target(
     class FakeOmegaConf:
         @staticmethod
         def load(path: Path) -> dict[str, str]:
-            return {"_target_": "stable_worldmodel.wm.pldm.PLDM"}
+            return {"_target_": "stable_worldmodel.wm.lewm_malicious.Run"}
 
     def hf_hub_download(
         *,
@@ -340,7 +509,7 @@ def test_build_checkpoint_rejects_non_leworldmodel_config_target(
         lambda: (object(), hf_hub_download, lambda _config: object(), FakeOmegaConf),
     )
 
-    with pytest.raises(SystemExit, match="did not describe a LeWM/JEPA model target"):
+    with pytest.raises(SystemExit, match="disallowed Hydra _target_"):
         leworldmodel_checkpoint.build_checkpoint(
             repo_id="quentinll/lewm-pusht",
             policy="pusht/lewm",

--- a/tests/test_leworldmodel_smoke_script.py
+++ b/tests/test_leworldmodel_smoke_script.py
@@ -8,7 +8,7 @@ from types import ModuleType, SimpleNamespace
 
 import pytest
 
-from worldforge.models import ProviderEvent
+from worldforge.models import ProviderEvent, WorldStateError
 from worldforge.smoke import leworldmodel, leworldmodel_checkpoint
 
 
@@ -156,6 +156,10 @@ def test_checkpoint_builder_installs_stable_pretraining_backbone_shim(
     assert model.config.interpolate_pos_encoding is True
     assert model.add_pooling_layer is False
     assert model.use_mask_token is False
+    with pytest.raises(ValueError, match="pretrained=False"):
+        utils.vit_hf(pretrained=True)
+    with pytest.raises(ValueError, match="Unsupported LeWM PushT ViT parameters"):
+        utils.vit_hf(hidden_size=999)
 
 
 def test_build_checkpoint_saves_object_checkpoint_with_injected_runtime(
@@ -252,6 +256,8 @@ def test_build_checkpoint_saves_object_checkpoint_with_injected_runtime(
     model = FakeModel()
     torch = FakeTorch()
 
+    revision = "22b330c28c27ead4bfd1888615af1340e3fe9052"
+
     def hf_hub_download(
         *,
         repo_id: str,
@@ -260,7 +266,7 @@ def test_build_checkpoint_saves_object_checkpoint_with_injected_runtime(
         revision: str | None,
     ) -> str:
         assert repo_id == "quentinll/lewm-pusht"
-        assert revision == "abc123"
+        assert revision == "22b330c28c27ead4bfd1888615af1340e3fe9052"
         path = Path(local_dir) / filename
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(filename)
@@ -269,7 +275,16 @@ def test_build_checkpoint_saves_object_checkpoint_with_injected_runtime(
     monkeypatch.setattr(
         leworldmodel_checkpoint,
         "_load_optional_build_dependencies",
-        lambda: (torch, hf_hub_download, lambda config: model, FakeOmegaConf),
+        lambda: (
+            torch,
+            hf_hub_download,
+            lambda config: (
+                model
+                if isinstance(config, dict)
+                else pytest.fail("instantiate should receive sanitized config dict")
+            ),
+            FakeOmegaConf,
+        ),
     )
 
     summary = leworldmodel_checkpoint.build_checkpoint(
@@ -277,7 +292,7 @@ def test_build_checkpoint_saves_object_checkpoint_with_injected_runtime(
         policy="pusht/lewm",
         stablewm_home=tmp_path / "stablewm",
         cache_dir=tmp_path / "assets",
-        revision="abc123",
+        revision=revision,
     )
 
     assert summary == {
@@ -289,7 +304,7 @@ def test_build_checkpoint_saves_object_checkpoint_with_injected_runtime(
         "output": str(tmp_path / "stablewm/pusht/lewm_object.ckpt"),
         "policy": "pusht/lewm",
         "repo_id": "quentinll/lewm-pusht",
-        "revision": "abc123",
+        "revision": revision,
         "runtime_api": "stable_worldmodel.policy.AutoCostModel",
         "weights": str(tmp_path / "assets/weights.pt"),
     }
@@ -351,7 +366,7 @@ def test_build_checkpoint_rejects_nested_disallowed_config_target_before_instant
         ),
     )
 
-    with pytest.raises(SystemExit, match="disallowed Hydra _target_"):
+    with pytest.raises(WorldStateError, match="disallowed Hydra _target_"):
         leworldmodel_checkpoint.build_checkpoint(
             repo_id="quentinll/lewm-pusht",
             policy="pusht/lewm",
@@ -405,7 +420,7 @@ def test_build_checkpoint_rejects_interpolated_config_target_before_instantiate(
         ),
     )
 
-    with pytest.raises(SystemExit, match="must not use interpolation"):
+    with pytest.raises(WorldStateError, match="must not use interpolation"):
         leworldmodel_checkpoint.build_checkpoint(
             repo_id="quentinll/lewm-pusht",
             policy="pusht/lewm",
@@ -421,13 +436,74 @@ def test_leworldmodel_config_validation_uses_unresolved_omegaconf_container() ->
             assert resolve is False
             return {
                 "_target_": "stable_worldmodel.wm.lewm.LeWM",
-                "encoder": {"_target_": "stable_pretraining.backbone.utils.vit_hf"},
+                "encoder": {
+                    "_target_": "stable_pretraining.backbone.utils.vit_hf",
+                    "size": "tiny",
+                    "patch_size": 14,
+                    "image_size": 224,
+                    "pretrained": False,
+                    "use_mask_token": False,
+                },
             }
 
     assert (
-        leworldmodel_checkpoint._validate_leworldmodel_config(FakeOmegaConf, object())
+        leworldmodel_checkpoint._validate_leworldmodel_config(FakeOmegaConf, object())[0]
         == "stable_worldmodel.wm.lewm.LeWM"
     )
+
+
+def test_leworldmodel_config_validation_rejects_non_target_interpolation() -> None:
+    config = {
+        "_target_": "stable_worldmodel.wm.lewm.LeWM",
+        "encoder": {
+            "_target_": "stable_pretraining.backbone.utils.vit_hf",
+            "size": "tiny",
+            "patch_size": 14,
+            "image_size": 224,
+            "pretrained": False,
+            "use_mask_token": "${mask_token}",
+        },
+    }
+
+    with pytest.raises(WorldStateError, match="must not use interpolation"):
+        leworldmodel_checkpoint._validate_leworldmodel_config(object(), config)
+
+
+def test_leworldmodel_config_validation_rejects_unsafe_vit_parameters() -> None:
+    config = {
+        "_target_": "stable_worldmodel.wm.lewm.LeWM",
+        "encoder": {
+            "_target_": "stable_pretraining.backbone.utils.vit_hf",
+            "size": "tiny",
+            "patch_size": 14,
+            "image_size": 224,
+            "pretrained": True,
+            "use_mask_token": False,
+        },
+    }
+
+    with pytest.raises(WorldStateError, match="pretrained"):
+        leworldmodel_checkpoint._validate_leworldmodel_config(object(), config)
+
+
+def test_build_checkpoint_requires_pinned_commit_revision(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(
+        leworldmodel_checkpoint,
+        "_load_optional_build_dependencies",
+        lambda: pytest.fail("invalid revision should fail before optional dependency loading"),
+    )
+
+    with pytest.raises(WorldStateError, match="40-character commit SHA"):
+        leworldmodel_checkpoint.build_checkpoint(
+            repo_id="quentinll/lewm-pusht",
+            policy="pusht/lewm",
+            stablewm_home=tmp_path / "stablewm",
+            cache_dir=tmp_path / "assets",
+            revision="main",
+        )
 
 
 def test_build_checkpoint_rejects_incompatible_weights(
@@ -451,8 +527,18 @@ def test_build_checkpoint_rejects_incompatible_weights(
 
     class FakeOmegaConf:
         @staticmethod
-        def load(path: Path) -> dict[str, str]:
-            return {"_target_": "stable_worldmodel.wm.lewm.LeWM"}
+        def load(path: Path) -> dict[str, object]:
+            return {
+                "_target_": "stable_worldmodel.wm.lewm.LeWM",
+                "encoder": {
+                    "_target_": "stable_pretraining.backbone.utils.vit_hf",
+                    "size": "tiny",
+                    "patch_size": 14,
+                    "image_size": 224,
+                    "pretrained": False,
+                    "use_mask_token": False,
+                },
+            }
 
     def hf_hub_download(
         *,
@@ -461,7 +547,7 @@ def test_build_checkpoint_rejects_incompatible_weights(
         local_dir: str,
         revision: str | None,
     ) -> str:
-        assert revision is None
+        assert revision == "22b330c28c27ead4bfd1888615af1340e3fe9052"
         path = Path(local_dir) / filename
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(filename)
@@ -509,7 +595,7 @@ def test_build_checkpoint_rejects_non_leworldmodel_config_target(
         lambda: (object(), hf_hub_download, lambda _config: object(), FakeOmegaConf),
     )
 
-    with pytest.raises(SystemExit, match="disallowed Hydra _target_"):
+    with pytest.raises(WorldStateError, match="disallowed Hydra _target_"):
         leworldmodel_checkpoint.build_checkpoint(
             repo_id="quentinll/lewm-pusht",
             policy="pusht/lewm",

--- a/tests/test_robotics_showcase.py
+++ b/tests/test_robotics_showcase.py
@@ -6,6 +6,7 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from worldforge.models import WorldStateError
 from worldforge.smoke import pusht_showcase_inputs, robotics_showcase
 
 
@@ -381,6 +382,36 @@ def test_robotics_showcase_auto_downloads_missing_checkpoint(
     assert build_calls["repo_id"] == robotics_showcase.leworldmodel_checkpoint.DEFAULT_REPO_ID
     assert build_calls["revision"] == "abc123"
     assert build_calls["allow_unsafe_pickle"] is True
+
+
+def test_robotics_showcase_reports_checkpoint_validation_errors(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    def fake_build_checkpoint(**_kwargs: Any) -> dict[str, Any]:
+        raise WorldStateError("LeWorldModel Hugging Face revision must be pinned.")
+
+    monkeypatch.setattr(
+        robotics_showcase.leworldmodel_checkpoint,
+        "build_checkpoint",
+        fake_build_checkpoint,
+    )
+
+    try:
+        robotics_showcase.main(
+            [
+                "--stablewm-home",
+                str(tmp_path),
+                "--lewm-revision",
+                "branch-name",
+                "--no-json-output",
+                "--no-tui",
+            ]
+        )
+    except SystemExit as exc:
+        assert str(exc) == "LeWorldModel Hugging Face revision must be pinned."
+    else:
+        raise AssertionError("robotics_showcase.main() should exit on checkpoint validation")
 
 
 def test_robotics_showcase_health_only_does_not_auto_download_missing_checkpoint(


### PR DESCRIPTION
## Summary

This hardens the LeWorldModel checkpoint builder before it calls Hydra `instantiate` on a downloaded Hugging Face config.

Without this guard, a caller-selected or compromised model repo could make a normal checkpoint build execute local code in the operator environment before the later `torch.load(weights_only=True)` safety gate is ever reached.

Changes:

- validate downloaded LeWorldModel Hydra configs against an official PushT LeWM target allowlist before calling `instantiate`
- reject nested disallowed `_target_` values and interpolated `_target_` values before downloading weights or instantiating the model
- surface validation failures clearly in the robotics showcase and document the checkpoint builder safety gate

## Validation

- [x] `uv lock --check`
- [x] `uv run ruff check src tests examples scripts`
- [x] `uv run ruff format --check src tests examples scripts`
- [x] `uv run python scripts/generate_provider_docs.py --check`
- [x] `uv run mkdocs build --strict`
- [x] `uv run pytest tests/test_leworldmodel_smoke_script.py tests/test_robotics_showcase.py tests/test_leworldmodel_uv_tasks.py -q` (`40 passed`)
- [x] `uv run pytest -q` (`559 passed, 78 skipped`)
