### PR TITLE
Add JEPA-WMS smoke evidence manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,8 @@ releases may still include breaking changes when the public API needs to tighten
 - Added a provider cohort selection record that scores active and deferred provider candidates,
   selects the next evidence cohort, and keeps provider catalog claims unchanged until runtime
   evidence exists.
+- Added a JEPA-WMS runtime manifest for prepared-host smoke evidence and a stable `input_digest`
+  field for smoke run manifests with synthetic input summaries.
 - Added an optional live robotics showcase workflow for pull request and main-branch push
   validation.
   It runs real LeRobot policy inference plus real LeWorldModel checkpoint scoring in

--- a/docs/src/providers/README.md
+++ b/docs/src/providers/README.md
@@ -203,9 +203,9 @@ collector configuration.
 
 Optional live smoke entrypoints accept `--run-manifest <path>` for a validated
 `run_manifest.json`. The manifest is safe issue evidence: it stores command argv, package version,
-provider profile, capability, value-free env presence, runtime manifest id, input fixture digest,
-event count, result digest, and artifact paths. It does not store credential values, raw signed URL
-query strings, checkpoint bytes, or generated media bytes.
+provider profile, capability, value-free env presence, runtime manifest id, input digest, optional
+input fixture digest, event count, result digest, and artifact paths. It does not store credential
+values, raw signed URL query strings, checkpoint bytes, or generated media bytes.
 
 ## Authoring Standard
 

--- a/docs/src/providers/jepa-wms.md
+++ b/docs/src/providers/jepa-wms.md
@@ -27,6 +27,10 @@ Current decision: keep `jepa-wms` as a direct-construction candidate. Even when 
 successfully runs the smoke command below, WorldForge should not auto-register it until there is
 checked-in real-runtime evidence for the selected upstream model and task family.
 
+The packaged runtime manifest `jepa-wms:schema-1` exists only to make prepared-host smoke evidence
+machine-readable. It does not make `jepa-wms` a catalog provider, exported provider, or
+auto-registered runtime.
+
 ## Runtime Ownership
 
 WorldForge owns the candidate provider shell, score-result validation, event emission, and
@@ -179,8 +183,8 @@ uv run --with torch worldforge-smoke-jepa-wms \
 The command imports `torch` only at runtime, calls `JEPAWMSProvider.from_torch_hub(...)`, scores
 synthetic observation, goal, action-history, and action-candidate tensors, and writes a sanitized
 `run_manifest.json`. The manifest includes value-free environment presence, input shapes, runtime
-version fields such as torch version/model class, event count, and a score summary with candidate
-count, score direction, best index, and best score.
+manifest id, input digest, result digest, runtime version fields such as torch version/model class,
+event count, and a score summary with candidate count, score direction, best index, and best score.
 
 The smoke command does not download or pin checkpoints for users. Hosts remain responsible for the
 compatible `facebookresearch/jepa-wms` runtime, model names, checkpoint availability, device

--- a/src/worldforge/providers/jepa_wms.py
+++ b/src/worldforge/providers/jepa_wms.py
@@ -633,7 +633,7 @@ class JEPAWMSProvider(BaseProvider):
                 phase="success",
                 duration_ms=duration_ms,
                 metadata={
-                    "model_path": self.model_path,
+                    "model_configured": self.model_path is not None,
                     "candidate_count": len(result.scores),
                     "best_index": result.best_index,
                 },
@@ -645,7 +645,7 @@ class JEPAWMSProvider(BaseProvider):
                 phase="failure",
                 duration_ms=max(0.1, (perf_counter() - started) * 1000),
                 message=str(exc),
-                metadata={"model_path": self.model_path},
+                metadata={"model_configured": self.model_path is not None},
             )
             raise
         except (
@@ -659,14 +659,12 @@ class JEPAWMSProvider(BaseProvider):
             TypeError,
             ValueError,
         ) as exc:
-            error = ProviderError(
-                f"JEPA-WMS scoring failed for model path '{self.model_path}': {exc}"
-            )
+            error = ProviderError(f"JEPA-WMS scoring failed for configured model: {exc}")
             self._emit_operation_event(
                 "score",
                 phase="failure",
                 duration_ms=max(0.1, (perf_counter() - started) * 1000),
                 message=str(error),
-                metadata={"model_path": self.model_path},
+                metadata={"model_configured": self.model_path is not None},
             )
             raise error from exc

