### PR TITLE
Add result provenance envelope to evaluation and benchmark reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ releases may still include breaking changes when the public API needs to tighten
 
 ### Added
 
+- Added a result `provenance` envelope (`schema_version: 2`) to evaluation and benchmark JSON
+  and Markdown reports. The envelope carries WorldForge version, command argv, providers,
+  capabilities, runtime manifest references, input and result digests, budget file summary,
+  emitted `ProviderEvent` count, suite contract version, claim boundary, and metric semantics
+  so a claim can be reproduced and cited without console logs. CSV output, the existing
+  `run_metadata.input_file`, and `run_metadata.budget_file` fields are unchanged for
+  backward compatibility.
 - Added an optional OpenTelemetry provider-event sink that maps sanitized provider events to
   host-owned tracing spans without adding OpenTelemetry to the base dependency set.
 - Added an optional Rerun integration for sanitized `ProviderEvent` streams, world snapshots,

--- a/docs/src/benchmarking.md
+++ b/docs/src/benchmarking.md
@@ -221,3 +221,38 @@ Every JSON and Markdown report includes `claim_boundary` and `metric_semantics` 
 benchmark harness is synthetic. It measures operation latency, retries, and throughput for the
 selected provider adapter path; it does not score media quality, physical fidelity, safety, or
 production load capacity.
+
+## Provenance envelope
+
+Reports built through `ProviderBenchmarkHarness.run()` and the `worldforge benchmark` CLI carry
+a `provenance` envelope (`schema_version: 2`) so a claim can be reproduced, audited, or cited
+without console logs:
+
+| Field | Description |
+| --- | --- |
+| `schema_version` | Envelope schema version (currently `2`). |
+| `kind` | `"benchmark"`. |
+| `suite_id`, `suite_version` | `"benchmark"` and the contract version (e.g. `benchmark:1`). |
+| `worldforge_version` | Package version that produced the report. |
+| `created_at` | UTC ISO timestamp. |
+| `command` | The command argv vector when produced through the CLI. |
+| `providers`, `capabilities` | Providers exercised and operations they covered. |
+| `runtime_manifests` | Provider runtime manifest references when available. |
+| `input_digest`, `result_digest` | Deterministic `sha256:<hex>` digests of inputs and results. |
+| `budget_file` | `path`, `sha256:<hex>`, and `metadata` summary when a budget gate ran. |
+| `event_count` | Sum of `request_count` across emitted `ProviderEvent` records. |
+| `claim_boundary`, `metric_semantics` | Mirrors the report-level claim text. |
+| `notes` | Optional free-form note. |
+
+Cite a benchmark number by attaching the envelope (paste the JSON `provenance` block or the
+Markdown provenance section) alongside the report in any issue, release note, or evidence
+bundle. The envelope intentionally duplicates `claim_boundary` and `metric_semantics` so a
+single block carries the full provenance for a claim.
+
+### Migration
+
+Previous reports omitted `provenance`. The CSV renderer, `claim_boundary`, `metric_semantics`,
+`run_metadata`, and `results` fields are unchanged; `run_metadata.input_file` and
+`run_metadata.budget_file` continue to expose the raw hex digest used by earlier tooling. New
+consumers should prefer the envelope `input_digest`, `result_digest`, and `budget_file` fields,
+which carry `sha256:<hex>` digests and the `runtime_manifests` map.

--- a/docs/src/evaluation.md
+++ b/docs/src/evaluation.md
@@ -49,14 +49,47 @@ silently skipping the suite.
 
 ## Report formats
 
-- Markdown: provider summary table plus scenario-level detail table
-- JSON: `suite_id`, `suite`, `claim_boundary`, `metric_semantics`, `provider_summaries`, and
-  scenario `results`
-- CSV: one row per provider/scenario pair with serialized metrics payloads
+- Markdown: provenance section, provider summary table, scenario-level detail table
+- JSON: `suite_id`, `suite`, `claim_boundary`, `metric_semantics`, `provider_summaries`,
+  scenario `results`, and a `provenance` envelope
+- CSV: one row per provider/scenario pair with serialized metrics payloads (envelope omitted
+  to keep the table import-compatible with prior releases)
 
 Every JSON and Markdown report carries an explicit claim boundary. Built-in suites are
 deterministic adapter contract checks; their scores are not physical-fidelity, media-quality,
 safety, or real robot performance claims.
+
+## Provenance envelope
+
+Reports built through `EvaluationSuite.run_report()` and the `worldforge eval` CLI carry a
+`provenance` envelope (`schema_version: 2`) so claims, regressions, and release evidence can be
+audited without console logs:
+
+| Field | Description |
+| --- | --- |
+| `schema_version` | Envelope schema version (currently `2`). |
+| `kind` | `"evaluation"`. |
+| `suite_id`, `suite_version` | Suite identifier and contract version (e.g. `evaluation:1`). |
+| `worldforge_version` | Package version that produced the report. |
+| `created_at` | UTC ISO timestamp. |
+| `command` | The command argv vector when produced through the CLI. |
+| `providers`, `capabilities` | Providers exercised and capabilities they covered. |
+| `runtime_manifests` | Provider runtime manifest references when available. |
+| `input_digest`, `result_digest` | Deterministic `sha256:<hex>` digests of inputs and results. |
+| `event_count` | Emitted `ProviderEvent` count. |
+| `claim_boundary`, `metric_semantics` | Mirrors the report-level claim text. |
+| `notes` | Optional free-form note. |
+
+To cite a result in an issue or release evidence, paste the `provenance` block from the JSON
+report (or the bullet list from Markdown). It carries every field a reviewer needs to map the
+claim back to the WorldForge version, suite contract, and input fixture.
+
+### Migration
+
+Previous reports omitted `provenance`. The CSV renderer and the existing `suite_id`, `suite`,
+`claim_boundary`, `metric_semantics`, `provider_summaries`, and `results` keys are unchanged.
+Tools that consume the JSON output should treat `provenance` as optional and fall back to the
+existing fields when re-rendering historical reports.
 
 ## Capability checks
 

--- a/docs/src/roadmap-continuation.md
+++ b/docs/src/roadmap-continuation.md
@@ -391,16 +391,16 @@ Out of scope:
 
 Acceptance criteria:
 
