### PR TITLE
Add benchmark preset suites for release regressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ releases may still include breaking changes when the public API needs to tighten
 
 ### Added
 
+- Added five named benchmark presets — `mock-smoke`, `parser-overhead`, `remote-media-dryrun`,
+  `prepared-host`, and `release-evidence` — exposed through new `worldforge benchmark
+  --list-presets`, `--show-preset`, and `--preset` flags. Presets bundle a deterministic input
+  fixture, an optional budget file, and a runtime-profile gate so checkout-safe regression
+  checks, remote-media dry-runs, prepared-host evidence runs, and release gating each have a
+  named entry point. Remote-media and prepared-host presets skip with a typed reason when the
+  required provider environment is missing; checkout-safe and release presets fail non-zero on
+  budget violations. Public surface lives at `worldforge.benchmark_presets` (`BenchmarkPreset`,
+  `list_presets`, `get_preset`, `load_preset_inputs`, `load_preset_budgets`).
 - Added a packaged capability fixture corpus under `worldforge.testing.fixtures` covering the
   `predict`, `reason`, `embed`, `generate`, `transfer`, `score`, and `policy` capabilities.
   Each capability ships one valid baseline plus at least two invalid boundary fixtures with

--- a/docs/src/benchmarking.md
+++ b/docs/src/benchmarking.md
@@ -222,6 +222,51 @@ benchmark harness is synthetic. It measures operation latency, retries, and thro
 selected provider adapter path; it does not score media quality, physical fidelity, safety, or
 production load capacity.
 
+## Presets
+
+Named presets bundle a deterministic input fixture, an optional budget file, and a runtime
+gate so maintainers can run release-regression workloads without re-deriving inputs and
+budgets each time. Five presets ship with the wheel today, grouped into four categories:
+
+| Preset | Category | Providers | Operations | Iterations | Failure tolerance |
+| --- | --- | --- | --- | ---: | --- |
+| `mock-smoke` | checkout-safe | `mock` | predict, generate, embed | 5 | fail-on-violation |
+| `parser-overhead` | checkout-safe | `mock` | predict, reason, generate, transfer, embed | 20 | fail-on-violation |
+| `remote-media-dryrun` | remote-media | `cosmos`, `runway` | generate | 1 | skip-when-env-missing |
+| `prepared-host` | prepared-host | `leworldmodel`, `lerobot`, `gr00t` | score, policy | 3 | skip-when-env-missing |
+| `release-evidence` | release | `mock` | predict, reason, generate, transfer, embed | 10 | fail-on-violation |
+
+List, inspect, and run presets through the existing `benchmark` subcommand:
+
+```bash
+uv run worldforge benchmark --list-presets
+uv run worldforge benchmark --show-preset release-evidence
+uv run worldforge benchmark --preset mock-smoke
+uv run worldforge benchmark --preset release-evidence --format json --run-workspace .worldforge
+```
+
+`--preset` overrides `--provider`, `--operation`, `--iterations`, `--concurrency`, `--input-file`,
+and `--budget-file`. The `--format` and `--run-workspace` flags still apply.
+
+### Failure tolerance and skip semantics
+
+- **fail-on-violation** (`mock-smoke`, `parser-overhead`, `release-evidence`). The preset runs
+  unconditionally; budget violations exit non-zero with the standard violation table that
+  carries provider, operation, metric, observed value, threshold, and budget selector.
+- **skip-when-env-missing** (`remote-media-dryrun`, `prepared-host`). Each gated preset checks
+  every provider runtime profile it requires through
+  `worldforge.testing.runtime_profiles.provider_profile_skip_reason`. If no eligible runtime
+  is configured the preset prints a typed reason and exits 0; release CI treats this as
+  "evidence not available on this host" rather than a failure.
+
+### Adding a preset
+
+`BenchmarkPreset` is a frozen dataclass under `worldforge.benchmark_presets`. Add a new entry
+to the `_BENCHMARK_PRESETS` tuple, ship the matching `inputs-*.json` and (optionally)
+`budget-*.json` next to it under `src/worldforge/benchmark_presets/_data/`, and add coverage
+in `tests/test_benchmark_presets.py`. Keep the inputs deterministic and small; binary clip
+frames belong inside the JSON via `frames_base64` rather than as separate media files.
+
 ## Provenance envelope
 
 Reports built through `ProviderBenchmarkHarness.run()` and the `worldforge benchmark` CLI carry

--- a/docs/src/roadmap-continuation.md
+++ b/docs/src/roadmap-continuation.md
@@ -459,16 +459,16 @@ Out of scope:
 
 Acceptance criteria:
 
-- [ ] Presets can be listed and run from the CLI or documented make targets.
-- [ ] Checkout-safe presets run without credentials, network, GPUs, or optional runtimes.
-- [ ] Prepared-host presets skip or fail with typed reasons when prerequisites are missing.
-- [ ] Budget violations include operation, metric, threshold, observed value, and artifact path.
+- [x] Presets can be listed and run from the CLI or documented make targets.
+- [x] Checkout-safe presets run without credentials, network, GPUs, or optional runtimes.
+- [x] Prepared-host presets skip or fail with typed reasons when prerequisites are missing.
+- [x] Budget violations include operation, metric, threshold, observed value, and artifact path.
 
 Validation:
 
 ```bash
-uv run pytest tests/test_benchmark.py tests/test_cli_help_snapshots.py
-uv run worldforge benchmark --provider mock --operation generate --budget-file examples/benchmark-budget.json
+uv run pytest tests/test_benchmark.py tests/test_benchmark_presets.py tests/test_cli_help_snapshots.py
+uv run worldforge benchmark --preset mock-smoke
 uv run mkdocs build --strict
 ```
 

