### PR TITLE
Harden remote media artifact tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,9 @@ releases may still include breaking changes when the public API needs to tighten
 
 - Preserved LeRobot loader provenance after lazy policy loading so real `from_pretrained` runs no
   longer report as `injected_policy` in policy result metadata or provider events.
+- Documented first triage commands for Cosmos and Runway media artifacts and added focused
+  provider-level regression tests for failed, malformed, unsupported, expired, and retry-exhausted
+  remote media paths.
 
 ## 0.5.0 - 2026-04-24
 

--- a/docs/src/providers/cosmos.md
+++ b/docs/src/providers/cosmos.md
@@ -150,6 +150,11 @@ input shape summary, result digest, and artifact path. Hosts own retention of th
 copy the artifact out of temporary storage immediately when it is needed for release or issue
 evidence.
 
+Artifact lifetime assumption: Cosmos media evidence is durable only after the host has persisted
+the local output path. If a media workflow fails, first triage with
+`uv run worldforge provider health cosmos`; if health is ready, inspect the typed provider error
+for malformed inline media, failed-task payloads, or unsupported artifact references.
+
 ## Tests
 
 - `tests/test_remote_video_providers.py` covers Cosmos health parsing, generation success,

--- a/docs/src/providers/runway.md
+++ b/docs/src/providers/runway.md
@@ -151,6 +151,12 @@ the downloaded bytes immediately if the media is needed for issue evidence, benc
 or release notes. If an artifact has expired, rerun the task rather than attempting to reconstruct a
 signed URL from logs or manifests.
 