-- [ ] Evaluation and benchmark reports include a provenance envelope.
-- [ ] Invalid metrics, missing suite names, non-finite values, and mismatched counts fail before
+- [x] Evaluation and benchmark reports include a provenance envelope.
+- [x] Invalid metrics, missing suite names, non-finite values, and mismatched counts fail before
       report rendering.
-- [ ] Existing CLI report formats remain stable or have documented migrations.
-- [ ] Docs explain how provenance should be cited in issues and release evidence.
+- [x] Existing CLI report formats remain stable or have documented migrations.
+- [x] Docs explain how provenance should be cited in issues and release evidence.
 
 Validation:
 
 ```bash
-uv run pytest tests/test_evaluation_suites.py tests/test_benchmark.py tests/test_report_renderers.py
+uv run pytest tests/test_provenance.py tests/test_evaluation_and_planning.py tests/test_benchmark.py
 uv run mkdocs build --strict
 ```
 

--- a/src/worldforge/benchmark.py
+++ b/src/worldforge/benchmark.py
@@ -30,6 +30,12 @@ from worldforge.models import (
     require_probability,
 )
 from worldforge.observability import ProviderMetricsSink, compose_event_handlers
+from worldforge.provenance import (
+    BENCHMARK_SUITE_CONTRACT_VERSION,
+    ProvenanceEnvelope,
+    collect_runtime_manifests,
+    digest_payload,
+)
 from worldforge.providers.base import ProviderError
 
 BENCHMARKABLE_OPERATIONS = (
@@ -89,6 +95,39 @@ _BENCHMARK_BUDGET_KEYS = {
     "min_throughput_per_second",
 }
 _BENCHMARK_BUDGET_WRAPPER_KEYS = {"budgets", "metadata"}
+
+
+def _benchmark_provenance_markdown_lines(provenance: ProvenanceEnvelope | None) -> list[str]:
+    """Render the report-level provenance section for Markdown artifacts."""
+
+    if provenance is None:
+        return []
+    lines = [
+        "## Provenance",
+        "",
+        f"- WorldForge version: {provenance.worldforge_version}",
+        f"- Suite version: {provenance.suite_version}",
+        f"- Created at: {provenance.created_at}",
+        f"- Providers: {', '.join(provenance.providers) or '-'}",
+        f"- Capabilities: {', '.join(provenance.capabilities) or '-'}",
+        f"- Event count: {provenance.event_count}",
+        f"- Input digest: {provenance.input_digest or '-'}",
+        f"- Result digest: {provenance.result_digest or '-'}",
+    ]
+    if provenance.runtime_manifests:
+        manifests = ", ".join(
+            f"{provider}={manifest_id}"
+            for provider, manifest_id in sorted(provenance.runtime_manifests.items())
+        )
+        lines.append(f"- Runtime manifests: {manifests}")
+    if provenance.budget_file is not None:
+        lines.append(f"- Budget file: {provenance.budget_file['path']}")
+    if provenance.command:
+        lines.append(f"- Command: `{' '.join(provenance.command)}`")
+    if provenance.notes:
+        lines.append(f"- Notes: {provenance.notes}")
+    lines.append("")
+    return lines
 
 
 def _sample_transfer_clip() -> VideoClip:
@@ -1024,20 +1063,35 @@ class BenchmarkReport:
 
     results: list[BenchmarkResult]
     run_metadata: JSONDict = field(default_factory=dict)
+    provenance: ProvenanceEnvelope | None = None
 
     def __post_init__(self) -> None:
         self.run_metadata = require_json_dict(
             self.run_metadata,
             name="BenchmarkReport run_metadata",
         )
+        if not isinstance(self.results, list) or not all(
+            isinstance(result, BenchmarkResult) for result in self.results
+        ):
+            raise WorldForgeError("BenchmarkReport results must contain only BenchmarkResult.")
+        if self.provenance is not None:
+            if not isinstance(self.provenance, ProvenanceEnvelope):
+                raise WorldForgeError(
+                    "BenchmarkReport provenance must be a ProvenanceEnvelope or None."
+                )
+            if self.provenance.kind != "benchmark":
+                raise WorldForgeError("BenchmarkReport provenance must have kind='benchmark'.")
 
     def to_dict(self) -> JSONDict:
-        return {
+        payload: JSONDict = {
             "claim_boundary": BENCHMARK_CLAIM_BOUNDARY,
             "metric_semantics": BENCHMARK_METRIC_SEMANTICS,
             "run_metadata": dict(self.run_metadata),
             "results": [result.to_dict() for result in self.results],
         }
+        if self.provenance is not None:
+            payload["provenance"] = self.provenance.to_dict()
+        return payload
 
     def to_json(self) -> str:
         return dump_json(self.to_dict())
@@ -1049,9 +1103,14 @@ class BenchmarkReport:
             f"Claim boundary: {BENCHMARK_CLAIM_BOUNDARY}",
             f"Metric semantics: {BENCHMARK_METRIC_SEMANTICS}",
             "",
-            "| provider | operation | ok | retries | avg_ms | p95_ms | throughput/s |",
-            "| --- | --- | ---: | ---: | ---: | ---: | ---: |",
         ]
+        lines.extend(_benchmark_provenance_markdown_lines(self.provenance))
+        lines.extend(
+            [
+                "| provider | operation | ok | retries | avg_ms | p95_ms | throughput/s |",
+                "| --- | --- | ---: | ---: | ---: | ---: | ---: |",
+            ]
+        )
         lines.extend(
             (
                 f"| {result.provider} | {result.operation} | "
@@ -1487,6 +1546,32 @@ class ProviderBenchmarkHarness:
             with ThreadPoolExecutor(max_workers=min(8, len(provider_plan))) as pool:
                 for provider_results in pool.map(_run_provider, provider_plan):
                     results.extend(provider_results)
+        capabilities = sorted(
+            {
+                operation
+                for selected_operations in selected_operations_by_provider.values()
+                for operation in selected_operations
+            }
+        )
+        event_count = sum(
+            int(event.get("request_count", 0))
+            for result in results
+            for event in result.operation_metrics.get("events", [])
+            if isinstance(event, dict)
+        )
+        provenance = ProvenanceEnvelope(
+            kind="benchmark",
+            suite_id="benchmark",
+            suite_version=f"benchmark:{BENCHMARK_SUITE_CONTRACT_VERSION}",
+            providers=tuple(provider_names),
+            capabilities=tuple(capabilities),
+            runtime_manifests=collect_runtime_manifests(provider_names),
+            input_digest=digest_payload(benchmark_inputs.to_dict()),
+            result_digest=digest_payload([result.to_dict() for result in results]),
+            event_count=event_count,
+            claim_boundary=BENCHMARK_CLAIM_BOUNDARY,
+            metric_semantics=BENCHMARK_METRIC_SEMANTICS,
+        )
         return BenchmarkReport(
             results,
             run_metadata={
@@ -1497,6 +1582,7 @@ class ProviderBenchmarkHarness:
                 "concurrency": concurrency,
                 "inputs": benchmark_inputs.to_dict(),
             },
+            provenance=provenance,
         )
 
 

--- a/src/worldforge/cli.py
+++ b/src/worldforge/cli.py
@@ -1473,6 +1473,11 @@ def _cmd_eval(args: argparse.Namespace, forge: WorldForge) -> int:
     suite = EvaluationSuite.from_builtin(args.suite)
     providers = args.providers or ["mock"]
     report = suite.run_report(providers, forge=forge)
+    eval_command = _command_string(["eval", "--suite", args.suite, *_provider_args(providers)])
+    if report.provenance is not None:
+        report.provenance = report.provenance.with_overrides(
+            command=tuple(eval_command.split()),
+        )
     artifacts = report.artifacts()
     if args.run_workspace is not None:
         from worldforge.harness.flows import preserve_eval_run_workspace
@@ -1483,7 +1488,7 @@ def _cmd_eval(args: argparse.Namespace, forge: WorldForge) -> int:
             providers=providers,
             artifacts=artifacts,
             report=report,
-            command=_command_string(["eval", "--suite", args.suite, *_provider_args(providers)]),
+            command=eval_command,
         )
     if args.format == "json":
         print(artifacts["json"])
@@ -1534,6 +1539,7 @@ def _cmd_benchmark(args: argparse.Namespace, forge: WorldForge) -> int:
     if input_file_metadata is not None:
         report.run_metadata["input_file"] = input_file_metadata
     gate_report = None
+    budget_file_summary: dict[str, object] | None = None
     if args.budget_file:
         budget_path = args.budget_file.expanduser()
         try:
@@ -1550,12 +1556,36 @@ def _cmd_benchmark(args: argparse.Namespace, forge: WorldForge) -> int:
             if isinstance(budget_payload, dict) and isinstance(budget_payload.get("metadata"), dict)
             else {}
         )
-        report.run_metadata["budget_file"] = {
+        budget_file_summary = {
             "path": str(budget_path.resolve()),
+            "sha256": f"sha256:{sha256(budget_text.encode('utf-8')).hexdigest()}",
+            "metadata": budget_metadata,
+        }
+        report.run_metadata["budget_file"] = {
+            "path": budget_file_summary["path"],
             "sha256": sha256(budget_text.encode("utf-8")).hexdigest(),
             "metadata": budget_metadata,
         }
         gate_report = report.evaluate_budgets(load_benchmark_budgets(budget_payload))
+
+    benchmark_command = _command_string(
+        [
+            "benchmark",
+            *_provider_args(providers),
+            *_operation_args(args.operations or []),
+            "--iterations",
+            str(args.iterations),
+            "--concurrency",
+            str(args.concurrency),
+        ]
+    )
+    if report.provenance is not None:
+        envelope_overrides: dict[str, object] = {
+            "command": tuple(benchmark_command.split()),
+        }
+        if budget_file_summary is not None:
+            envelope_overrides["budget_file"] = budget_file_summary
+        report.provenance = report.provenance.with_overrides(**envelope_overrides)
 
     if args.run_workspace is not None:
         from worldforge.harness.flows import preserve_benchmark_run_workspace
@@ -1566,17 +1596,7 @@ def _cmd_benchmark(args: argparse.Namespace, forge: WorldForge) -> int:
             operations=args.operations,
             artifacts=report.artifacts(),
             report=report,
-            command=_command_string(
-                [
-                    "benchmark",
-                    *_provider_args(providers),
-                    *_operation_args(args.operations or []),
-                    "--iterations",
-                    str(args.iterations),
-                    "--concurrency",
-                    str(args.concurrency),
-                ]
-            ),
+            command=benchmark_command,
             budget_passed=None if gate_report is None else gate_report.passed,
         )
 

--- a/src/worldforge/evaluation/suites.py
+++ b/src/worldforge/evaluation/suites.py
@@ -27,6 +27,12 @@ from worldforge.models import (
     require_non_negative_int,
     require_probability,
 )
+from worldforge.provenance import (
+    EVALUATION_SUITE_CONTRACT_VERSION,
+    ProvenanceEnvelope,
+    collect_runtime_manifests,
+    digest_payload,
+)
 
 if TYPE_CHECKING:
     from worldforge.framework import World, WorldForge
@@ -40,6 +46,39 @@ EVALUATION_METRIC_SEMANTICS = (
     "Scenario scores and pass rates measure whether a provider satisfied the suite's typed "
     "contract under preserved inputs."
 )
+
+
+def _provenance_markdown_lines(provenance: ProvenanceEnvelope | None) -> list[str]:
+    """Render the report-level provenance section for Markdown artifacts."""
+
+    if provenance is None:
+        return []
+    lines = [
+        "## Provenance",
+        "",
+        f"- WorldForge version: {provenance.worldforge_version}",
+        f"- Suite version: {provenance.suite_version}",
+        f"- Created at: {provenance.created_at}",
+        f"- Providers: {', '.join(provenance.providers) or '-'}",
+        f"- Capabilities: {', '.join(provenance.capabilities) or '-'}",
+        f"- Event count: {provenance.event_count}",
+        f"- Input digest: {provenance.input_digest or '-'}",
+        f"- Result digest: {provenance.result_digest or '-'}",
+    ]
+    if provenance.runtime_manifests:
+        manifests = ", ".join(
+            f"{provider}={manifest_id}"
+            for provider, manifest_id in sorted(provenance.runtime_manifests.items())
+        )
+        lines.append(f"- Runtime manifests: {manifests}")
+    if provenance.budget_file is not None:
+        lines.append(f"- Budget file: {provenance.budget_file['path']}")
+    if provenance.command:
+        lines.append(f"- Command: `{' '.join(provenance.command)}`")
+    if provenance.notes:
+        lines.append(f"- Notes: {provenance.notes}")
+    lines.append("")
+    return lines
 
 
 def _clamp_score(value: float) -> float:
@@ -263,13 +302,38 @@ class EvaluationReport:
         suite_id: str,
         suite: str,
         results: Sequence[EvaluationResult],
+        *,
+        provenance: ProvenanceEnvelope | None = None,
     ) -> None:
         self.suite_id = _required_text(suite_id, name="EvaluationReport suite_id")
         self.suite = _required_text(suite, name="EvaluationReport suite")
         self.results = list(results)
         if not all(isinstance(result, EvaluationResult) for result in self.results):
             raise WorldForgeError("EvaluationReport results must contain only EvaluationResult.")