--- a/src/worldforge/providers/runtime_manifests/jepa-wms.json
+++ b/src/worldforge/providers/runtime_manifests/jepa-wms.json
@@ -1,0 +1,19 @@
+{
+  "schema_version": 1,
+  "provider": "jepa-wms",
+  "capabilities": ["score"],
+  "optional_dependencies": ["torch", "facebookresearch/jepa-wms runtime"],
+  "required_env_vars": ["JEPA_WMS_MODEL_NAME"],
+  "optional_env_vars": ["JEPA_WMS_MODEL_PATH", "JEPA_WMS_DEVICE"],
+  "default_model": "jepa_wm_pusht",
+  "device_support": ["cpu", "cuda", "mps"],
+  "host_owned_artifacts": [
+    "JEPA-WMS checkpoint",
+    "torch-hub cache",
+    "task-shaped observation, goal, action-history, and action-candidate tensors"
+  ],
+  "minimum_smoke_command": "uv run --with torch worldforge-smoke-jepa-wms --model-name jepa_wm_pusht --device cpu --run-manifest .worldforge/runs/jepa-wms-live/run_manifest.json",
+  "expected_success_signal": "score_actions() returns finite lower-is-better candidate costs and writes a sanitized run_manifest.json with runtime and input digests",
+  "setup_hint": "install torch and the upstream facebookresearch/jepa-wms runtime in the host environment; keep checkpoints and task preprocessing host-owned",
+  "docs_path": "docs/src/providers/jepa-wms.md"
+}

--- a/src/worldforge/smoke/run_manifest.py
+++ b/src/worldforge/smoke/run_manifest.py
@@ -39,6 +39,7 @@ class LiveSmokeRunManifest:
     artifact_paths: Mapping[str, str] = field(default_factory=dict)
     event_count: int = 0
     input_summary: Mapping[str, Any] = field(default_factory=dict)
+    input_digest: str | None = None
     input_fixture_digest: str | None = None
     result_digest: str | None = None
     runtime_manifest_id: str | None = None
@@ -73,6 +74,7 @@ class LiveSmokeRunManifest:
             "runtime_manifest_id": self.runtime_manifest_id,
             "env_summary": [dict(item) for item in self.env_summary],
             "input_summary": _json_native(dict(self.input_summary)),
+            "input_digest": self.input_digest,
             "input_fixture_digest": self.input_fixture_digest,
             "event_count": self.event_count,
             "result_digest": self.result_digest,
