### PR TITLE
Add live smoke evidence registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,9 @@ releases may still include breaking changes when the public API needs to tighten
 - Added `validate_scene_artifact` for checkout-safe spatial scene artifact validation, plus tiny
   valid and malformed fixtures covering transforms, units, non-finite values, unsafe references,
   and oversized metadata.
+- Added a live-smoke evidence registry with schema validation, first-class missing-runtime and
+  missing-credential skip statuses, docs for safe provider issue attachments, and release-evidence
+  rendering support.
 - Added a JEPA-WMS runtime manifest for prepared-host smoke evidence and a stable `input_digest`
   field for smoke run manifests with synthetic input summaries.
 - Added an optional live robotics showcase workflow for pull request and main-branch push

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -26,6 +26,7 @@
 - [Next Provider Selection RFC](./provider-selection-rfc.md)
 - [Provider Cohort Selection Record](./provider-cohort-selection.md)
 - [Spatial Scene Artifact Boundary](./spatial-scene-artifact-boundary.md)
+- [Live Smoke Evidence Registry](./live-smoke-evidence.md)
 - [Python API](./api/python.md)
 - [Evaluation](./evaluation.md)
 - [Benchmarking](./benchmarking.md)

--- a/docs/src/live-smoke-evidence.json
+++ b/docs/src/live-smoke-evidence.json
@@ -1,0 +1,105 @@
+{
+  "schema_version": 1,
+  "entries": [
+    {
+      "provider": "jepa-wms",
+      "capability": "score",
+      "command": "uv run --with torch worldforge-smoke-jepa-wms --model-name jepa_wm_pusht --device cpu --run-manifest .worldforge/runs/jepa-wms-live/run_manifest.json",
+      "runtime_manifest": "jepa-wms:schema-1",
+      "date": "2026-05-05",
+      "version": "0.5.0",
+      "status": "not_run",
+      "artifact_path": null,
+      "skip_reason": "prepared-host smoke command documented; no sanitized run manifest is checked into the repository",
+      "known_limitations": [
+        "direct-construction candidate only",
+        "requires host-owned torch, upstream JEPA-WMS runtime, checkpoints, and task preprocessing"
+      ]
+    },
+    {
+      "provider": "jepa",
+      "capability": "score",
+      "command": "uv run --with torch worldforge-smoke-jepa-wms --model-name jepa_wm_pusht --device cpu --run-manifest .worldforge/runs/jepa-live/run_manifest.json",
+      "runtime_manifest": "jepa:schema-1",
+      "date": "2026-05-05",
+      "version": "0.5.0",
+      "status": "skipped_missing_runtime",
+      "artifact_path": null,
+      "skip_reason": "requires host-owned torch, facebookresearch/jepa-wms runtime, model assets, and JEPA_MODEL_NAME",
+      "known_limitations": [
+        "public adapter is score-only",
+        "checkpoint and task preprocessing remain host-owned"
+      ]
+    },
+    {
+      "provider": "cosmos",
+      "capability": "generate",
+      "command": "uv run worldforge-smoke-cosmos --run-manifest .worldforge/runs/cosmos-live/run_manifest.json",
+      "runtime_manifest": "cosmos:schema-1",
+      "date": "2026-05-05",
+      "version": "0.5.0",
+      "status": "skipped_missing_runtime",
+      "artifact_path": null,
+      "skip_reason": "requires a prepared Cosmos endpoint through COSMOS_BASE_URL",
+      "known_limitations": [
+        "host must persist generated media before endpoint artifact retention expires"
+      ]
+    },
+    {
+      "provider": "runway",
+      "capability": "generate",
+      "command": "uv run worldforge-smoke-runway --run-manifest .worldforge/runs/runway-live/run_manifest.json",
+      "runtime_manifest": "runway:schema-1",
+      "date": "2026-05-05",
+      "version": "0.5.0",
+      "status": "skipped_missing_credentials",
+      "artifact_path": null,
+      "skip_reason": "requires RUNWAYML_API_SECRET or RUNWAY_API_SECRET on a prepared host",
+      "known_limitations": [
+        "signed artifact URLs expire and must not be copied into issue evidence"
+      ]
+    },
+    {
+      "provider": "leworldmodel",
+      "capability": "score",
+      "command": "uv run worldforge-smoke-leworldmodel --run-manifest .worldforge/runs/leworldmodel-live/run_manifest.json",
+      "runtime_manifest": "leworldmodel:schema-1",
+      "date": "2026-05-05",
+      "version": "0.5.0",
+      "status": "skipped_missing_runtime",
+      "artifact_path": null,
+      "skip_reason": "requires stable-worldmodel, torch, checkpoint assets, and LEWORLDMODEL_POLICY or LEWM_POLICY",
+      "known_limitations": [
+        "score tensors remain task-preprocessed and host-owned"
+      ]
+    },
+    {
+      "provider": "gr00t",
+      "capability": "policy",
+      "command": "uv run python scripts/smoke_gr00t_policy.py --run-manifest .worldforge/runs/gr00t-live/run_manifest.json",
+      "runtime_manifest": "gr00t:schema-1",
+      "date": "2026-05-05",
+      "version": "0.5.0",
+      "status": "skipped_missing_runtime",
+      "artifact_path": null,
+      "skip_reason": "requires a reachable GR00T PolicyClient host through GROOT_POLICY_HOST",
+      "known_limitations": [
+        "embodiment action translation and robot safety remain host-owned"
+      ]
+    },
+    {
+      "provider": "lerobot",
+      "capability": "policy",
+      "command": "uv run python scripts/smoke_lerobot_policy.py --run-manifest .worldforge/runs/lerobot-live/run_manifest.json",
+      "runtime_manifest": "lerobot:schema-1",
+      "date": "2026-05-05",
+      "version": "0.5.0",
+      "status": "skipped_missing_runtime",
+      "artifact_path": null,
+      "skip_reason": "requires LeRobot runtime packages and LEROBOT_POLICY_PATH or LEROBOT_POLICY",
+      "known_limitations": [
+        "policy checkpoints and action translators remain host-owned"
+      ]
+    }
+  ]
+}