--- a/src/worldforge/benchmark_presets/__init__.py
+++ b/src/worldforge/benchmark_presets/__init__.py
@@ -1,0 +1,381 @@
+"""Named benchmark presets for release regressions and provider evidence.
+
+Presets bundle a deterministic input fixture, an optional budget file, and a runtime-profile
+gate so maintainers can run "named" benchmark workloads without re-deriving inputs and
+budgets each time. Each preset belongs to one of four categories:
+
+- ``checkout-safe``: runs without credentials, network, GPUs, or optional runtimes; safe to
+  invoke from a clean checkout and from CI.
+- ``remote-media``: requires a remote-media provider (Cosmos or Runway) with its environment
+  configured; the CLI skips with a typed reason when the env is missing.
+- ``prepared-host``: requires a host that owns the optional runtime (LeWorldModel for ``score``;
+  LeRobot or GR00T for ``policy``); the CLI skips with a typed reason when the env is missing.
+- ``release``: gated regression check used for release evidence; bundles strict budgets that
+  fail the run when threshold violations land.
+
+The data files under :mod:`worldforge.benchmark_presets._data` are JSON documents that match
+the wire format of ``--input-file`` and ``--budget-file``. The presets ship with the wheel so
+``worldforge benchmark --preset <name>`` works from a ``pip install`` without checkout-time
+discovery.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from importlib import resources
+from typing import Any
+
+from worldforge.benchmark import (
+    BENCHMARKABLE_OPERATIONS,
+    BenchmarkBudget,
+    BenchmarkInputs,
+    load_benchmark_budgets,
+    load_benchmark_inputs,
+)
+from worldforge.models import JSONDict, WorldForgeError
+from worldforge.testing.runtime_profiles import (
+    PROVIDER_RUNTIME_PROFILES_BY_NAME,
+    provider_profile_skip_reason,
+)
+
+PRESET_CATEGORIES: tuple[str, ...] = (
+    "checkout-safe",
+    "remote-media",
+    "prepared-host",
+    "release",
+)
+"""Categories every preset belongs to. The CLI list output groups by category."""
+
+_DATA_PACKAGE = "worldforge.benchmark_presets._data"
+
+
+@dataclass(frozen=True, slots=True)
+class BenchmarkPreset:
+    """A named benchmark configuration suitable for release regressions or provider evidence."""
+
+    name: str
+    title: str
+    summary: str
+    category: str
+    providers: tuple[str, ...]
+    operations: tuple[str, ...]
+    iterations: int
+    concurrency: int
+    inputs_file: str | None
+    budget_file: str | None
+    failure_tolerance: str
+    requires_provider_profiles: tuple[str, ...] = ()
+    requires_provider_choice: tuple[str, ...] = ()
+    notes: str = ""
+    tags: tuple[str, ...] = field(default_factory=tuple)
+
+    def __post_init__(self) -> None:
+        if not self.name.strip():
+            raise WorldForgeError("BenchmarkPreset name must be a non-empty string.")
+        if self.category not in PRESET_CATEGORIES:
+            known = ", ".join(PRESET_CATEGORIES)
+            raise WorldForgeError(f"BenchmarkPreset category must be one of: {known}.")
+        if not self.providers:
+            raise WorldForgeError("BenchmarkPreset must declare at least one provider.")
+        if not self.operations:
+            raise WorldForgeError("BenchmarkPreset must declare at least one operation.")
+        unknown = [op for op in self.operations if op not in BENCHMARKABLE_OPERATIONS]
+        if unknown:
+            joined = ", ".join(unknown)
+            raise WorldForgeError(f"BenchmarkPreset has unknown operations: {joined}.")
+        if self.iterations <= 0:
+            raise WorldForgeError("BenchmarkPreset iterations must be greater than 0.")
+        if self.concurrency <= 0:
+            raise WorldForgeError("BenchmarkPreset concurrency must be greater than 0.")
+        if self.failure_tolerance not in {"fail-on-violation", "skip-when-env-missing"}:
+            raise WorldForgeError(
+                "BenchmarkPreset failure_tolerance must be 'fail-on-violation' "
+                "or 'skip-when-env-missing'."
+            )
+        unknown_profiles = [
+            profile
+            for profile in (*self.requires_provider_profiles, *self.requires_provider_choice)
+            if profile not in PROVIDER_RUNTIME_PROFILES_BY_NAME
+        ]
+        if unknown_profiles:
+            joined = ", ".join(unknown_profiles)
+            raise WorldForgeError(
+                f"BenchmarkPreset references unknown provider runtime profiles: {joined}."
+            )
+
+    def to_dict(self) -> JSONDict:
+        return {
+            "name": self.name,
+            "title": self.title,
+            "summary": self.summary,
+            "category": self.category,
+            "providers": list(self.providers),
+            "operations": list(self.operations),
+            "iterations": self.iterations,
+            "concurrency": self.concurrency,
+            "inputs_file": self.inputs_file,
+            "budget_file": self.budget_file,
+            "failure_tolerance": self.failure_tolerance,
+            "requires_provider_profiles": list(self.requires_provider_profiles),
+            "requires_provider_choice": list(self.requires_provider_choice),
+            "notes": self.notes,
+            "tags": list(self.tags),
+        }
+
+    def skip_reason(self, environ: Mapping[str, str] | None = None) -> str | None:
+        """Return a typed skip reason when a required runtime profile is unconfigured.
+
+        Presets in the ``checkout-safe`` and ``release`` categories never skip; ``remote-media``
+        and ``prepared-host`` presets skip with the first unmet provider profile reason.
+        """
+
+        env = os.environ if environ is None else environ
+        for profile in self.requires_provider_profiles:
+            reason = provider_profile_skip_reason(profile, env)
+            if reason is not None:
+                return reason
+        if self.requires_provider_choice:
+            reasons: list[str] = []
+            for profile in self.requires_provider_choice:
+                reason = provider_profile_skip_reason(profile, env)
+                if reason is None:
+                    return None
+                reasons.append(reason)
+            return "no eligible provider profile is configured: " + "; ".join(reasons)
+        return None
+
+    def configured_providers(
+        self,
+        environ: Mapping[str, str] | None = None,
+    ) -> tuple[str, ...]:
+        """Return the subset of ``providers`` whose runtime profile is configured.
+
+        Always returns the full ``providers`` tuple for presets that do not gate on a
+        provider runtime profile (``checkout-safe`` and ``release`` categories).
+        """
+
+        env = os.environ if environ is None else environ
+        gated = set(self.requires_provider_profiles) | set(self.requires_provider_choice)
+        if not gated:
+            return self.providers
+        configured = [
+            provider
+            for provider in self.providers
+            if provider not in gated or provider_profile_skip_reason(provider, env) is None
+        ]
+        return tuple(configured)
+
+
+def _data_text(filename: str) -> str:
+    try:
+        return resources.files(_DATA_PACKAGE).joinpath(filename).read_text(encoding="utf-8")
+    except FileNotFoundError as exc:
+        raise WorldForgeError(f"Benchmark preset data file not found: {filename}") from exc
+
+
+def _data_payload(filename: str) -> Any:
+    try:
+        return json.loads(_data_text(filename))
+    except json.JSONDecodeError as exc:
+        raise WorldForgeError(
+            f"Benchmark preset data file {filename} contains invalid JSON."
+        ) from exc
+
+
+def load_preset_inputs(preset: BenchmarkPreset) -> BenchmarkInputs:
+    """Return validated :class:`BenchmarkInputs` for a preset.
+
+    Returns the default ``BenchmarkInputs()`` when the preset does not bundle an inputs file
+    (e.g. presets that exercise only operations whose mock defaults are sufficient).
+    """
+
+    if preset.inputs_file is None:
+        return BenchmarkInputs()
+    return load_benchmark_inputs(_data_payload(preset.inputs_file))
+
+
+def load_preset_budgets(preset: BenchmarkPreset) -> list[BenchmarkBudget]:
+    """Return validated :class:`BenchmarkBudget` entries for a preset, or ``[]`` when absent."""
+
+    if preset.budget_file is None:
+        return []
+    return load_benchmark_budgets(_data_payload(preset.budget_file))
+
+
+def preset_inputs_payload(preset: BenchmarkPreset) -> JSONDict | None:
+    """Return the raw inputs JSON for a preset, useful for digesting in run manifests."""
+
+    if preset.inputs_file is None:
+        return None
+    payload = _data_payload(preset.inputs_file)
+    if not isinstance(payload, dict):
+        raise WorldForgeError(f"Preset inputs payload {preset.inputs_file} must be a JSON object.")
+    return payload
+
+
+def preset_budget_payload(preset: BenchmarkPreset) -> JSONDict | None:
+    """Return the raw budget JSON for a preset, or ``None`` when no budget is bundled."""
+
+    if preset.budget_file is None:
+        return None
+    payload = _data_payload(preset.budget_file)
+    if not isinstance(payload, dict):
+        raise WorldForgeError(f"Preset budget payload {preset.budget_file} must be a JSON object.")
+    return payload
+
+
+_BENCHMARK_PRESETS: tuple[BenchmarkPreset, ...] = (
+    BenchmarkPreset(
+        name="mock-smoke",
+        title="Mock provider smoke",
+        summary=(
+            "Fast checkout-safe regression check: runs the mock provider across predict, generate, "
+            "and embed with five iterations and a tight success-rate gate."
+        ),
+        category="checkout-safe",
+        providers=("mock",),
+        operations=("predict", "generate", "embed"),
+        iterations=5,
+        concurrency=1,
+        inputs_file="inputs-mock.json",
+        budget_file="budget-mock-smoke.json",
+        failure_tolerance="fail-on-violation",
+        notes="Use this preset for every-branch CI regression checks.",
+        tags=("ci", "smoke"),
+    ),
+    BenchmarkPreset(
+        name="parser-overhead",
+        title="Provider parser overhead",
+        summary=(
+            "Latency-bounded measurement of WorldForge adapter-path overhead. Runs every "
+            "mock-supported operation with twenty serial iterations to stabilise latency stats."
+        ),
+        category="checkout-safe",
+        providers=("mock",),
+        operations=("predict", "reason", "generate", "transfer", "embed"),
+        iterations=20,
+        concurrency=1,
+        inputs_file="inputs-mock.json",
+        budget_file="budget-parser-overhead.json",
+        failure_tolerance="fail-on-violation",
+        notes=(
+            "Latencies above the documented thresholds usually mean an unrelated import or "
+            "validation regression in the adapter path; preserve the run workspace before "
+            "loosening budgets."
+        ),
+        tags=("ci", "latency"),
+    ),
+    BenchmarkPreset(
+        name="remote-media-dryrun",
+        title="Remote media dry-run",
+        summary=(
+            "Single-iteration dry-run for remote media providers. Skips with a typed reason when "
+            "neither Cosmos nor Runway is configured."
+        ),
+        category="remote-media",
+        providers=("cosmos", "runway"),
+        operations=("generate",),
+        iterations=1,
+        concurrency=1,
+        inputs_file="inputs-remote-media.json",
+        budget_file=None,
+        failure_tolerance="skip-when-env-missing",
+        requires_provider_choice=("cosmos", "runway"),
+        notes=(
+            "Configure COSMOS_BASE_URL, RUNWAYML_API_SECRET, or RUNWAY_API_SECRET on a host "
+            "that is allowed to reach the upstream API. The preset does not assert latency or "
+            "throughput claims; treat the report as informational evidence."
+        ),
+        tags=("remote",),
+    ),
+    BenchmarkPreset(
+        name="prepared-host",
+        title="Prepared-host score and policy",
+        summary=(
+            "Three-iteration evidence run for prepared-host providers. Skips with a typed reason "
+            "when no eligible runtime (LeWorldModel for score; LeRobot or GR00T for policy) is "
+            "configured."
+        ),
+        category="prepared-host",
+        providers=("leworldmodel", "lerobot", "gr00t"),
+        operations=("score", "policy"),
+        iterations=3,
+        concurrency=1,
+        inputs_file="inputs-prepared-host.json",
+        budget_file=None,
+        failure_tolerance="skip-when-env-missing",
+        requires_provider_choice=("leworldmodel", "lerobot", "gr00t"),
+        notes=(
+            "Score and policy expectations vary across runtimes. The preset emits sanitized "
+            "ProviderEvent metadata only and does not capture raw checkpoint contents."
+        ),
+        tags=("optional-runtime",),
+    ),
+    BenchmarkPreset(
+        name="release-evidence",
+        title="Release evidence",
+        summary=(
+            "Release-gated regression check across every mock-supported operation with strict "
+            "latency, throughput, and success-rate budgets. Pair with --run-workspace to "
+            "preserve manifests for release attestation."
+        ),
+        category="release",
+        providers=("mock",),
+        operations=("predict", "reason", "generate", "transfer", "embed"),
+        iterations=10,
+        concurrency=2,
+        inputs_file="inputs-mock.json",
+        budget_file="budget-release-evidence.json",
+        failure_tolerance="fail-on-violation",
+        notes=(
+            "Failures must be triaged with preserved artifacts before threshold loosening; the "
+            "release-evidence budget tracks deliberate, machine-class-aware regressions only."
+        ),
+        tags=("release",),
+    ),
+)
+
+
+_BENCHMARK_PRESETS_BY_NAME: dict[str, BenchmarkPreset] = {
+    preset.name: preset for preset in _BENCHMARK_PRESETS
+}
+
+
+def list_preset_names() -> tuple[str, ...]:
+    """Return the canonical preset names in display order."""
+
+    return tuple(preset.name for preset in _BENCHMARK_PRESETS)
+
+
+def list_presets() -> tuple[BenchmarkPreset, ...]:
+    """Return every preset in display order."""
+
+    return _BENCHMARK_PRESETS
+
+
+def get_preset(name: str) -> BenchmarkPreset:
+    """Return one preset by name. Raises :class:`WorldForgeError` for unknown names."""
+
+    try:
+        return _BENCHMARK_PRESETS_BY_NAME[name]
+    except KeyError as exc:
+        known = ", ".join(_BENCHMARK_PRESETS_BY_NAME)
+        raise WorldForgeError(
+            f"Unknown benchmark preset '{name}'. Known presets: {known}."
+        ) from exc
+
+
+__all__ = [
+    "PRESET_CATEGORIES",
+    "BenchmarkPreset",
+    "get_preset",
+    "list_preset_names",
+    "list_presets",
+    "load_preset_budgets",
+    "load_preset_inputs",
+    "preset_budget_payload",
+    "preset_inputs_payload",
+]

--- a/src/worldforge/benchmark_presets/_data/__init__.py
+++ b/src/worldforge/benchmark_presets/_data/__init__.py
@@ -1,0 +1,3 @@
+"""Packaged benchmark preset data files (inputs and budget JSON)."""
+
+from __future__ import annotations

--- a/src/worldforge/benchmark_presets/_data/budget-mock-smoke.json
+++ b/src/worldforge/benchmark_presets/_data/budget-mock-smoke.json
@@ -1,0 +1,14 @@
+{
+  "metadata": {
+    "preset": "mock-smoke",
+    "purpose": "fast checkout-safe regression gate; budgets are intentionally loose so unrelated CI noise does not trip the gate"
+  },
+  "budgets": [
+    {
+      "provider": "mock",
+      "min_success_rate": 1.0,
+      "max_error_count": 0,
+      "max_retry_count": 0
+    }
+  ]
+}

--- a/src/worldforge/benchmark_presets/_data/budget-parser-overhead.json
+++ b/src/worldforge/benchmark_presets/_data/budget-parser-overhead.json
@@ -1,0 +1,16 @@
+{
+  "metadata": {
+    "preset": "parser-overhead",
+    "purpose": "latency-bounded gate for adapter-path overhead measured against the mock provider; loosen only with preserved evidence"
+  },
+  "budgets": [
+    {
+      "provider": "mock",
+      "min_success_rate": 1.0,
+      "max_error_count": 0,
+      "max_retry_count": 0,
+      "max_average_latency_ms": 50.0,
+      "max_p95_latency_ms": 200.0
+    }
+  ]
+}

--- a/src/worldforge/benchmark_presets/_data/budget-release-evidence.json
+++ b/src/worldforge/benchmark_presets/_data/budget-release-evidence.json
@@ -1,0 +1,17 @@
+{
+  "metadata": {
+    "preset": "release-evidence",
+    "purpose": "release-gated benchmark budgets. Failures must be triaged with preserved artifacts before threshold loosening."
+  },
+  "budgets": [
+    {
+      "provider": "mock",
+      "min_success_rate": 1.0,
+      "max_error_count": 0,
+      "max_retry_count": 0,
+      "max_average_latency_ms": 100.0,
+      "max_p95_latency_ms": 400.0,
+      "min_throughput_per_second": 5.0
+    }
+  ]
+}

--- a/src/worldforge/benchmark_presets/_data/inputs-mock.json
+++ b/src/worldforge/benchmark_presets/_data/inputs-mock.json
@@ -1,0 +1,35 @@
+{
+  "metadata": {
+    "purpose": "deterministic checkout-safe inputs for mock-provider benchmark presets",
+    "runtime": "mock provider — runs without credentials, network, GPU, or optional runtimes",
+    "presets": ["mock-smoke", "parser-overhead", "release-evidence"]
+  },
+  "inputs": {
+    "prediction_action": {
+      "type": "move_to",
+      "parameters": {
+        "target": {"x": 0.25, "y": 0.5, "z": 0.0},
+        "speed": 1.0
+      }
+    },
+    "prediction_steps": 2,
+    "reason_query": "How many objects are tracked?",
+    "generation_prompt": "preset orbiting cube",
+    "generation_duration_seconds": 1.0,
+    "transfer_prompt": "preset transfer rerender",
+    "transfer_width": 320,
+    "transfer_height": 180,
+    "transfer_fps": 12.0,
+    "transfer_clip": {
+      "frames_base64": ["d29ybGRmb3JnZS1wcmVzZXQtZnJhbWU="],
+      "fps": 8.0,
+      "resolution": [160, 90],
+      "duration_seconds": 1.0,
+      "metadata": {
+        "content_type": "application/octet-stream",
+        "mode": "preset-benchmark-seed"
+      }
+    },
+    "embedding_text": "preset cube state"
+  }
+}

--- a/src/worldforge/benchmark_presets/_data/inputs-prepared-host.json
+++ b/src/worldforge/benchmark_presets/_data/inputs-prepared-host.json
@@ -1,0 +1,31 @@
+{
+  "metadata": {
+    "purpose": "score and policy info shaped to satisfy any prepared-host runtime that advertises those capabilities. Reuses the synthetic shape from the capability fixture corpus.",
+    "runtime": "requires a prepared-host runtime (leworldmodel for score; lerobot or gr00t for policy). The CLI skips with a typed reason when env is missing.",
+    "presets": ["prepared-host"]
+  },
+  "inputs": {
+    "score_info": {
+      "pixels": [[[[0.0], [0.1]], [[0.2], [0.3]]]],
+      "goal": [[[0.3, 0.5, 0.0]]],
+      "action": [[[0.0, 0.5, 0.0]]],
+      "metadata": {"mode": "preset-prepared-host"}
+    },
+    "score_action_candidates": [
+      [
+        [[0.0, 0.5, 0.0], [0.1, 0.5, 0.0]],
+        [[0.0, 0.5, 0.0], [0.3, 0.5, 0.0]]
+      ]
+    ],
+    "policy_info": {
+      "observation": {
+        "video": {"front": [[[[[0, 0, 0]]]]]},
+        "state": {"eef": [[[0.0, 0.5, 0.0]]]},
+        "language": {"task": [["move the object"]]}
+      },
+      "action_horizon": 1,
+      "embodiment_tag": "preset",
+      "mode": "select_action"
+    }
+  }
+}

--- a/src/worldforge/benchmark_presets/_data/inputs-remote-media.json
+++ b/src/worldforge/benchmark_presets/_data/inputs-remote-media.json
@@ -1,0 +1,25 @@
+{
+  "metadata": {
+    "purpose": "minimal generation prompt for remote media providers (cosmos, runway). Single iteration keeps live-call cost bounded.",
+    "runtime": "requires the target remote provider's environment to be configured. The CLI skips with a typed reason when env is missing.",
+    "presets": ["remote-media-dryrun"]
+  },
+  "inputs": {
+    "generation_prompt": "preset remote-media dryrun: orbiting cube",
+    "generation_duration_seconds": 1.0,
+    "transfer_prompt": "preset remote-media dryrun: rerender",
+    "transfer_width": 256,
+    "transfer_height": 144,
+    "transfer_fps": 8.0,
+    "transfer_clip": {
+      "frames_base64": ["d29ybGRmb3JnZS1yZW1vdGUtbWVkaWEtcHJlc2V0LWZyYW1l"],
+      "fps": 8.0,
+      "resolution": [160, 90],
+      "duration_seconds": 1.0,
+      "metadata": {
+        "content_type": "application/octet-stream",
+        "mode": "preset-remote-media-dryrun"
+      }
+    }
+  }
+}

--- a/src/worldforge/cli.py
+++ b/src/worldforge/cli.py
@@ -25,6 +25,15 @@ from worldforge.benchmark import (
     load_benchmark_budgets,
     load_benchmark_inputs,
 )
+from worldforge.benchmark_presets import (
+    BenchmarkPreset,
+    get_preset,
+    list_presets,
+    load_preset_budgets,
+    load_preset_inputs,
+    preset_budget_payload,
+    preset_inputs_payload,
+)
 from worldforge.evaluation import EvaluationSuite
 from worldforge.models import CAPABILITY_NAMES
 from worldforge.providers import ProviderError
@@ -965,6 +974,27 @@ def _build_parser() -> argparse.ArgumentParser:
         type=Path,
         help="Preserve sanitized benchmark artifacts under RUN_WORKSPACE/runs/<run-id>/.",
     )
+    benchmark.add_argument(
+        "--preset",
+        dest="preset",
+        default=None,
+        help=(
+            "Run a named benchmark preset (overrides --provider, --operation, --iterations, "
+            "--concurrency, --input-file, and --budget-file). Use --list-presets for the catalogue."
+        ),
+    )
+    benchmark.add_argument(
+        "--list-presets",
+        dest="list_presets",
+        action="store_true",
+        help="List benchmark presets and exit.",
+    )
+    benchmark.add_argument(
+        "--show-preset",
+        dest="show_preset",
+        default=None,
+        help="Print one benchmark preset's details and exit.",
+    )
 
     harness = subparsers.add_parser("harness", help="Launch TheWorldHarness TUI.")
     harness.add_argument(
@@ -1499,7 +1529,222 @@ def _cmd_eval(args: argparse.Namespace, forge: WorldForge) -> int:
     return 0
 
 
+def _print_preset_list(args: argparse.Namespace) -> int:
+    presets = list_presets()
+    if args.format == "json":
+        print(
+            json.dumps(
+                {"presets": [preset.to_dict() for preset in presets]},
+                sort_keys=True,
+                separators=(",", ":"),
+            )
+        )
+        return 0
+    if args.format == "csv":
+        rows = ["name,category,providers,operations,iterations,budget_file,failure_tolerance"]
+        rows.extend(
+            f"{preset.name},{preset.category},"
+            f"{'+'.join(preset.providers)},"
+            f"{'+'.join(preset.operations)},"
+            f"{preset.iterations},"
+            f"{preset.budget_file or ''},"
+            f"{preset.failure_tolerance}"
+            for preset in presets
+        )
+        print("\n".join(rows))
+        return 0
+    lines = ["# Benchmark Presets", ""]
+    for category in ("checkout-safe", "remote-media", "prepared-host", "release"):
+        section = [preset for preset in presets if preset.category == category]
+        if not section:
+            continue
+        lines.append(f"## {category}")
+        lines.append("")
+        for preset in section:
+            providers = ", ".join(preset.providers)
+            operations = ", ".join(preset.operations)
+            skip = preset.skip_reason()
+            status = f"skip: {skip}" if skip else "ready"
+            lines.append(
+                f"- **{preset.name}** — {preset.title}. providers=[{providers}] "
+                f"operations=[{operations}] iterations={preset.iterations} "
+                f"failure_tolerance={preset.failure_tolerance} status={status}"
+            )
+            lines.append(f"  {preset.summary}")
+        lines.append("")
+    print("\n".join(lines).rstrip())
+    return 0
+
+
+def _print_preset_show(args: argparse.Namespace) -> int:
+    preset = get_preset(args.show_preset)
+    payload = {
+        "preset": preset.to_dict(),
+        "skip_reason": preset.skip_reason(),
+        "configured_providers": list(preset.configured_providers()),
+        "inputs_payload": preset_inputs_payload(preset),
+        "budget_payload": preset_budget_payload(preset),
+    }
+    if args.format == "json":
+        print(json.dumps(payload, sort_keys=True, separators=(",", ":")))
+        return 0
+    lines = [
+        f"# {preset.title}",
+        "",
+        f"Name: {preset.name}",
+        f"Category: {preset.category}",
+        f"Providers: {', '.join(preset.providers)}",
+        f"Operations: {', '.join(preset.operations)}",
+        f"Iterations: {preset.iterations} (concurrency={preset.concurrency})",
+        f"Failure tolerance: {preset.failure_tolerance}",
+        f"Inputs file: {preset.inputs_file or '-'}",
+        f"Budget file: {preset.budget_file or '-'}",
+    ]
+    if preset.requires_provider_profiles:
+        lines.append(f"Required runtimes: {', '.join(preset.requires_provider_profiles)}")
+    if preset.requires_provider_choice:
+        lines.append(f"Any-of runtimes: {', '.join(preset.requires_provider_choice)}")
+    skip = preset.skip_reason()
+    lines.append(f"Skip reason: {skip or 'none (preset can run on this host)'}")
+    lines.append("")
+    lines.append(preset.summary)
+    if preset.notes:
+        lines.append("")
+        lines.append(preset.notes)
+    print("\n".join(lines))
+    return 0
+
+
+def _run_preset_benchmark(
+    preset: BenchmarkPreset,
+    args: argparse.Namespace,
+    forge: WorldForge,
+) -> int:
+    skip_reason = preset.skip_reason()
+    if skip_reason is not None:
+        if preset.failure_tolerance == "skip-when-env-missing":
+            payload = {
+                "preset": preset.name,
+                "status": "skipped",
+                "reason": skip_reason,
+            }
+            if args.format == "json":
+                print(json.dumps(payload, sort_keys=True, separators=(",", ":")))
+            else:
+                print(f"# Benchmark preset '{preset.name}' skipped\n\nReason: {skip_reason}")
+            return 0
+        raise WorldForgeError(
+            f"Benchmark preset '{preset.name}' cannot run on this host: {skip_reason}"
+        )
+
+    providers = preset.configured_providers()
+    if not providers:
+        raise WorldForgeError(
+            f"Benchmark preset '{preset.name}' has no configured providers on this host."
+        )
+    inputs = load_preset_inputs(preset)
+    budgets = load_preset_budgets(preset)
+    harness = ProviderBenchmarkHarness(forge=forge)
+    report = harness.run(
+        list(providers),
+        operations=list(preset.operations),
+        iterations=preset.iterations,
+        concurrency=preset.concurrency,
+        inputs=inputs,
+    )
+    inputs_payload = preset_inputs_payload(preset)
+    if inputs_payload is not None:
+        inputs_text = json.dumps(inputs_payload, sort_keys=True).encode("utf-8")
+        report.run_metadata["input_file"] = {
+            "path": f"benchmark_presets/_data/{preset.inputs_file}",
+            "sha256": sha256(inputs_text).hexdigest(),
+            "metadata": (
+                inputs_payload.get("metadata")
+                if isinstance(inputs_payload.get("metadata"), dict)
+                else {}
+            ),
+        }
+    gate_report = None
+    budget_file_summary: dict[str, object] | None = None
+    if budgets:
+        budget_payload = preset_budget_payload(preset)
+        if budget_payload is not None:
+            budget_metadata = (
+                budget_payload.get("metadata")
+                if isinstance(budget_payload.get("metadata"), dict)
+                else {}
+            )
+            budget_text = json.dumps(budget_payload, sort_keys=True)
+            budget_file_summary = {
+                "path": f"benchmark_presets/_data/{preset.budget_file}",
+                "sha256": f"sha256:{sha256(budget_text.encode('utf-8')).hexdigest()}",
+                "metadata": budget_metadata,
+            }
+            report.run_metadata["budget_file"] = {
+                "path": budget_file_summary["path"],
+                "sha256": sha256(budget_text.encode("utf-8")).hexdigest(),
+                "metadata": budget_metadata,
+            }
+        gate_report = report.evaluate_budgets(budgets)
+
+    report.run_metadata["preset"] = preset.to_dict()
+
+    benchmark_command = _command_string(["benchmark", "--preset", preset.name])
+    if report.provenance is not None:
+        envelope_overrides: dict[str, object] = {
+            "command": tuple(benchmark_command.split()),
+            "notes": f"benchmark preset: {preset.name}",
+        }
+        if budget_file_summary is not None:
+            envelope_overrides["budget_file"] = budget_file_summary
+        report.provenance = report.provenance.with_overrides(**envelope_overrides)
+
+    if args.run_workspace is not None:
+        from worldforge.harness.flows import preserve_benchmark_run_workspace
+
+        preserve_benchmark_run_workspace(
+            args.run_workspace,
+            providers=list(providers),
+            operations=list(preset.operations),
+            artifacts=report.artifacts(),
+            report=report,
+            command=benchmark_command,
+            budget_passed=None if gate_report is None else gate_report.passed,
+        )
+
+    if args.format == "json":
+        if gate_report is None:
+            print(report.to_json())
+        else:
+            print(
+                json.dumps(
+                    {
+                        "preset": preset.name,
+                        "benchmark": report.to_dict(),
+                        "gate": gate_report.to_dict(),
+                    },
+                    sort_keys=True,
+                    separators=(",", ":"),
+                )
+            )
+    elif args.format == "csv":
+        print(gate_report.to_csv() if gate_report is not None else report.to_csv())
+    else:
+        print(report.to_markdown())
+        if gate_report is not None:
+            print()
+            print(gate_report.to_markdown())
+    return 0 if gate_report is None or gate_report.passed else 1
+
+
 def _cmd_benchmark(args: argparse.Namespace, forge: WorldForge) -> int:
+    if args.list_presets:
+        return _print_preset_list(args)
+    if args.show_preset is not None:
+        return _print_preset_show(args)
+    if args.preset is not None:
+        return _run_preset_benchmark(get_preset(args.preset), args, forge)
+
     harness = ProviderBenchmarkHarness(forge=forge)
     providers = args.providers or ["mock"]
     benchmark_inputs = None

--- a/tests/test_benchmark_presets.py
+++ b/tests/test_benchmark_presets.py
@@ -1,0 +1,325 @@
+"""Tests for the benchmark preset registry and CLI integration."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from worldforge import WorldForgeError
+from worldforge.benchmark_presets import (
+    PRESET_CATEGORIES,
+    BenchmarkPreset,
+    get_preset,
+    list_preset_names,
+    list_presets,
+    load_preset_budgets,
+    load_preset_inputs,
+    preset_budget_payload,
+    preset_inputs_payload,
+)
+
+
+def test_preset_catalogue_covers_required_categories() -> None:
+    categories = {preset.category for preset in list_presets()}
+    assert {"checkout-safe", "remote-media", "prepared-host", "release"} <= categories
+    assert categories <= set(PRESET_CATEGORIES)
+    names = list_preset_names()
+    assert names == tuple(preset.name for preset in list_presets())
+    assert len(names) == len(set(names))
+
+
+@pytest.mark.parametrize("name", list_preset_names())
+def test_preset_inputs_and_budgets_load(name: str) -> None:
+    preset = get_preset(name)
+    inputs = load_preset_inputs(preset)
+    assert inputs is not None
+    if preset.budget_file is None:
+        assert load_preset_budgets(preset) == []
+    else:
+        budgets = load_preset_budgets(preset)
+        assert budgets
+
+
+def test_get_preset_rejects_unknown_name() -> None:
+    with pytest.raises(WorldForgeError, match="Unknown benchmark preset"):
+        get_preset("does-not-exist")
+
+
+def test_checkout_safe_presets_never_skip(monkeypatch) -> None:
+    monkeypatch.delenv("COSMOS_BASE_URL", raising=False)
+    monkeypatch.delenv("RUNWAYML_API_SECRET", raising=False)
+    monkeypatch.delenv("RUNWAY_API_SECRET", raising=False)
+    monkeypatch.delenv("LEWORLDMODEL_POLICY", raising=False)
+    monkeypatch.delenv("LEWM_POLICY", raising=False)
+    monkeypatch.delenv("LEROBOT_POLICY_PATH", raising=False)
+    monkeypatch.delenv("LEROBOT_POLICY", raising=False)
+    monkeypatch.delenv("GROOT_POLICY_HOST", raising=False)
+    for preset in list_presets():
+        if preset.category in ("checkout-safe", "release"):
+            assert preset.skip_reason() is None
+
+
+def test_remote_media_preset_skips_when_env_missing(monkeypatch) -> None:
+    monkeypatch.delenv("COSMOS_BASE_URL", raising=False)
+    monkeypatch.delenv("RUNWAYML_API_SECRET", raising=False)
+    monkeypatch.delenv("RUNWAY_API_SECRET", raising=False)
+    preset = get_preset("remote-media-dryrun")
+    reason = preset.skip_reason()
+    assert reason is not None
+    assert "cosmos" in reason
+    assert "runway" in reason
+
+
+def test_remote_media_preset_runs_when_env_present(monkeypatch) -> None:
+    monkeypatch.setenv("COSMOS_BASE_URL", "https://cosmos.example/api")
+    preset = get_preset("remote-media-dryrun")
+    assert preset.skip_reason() is None
+    configured = preset.configured_providers()
+    assert "cosmos" in configured
+
+
+def test_prepared_host_preset_skips_when_env_missing(monkeypatch) -> None:
+    for env_var in (
+        "LEWORLDMODEL_POLICY",
+        "LEWM_POLICY",
+        "LEROBOT_POLICY_PATH",
+        "LEROBOT_POLICY",
+        "GROOT_POLICY_HOST",
+    ):
+        monkeypatch.delenv(env_var, raising=False)
+    preset = get_preset("prepared-host")
+    reason = preset.skip_reason()
+    assert reason is not None
+    assert "leworldmodel" in reason
+    assert "lerobot" in reason
+    assert "gr00t" in reason
+
+
+def test_preset_payloads_round_trip() -> None:
+    for preset in list_presets():
+        envelope = preset.to_dict()
+        assert envelope["name"] == preset.name
+        assert envelope["category"] == preset.category
+        if preset.inputs_file is not None:
+            payload = preset_inputs_payload(preset)
+            assert payload is not None
+            assert "inputs" in payload
+        if preset.budget_file is not None:
+            budget = preset_budget_payload(preset)
+            assert budget is not None
+            assert "budgets" in budget
+
+
+def test_invalid_preset_construction_is_rejected() -> None:
+    with pytest.raises(WorldForgeError, match="non-empty string"):
+        BenchmarkPreset(
+            name="",
+            title="",
+            summary="",
+            category="checkout-safe",
+            providers=("mock",),
+            operations=("predict",),
+            iterations=1,
+            concurrency=1,
+            inputs_file=None,
+            budget_file=None,
+            failure_tolerance="fail-on-violation",
+        )
+    with pytest.raises(WorldForgeError, match="category"):
+        BenchmarkPreset(
+            name="bogus",
+            title="bogus",
+            summary="bogus",
+            category="not-a-category",
+            providers=("mock",),
+            operations=("predict",),
+            iterations=1,
+            concurrency=1,
+            inputs_file=None,
+            budget_file=None,
+            failure_tolerance="fail-on-violation",
+        )
+    with pytest.raises(WorldForgeError, match="failure_tolerance"):
+        BenchmarkPreset(
+            name="bogus",
+            title="bogus",
+            summary="bogus",
+            category="checkout-safe",
+            providers=("mock",),
+            operations=("predict",),
+            iterations=1,
+            concurrency=1,
+            inputs_file=None,
+            budget_file=None,
+            failure_tolerance="other",
+        )
+
+
+def test_cli_lists_presets_in_json(monkeypatch, capsys) -> None:
+    monkeypatch.delenv("COSMOS_BASE_URL", raising=False)
+    from worldforge.cli import _build_parser, _cmd_benchmark
+    from worldforge.framework import WorldForge
+
+    parser = _build_parser()
+    args = parser.parse_args(["benchmark", "--list-presets", "--format", "json"])
+    forge = WorldForge(state_dir=None)
+    rc = _cmd_benchmark(args, forge)
+    out = capsys.readouterr().out
+    assert rc == 0
+    payload = json.loads(out)
+    names = {entry["name"] for entry in payload["presets"]}
+    assert {"mock-smoke", "parser-overhead", "release-evidence"} <= names
+
+
+def test_cli_runs_mock_smoke_preset(monkeypatch, capsys, tmp_path) -> None:
+    from worldforge.cli import _build_parser, _cmd_benchmark
+    from worldforge.framework import WorldForge
+
+    parser = _build_parser()
+    args = parser.parse_args(
+        ["benchmark", "--preset", "mock-smoke", "--format", "json", "--state-dir", str(tmp_path)]
+    )
+    forge = WorldForge(state_dir=tmp_path)
+    rc = _cmd_benchmark(args, forge)
+    out = capsys.readouterr().out
+    assert rc == 0
+    payload = json.loads(out)
+    assert payload["preset"] == "mock-smoke"
+    assert payload["benchmark"]["run_metadata"]["preset"]["name"] == "mock-smoke"
+    assert payload["gate"]["passed"] is True
+
+
+def test_cli_skips_remote_media_dryrun_when_env_missing(monkeypatch, capsys) -> None:
+    for env_var in ("COSMOS_BASE_URL", "RUNWAYML_API_SECRET", "RUNWAY_API_SECRET"):
+        monkeypatch.delenv(env_var, raising=False)
+    from worldforge.cli import _build_parser, _cmd_benchmark
+    from worldforge.framework import WorldForge
+
+    parser = _build_parser()
+    args = parser.parse_args(["benchmark", "--preset", "remote-media-dryrun", "--format", "json"])
+    forge = WorldForge(state_dir=None)
+    rc = _cmd_benchmark(args, forge)
+    out = capsys.readouterr().out
+    assert rc == 0
+    payload = json.loads(out)
+    assert payload["status"] == "skipped"
+    assert "cosmos" in payload["reason"]
+
+
+def test_cli_lists_presets_in_markdown(monkeypatch, capsys) -> None:
+    monkeypatch.delenv("COSMOS_BASE_URL", raising=False)
+    from worldforge.cli import _build_parser, _cmd_benchmark
+    from worldforge.framework import WorldForge
+
+    parser = _build_parser()
+    args = parser.parse_args(["benchmark", "--list-presets"])
+    forge = WorldForge(state_dir=None)
+    rc = _cmd_benchmark(args, forge)
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "# Benchmark Presets" in out
+    assert "## checkout-safe" in out
+    assert "mock-smoke" in out
+
+
+def test_cli_lists_presets_in_csv(monkeypatch, capsys) -> None:
+    from worldforge.cli import _build_parser, _cmd_benchmark
+    from worldforge.framework import WorldForge
+
+    parser = _build_parser()
+    args = parser.parse_args(["benchmark", "--list-presets", "--format", "csv"])
+    forge = WorldForge(state_dir=None)
+    rc = _cmd_benchmark(args, forge)
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert out.startswith("name,category,providers,operations,iterations")
+    assert "mock-smoke,checkout-safe" in out
+
+
+def test_cli_runs_preset_in_markdown_with_workspace(tmp_path, capsys) -> None:
+    from worldforge.cli import _build_parser, _cmd_benchmark
+    from worldforge.framework import WorldForge
+
+    parser = _build_parser()
+    workspace_dir = tmp_path / "workspace"
+    args = parser.parse_args(
+        [
+            "benchmark",
+            "--preset",
+            "mock-smoke",
+            "--run-workspace",
+            str(workspace_dir),
+            "--state-dir",
+            str(tmp_path / "worlds"),
+        ]
+    )
+    forge = WorldForge(state_dir=tmp_path / "worlds")
+    rc = _cmd_benchmark(args, forge)
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "# Benchmark Report" in out
+    assert "# Benchmark Gate Report" in out
+    runs_dir = workspace_dir / "runs"
+    assert runs_dir.exists()
+
+
+def test_cli_preset_csv_output(tmp_path, capsys) -> None:
+    from worldforge.cli import _build_parser, _cmd_benchmark
+    from worldforge.framework import WorldForge
+
+    parser = _build_parser()
+    args = parser.parse_args(
+        ["benchmark", "--preset", "mock-smoke", "--format", "csv", "--state-dir", str(tmp_path)]
+    )
+    forge = WorldForge(state_dir=tmp_path)
+    rc = _cmd_benchmark(args, forge)
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert out.startswith("provider,operation,metric")  # gate CSV preferred when budgets present
+
+
+def test_cli_skips_remote_media_dryrun_in_markdown(monkeypatch, capsys) -> None:
+    for env_var in ("COSMOS_BASE_URL", "RUNWAYML_API_SECRET", "RUNWAY_API_SECRET"):
+        monkeypatch.delenv(env_var, raising=False)
+    from worldforge.cli import _build_parser, _cmd_benchmark
+    from worldforge.framework import WorldForge
+
+    parser = _build_parser()
+    args = parser.parse_args(["benchmark", "--preset", "remote-media-dryrun"])
+    forge = WorldForge(state_dir=None)
+    rc = _cmd_benchmark(args, forge)
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "skipped" in out
+    assert "cosmos" in out
+
+
+def test_cli_show_preset_markdown(capsys) -> None:
+    from worldforge.cli import _build_parser, _cmd_benchmark
+    from worldforge.framework import WorldForge
+
+    parser = _build_parser()
+    args = parser.parse_args(["benchmark", "--show-preset", "release-evidence"])
+    forge = WorldForge(state_dir=None)
+    rc = _cmd_benchmark(args, forge)
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "# Release evidence" in out
+    assert "Category: release" in out
+    assert "Skip reason:" in out
+
+
+def test_cli_show_preset(monkeypatch, capsys) -> None:
+    from worldforge.cli import _build_parser, _cmd_benchmark
+    from worldforge.framework import WorldForge
+
+    parser = _build_parser()
+    args = parser.parse_args(["benchmark", "--show-preset", "release-evidence", "--format", "json"])
+    forge = WorldForge(state_dir=None)
+    rc = _cmd_benchmark(args, forge)
+    out = capsys.readouterr().out
+    assert rc == 0
+    payload = json.loads(out)
+    assert payload["preset"]["name"] == "release-evidence"
+    assert payload["budget_payload"]["budgets"]