@@ -93,6 +95,7 @@ def build_run_manifest(
     event_count: int = 0,
     input_summary: Mapping[str, Any] | None = None,
     input_fixture: Path | str | None = None,
+    input_digest: str | None = None,
     result: Mapping[str, Any] | None = None,
     result_digest: str | None = None,
     environ: Mapping[str, str] | None = None,
@@ -112,6 +115,15 @@ def build_run_manifest(
     resolved_result_digest = result_digest
     if resolved_result_digest is None and result is not None:
         resolved_result_digest = digest_json_value(dict(result))
+    resolved_input_fixture_digest = (
+        digest_file(input_fixture) if input_fixture is not None else None
+    )
+    resolved_input_digest = input_digest
+    if resolved_input_digest is None:
+        if resolved_input_fixture_digest is not None:
+            resolved_input_digest = resolved_input_fixture_digest
+        elif input_summary:
+            resolved_input_digest = digest_json_value(dict(input_summary))
 
     return LiveSmokeRunManifest(
         run_id=run_id,
@@ -122,7 +134,8 @@ def build_run_manifest(
         runtime_manifest_id=runtime_manifest_id,
         env_summary=tuple(env_summary(env_vars, environ=environ)),
         input_summary=input_summary or {},
-        input_fixture_digest=digest_file(input_fixture) if input_fixture is not None else None,
+        input_digest=resolved_input_digest,
+        input_fixture_digest=resolved_input_fixture_digest,
         event_count=event_count,
         result_digest=resolved_result_digest,
         artifact_paths=_artifact_path_summary(artifact_paths or {}),
@@ -176,7 +189,7 @@ def digest_file(path: Path | str) -> str:
 
 
 def digest_json_value(value: Mapping[str, Any]) -> str:
-    """Return a stable sha256 digest for a JSON-like result summary."""
+    """Return a stable sha256 digest for a JSON-like summary."""
 
     payload = dump_json(require_json_dict(_json_native(dict(value)), name="Run manifest result"))
     return f"sha256:{hashlib.sha256(payload.encode('utf-8')).hexdigest()}"

--- a/tests/test_jepa_wms_provider.py
+++ b/tests/test_jepa_wms_provider.py
@@ -326,6 +326,11 @@ def test_jepa_wms_fake_runtime_scores_fixture_payload_and_contract() -> None:
     assert runtime.calls[-1]["info"] == payload["info"]
     assert events[-1].operation == "score"
     assert events[-1].phase == "success"
+    assert events[-1].metadata == {
+        "best_index": 1,
+        "candidate_count": 3,
+        "model_configured": True,
+    }
 
 
 def test_jepa_wms_torchhub_runtime_scores_and_plans_through_world(tmp_path) -> None:
@@ -658,6 +663,7 @@ def test_jepa_wms_runtime_error_response_emits_failure_event() -> None:
     assert events[-1].operation == "score"
     assert events[-1].phase == "failure"
     assert "checkpoint_expired" in events[-1].message
+    assert events[-1].metadata == {"model_configured": True}
 
 
 @pytest.mark.parametrize(
@@ -910,7 +916,11 @@ def test_jepa_wms_prepared_host_smoke_writes_runtime_manifest(
     assert manifest["provider_profile"] == "jepa-wms"
     assert manifest["capability"] == "score"
     assert manifest["status"] == "passed"
+    assert manifest["runtime_manifest_id"] == "jepa-wms:schema-1"
+    assert manifest["input_digest"].startswith("sha256:")
+    assert manifest["result_digest"].startswith("sha256:")
     assert manifest["event_count"] == 1
+    assert manifest["input_summary"]["inputs"]["shapes"]["action_candidates"] == [1, 3, 4, 10]
     assert manifest["input_summary"]["runtime_version"]["torch"] == "2.9.0-test"
     assert manifest["input_summary"]["score_summary"]["best_score"] == 0.1
     assert manifest["artifact_paths"]["summary_json"] == str(summary_path)

--- a/tests/test_provider_runtime_manifests.py
+++ b/tests/test_provider_runtime_manifests.py
@@ -17,7 +17,16 @@ from worldforge.providers.runtime_manifest import (
     missing_optional_dependency_detail,
 )
 
-EXPECTED_MANIFEST_PROVIDERS = ("cosmos", "gr00t", "jepa", "lerobot", "leworldmodel", "runway")
+EXPECTED_MANIFEST_PROVIDERS = (
+    "cosmos",
+    "gr00t",
+    "jepa-wms",
+    "jepa",
+    "lerobot",
+    "leworldmodel",
+    "runway",
+)
+DIRECT_CONSTRUCTION_MANIFEST_PROVIDERS = {"jepa-wms"}
 
 
 def test_runtime_manifests_cover_real_optional_providers() -> None:
@@ -27,9 +36,13 @@ def test_runtime_manifests_cover_real_optional_providers() -> None:
     assert manifest_names == EXPECTED_MANIFEST_PROVIDERS
     catalog = {entry.name: entry.create().profile() for entry in PROVIDER_CATALOG}
     for manifest in manifests:
-        profile = catalog[manifest.provider]
         assert manifest.schema_version == 1
-        assert set(manifest.capabilities) <= set(profile.capabilities.enabled_names())
+        if manifest.provider in DIRECT_CONSTRUCTION_MANIFEST_PROVIDERS:
+            assert manifest.provider not in catalog
+            assert manifest.capabilities == ("score",)
+        else:
+            profile = catalog[manifest.provider]
+            assert set(manifest.capabilities) <= set(profile.capabilities.enabled_names())
         assert manifest.docs_path == f"docs/src/providers/{manifest.provider}.md"
         assert manifest.minimum_smoke_command
         assert manifest.expected_success_signal

--- a/tests/test_smoke_run_manifest.py
+++ b/tests/test_smoke_run_manifest.py
@@ -40,6 +40,7 @@ def test_build_run_manifest_records_value_free_runtime_evidence(
 
     assert manifest["schema_version"] == 1
     assert manifest["runtime_manifest_id"] == "runway:schema-1"
+    assert manifest["input_digest"] == digest_file(input_fixture)
     assert manifest["input_fixture_digest"] == digest_file(input_fixture)
     assert manifest["result_digest"] == digest_json_value(
         {"task_id": "task-1", "status": "succeeded"}
@@ -79,6 +80,10 @@ def test_write_run_manifest_validates_before_writing(tmp_path: Path) -> None:
 
 
 def test_run_manifest_preserves_safe_input_summary() -> None:
+    input_summary = {
+        "bridge": "pusht",
+        "score_shapes": {"action_candidates": [1, 3, 4, 10]},
+    }
     manifest = build_run_manifest(
         run_id="run-1",
         provider_profile="leworldmodel",
@@ -86,16 +91,11 @@ def test_run_manifest_preserves_safe_input_summary() -> None:
         status="passed",
         env_vars=("LEWORLDMODEL_POLICY",),
         command_argv=("lewm-real",),
-        input_summary={
-            "bridge": "pusht",
-            "score_shapes": {"action_candidates": [1, 3, 4, 10]},
-        },
+        input_summary=input_summary,
     ).to_dict()
 
-    assert manifest["input_summary"] == {
-        "bridge": "pusht",
-        "score_shapes": {"action_candidates": [1, 3, 4, 10]},
-    }
+    assert manifest["input_summary"] == input_summary
+    assert manifest["input_digest"] == digest_json_value(input_summary)
 
 
 def test_run_manifest_rejects_secret_like_values_and_signed_urls(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- Add a packaged `jepa-wms:schema-1` runtime manifest for direct-construction prepared-host smoke evidence without catalog auto-registration.
- Add stable `input_digest` support for smoke run manifests, including synthetic input summaries.
- Remove raw `model_path` metadata from JEPA-WMS provider events and document the manifest/evidence contract.

## Validation

- `uv run pytest tests/test_jepa_wms_provider.py tests/test_provider_contracts.py tests/test_smoke_run_manifest.py tests/test_provider_catalog_docs.py tests/test_docs_site.py -q`
- `uv run pytest`
- `uv run ruff check src tests examples scripts`
- `uv run ruff format --check src tests examples scripts`
- `uv run python scripts/generate_provider_docs.py --check`
- `uv run mkdocs build --strict`
- `bash scripts/test_package.sh`

Closes #133