+Artifact lifetime assumption: downloaded bytes are durable only after the host writes or copies the
+local artifact path. First triage command for Runway media failures:
+`uv run worldforge provider health runway`. If health is ready, inspect provider events for
+`operation=="artifact download"` and sanitized `target` values, then rerun the task when the URL has
+expired.
+
 Separate benchmark input fixtures are provided for the two capabilities:
 
 ```bash

--- a/tests/test_cosmos_provider.py
+++ b/tests/test_cosmos_provider.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import httpx
+import pytest
+
+from worldforge.providers import CosmosProvider
+from worldforge.providers.base import ProviderError
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _fixture(name: str) -> dict[str, object]:
+    return json.loads((ROOT / "tests" / "fixtures" / "providers" / name).read_text())
+
+
+@pytest.mark.parametrize(
+    ("fixture_name", "match"),
+    [
+        ("cosmos_generate_failed_task.json", "generation task failed: model rejected prompt"),
+        ("cosmos_generate_unsupported_artifact.json", "returned artifact references"),
+        ("cosmos_generate_missing_video.json", "field 'b64_video'"),
+    ],
+)
+def test_cosmos_provider_rejects_remote_media_artifact_contract_failures(
+    fixture_name: str,
+    match: str,
+) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "POST" and request.url.path == "/v1/infer":
+            return httpx.Response(200, json=_fixture(fixture_name))
+        raise AssertionError(f"Unexpected request: {request.method} {request.url}")
+
+    provider = CosmosProvider(
+        base_url="http://cosmos.test",
+        transport=httpx.MockTransport(handler),
+    )
+
+    with pytest.raises(ProviderError, match=match):
+        provider.generate("drive through the city", duration_seconds=2.0)

--- a/tests/test_runway_provider.py
+++ b/tests/test_runway_provider.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import httpx
+import pytest
+
+from worldforge import GenerationOptions, ProviderEvent, ProviderRequestPolicy
+from worldforge.providers import RunwayProvider
+from worldforge.providers.base import ProviderError
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _fixture(name: str) -> dict[str, object]:
+    return json.loads((ROOT / "tests" / "fixtures" / "providers" / name).read_text())
+
+
+@pytest.mark.parametrize(
+    ("fixture_name", "match"),
+    [
+        ("runway_task_failed.json", "failed with status FAILED: moderation rejected prompt"),
+        ("runway_task_empty_output.json", "completed without outputs"),
+        ("runway_task_partial_output.json", "invalid entries"),
+    ],
+)
+def test_runway_provider_rejects_malformed_or_failed_task_outputs(
+    monkeypatch: pytest.MonkeyPatch,
+    fixture_name: str,
+    match: str,
+) -> None:
+    monkeypatch.setenv("RUNWAYML_API_SECRET", "runway-test-key")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "POST" and request.url.path == "/v1/image_to_video":
+            return httpx.Response(200, json=_fixture("runway_create_success.json"))
+        if request.method == "GET" and request.url.path == "/v1/tasks/task_generate":
+            return httpx.Response(200, json=_fixture(fixture_name))
+        raise AssertionError(f"Unexpected request: {request.method} {request.url}")
+
+    provider = RunwayProvider(
+        transport=httpx.MockTransport(handler),
+        poll_interval_seconds=0.0,
+        max_polls=1,
+    )
+
+    with pytest.raises(ProviderError, match=match):
+        provider.generate("a rainy alley at night", duration_seconds=4.0)
+
+
+def test_runway_provider_download_retry_exhaustion_keeps_signed_url_out_of_events(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("RUNWAYML_API_SECRET", "runway-test-key")
+    events: list[ProviderEvent] = []
+    attempts = {"download": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "POST" and request.url.path == "/v1/image_to_video":
+            return httpx.Response(200, json={"id": "task_generate"})
+        if request.method == "GET" and request.url.path == "/v1/tasks/task_generate":
+            return httpx.Response(
+                200,
+                json={
+                    "id": "task_generate",
+                    "status": "SUCCEEDED",
+                    "output": [
+                        "https://downloads.example.com/generated.mp4"
+                        "?X-Amz-Signature=download-secret&token=download-token"
+                    ],
+                },
+            )
+        if request.method == "GET" and request.url.host == "downloads.example.com":
+            attempts["download"] += 1
+            return httpx.Response(503, text="retry exhausted")
+        raise AssertionError(f"Unexpected request: {request.method} {request.url}")
+
+    provider = RunwayProvider(
+        request_policy=ProviderRequestPolicy.remote_defaults(
+            request_timeout_seconds=30.0,
+            read_retry_attempts=2,
+            read_backoff_seconds=0.0,
+        ),
+        event_handler=events.append,
+        transport=httpx.MockTransport(handler),
+        poll_interval_seconds=0.0,
+        max_polls=1,
+    )
+
+    with pytest.raises(ProviderError, match="artifact download failed with status 503"):
+        provider.generate(
+            "a rainy alley at night",
+            duration_seconds=4.0,
+            options=GenerationOptions(fps=24.0),
+        )
+
+    assert attempts["download"] == 2
+    download_events = [event for event in events if event.operation == "artifact download"]
+    assert [(event.phase, event.status_code) for event in download_events] == [
+        ("retry", 503),
+        ("failure", 503),
+    ]
+    assert [event.target for event in download_events] == [
+        "https://downloads.example.com/generated.mp4",
+        "https://downloads.example.com/generated.mp4",
+    ]
+    exported = json.dumps([event.to_dict() for event in events])
+    assert "download-secret" not in exported
+    assert "X-Amz-Signature" not in exported


### PR DESCRIPTION
## Problem
Cosmos and Runway media paths need explicit retention and failure coverage around failed tasks, malformed provider payloads, unsupported artifact references, expired signed URLs, and retry-exhausted downloads.

## Solution
- Added provider-specific regression tests for Cosmos failed/malformed/unsupported media responses.
- Added Runway regression tests for failed or malformed task outputs and retry-exhausted artifact downloads.
- Verified download provider events keep signed URL query secrets out of emitted targets and exported event payloads.
- Documented first triage commands and artifact lifetime assumptions for both provider pages.

## Validation
- `uv run pytest tests/test_cosmos_provider.py tests/test_runway_provider.py tests/test_remote_video_providers.py tests/test_observability.py -q`
- `uv run pytest`
- `uv run ruff check src tests examples scripts`
- `uv run ruff format --check src tests examples scripts`
- `uv run python scripts/generate_provider_docs.py --check`
- `uv run mkdocs build --strict`
- `git diff --check`

Closes #134