--- a/docs/src/live-smoke-evidence.md
+++ b/docs/src/live-smoke-evidence.md
@@ -1,0 +1,79 @@
+# Live Smoke Evidence Registry
+
+Issue: [#144](https://github.com/AbdelStark/worldforge/issues/144).
+
+The live-smoke evidence registry is the publishable index for optional provider smokes. It records
+which providers have a recent sanitized manifest, which were skipped, and why. It is not a
+benchmark and does not claim model quality, physical fidelity, or robot safety.
+
+Registry JSON: [`live-smoke-evidence.json`](./live-smoke-evidence.json).
+
+## Entry Contract
+
+Each entry records:
+
+| Field | Contract |
+| --- | --- |
+| `provider` | Provider profile or candidate name. |
+| `capability` | One WorldForge capability such as `generate`, `score`, or `policy`. |
+| `command` | Smoke command to run on a prepared host. Do not inline secrets. |
+| `runtime_manifest` | Runtime manifest id such as `runway:schema-1`, or `null` if none exists. |
+| `date` | Registry decision date as `YYYY-MM-DD`. |
+| `version` | WorldForge package version used for the registry row. |
+| `status` | `passed`, `failed`, `not_run`, `skipped_missing_runtime`, `skipped_missing_credentials`, or `skipped_not_configured`. |
+| `artifact_path` | Sanitized `run_manifest.json` or artifact path for passed/failed evidence, otherwise `null`. |
+| `skip_reason` | Required for skipped or not-run entries. |
+| `known_limitations` | List of explicit caveats and host-owned responsibilities. |
+
+Validate the registry in tests or release tooling:
+
+```python
+from worldforge import validate_live_smoke_registry
+
+registry = validate_live_smoke_registry(payload)
+```
+
+The validator rejects signed URLs, URL query strings, fragments, obvious secret material,
+secret-like metadata keys, duplicate provider/capability rows, missing skip reasons, and missing
+artifact paths for passed or failed evidence.
+
+## Status Semantics
+
+- `passed`: a prepared host ran the command and preserved a sanitized manifest.
+- `failed`: a prepared host ran the command and preserved a sanitized failure manifest.
+- `not_run`: the command exists, but no run was attempted or linked for this release.
+- `skipped_missing_runtime`: the host lacks an optional runtime, checkpoint, endpoint, device, or
+  server needed for the smoke.
+- `skipped_missing_credentials`: the host lacks required provider credentials.
+- `skipped_not_configured`: the provider is intentionally not configured for this release.
+
+Skipped rows are evidence. They prevent release notes and issues from silently omitting optional
+providers that could not run on the current host.
+
+## Attaching Manifests To Issues
+
+When a prepared-host smoke passes, attach the sanitized `run_manifest.json` and any small
+checkout-safe summaries it links. Do not attach:
+
+- raw credentials or environment dumps;
+- signed artifact URLs or URLs with query strings;
+- raw tensors, media blobs, checkpoints, model weights, or robot-controller logs;
+- host-local absolute paths unless the issue is explicitly documenting local-only evidence;
+- claims that a live smoke is a benchmark or a physical-fidelity proof.
+
+If a smoke is skipped, attach the registry row or paste the provider, status, command, skip reason,
+and known limitations. That is enough to show whether the blocker is missing credentials, missing
+optional runtime, or an intentional release choice.
+
+## Release Evidence
+
+`scripts/generate_release_evidence.py` includes the registry by default:
+
+```bash
+uv run python scripts/generate_release_evidence.py \
+  --live-smoke-registry docs/src/live-smoke-evidence.json \
+  --output .worldforge/release-evidence/release-evidence.md
+```
+
+Release evidence may still link individual `--run-manifest` files. The registry is the summary
+surface; the run manifests are the per-run evidence.

--- a/docs/src/operations.md
+++ b/docs/src/operations.md
@@ -504,6 +504,7 @@ Generate the release evidence bundle after local gates and optional smokes finis
 
 ```bash
 uv run python scripts/generate_release_evidence.py \
+  --live-smoke-registry docs/src/live-smoke-evidence.json \
   --run-manifest .worldforge/runs/<run-id>/run_manifest.json \
   --benchmark-artifact .worldforge/reports/benchmark-<timestamp>-<run-id>.json \
   --artifact dist/worldforge_ai-<version>-py3-none-any.whl
@@ -511,8 +512,9 @@ uv run python scripts/generate_release_evidence.py \
 
 The report defaults to `.worldforge/release-evidence/release-evidence.md`. It can be generated
 without credentials; providers without linked live-smoke manifests are recorded as `not configured`
-or `skipped` rather than being silently omitted. Attach the report and linked artifacts when a
-release note or provider promotion claims live-provider coverage.
+or `skipped` rather than being silently omitted, and the live-smoke registry records
+missing-runtime and missing-credential skips. Attach the report and linked artifacts when a release
+note or provider promotion claims live-provider coverage.
 
 The tag-triggered release workflow repeats the full quality gate before building distributions or
 publishing release artifacts.

--- a/docs/src/playbooks.md
+++ b/docs/src/playbooks.md
@@ -661,6 +661,7 @@ Finally generate the release evidence bundle:
 
 ```bash
 uv run python scripts/generate_release_evidence.py \
+  --live-smoke-registry docs/src/live-smoke-evidence.json \
   --run-manifest .worldforge/runs/<run-id>/run_manifest.json \
   --benchmark-artifact .worldforge/reports/benchmark-<timestamp>-<run-id>.json \
   --artifact dist/worldforge_ai-<version>-py3-none-any.whl
@@ -668,9 +669,9 @@ uv run python scripts/generate_release_evidence.py \
 
 The default report path is `.worldforge/release-evidence/release-evidence.md`. The generator does
 not require provider credentials; absent live smokes are listed explicitly as `not configured` or
-`skipped`, and passed/failed/skipped live runs link back to their preserved `run_manifest.json`
-files and artifact summaries. Use `--known-limitation` for release-scoped caveats that should
-travel with the bundle.
+`skipped`, the registry records missing-runtime and missing-credential skips, and
+passed/failed/skipped live runs link back to their preserved `run_manifest.json` files and artifact
+summaries. Use `--known-limitation` for release-scoped caveats that should travel with the bundle.
 
 Success signal:
 

--- a/docs/src/providers/README.md
+++ b/docs/src/providers/README.md
@@ -207,6 +207,10 @@ provider profile, capability, value-free env presence, runtime manifest id, inpu
 input fixture digest, event count, result digest, and artifact paths. It does not store credential
 values, raw signed URL query strings, checkpoint bytes, or generated media bytes.
 
+Use the [Live Smoke Evidence Registry](../live-smoke-evidence.md) to see which optional provider
+smokes have current evidence, which were skipped, and how to attach sanitized `run_manifest.json`
+files to provider issues.
+
 ## Authoring Standard
 
 Before adding or promoting a provider, document:

--- a/docs/src/roadmap-continuation.md
+++ b/docs/src/roadmap-continuation.md
@@ -315,6 +315,8 @@ uv run mkdocs build --strict
 
 ### WF-A8: Build The Provider Live-Smoke Evidence Registry
 
+Registry: [Live Smoke Evidence Registry](./live-smoke-evidence.md).
+
 Problem: prepared-host smoke results are currently preserved per run, but maintainers need a
 single lightweight registry that records which optional providers have recent evidence and which
 were skipped.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -66,6 +66,7 @@ nav:
   - Next Provider Selection RFC: provider-selection-rfc.md
   - Provider Cohort Selection Record: provider-cohort-selection.md
   - Spatial Scene Artifact Boundary: spatial-scene-artifact-boundary.md
+  - Live Smoke Evidence Registry: live-smoke-evidence.md
   - Python API: api/python.md
   - Evaluation: evaluation.md
   - Benchmarking: benchmarking.md

--- a/scripts/generate_release_evidence.py
+++ b/scripts/generate_release_evidence.py
@@ -17,9 +17,14 @@ SRC = ROOT / "src"
 if str(SRC) not in sys.path:
     sys.path.insert(0, str(SRC))
 
+from worldforge.live_smoke_evidence import (  # noqa: E402
+    render_live_smoke_registry_table,
+    validate_live_smoke_registry,
+)
 from worldforge.smoke.run_manifest import validate_run_manifest  # noqa: E402
 
 DEFAULT_OUTPUT = ROOT / ".worldforge" / "release-evidence" / "release-evidence.md"
+DEFAULT_LIVE_SMOKE_REGISTRY = ROOT / "docs" / "src" / "live-smoke-evidence.json"
 DEFAULT_RUNS_DIR = ROOT / ".worldforge" / "runs"
 DEFAULT_REPORTS_DIR = ROOT / ".worldforge" / "reports"
 DEFAULT_DIST_DIR = ROOT / "dist"
@@ -84,6 +89,15 @@ def _parser() -> argparse.ArgumentParser:
         help="Optional live-smoke run_manifest.json to include. Can be repeated.",
     )
     parser.add_argument(
+        "--live-smoke-registry",
+        type=Path,
+        default=DEFAULT_LIVE_SMOKE_REGISTRY,
+        help=(
+            "Publishable live-smoke evidence registry JSON. Defaults to "
+            "docs/src/live-smoke-evidence.json."
+        ),
+    )
+    parser.add_argument(
         "--benchmark-artifact",
         type=Path,
         action="append",
@@ -110,6 +124,7 @@ def main(argv: list[str] | None = None) -> int:
     args = _parser().parse_args(argv)
     output = args.output.expanduser().resolve()
     manifests = _collect_manifests(args.run_manifest)
+    live_smoke_registry = _load_live_smoke_registry(args.live_smoke_registry)
     benchmark_artifacts = _dedupe_paths(
         [*args.benchmark_artifact, *_glob_existing(DEFAULT_REPORTS_DIR, "*.json")]
     )
@@ -117,6 +132,7 @@ def main(argv: list[str] | None = None) -> int:
     report = render_release_evidence(
         output=output,
         manifests=manifests,
+        live_smoke_registry=live_smoke_registry,
         benchmark_artifacts=benchmark_artifacts,
         artifacts=artifacts,
         known_limitations=tuple(args.known_limitation),
@@ -133,6 +149,7 @@ def render_release_evidence(
     manifests: tuple[ManifestEvidence, ...],
     benchmark_artifacts: tuple[Path, ...],
     artifacts: tuple[Path, ...],
+    live_smoke_registry: dict[str, Any] | None = None,
     known_limitations: tuple[str, ...] = (),
 ) -> str:
     commit = _git_output("rev-parse", "--short", "HEAD") or "unknown"
@@ -170,6 +187,18 @@ def render_release_evidence(
         {manifest.provider for manifest in manifests if manifest.provider not in LIVE_PROVIDER_ENV}
     )
     lines.extend(_render_provider_row(provider, manifests, output) for provider in extra_providers)
+
+    lines.extend(
+        [
+            "",
+            "## Live Smoke Evidence Registry",
+            "",
+        ]
+    )
+    if live_smoke_registry is None:
+        lines.append("- No live-smoke evidence registry linked.")
+    else:
+        lines.extend(render_live_smoke_registry_table(live_smoke_registry))
 
     lines.extend(
         [
@@ -228,6 +257,16 @@ def _collect_manifests(paths: list[Path]) -> tuple[ManifestEvidence, ...]:
             ManifestEvidence(path=path.resolve(), payload=validate_run_manifest(payload))
         )
     return tuple(evidence)
+
+
+def _load_live_smoke_registry(path: Path | None) -> dict[str, Any] | None:
+    if path is None:
+        return None
+    registry_path = path.expanduser()
+    if not registry_path.exists():
+        return None
+    payload = json.loads(registry_path.read_text(encoding="utf-8"))
+    return validate_live_smoke_registry(payload)
 
 
 def _render_provider_row(

--- a/src/worldforge/__init__.py
+++ b/src/worldforge/__init__.py
@@ -50,6 +50,8 @@ _EXPORTS: dict[str, str] = {  # pragma: no cover - initialized before pytest-cov
     "EvaluationSuite": "worldforge.evaluation",
     "GenerationEval": "worldforge.evaluation",
     "GenerationEvaluationSuite": "worldforge.evaluation",
+    "LIVE_SMOKE_EVIDENCE_SCHEMA_VERSION": "worldforge.live_smoke_evidence",
+    "LIVE_SMOKE_EVIDENCE_STATUSES": "worldforge.live_smoke_evidence",
     "PhysicsEval": "worldforge.evaluation",
     "PhysicsEvaluationSuite": "worldforge.evaluation",
     "PlanningEval": "worldforge.evaluation",
@@ -105,7 +107,10 @@ _EXPORTS: dict[str, str] = {  # pragma: no cover - initialized before pytest-cov
     "WorldForgeError": "worldforge.models",
     "WorldStateError": "worldforge.models",
     "create_rerun_event_handler": "worldforge.rerun",
+    "render_live_smoke_registry_table": "worldforge.live_smoke_evidence",
     "validate_scene_artifact": "worldforge.scene_artifacts",
+    "validate_live_smoke_entry": "worldforge.live_smoke_evidence",
+    "validate_live_smoke_registry": "worldforge.live_smoke_evidence",
 }
 
 __all__ = sorted((*_EXPORTS, "__version__"))

--- a/src/worldforge/live_smoke_evidence.py
+++ b/src/worldforge/live_smoke_evidence.py
@@ -1,0 +1,159 @@
+"""Validation and rendering helpers for live-smoke evidence registries."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from typing import Any
+
+from worldforge.models import (
+    JSONDict,
+    WorldForgeError,
+    _redact_observable_value,
+    _sanitize_observable_target,
+    require_json_dict,
+)
+
+LIVE_SMOKE_EVIDENCE_SCHEMA_VERSION = 1
+LIVE_SMOKE_EVIDENCE_STATUSES = frozenset(
+    {
+        "passed",
+        "failed",
+        "not_run",
+        "skipped_missing_runtime",
+        "skipped_missing_credentials",
+        "skipped_not_configured",
+    }
+)
+
+_DATE_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+_SKIP_STATUSES = frozenset(
+    {"not_run", "skipped_missing_runtime", "skipped_missing_credentials", "skipped_not_configured"}
+)
+
+
+def validate_live_smoke_registry(payload: Mapping[str, Any]) -> JSONDict:
+    """Validate a publishable live-smoke evidence registry."""
+
+    registry = require_json_dict(dict(payload), name="Live smoke evidence registry")
+    if registry.get("schema_version") != LIVE_SMOKE_EVIDENCE_SCHEMA_VERSION:
+        raise WorldForgeError(
+            "Live smoke evidence registry schema_version must be "
+            f"{LIVE_SMOKE_EVIDENCE_SCHEMA_VERSION}."
+        )
+    entries = registry.get("entries")
+    if not isinstance(entries, list):
+        raise WorldForgeError("Live smoke evidence registry entries must be a list.")
+    seen: set[tuple[str, str]] = set()
+    for index, entry in enumerate(entries):
+        validated = validate_live_smoke_entry(entry, name=f"Live smoke evidence entry[{index}]")
+        identity = (str(validated["provider"]), str(validated["capability"]))
+        if identity in seen:
+            raise WorldForgeError(
+                "Live smoke evidence registry entries must be unique by provider and capability."
+            )
+        seen.add(identity)
+        entries[index] = validated
+    return registry
+
+
+def validate_live_smoke_entry(
+    payload: object,
+    *,
+    name: str = "Live smoke evidence entry",
+) -> JSONDict:
+    """Validate one registry entry and return a JSON-native copy."""
+
+    entry = require_json_dict(payload, name=name, allow_empty=False)
+    provider = _require_non_empty_string(entry.get("provider"), name=f"{name}.provider")
+    _require_non_empty_string(entry.get("capability"), name=f"{name}.capability")
+    _require_non_empty_string(entry.get("command"), name=f"{name}.command")
+    runtime_manifest = entry.get("runtime_manifest")
+    if runtime_manifest is not None:
+        _require_non_empty_string(runtime_manifest, name=f"{name}.runtime_manifest")
+    date = _require_non_empty_string(entry.get("date"), name=f"{name}.date")
+    if not _DATE_PATTERN.match(date):
+        raise WorldForgeError(f"{name}.date must use YYYY-MM-DD.")
+    _require_non_empty_string(entry.get("version"), name=f"{name}.version")
+    status = _require_choice(
+        entry.get("status"),
+        LIVE_SMOKE_EVIDENCE_STATUSES,
+        name=f"{name}.status",
+    )
+    artifact_path = entry.get("artifact_path")
+    if artifact_path is not None:
+        _require_safe_string(artifact_path, name=f"{name}.artifact_path")
+    if status in {"passed", "failed"} and artifact_path is None:
+        raise WorldForgeError(f"{name}.artifact_path is required for {status} evidence.")
+    skip_reason = entry.get("skip_reason")
+    if status in _SKIP_STATUSES or skip_reason is not None:
+        _require_non_empty_string(skip_reason, name=f"{name}.skip_reason")
+    limitations = entry.get("known_limitations")
+    if not isinstance(limitations, list):
+        raise WorldForgeError(f"{name}.known_limitations must be a list.")
+    for index, limitation in enumerate(limitations):
+        _require_non_empty_string(limitation, name=f"{name}.known_limitations[{index}]")
+    _reject_unsafe_values(entry, name=f"{name} ({provider})")
+    return entry
+
+
+def render_live_smoke_registry_table(payload: Mapping[str, Any]) -> list[str]:
+    """Render a validated registry as Markdown table rows."""
+
+    registry = validate_live_smoke_registry(payload)
+    lines = [
+        "| Provider | Capability | Status | Evidence |",
+        "| --- | --- | --- | --- |",
+    ]
+    for entry in registry["entries"]:
+        evidence = entry.get("artifact_path") or entry.get("skip_reason") or "not recorded"
+        lines.append(
+            f"| `{entry['provider']}` | `{entry['capability']}` | {entry['status']} | {evidence} |"
+        )
+    return lines
+
+
+def _reject_unsafe_values(value: object, *, name: str) -> None:
+    if isinstance(value, str):
+        if _redact_observable_value(value) != value:
+            raise WorldForgeError(f"{name} contains secret-like material.")
+        sanitized = _sanitize_observable_target(value)
+        if sanitized != value:
+            raise WorldForgeError(f"{name} contains an unsafe URL.")
+    elif isinstance(value, list):
+        for index, item in enumerate(value):
+            _reject_unsafe_values(item, name=f"{name}[{index}]")
+    elif isinstance(value, dict):
+        for key, item in value.items():
+            if _redact_observable_value("", key=str(key)) != "":
+                raise WorldForgeError(f"{name}.{key} is a secret-like field.")
+            _reject_unsafe_values(item, name=f"{name}.{key}")
+
+
+def _require_safe_string(value: object, *, name: str) -> str:
+    text = _require_non_empty_string(value, name=name)
+    if _sanitize_observable_target(text) != text:
+        raise WorldForgeError(f"{name} must not contain signed URL query strings or fragments.")
+    return text
+
+
+def _require_non_empty_string(value: object, *, name: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise WorldForgeError(f"{name} must be a non-empty string.")
+    return value
+
+
+def _require_choice(value: object, choices: frozenset[str], *, name: str) -> str:
+    if not isinstance(value, str) or value not in choices:
+        formatted = ", ".join(sorted(choices))
+        raise WorldForgeError(f"{name} must be one of: {formatted}.")
+    return value
+
+
+__all__ = [
+    "LIVE_SMOKE_EVIDENCE_SCHEMA_VERSION",
+    "LIVE_SMOKE_EVIDENCE_STATUSES",
+    "render_live_smoke_registry_table",
+    "validate_live_smoke_entry",
+    "validate_live_smoke_registry",
+]

--- a/tests/test_docs_site.py
+++ b/tests/test_docs_site.py
@@ -433,6 +433,28 @@ def test_spatial_scene_artifact_boundary_covers_issue_138_contract() -> None:
     assert "Spatial Scene Artifact Boundary" in continuation
 
 
+def test_live_smoke_evidence_registry_docs_cover_issue_144_contract() -> None:
+    registry_doc = (ROOT / "docs/src/live-smoke-evidence.md").read_text(encoding="utf-8")
+    registry_json = (ROOT / "docs/src/live-smoke-evidence.json").read_text(encoding="utf-8")
+    provider_index = (ROOT / "docs/src/providers/README.md").read_text(encoding="utf-8")
+    operations = (ROOT / "docs/src/operations.md").read_text(encoding="utf-8")
+    summary = (ROOT / "docs/src/SUMMARY.md").read_text(encoding="utf-8")
+    mkdocs = (ROOT / "mkdocs.yml").read_text(encoding="utf-8")
+
+    assert "Issue: [#144]" in registry_doc
+    assert "skipped_missing_runtime" in registry_doc
+    assert "skipped_missing_credentials" in registry_doc
+    assert "validate_live_smoke_registry" in registry_doc
+    assert "signed artifact URLs" in registry_doc
+    assert "It is not a" in registry_doc
+    assert "benchmark" in registry_doc
+    assert "skipped_missing_credentials" in registry_json
+    assert "Live Smoke Evidence Registry" in provider_index
+    assert "--live-smoke-registry docs/src/live-smoke-evidence.json" in operations
+    assert "[Live Smoke Evidence Registry](./live-smoke-evidence.md)" in summary
+    assert "Live Smoke Evidence Registry: live-smoke-evidence.md" in mkdocs
+
+
 def test_genie_scaffold_docs_record_runtime_contract_defer_decision() -> None:
     provider_page = (ROOT / "docs/src/providers/genie.md").read_text(encoding="utf-8")
     provider_index = (ROOT / "docs/src/providers/README.md").read_text(encoding="utf-8")

--- a/tests/test_live_smoke_evidence.py
+++ b/tests/test_live_smoke_evidence.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from worldforge import (
+    LIVE_SMOKE_EVIDENCE_SCHEMA_VERSION,
+    LIVE_SMOKE_EVIDENCE_STATUSES,
+    WorldForgeError,
+    render_live_smoke_registry_table,
+    validate_live_smoke_entry,
+    validate_live_smoke_registry,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+REGISTRY_PATH = ROOT / "docs" / "src" / "live-smoke-evidence.json"
+SCRIPT = ROOT / "scripts" / "generate_release_evidence.py"
+SPEC = importlib.util.spec_from_file_location("generate_release_evidence_for_registry", SCRIPT)
+assert SPEC is not None
+generate_release_evidence = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+sys.modules["generate_release_evidence_for_registry"] = generate_release_evidence
+SPEC.loader.exec_module(generate_release_evidence)
+
+
+def _registry() -> dict[str, object]:
+    return json.loads(REGISTRY_PATH.read_text(encoding="utf-8"))
+
+
+def test_docs_live_smoke_registry_validates_and_records_first_class_skips() -> None:
+    registry = validate_live_smoke_registry(_registry())
+
+    assert registry["schema_version"] == LIVE_SMOKE_EVIDENCE_SCHEMA_VERSION
+    statuses = {entry["status"] for entry in registry["entries"]}
+    assert "skipped_missing_runtime" in statuses
+    assert "skipped_missing_credentials" in statuses
+    assert "not_run" in statuses
+    assert statuses <= LIVE_SMOKE_EVIDENCE_STATUSES
+
+    providers = {(entry["provider"], entry["capability"]) for entry in registry["entries"]}
+    assert ("runway", "generate") in providers
+    assert ("jepa-wms", "score") in providers
+
+    for entry in registry["entries"]:
+        if entry["status"].startswith("skipped") or entry["status"] == "not_run":
+            assert entry["skip_reason"]
+            assert entry["artifact_path"] is None
+        assert entry["command"]
+        assert entry["known_limitations"]
+
+
+def test_live_smoke_registry_rejects_unsafe_entries() -> None:
+    entry = {
+        "provider": "runway",
+        "capability": "generate",
+        "command": "uv run worldforge-smoke-runway",
+        "runtime_manifest": "runway:schema-1",
+        "date": "2026-05-05",
+        "version": "0.5.0",
+        "status": "passed",
+        "artifact_path": "https://example.test/run_manifest.json?token=secret",
+        "skip_reason": None,
+        "known_limitations": ["fixture"],
+    }
+
+    with pytest.raises(WorldForgeError, match="query strings"):
+        validate_live_smoke_entry(entry)
+
+    entry = {**entry, "artifact_path": ".worldforge/runs/runway/run_manifest.json"}
+    entry["secret_token"] = "redacted"
+
+    with pytest.raises(WorldForgeError, match="secret-like field"):
+        validate_live_smoke_entry(entry)
+
+
+def test_live_smoke_registry_requires_skip_reasons_and_artifacts() -> None:
+    skipped = {
+        "provider": "cosmos",
+        "capability": "generate",
+        "command": "uv run worldforge-smoke-cosmos",
+        "runtime_manifest": "cosmos:schema-1",
+        "date": "2026-05-05",
+        "version": "0.5.0",
+        "status": "skipped_missing_runtime",
+        "artifact_path": None,
+        "skip_reason": "",
+        "known_limitations": ["fixture"],
+    }
+
+    with pytest.raises(WorldForgeError, match="skip_reason"):
+        validate_live_smoke_entry(skipped)
+
+    passed = {**skipped, "status": "passed", "skip_reason": None}
+
+    with pytest.raises(WorldForgeError, match="artifact_path"):
+        validate_live_smoke_entry(passed)
+
+
+def test_release_evidence_can_include_registry_without_manual_copy_paste(tmp_path: Path) -> None:
+    registry = validate_live_smoke_registry(_registry())
+    report = generate_release_evidence.render_release_evidence(
+        output=tmp_path / "release-evidence.md",
+        manifests=(),
+        benchmark_artifacts=(),
+        artifacts=(),
+        live_smoke_registry=registry,
+    )
+
+    assert "## Live Smoke Evidence Registry" in report
+    assert "| `runway` | `generate` | skipped_missing_credentials |" in report
+    assert "requires RUNWAYML_API_SECRET or RUNWAY_API_SECRET" in report
+
+
+def test_live_smoke_registry_markdown_renderer_is_stable() -> None:
+    lines = render_live_smoke_registry_table(_registry())
+
+    assert lines[0] == "| Provider | Capability | Status | Evidence |"
+    assert any("skipped_missing_runtime" in line for line in lines)

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -35,6 +35,8 @@ def test_top_level_exports_and_subpackages_import() -> None:
     assert worldforge.RunnableModel is not None
     assert worldforge.GenerationOptions is not None
     assert worldforge.GenerationEvaluationSuite is not None
+    assert worldforge.LIVE_SMOKE_EVIDENCE_SCHEMA_VERSION == 1
+    assert "skipped_missing_runtime" in worldforge.LIVE_SMOKE_EVIDENCE_STATUSES
     assert worldforge.ProviderEvent is not None
     assert worldforge.ProviderBenchmarkHarness is not None
     assert worldforge.ProviderBudgetExceededError is not None
@@ -53,6 +55,8 @@ def test_top_level_exports_and_subpackages_import() -> None:
     assert worldforge.WorldForgeError is not None
     assert worldforge.WorldStateError is not None
     assert worldforge.SceneObjectPatch is not None
+    assert worldforge.render_live_smoke_registry_table is not None
+    assert worldforge.validate_live_smoke_registry is not None
     assert worldforge.validate_scene_artifact is not None
     assert worldforge.load_benchmark_budgets is not None
     assert worldforge.load_benchmark_inputs is not None


### PR DESCRIPTION
## Problem
Optional live-smoke results are preserved per run, but maintainers need one safe registry that records which providers have evidence and which were skipped.

## Solution
- Added a docs-backed `docs/src/live-smoke-evidence.json` registry and `docs/src/live-smoke-evidence.md` operator guidance.
- Added `worldforge.live_smoke_evidence` validators/rendering helpers with first-class `skipped_missing_runtime` and `skipped_missing_credentials` statuses.
- Linked the registry from provider docs, operations, playbooks, roadmap continuation, docs nav, and changelog.
- Extended `scripts/generate_release_evidence.py` with `--live-smoke-registry`, defaulting to the docs registry, so release evidence includes the registry without manual copy-paste.
- Added regression tests for schema validation, unsafe registry rejection, skip semantics, release-evidence rendering, docs wiring, and public lazy exports.

## Validation
- `uv run pytest tests/test_live_smoke_evidence.py tests/test_smoke_run_manifest.py`
- `uv run pytest tests/test_live_smoke_evidence.py tests/test_smoke_run_manifest.py tests/test_release_evidence.py tests/test_docs_site.py tests/test_public_api.py -q`
- `uv run pytest`
- `uv run ruff check src tests examples scripts`
- `uv run ruff format --check src tests examples scripts`
- `uv run python scripts/generate_provider_docs.py --check`
- `uv run mkdocs build --strict`
- `bash scripts/test_package.sh`
- `git diff --check`

Closes #144