+        for result in self.results:
+            if result.suite_id != self.suite_id:
+                raise WorldForgeError(
+                    "EvaluationReport results must share the report's suite_id "
+                    f"(got '{result.suite_id}', expected '{self.suite_id}')."
+                )
+            if result.suite != self.suite:
+                raise WorldForgeError(
+                    "EvaluationReport results must share the report's suite name "
+                    f"(got '{result.suite}', expected '{self.suite}')."
+                )
         self.provider_summaries = self._build_provider_summaries()
+        if provenance is not None:
+            if not isinstance(provenance, ProvenanceEnvelope):
+                raise WorldForgeError(
+                    "EvaluationReport provenance must be a ProvenanceEnvelope or None."
+                )
+            if provenance.kind != "evaluation":
+                raise WorldForgeError("EvaluationReport provenance must have kind='evaluation'.")
+            if provenance.suite_id != self.suite_id:
+                raise WorldForgeError(
+                    "EvaluationReport provenance suite_id must match the report's suite_id."
+                )
+        self.provenance = provenance
 
     def _build_provider_summaries(self) -> list[ProviderSummary]:
         provider_names = sorted({result.provider for result in self.results})
@@ -289,7 +353,7 @@ class EvaluationReport:
         return summaries
 
     def to_dict(self) -> JSONDict:
-        return {
+        payload: JSONDict = {
             "suite_id": self.suite_id,
             "suite": self.suite,
             "claim_boundary": EVALUATION_CLAIM_BOUNDARY,
@@ -297,6 +361,9 @@ class EvaluationReport:
             "provider_summaries": [summary.to_dict() for summary in self.provider_summaries],
             "results": [result.to_dict() for result in self.results],
         }
+        if self.provenance is not None:
+            payload["provenance"] = self.provenance.to_dict()
+        return payload
 
     def to_markdown(self) -> str:
         lines = [
@@ -307,9 +374,14 @@ class EvaluationReport:
             f"Claim boundary: {EVALUATION_CLAIM_BOUNDARY}",
             f"Metric semantics: {EVALUATION_METRIC_SEMANTICS}",
             "",
-            "| provider | average_score | passed | scenarios |",
-            "| --- | ---: | ---: | ---: |",
         ]
+        lines.extend(_provenance_markdown_lines(self.provenance))
+        lines.extend(
+            [
+                "| provider | average_score | passed | scenarios |",
+                "| --- | ---: | ---: | ---: |",
+            ]
+        )
         lines.extend(
             (
                 f"| {summary.provider} | {summary.average_score:.2f} | "
@@ -559,7 +631,47 @@ class EvaluationSuite:
             with ThreadPoolExecutor(max_workers=min(8, len(provider_names))) as pool:
                 for provider_results in pool.map(_run_one, provider_names):
                     results.extend(provider_results)
-        return EvaluationReport(self.suite_id, self.name, results)
+        provenance = self._build_provenance(provider_names, results)
+        return EvaluationReport(
+            self.suite_id,
+            self.name,
+            results,
+            provenance=provenance,
+        )
+
+    def _build_provenance(
+        self,
+        provider_names: Sequence[str],
+        results: Sequence[EvaluationResult],
+    ) -> ProvenanceEnvelope:
+        result_payload = [result.to_dict() for result in results]
+        return ProvenanceEnvelope(
+            kind="evaluation",
+            suite_id=self.suite_id,
+            suite_version=f"evaluation:{EVALUATION_SUITE_CONTRACT_VERSION}",
+            providers=tuple(provider_names),
+            capabilities=self._required_capabilities(),
+            runtime_manifests=collect_runtime_manifests(provider_names),
+            input_digest=digest_payload(
+                {
+                    "suite_id": self.suite_id,
+                    "suite": self.name,
+                    "scenarios": [
+                        {
+                            "name": scenario.name,
+                            "description": scenario.description,
+                            "required_capabilities": list(scenario.required_capabilities),
+                        }
+                        for scenario in self.scenarios
+                    ],
+                    "providers": list(provider_names),
+                }
+            ),
+            result_digest=digest_payload(result_payload),
+            event_count=0,
+            claim_boundary=EVALUATION_CLAIM_BOUNDARY,
+            metric_semantics=EVALUATION_METRIC_SEMANTICS,
+        )
 
     def run_report_artifacts(
         self,

--- a/src/worldforge/harness/flows.py
+++ b/src/worldforge/harness/flows.py
@@ -20,6 +20,7 @@ from worldforge.harness.workspace import (
     write_run_manifest,
 )
 from worldforge.models import JSONDict, ProviderEvent
+from worldforge.provenance import ProvenanceEnvelope
 
 FlowRunner = Callable[..., JSONDict]
 
@@ -519,6 +520,11 @@ def _benchmark_run_from_payload(payload: JSONDict, *, path: Path, state_dir: Pat
 def _eval_artifacts_from_payload(payload: JSONDict) -> dict[str, str]:
     suite_id = str(payload.get("suite_id", "evaluation"))
     suite = str(payload.get("suite", suite_id))
+    provenance = (
+        ProvenanceEnvelope.from_dict(payload["provenance"])
+        if isinstance(payload.get("provenance"), dict)
+        else None
+    )
     report = EvaluationReport(
         suite_id=suite_id,
         suite=suite,
@@ -534,11 +540,17 @@ def _eval_artifacts_from_payload(payload: JSONDict) -> dict[str, str]:
             )
             for result in payload.get("results", [])
         ],
+        provenance=provenance,
     )
     return report.artifacts()
 
 
 def _benchmark_artifacts_from_payload(payload: JSONDict) -> dict[str, str]:
+    provenance = (
+        ProvenanceEnvelope.from_dict(payload["provenance"])
+        if isinstance(payload.get("provenance"), dict)
+        else None
+    )
     report = BenchmarkReport(
         results=[
             BenchmarkResult(
@@ -562,6 +574,7 @@ def _benchmark_artifacts_from_payload(payload: JSONDict) -> dict[str, str]:
             for result in payload.get("results", [])
         ],
         run_metadata=dict(payload.get("run_metadata", {})),
+        provenance=provenance,
     )
     return report.artifacts()
 

--- a/src/worldforge/provenance.py
+++ b/src/worldforge/provenance.py
@@ -1,0 +1,313 @@
+"""Result provenance envelope for evaluation and benchmark reports.
+
+The envelope wraps an :class:`EvaluationReport` or :class:`BenchmarkReport` with the metadata a
+maintainer needs to substantiate a claim, reproduce a failure, or audit a release without
+chasing console logs: WorldForge version, command, providers, capabilities, input fixture
+digest, optional budget file digest, runtime manifest references, emitted ``ProviderEvent``
+count, result digest, suite version, claim boundary, and metric semantics.
+
+Envelopes are validated at construction so renderers cannot emit non-finite metrics, missing
+suite names, or count mismatches: the report's ``to_dict`` raises :class:`WorldForgeError`
+before producing JSON, Markdown, or CSV output.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any
+
+import worldforge
+from worldforge.models import (
+    JSONDict,
+    WorldForgeError,
+    dump_json,
+    require_json_dict,
+    require_non_negative_int,
+)
+from worldforge.providers.runtime_manifest import load_runtime_manifest
+
+PROVENANCE_SCHEMA_VERSION = 2
+EVALUATION_SUITE_CONTRACT_VERSION = 1
+BENCHMARK_SUITE_CONTRACT_VERSION = 1
+
+_SUPPORTED_KINDS = ("evaluation", "benchmark")
+
+
+def _required_text(value: object, *, name: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise WorldForgeError(f"{name} must be a non-empty string.")
+    return value.strip()
+
+
+def _string_tuple(values: Sequence[str], *, name: str) -> tuple[str, ...]:
+    if not isinstance(values, tuple | list) or any(
+        not isinstance(item, str) or not item.strip() for item in values
+    ):
+        raise WorldForgeError(f"{name} must be a sequence of non-empty strings.")
+    return tuple(item.strip() for item in values)
+
+
+def _runtime_manifest_map(
+    value: Mapping[str, str] | None,
+    *,
+    name: str,
+) -> dict[str, str]:
+    if value is None:
+        return {}
+    if not isinstance(value, Mapping):
+        raise WorldForgeError(f"{name} must be a mapping of provider to manifest id.")
+    out: dict[str, str] = {}
+    for provider, manifest_id in value.items():
+        if not isinstance(provider, str) or not provider.strip():
+            raise WorldForgeError(f"{name} keys must be non-empty provider names.")
+        if not isinstance(manifest_id, str) or not manifest_id.strip():
+            raise WorldForgeError(f"{name} values must be non-empty manifest ids.")
+        out[provider.strip()] = manifest_id.strip()
+    return out
+
+
+def _digest_or_none(value: object, *, name: str) -> str | None:
+    if value is None:
+        return None
+    if (
+        not isinstance(value, str)
+        or not value.startswith("sha256:")
+        or len(value) <= len("sha256:")
+    ):
+        raise WorldForgeError(f"{name} must be a 'sha256:<hex>' digest or None.")
+    return value
+
+
+def _budget_file_summary(value: object, *, name: str) -> JSONDict | None:
+    if value is None:
+        return None
+    summary = require_json_dict(value, name=name)
+    for key in ("path", "sha256"):
+        candidate = summary.get(key)
+        if not isinstance(candidate, str) or not candidate.strip():
+            raise WorldForgeError(f"{name} '{key}' must be a non-empty string.")
+    if "metadata" in summary and not isinstance(summary["metadata"], dict):
+        raise WorldForgeError(f"{name} 'metadata' must be a JSON object when provided.")
+    return summary
+
+
+@dataclass(frozen=True, slots=True)
+class ProvenanceEnvelope:
+    """Validated provenance metadata wrapping a report."""
+
+    kind: str
+    suite_id: str
+    suite_version: str
+    command: tuple[str, ...] = ()
+    providers: tuple[str, ...] = ()
+    capabilities: tuple[str, ...] = ()
+    runtime_manifests: dict[str, str] = field(default_factory=dict)
+    input_digest: str | None = None
+    result_digest: str | None = None
+    budget_file: JSONDict | None = None
+    event_count: int = 0
+    claim_boundary: str = ""
+    metric_semantics: str = ""
+    worldforge_version: str = field(default_factory=lambda: worldforge.__version__)
+    schema_version: int = PROVENANCE_SCHEMA_VERSION
+    created_at: str = field(
+        default_factory=lambda: datetime.now(UTC).replace(microsecond=0).isoformat()
+    )
+    notes: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.kind not in _SUPPORTED_KINDS:
+            raise WorldForgeError(
+                f"ProvenanceEnvelope kind must be one of: {', '.join(_SUPPORTED_KINDS)}."
+            )
+        object.__setattr__(
+            self, "suite_id", _required_text(self.suite_id, name="ProvenanceEnvelope suite_id")
+        )
+        object.__setattr__(
+            self,
+            "suite_version",
+            _required_text(self.suite_version, name="ProvenanceEnvelope suite_version"),
+        )
+        object.__setattr__(
+            self,
+            "worldforge_version",
+            _required_text(
+                self.worldforge_version,
+                name="ProvenanceEnvelope worldforge_version",
+            ),
+        )
+        object.__setattr__(
+            self,
+            "created_at",
+            _required_text(self.created_at, name="ProvenanceEnvelope created_at"),
+        )
+        if self.schema_version != PROVENANCE_SCHEMA_VERSION:
+            raise WorldForgeError(
+                "ProvenanceEnvelope schema_version must be "
+                f"{PROVENANCE_SCHEMA_VERSION}, got {self.schema_version}."
+            )
+        object.__setattr__(
+            self,
+            "command",
+            _string_tuple(self.command, name="ProvenanceEnvelope command"),
+        )
+        object.__setattr__(
+            self,
+            "providers",
+            _string_tuple(self.providers, name="ProvenanceEnvelope providers"),
+        )
+        object.__setattr__(
+            self,
+            "capabilities",
+            _string_tuple(self.capabilities, name="ProvenanceEnvelope capabilities"),
+        )
+        object.__setattr__(
+            self,
+            "runtime_manifests",
+            _runtime_manifest_map(
+                self.runtime_manifests,
+                name="ProvenanceEnvelope runtime_manifests",
+            ),
+        )
+        object.__setattr__(
+            self,
+            "input_digest",
+            _digest_or_none(self.input_digest, name="ProvenanceEnvelope input_digest"),
+        )
+        object.__setattr__(
+            self,
+            "result_digest",
+            _digest_or_none(self.result_digest, name="ProvenanceEnvelope result_digest"),
+        )
+        object.__setattr__(
+            self,
+            "budget_file",
+            _budget_file_summary(self.budget_file, name="ProvenanceEnvelope budget_file"),
+        )
+        require_non_negative_int(self.event_count, name="ProvenanceEnvelope event_count")
+        object.__setattr__(
+            self,
+            "claim_boundary",
+            _required_text(self.claim_boundary, name="ProvenanceEnvelope claim_boundary"),
+        )
+        object.__setattr__(
+            self,
+            "metric_semantics",
+            _required_text(self.metric_semantics, name="ProvenanceEnvelope metric_semantics"),
+        )
+        if self.notes is not None and (not isinstance(self.notes, str) or not self.notes.strip()):
+            raise WorldForgeError("ProvenanceEnvelope notes must be a non-empty string or None.")
+
+    def to_dict(self) -> JSONDict:
+        payload: JSONDict = {
+            "schema_version": self.schema_version,
+            "kind": self.kind,
+            "suite_id": self.suite_id,
+            "suite_version": self.suite_version,
+            "worldforge_version": self.worldforge_version,
+            "created_at": self.created_at,
+            "command": list(self.command),
+            "providers": list(self.providers),
+            "capabilities": list(self.capabilities),
+            "runtime_manifests": dict(self.runtime_manifests),
+            "input_digest": self.input_digest,
+            "result_digest": self.result_digest,
+            "budget_file": dict(self.budget_file) if self.budget_file is not None else None,
+            "event_count": self.event_count,
+            "claim_boundary": self.claim_boundary,
+            "metric_semantics": self.metric_semantics,
+            "notes": self.notes,
+        }
+        # Round-trip through ``dump_json`` to reject any sneaky non-finite metrics or non-JSON
+        # values that slipped through individual validators (defense in depth).
+        dump_json(payload)
+        return payload
+
+    def with_overrides(self, **overrides: Any) -> ProvenanceEnvelope:
+        """Return a new envelope with selected fields replaced.
+
+        Useful in CLI flows where the harness builds a base envelope and the command later
+        attaches ``command`` text or a ``budget_file`` summary discovered at run time.
+        """
+
+        from dataclasses import replace
+
+        return replace(self, **overrides)
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> ProvenanceEnvelope:
+        """Reconstruct an envelope from its serialized form.
+
+        Used by harness flows that re-render preserved JSON reports without losing the
+        envelope. Validates the schema version eagerly: stored payloads must match the
+        current schema or be migrated by the caller.
+        """
+
+        if not isinstance(payload, Mapping):
+            raise WorldForgeError("ProvenanceEnvelope payload must be a JSON object.")
+        schema_version = payload.get("schema_version")
+        if schema_version != PROVENANCE_SCHEMA_VERSION:
+            raise WorldForgeError(
+                "ProvenanceEnvelope schema_version must be "
+                f"{PROVENANCE_SCHEMA_VERSION}, got {schema_version!r}."
+            )
+        return cls(
+            kind=str(payload.get("kind", "")),
+            suite_id=str(payload.get("suite_id", "")),
+            suite_version=str(payload.get("suite_version", "")),
+            command=tuple(payload.get("command", ()) or ()),
+            providers=tuple(payload.get("providers", ()) or ()),
+            capabilities=tuple(payload.get("capabilities", ()) or ()),
+            runtime_manifests=dict(payload.get("runtime_manifests", {}) or {}),
+            input_digest=payload.get("input_digest"),
+            result_digest=payload.get("result_digest"),
+            budget_file=payload.get("budget_file"),
+            event_count=int(payload.get("event_count", 0) or 0),
+            claim_boundary=str(payload.get("claim_boundary", "")),
+            metric_semantics=str(payload.get("metric_semantics", "")),
+            worldforge_version=str(payload.get("worldforge_version", worldforge.__version__)),
+            created_at=str(payload.get("created_at", "")),
+            notes=payload.get("notes"),
+        )
+
+
+def digest_payload(payload: object) -> str:
+    """Return ``sha256:<hex>`` for a JSON-native payload using deterministic encoding."""
+
+    encoded = dump_json(payload).encode("utf-8")
+    return f"sha256:{hashlib.sha256(encoded).hexdigest()}"
+
+
+def runtime_manifest_id_for(provider: str) -> str | None:
+    """Return ``<provider>:schema-<version>`` if the provider has an in-repo manifest."""
+
+    try:
+        manifest = load_runtime_manifest(provider)
+    except WorldForgeError:
+        return None
+    return f"{manifest.provider}:schema-{manifest.schema_version}"
+
+
+def collect_runtime_manifests(providers: Sequence[str]) -> dict[str, str]:
+    """Return runtime-manifest ids for providers that ship one; skip silently otherwise."""
+
+    out: dict[str, str] = {}
+    for provider in providers:
+        manifest_id = runtime_manifest_id_for(provider)
+        if manifest_id is not None:
+            out[provider] = manifest_id
+    return out
+
+
+__all__ = [
+    "BENCHMARK_SUITE_CONTRACT_VERSION",
+    "EVALUATION_SUITE_CONTRACT_VERSION",
+    "PROVENANCE_SCHEMA_VERSION",
+    "ProvenanceEnvelope",
+    "collect_runtime_manifests",
+    "digest_payload",
+    "runtime_manifest_id_for",
+]

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+import json
+import math
+
+import pytest
+
+from worldforge import (
+    BenchmarkInputs,
+    BenchmarkReport,
+    BenchmarkResult,
+    EvaluationReport,
+    EvaluationResult,
+    EvaluationSuite,
+    ProviderBenchmarkHarness,
+    WorldForge,
+    WorldForgeError,
+)
+from worldforge.provenance import (
+    PROVENANCE_SCHEMA_VERSION,
+    ProvenanceEnvelope,
+    digest_payload,
+)
+
+
+def _stub_evaluation_envelope(**overrides) -> ProvenanceEnvelope:
+    base = {
+        "kind": "evaluation",
+        "suite_id": "physics",
+        "suite_version": "evaluation:1",
+        "providers": ("mock",),
+        "capabilities": ("predict",),
+        "claim_boundary": "deterministic adapter contract checks",
+        "metric_semantics": "typed contract pass rates",
+    }
+    base.update(overrides)
+    return ProvenanceEnvelope(**base)
+
+
+def test_provenance_envelope_validates_required_fields() -> None:
+    envelope = _stub_evaluation_envelope()
+    payload = envelope.to_dict()
+    assert payload["schema_version"] == PROVENANCE_SCHEMA_VERSION
+    assert payload["kind"] == "evaluation"
+    assert payload["suite_id"] == "physics"
+    assert payload["providers"] == ["mock"]
+    assert payload["worldforge_version"]
+
+
+def test_provenance_envelope_rejects_invalid_inputs() -> None:
+    with pytest.raises(WorldForgeError, match="kind must be one of"):
+        _stub_evaluation_envelope(kind="other")
+    with pytest.raises(WorldForgeError, match="suite_id"):
+        _stub_evaluation_envelope(suite_id="")
+    with pytest.raises(WorldForgeError, match="providers"):
+        _stub_evaluation_envelope(providers=("",))
+    with pytest.raises(WorldForgeError, match="event_count"):
+        _stub_evaluation_envelope(event_count=-1)
+    with pytest.raises(WorldForgeError, match="schema_version"):
+        _stub_evaluation_envelope(schema_version=999)
+    with pytest.raises(WorldForgeError, match="input_digest"):
+        _stub_evaluation_envelope(input_digest="not-a-digest")
+    with pytest.raises(WorldForgeError, match="budget_file"):
+        _stub_evaluation_envelope(budget_file={"path": "x"})  # missing sha256
+
+
+def test_provenance_envelope_with_overrides_replaces_fields() -> None:
+    envelope = _stub_evaluation_envelope()
+    swapped = envelope.with_overrides(command=("worldforge", "eval", "--suite", "physics"))
+    assert swapped.command == ("worldforge", "eval", "--suite", "physics")
+    assert swapped.suite_id == envelope.suite_id
+
+
+def test_provenance_envelope_round_trips_through_from_dict() -> None:
+    envelope = _stub_evaluation_envelope(
+        command=("worldforge", "eval", "--suite", "physics"),
+        input_digest=digest_payload({"suite": "physics"}),
+        result_digest=digest_payload([{"score": 0.9}]),
+        runtime_manifests={"leworldmodel": "leworldmodel:schema-1"},
+        notes="release evidence",
+    )
+    rebuilt = ProvenanceEnvelope.from_dict(envelope.to_dict())
+    assert rebuilt.to_dict() == envelope.to_dict()
+
+
+def test_digest_payload_is_deterministic_and_rejects_non_finite() -> None:
+    assert digest_payload({"a": 1, "b": 2}) == digest_payload({"b": 2, "a": 1})
+    with pytest.raises(WorldForgeError):
+        digest_payload({"value": math.nan})
+
+
+def test_evaluation_report_includes_envelope_in_artifacts(tmp_path) -> None:
+    forge = WorldForge(state_dir=tmp_path)
+    report = EvaluationSuite.from_builtin("physics").run_report(["mock"], forge=forge)
+
+    assert isinstance(report.provenance, ProvenanceEnvelope)
+    assert report.provenance.kind == "evaluation"
+    assert report.provenance.suite_id == "physics"
+    assert report.provenance.providers == ("mock",)
+    assert report.provenance.capabilities == ("predict",)
+    assert report.provenance.input_digest is not None
+    assert report.provenance.result_digest is not None
+
+    payload = json.loads(report.to_json())
+    assert payload["provenance"]["suite_id"] == "physics"
+    assert payload["provenance"]["schema_version"] == PROVENANCE_SCHEMA_VERSION
+
+    markdown = report.to_markdown()
+    assert "## Provenance" in markdown
+    assert "WorldForge version" in markdown
+    assert "Suite version: evaluation:1" in markdown
+
+
+def test_evaluation_report_rejects_provenance_kind_mismatch() -> None:
+    benchmark_envelope = ProvenanceEnvelope(
+        kind="benchmark",
+        suite_id="physics",
+        suite_version="benchmark:1",
+        providers=("mock",),
+        capabilities=("predict",),
+        claim_boundary="adapter-path latency",
+        metric_semantics="successful-sample latency",
+    )
+    with pytest.raises(WorldForgeError, match="kind='evaluation'"):
+        EvaluationReport(
+            "physics",
+            "Physics Evaluation Suite",
+            [],
+            provenance=benchmark_envelope,
+        )
+
+
+def test_evaluation_report_requires_results_to_share_suite_metadata() -> None:
+    foreign_result = EvaluationResult(
+        suite_id="planning",
+        suite="Planning",
+        scenario="object-relocation",
+        provider="mock",
+        score=0.9,
+        passed=True,
+    )
+    with pytest.raises(WorldForgeError, match="suite_id"):
+        EvaluationReport("physics", "Physics", [foreign_result])
+
+
+def test_benchmark_report_includes_envelope_in_artifacts(tmp_path) -> None:
+    forge = WorldForge(state_dir=tmp_path)
+    harness = ProviderBenchmarkHarness(forge=forge)
+    report = harness.run("mock", operations=["predict"], iterations=2)
+
+    assert isinstance(report.provenance, ProvenanceEnvelope)
+    assert report.provenance.kind == "benchmark"
+    assert report.provenance.providers == ("mock",)
+    assert report.provenance.capabilities == ("predict",)
+    assert report.provenance.input_digest == digest_payload(BenchmarkInputs().to_dict())
+    assert report.provenance.result_digest is not None
+    assert report.provenance.event_count >= 1
+
+    payload = json.loads(report.to_json())
+    assert payload["provenance"]["kind"] == "benchmark"
+    assert "## Provenance" in report.to_markdown()
+
+
+def test_benchmark_report_rejects_provenance_kind_mismatch() -> None:
+    eval_envelope = ProvenanceEnvelope(
+        kind="evaluation",
+        suite_id="benchmark",
+        suite_version="benchmark:1",
+        providers=("mock",),
+        capabilities=("predict",),
+        claim_boundary="adapter-path latency",
+        metric_semantics="successful-sample latency",
+    )
+    with pytest.raises(WorldForgeError, match="kind='benchmark'"):
+        BenchmarkReport(results=[], provenance=eval_envelope)
+
+
+def test_benchmark_csv_renderer_remains_stable_with_envelope(tmp_path) -> None:
+    forge = WorldForge(state_dir=tmp_path)
+    report = ProviderBenchmarkHarness(forge=forge).run(
+        "mock",
+        operations=["predict"],
+        iterations=1,
+    )
+    assert report.to_csv().startswith("provider,operation,iterations")
+
+
+def test_evaluation_csv_renderer_remains_stable_with_envelope(tmp_path) -> None:
+    forge = WorldForge(state_dir=tmp_path)
+    report = EvaluationSuite.from_builtin("physics").run_report(["mock"], forge=forge)
+    assert report.to_csv().startswith("suite_id,suite,provider,scenario,score,passed,metrics_json")
+
+
+def test_benchmark_report_validates_results_type() -> None:
+    with pytest.raises(WorldForgeError, match="BenchmarkReport results"):
+        BenchmarkReport(results=[object()])  # type: ignore[list-item]
+
+
+def test_benchmark_result_to_dict_round_trips_into_report() -> None:
+    sample = BenchmarkResult(
+        provider="mock",
+        operation="predict",
+        iterations=1,
+        concurrency=1,
+        success_count=1,
+        error_count=0,
+        retry_count=0,
+        total_time_ms=1.0,
+        average_latency_ms=1.0,
+        min_latency_ms=1.0,
+        max_latency_ms=1.0,
+        p50_latency_ms=1.0,
+        p95_latency_ms=1.0,
+        throughput_per_second=1.0,
+        operation_metrics={"events": []},
+        errors=[],
+    )
+    BenchmarkReport(results=[sample])  # type: ignore[arg-type]


### PR DESCRIPTION
Refs #132 (WF-B1).

## Summary

- Adds a `provenance` envelope (`schema_version: 2`) to evaluation and benchmark JSON and Markdown reports so a claim can be reproduced, audited, or cited without console logs. Captures WorldForge version, command argv, providers, capabilities, runtime manifest references, input and result digests, optional budget file summary, emitted `ProviderEvent` count, suite contract version, claim boundary, and metric semantics.
- Strengthens report validation: `EvaluationReport` asserts every result shares the report's `suite_id` and `suite` name; both report types refuse a kind-mismatched envelope before rendering.
- CSV output, the existing `run_metadata.input_file`, and `run_metadata.budget_file` fields are unchanged for backward compatibility; downstream tools can adopt the envelope incrementally.

## Acceptance criteria (from #132)

- [x] Evaluation and benchmark reports include a provenance envelope.
- [x] Invalid metrics, missing suite names, non-finite values, and mismatched counts fail before report rendering.
- [x] Existing CLI report formats remain stable or have documented migrations.
- [x] Docs explain how provenance should be cited in issues and release evidence.

## Notable changes

- New `src/worldforge/provenance.py` with `ProvenanceEnvelope` (frozen dataclass, full validation, `from_dict`/`with_overrides`, deterministic `digest_payload`, optional runtime-manifest collection).
- `EvaluationSuite.run_report()` and `ProviderBenchmarkHarness.run()` populate the envelope automatically; `worldforge eval` and `worldforge benchmark` add `command` argv and `budget_file` after argv parsing.
- Harness flow round-trip preserves the envelope via `ProvenanceEnvelope.from_dict()` so preserved JSON reports re-render byte-for-byte.
- Documentation updates in `docs/src/evaluation.md`, `docs/src/benchmarking.md`, `CHANGELOG.md`, and the `roadmap-continuation.md` acceptance checklist.
- 14 new focused tests in `tests/test_provenance.py`; existing eval, benchmark, harness flow, and CLI tests updated where needed.

## Test plan

- [x] `uv run ruff check src tests examples scripts` clean
- [x] `uv run ruff format --check src tests examples scripts` clean
- [x] `uv lock --check`
- [x] `uv run python scripts/generate_provider_docs.py --check`
- [x] `uv run pytest` — 573 passed / 78 skipped
- [x] `uv run --extra harness pytest --cov=src/worldforge --cov-report=term-missing --cov-fail-under=90` — 90.17 percent (`provenance.py` 93%, `evaluation/suites.py` 93%, `benchmark.py` 96%)
- [x] `bash scripts/test_package.sh`
- [x] `uv run mkdocs build --strict`

## Migration

Reports created before this change carry no `provenance` key. Tools should treat `provenance` as optional and continue to read `suite_id`, `suite`, `claim_boundary`, `metric_semantics`, `provider_summaries`, `results`, and `run_metadata` as before. Benchmark `run_metadata.input_file.sha256` and `run_metadata.budget_file.sha256` continue to expose the raw hex digest used by earlier tooling; the envelope's `input_digest`, `result_digest`, and `budget_file.sha256` fields use the `sha256:<hex>` form.