### PR TITLE
Cover Genie scaffold defer decision

### DIFF
--- a/docs/src/providers/genie.md
+++ b/docs/src/providers/genie.md
@@ -20,6 +20,11 @@ boundary.
 Until those boundaries exist, WorldForge must not present deterministic local surrogate behavior as
 a Genie implementation. Keeping the provider as `scaffold` is the accurate production behavior.
 
+Revisit trigger: a maintained upstream API, SDK, or local runtime must publish a callable
+artifact-generation contract with documented authentication, inputs, outputs, failure modes,
+licensing, and smoke evidence. A web-only interactive prototype is not enough to change the
+provider capability flags.
+
 References:
 
 - [Genie 3 - Google DeepMind](https://deepmind.google/models/genie/)

--- a/tests/test_docs_site.py
+++ b/tests/test_docs_site.py
@@ -443,6 +443,7 @@ def test_genie_scaffold_docs_record_runtime_contract_defer_decision() -> None:
     assert "Project Genie announcement" in provider_page
     assert "not a supported automation API" in provider_page
     assert "must not present deterministic local surrogate behavior" in provider_page
+    assert "Revisit trigger" in provider_page
     assert "fixture-backed parser tests" in provider_page
     assert "sanitized `run_manifest.json`" in provider_page
     assert "| [`genie`](./genie.md) | `scaffold` | scaffold | `GENIE_API_KEY` |" in provider_index

--- a/tests/test_remote_scaffold_providers.py
+++ b/tests/test_remote_scaffold_providers.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from worldforge.providers import GenieProvider, ProviderError
+from worldforge.testing import assert_provider_contract
+
+
+def test_genie_provider_remains_fail_closed_without_runtime_contract(monkeypatch) -> None:
+    monkeypatch.delenv("GENIE_API_KEY", raising=False)
+    monkeypatch.delenv("WORLDFORGE_ENABLE_SCAFFOLD_SURROGATES", raising=False)
+
+    provider = GenieProvider()
+    profile = provider.profile()
+
+    assert profile.implementation_status == "scaffold"
+    assert profile.capabilities.enabled_names() == []
+    assert profile.artifact_types == []
+    assert provider.configured() is False
+    assert provider.health().healthy is False
+    assert "GENIE_API_KEY" in provider.health().details
+
+    report = assert_provider_contract(provider)
+    assert report.configured is False
+    assert report.exercised_operations == []
+
+
+def test_configured_genie_scaffold_does_not_enable_generate(monkeypatch) -> None:
+    monkeypatch.setenv("GENIE_API_KEY", "genie-test-secret")
+    monkeypatch.delenv("WORLDFORGE_ENABLE_SCAFFOLD_SURROGATES", raising=False)
+
+    provider = GenieProvider()
+    summary = provider.config_summary().to_dict()
+
+    assert provider.configured() is True
+    assert provider.health().healthy is True
+    assert provider.profile().capabilities.enabled_names() == []
+    assert "genie-test-secret" not in json.dumps(summary)
+
+    report = assert_provider_contract(provider)
+    assert report.configured is True
+    assert report.exercised_operations == []
+
+    with pytest.raises(ProviderError, match="scaffold"):
+        provider.generate("make an interactive world", duration_seconds=2.0)
+
+
+def test_genie_scaffold_surrogate_requires_explicit_test_opt_in(monkeypatch) -> None:
+    monkeypatch.setenv("GENIE_API_KEY", "genie-test-secret")
+    monkeypatch.setenv("WORLDFORGE_ENABLE_SCAFFOLD_SURROGATES", "1")
+
+    clip = GenieProvider().generate("local plumbing test only", duration_seconds=1.0)
+
+    assert clip.metadata["mode"] == "stub-remote-adapter"
+    assert clip.metadata["credential_env"] == "GENIE_API_KEY"


### PR DESCRIPTION
## Problem
#139 requires the Genie runtime decision to close with a documented defer path and an exact validation target for remote scaffold providers. The docs already kept Genie fail-closed, but the issue's named test file did not exist.

## Solution
- Added `tests/test_remote_scaffold_providers.py` covering Genie as a configured and unconfigured fail-closed scaffold.
- Verified `GENIE_API_KEY` affects diagnostics/configuration only and does not enable `generate` unless the explicit local scaffold surrogate test opt-in is set.
- Added a provider-doc revisit trigger that names the upstream contract evidence required before capability flags can change.
- Pinned that revisit trigger in the docs-site regression.

## Validation
- `uv run pytest tests/test_remote_scaffold_providers.py tests/test_provider_catalog_docs.py`
- `uv run pytest tests/test_remote_scaffold_providers.py tests/test_provider_catalog_docs.py tests/test_docs_site.py tests/test_provider_contracts.py tests/test_provider_events.py -q`
- `uv run pytest`
- `uv run ruff check src tests examples scripts`
- `uv run ruff format --check src tests examples scripts`
- `uv run python scripts/generate_provider_docs.py --check`
- `uv run mkdocs build --strict`
- `git diff --check`

Closes #139