--- a/tests/test_cli_help_snapshots.py
+++ b/tests/test_cli_help_snapshots.py
@@ -144,7 +144,8 @@ usage: worldforge benchmark [-h] [--provider PROVIDERS]
                             [--input-file INPUT_FILE]
                             [--budget-file BUDGET_FILE]
                             [--state-dir STATE_DIR]
-                            [--run-workspace RUN_WORKSPACE]
+                            [--run-workspace RUN_WORKSPACE] [--preset PRESET]
+                            [--list-presets] [--show-preset SHOW_PRESET]
 
 options:
   -h, --help            show this help message and exit
@@ -168,6 +169,13 @@ options:
   --run-workspace RUN_WORKSPACE
                         Preserve sanitized benchmark artifacts under
                         RUN_WORKSPACE/runs/<run-id>/.
+  --preset PRESET       Run a named benchmark preset (overrides --provider,
+                        --operation, --iterations, --concurrency, --input-
+                        file, and --budget-file). Use --list-presets for the
+                        catalogue.
+  --list-presets        List benchmark presets and exit.
+  --show-preset SHOW_PRESET
+                        Print one benchmark preset's details and exit.
 """,
 }
 


### PR DESCRIPTION
Refs #136 (WF-B3). Builds on the provenance envelope (#155) and the capability fixture corpus (#156).

## Summary

Ships five named benchmark presets so maintainers can run release-regression workloads from a single CLI flag without re-deriving inputs and budgets:

- **`mock-smoke`** (checkout-safe). Fast every-branch CI smoke check on the mock provider with a tight success-rate gate.
- **`parser-overhead`** (checkout-safe). Twenty-iteration latency-bounded run that measures WorldForge adapter-path overhead through the mock.
- **`remote-media-dryrun`** (remote-media). Single-iteration dry-run for `cosmos` or `runway`. Skips with a typed reason when neither env is configured.
- **`prepared-host`** (prepared-host). Three-iteration evidence run for any configured prepared-host runtime (LeWorldModel for `score`; LeRobot or GR00T for `policy`). Skips with a typed reason when no eligible runtime is available.
- **`release-evidence`** (release). Release-gated regression check across every mock-supported operation with strict latency, throughput, and success-rate budgets, intended to be paired with `--run-workspace` for release attestation.

Each preset is a frozen `BenchmarkPreset` dataclass under `worldforge.benchmark_presets`, validated at construction (category, providers, operations, iterations, concurrency, failure tolerance, runtime profiles). Preset inputs and budgets ship as JSON files under `src/worldforge/benchmark_presets/_data/` matching the existing `--input-file` and `--budget-file` wire formats; they are part of the wheel via the existing `src/worldforge` package layout.

## CLI

Three new flags on the existing `benchmark` subcommand. `--preset NAME` overrides `--provider`, `--operation`, `--iterations`, `--concurrency`, `--input-file`, and `--budget-file`. `--list-presets` and `--show-preset NAME` print the catalogue or one preset's details (markdown, json, or csv) and exit. The preset name is recorded in `run_metadata.preset` and threaded into the provenance envelope's `command` argv and `notes` when the report runs.

```bash
uv run worldforge benchmark --list-presets
uv run worldforge benchmark --show-preset release-evidence
uv run worldforge benchmark --preset mock-smoke
uv run worldforge benchmark --preset release-evidence --format json --run-workspace .worldforge
```

## Skip semantics

Presets that gate on a provider runtime profile call `worldforge.testing.runtime_profiles.provider_profile_skip_reason`. When the preset's `failure_tolerance` is `skip-when-env-missing` the CLI prints a typed reason and exits 0 (release CI treats this as "evidence not available on this host"). `fail-on-violation` presets always run; budget violations exit non-zero with the standard violation table that carries provider, operation, metric, observed value, threshold, and budget selector.

## Acceptance criteria (from #136)

- [x] Presets can be listed and run from the CLI or documented make targets.
- [x] Checkout-safe presets run without credentials, network, GPUs, or optional runtimes.
- [x] Prepared-host presets skip or fail with typed reasons when prerequisites are missing.
- [x] Budget violations include operation, metric, threshold, observed value, and artifact path.

## Test plan

- [x] `uv run ruff check src tests examples scripts` clean
- [x] `uv run ruff format --check src tests examples scripts` clean
- [x] `uv lock --check`
- [x] `uv run python scripts/generate_provider_docs.py --check`
- [x] `uv run pytest` — 702 passed / 2 skipped
- [x] `uv run --extra harness pytest --cov=src/worldforge --cov-report=term-missing --cov-fail-under=90` — 90.14 percent
- [x] `bash scripts/test_package.sh` — preset data ships in the wheel automatically
- [x] `uv run mkdocs build --strict`

## Migration

Pure addition. No public API was renamed or removed. Existing `worldforge benchmark` flags still work unchanged; `--preset` is a new override path. Downstream issues (WF-B5 evidence bundles, WF-B6 budget calibration) can now consume `worldforge.benchmark_presets.list_presets()` instead of re-deriving the catalogue.