### PR TITLE
Add public claim evidence map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ releases may still include breaking changes when the public API needs to tighten
 
 ### Added
 
+- Added a claim-to-evidence map for public README-level claims, capability surfaces, runtime
+  boundaries, preserved artifacts, and explicit non-claims.
 - Added five named benchmark presets — `mock-smoke`, `parser-overhead`, `remote-media-dryrun`,
   `prepared-host`, and `release-evidence` — exposed through new `worldforge benchmark
   --list-presets`, `--show-preset`, and `--preset` flags. Presets bundle a deterministic input

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ controllers, and deployment host-owned.
 [**Capability Model**](#capability-model) ·
 [**Architecture**](#architecture) ·
 [**Quality**](https://abdelstark.github.io/worldforge/quality/) ·
+[**Evidence**](https://abdelstark.github.io/worldforge/claim-evidence-map/) ·
 [**Docs**](https://abdelstark.github.io/worldforge/) ·
 [**Playbooks**](https://abdelstark.github.io/worldforge/playbooks/) ·
 [**Support**](./SUPPORT.md) ·
@@ -176,6 +177,8 @@ Planning, evaluation, benchmarks, diagnostics, and persistence are built on top 
 not on any specific runtime.
 Benchmark budget files can turn success rate, error count, retry count, latency, and throughput
 thresholds into non-zero CLI gates for release checks or preserved benchmark claims.
+The [claim-to-evidence map](https://abdelstark.github.io/worldforge/claim-evidence-map/) links
+public capability and runtime claims to concrete tests, commands, artifacts, and non-claims.
 
 WorldForge is not a hosted service, a model API abstraction, or a training framework. Optional
 runtimes, robot stacks, credentials, checkpoints, and durable storage remain the host

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -27,6 +27,7 @@
 - [Provider Cohort Selection Record](./provider-cohort-selection.md)
 - [Spatial Scene Artifact Boundary](./spatial-scene-artifact-boundary.md)
 - [Live Smoke Evidence Registry](./live-smoke-evidence.md)
+- [Claim-To-Evidence Map](./claim-evidence-map.md)
 - [Python API](./api/python.md)
 - [Evaluation](./evaluation.md)
 - [Benchmarking](./benchmarking.md)

--- a/docs/src/claim-evidence-map.md
+++ b/docs/src/claim-evidence-map.md
@@ -1,0 +1,75 @@
+# Claim-To-Evidence Map
+
+Issue: [#140](https://github.com/AbdelStark/worldforge/issues/140)
+
+Status: active public evidence map.
+
+This page maps public WorldForge claims to the evidence class that supports them. Use it when
+citing README claims in issues, release evidence, or provider promotion reviews. It does not add
+new benchmark numbers, broaden provider capabilities, or turn deterministic checks into physical
+fidelity claims.
+
+## Evidence Classes
+
+| Class | Meaning | Expected evidence |
+| --- | --- | --- |
+| `checkout-tested` | Runs from a clean checkout without credentials, network, GPUs, or optional model runtimes. | Local pytest, CLI, docs, and package commands. |
+| `fixture-tested` | Covered by synthetic JSON fixtures or recorded parser fixtures that stay in the repository. | `tests/fixtures/`, `worldforge.testing` fixtures, provider parser tests, or contract helpers. |
+| `prepared-host smoke-tested` | Requires host-owned credentials, checkpoints, optional runtimes, or robot/model assets. | A documented command plus sanitized `run_manifest.json` or live-smoke registry row. |
+| `release-gated` | Part of release evidence or CI quality gates. | Coverage, package contract, benchmark preset, docs build, or release evidence report. |
+| `deferred` | A design or scaffold exists, but executable public behavior is intentionally withheld. | Explicit blocker, revisit trigger, or fail-closed scaffold docs. |
+| `unsupported` | WorldForge does not claim or own this behavior. | Public non-claim and first routing step to host or upstream owner. |
+
+## Capability Claims
+
+| Public claim | Evidence class | Evidence | Command or artifact | Boundary |
+| --- | --- | --- | --- | --- |
+| `predict` is a provider capability for state rollout. | `checkout-tested` | `tests/test_world_lifecycle.py`, `tests/test_provider_contracts.py`, `tests/test_capability_fixtures.py` | `uv run worldforge world predict <world-id> --object-id <object-id> --x 0.4 --y 0.5 --z 0` | Built-in deterministic checks do not prove physical fidelity. |
+| `score` ranks action candidates for score-model workflows. | `fixture-tested`; `prepared-host smoke-tested` for real runtimes | `tests/test_leworldmodel_provider.py`, `tests/test_jepa_provider.py`, `tests/test_jepa_wms_provider.py`, `tests/fixtures/providers/*score*` | `uv run worldforge-demo-leworldmodel`; live-smoke registry rows for `leworldmodel`, `jepa`, and `jepa-wms` | Tensors, checkpoints, preprocessing, and devices stay host-owned. |
+| `policy` returns embodiment-specific action chunks. | `fixture-tested`; `prepared-host smoke-tested` for real runtimes | `tests/test_lerobot_provider.py`, `tests/test_gr00t_provider.py`, `tests/test_provider_contracts.py` | `scripts/robotics-showcase --json-only --no-tui --no-rerun`; uploaded `run_manifest.json` in live robotics CI | WorldForge preserves raw actions and requires host-owned translators before executable actions. |
+| `generate` produces media artifacts. | `checkout-tested`; `fixture-tested`; `prepared-host smoke-tested` for remote APIs | `tests/test_cosmos_provider.py`, `tests/test_runway_provider.py`, `tests/test_remote_video_providers.py` | `uv run worldforge benchmark --preset remote-media-dryrun` on a configured host | Returned media is an artifact contract, not a quality or safety claim. |
+| `transfer` transforms a media artifact. | `checkout-tested`; `fixture-tested` | `tests/test_remote_video_providers.py`, `tests/test_provider_contracts.py`, `src/worldforge/testing/fixtures/transfer/` | `uv run worldforge benchmark --provider mock --operation transfer --input-file examples/benchmark-inputs.json` | Remote transfer requires provider credentials and artifact retention by the host. |
+| `reason` and `embed` are narrow mock-supported capability surfaces. | `checkout-tested` | `tests/test_provider_contracts.py`, `tests/test_capability_fixtures.py`, `tests/test_benchmark.py` | `uv run worldforge benchmark --preset parser-overhead` | They are contract and adapter-path checks, not general-purpose LLM or embedding quality claims. |
+| `plan` is a WorldForge facade over composed surfaces. | `checkout-tested` | `tests/test_evaluation_and_planning.py`, `tests/test_capability_dual_routing.py` | `uv run worldforge eval --suite planning --provider mock --format json` | `plan` is not advertised as a provider-owned capability by default. |
+
+## Provider And Runtime Claims
+
+| Public claim | Evidence class | Evidence | Command or artifact | Boundary |
+| --- | --- | --- | --- | --- |
+| The `mock` provider is stable and deterministic. | `checkout-tested`; `release-gated` | `tests/test_provider_contracts.py`, `tests/test_benchmark_presets.py` | `uv run worldforge benchmark --preset mock-smoke` | Synthetic provider behavior is not runtime fidelity evidence. |
+| Cosmos and Runway are remote media adapters. | `fixture-tested`; `prepared-host smoke-tested` when configured | `tests/fixtures/providers/cosmos_*.json`, `tests/fixtures/providers/runway_*.json`, provider docs | `uv run worldforge benchmark --preset remote-media-dryrun` | Credentials, upstream availability, returned artifact retention, and paid usage stay host-owned. |
+| LeWorldModel exposes `score`. | `fixture-tested`; `prepared-host smoke-tested` | `tests/test_leworldmodel_provider.py`, `tests/test_lerobot_leworldmodel_smoke_script.py`, live-smoke registry | `scripts/robotics-showcase --json-only --no-tui --no-rerun` | `stable-worldmodel`, torch, checkpoints, tensors, and device behavior are optional runtime concerns. |
+| LeRobot and GR00T expose `policy`. | `fixture-tested`; `prepared-host smoke-tested` | `tests/test_lerobot_provider.py`, `tests/test_gr00t_provider.py`, live-smoke registry | `scripts/robotics-showcase` for LeRobot; `scripts/smoke_gr00t_policy.py --help` for GR00T setup | Robot controllers, safety checks, and action translators are host-owned. |
+| JEPA is experimental and score-only. | `fixture-tested`; `prepared-host smoke-tested` only when host evidence exists | `tests/test_jepa_provider.py`, `tests/test_jepa_wms_provider.py`, runtime manifest docs | `uv run worldforge-smoke-jepa-wms --help` | Torch-hub runtime, weights, preprocessing, and license review stay host-owned. |
+| Genie is a scaffold reservation. | `deferred` | `tests/test_remote_scaffold_providers.py`, `docs/src/providers/genie.md` | Revisit trigger in the Genie provider docs | No public automation API contract is claimed; scaffold behavior remains fail-closed. |
+| Nano World Model is a candidate, not a provider surface. | `deferred` | `docs/src/provider-cohort-selection.md` | Follow the assigned candidate issue before any catalog claim | No `nanowm` provider is exported or auto-registered. |
+
+## Workflow And Artifact Claims
+
+| Public claim | Evidence class | Evidence | Command or artifact | Boundary |
+| --- | --- | --- | --- | --- |
+| Evaluation reports carry provenance and claim boundaries. | `checkout-tested`; `release-gated` | `tests/test_provenance.py`, `tests/test_evaluation_and_planning.py`, `docs/src/evaluation.md` | `uv run worldforge eval --suite planning --provider mock --format json` | Scores are deterministic contract signals, not physical or media-quality metrics. |
+| Benchmark reports carry provenance, budgets, and preset gates. | `checkout-tested`; `release-gated` | `tests/test_benchmark.py`, `tests/test_benchmark_presets.py`, `docs/src/benchmarking.md` | `uv run worldforge benchmark --preset release-evidence --format json --run-workspace .worldforge` | Timings are process-local adapter-path measurements, not machine-independent performance claims. |
+| Live-smoke evidence is indexed in a publishable registry. | `prepared-host smoke-tested`; `release-gated` | `tests/test_live_smoke_evidence.py`, `docs/src/live-smoke-evidence.json` | `uv run python scripts/generate_release_evidence.py --live-smoke-registry docs/src/live-smoke-evidence.json` | Missing optional runtimes or credentials are explicit skip states, not silent omissions. |
+| Rerun records sanitized events and artifacts when the extra is installed. | `checkout-tested`; `prepared-host smoke-tested` for robotics showcase | `tests/test_rerun_integration.py`, `tests/test_robotics_showcase.py` | `uv run --extra rerun worldforge-demo-rerun`; `/tmp/worldforge-robotics-showcase/real-run.rrd` | Rerun is optional observability, not a provider capability or base dependency. |
+| TheWorldHarness is optional and Textual-isolated. | `checkout-tested`; `release-gated` | `tests/test_harness_flows.py`, `tests/test_harness_cli.py`, `tests/test_harness_tui.py` | `uv run --extra harness worldforge-harness` | Non-TUI flow logic stays independent from Textual imports. |
+| Local JSON persistence is the authoritative built-in store. | `checkout-tested` | `tests/test_world_lifecycle.py`, `tests/test_cli_world_commands.py`, persistence ADR | `uv run worldforge world export <world-id> --output world.json` | It is not a concurrent multi-writer database or service-grade durable store. |
+| Quality gates run on Python 3.13 with coverage, docs, package, and lint checks. | `release-gated` | `.github/workflows/ci.yml`, `scripts/test_package.sh`, `docs/src/quality.md` | `uv run --extra harness pytest --cov=src/worldforge --cov-report=term-missing --cov-fail-under=90` | Passing gates does not expand runtime capability claims. |
+
+## Unsupported Or Non-Claims
+
+| Non-claim | Evidence class | First routing step |
+| --- | --- | --- |
+| Physical fidelity, media quality, robot safety certification, or real-world control safety. | `unsupported` | Treat the WorldForge report as adapter evidence only; use task-specific host evaluation and safety review. |
+| Upstream provider SLA, paid API availability, rate limits, credential management, or artifact retention. | `unsupported` | Check the provider's upstream status, credentials, and host retention policy. |
+| Training LeWorldModel, JEPA, NanoWM, GR00T, LeRobot, or any other model inside WorldForge. | `unsupported` | Use the upstream training repository and keep artifacts out of the WorldForge base package. |
+| Service-grade persistence, database migrations, lock files, or multi-writer storage. | `unsupported` | Follow the persistence adapter boundary ADR before introducing a host-owned store. |
+| Hosted dashboard, telemetry service, queue, deployment, auth, or alerting. | `unsupported` | Implement these in the host application and attach sanitized WorldForge run artifacts. |
+
+## Usage
+
+For issue or release notes, cite the row by claim and include the matching command or artifact.
+Expected success signals are the explicit test pass count, a benchmark gate with `Status: passed`,
+or a validated `run_manifest.json`. If the command fails, the first triage step is to open the
+linked docs page for that row and check whether the provider is checkout-safe, fixture-backed,
+credentialed, prepared-host, deferred, or unsupported.

--- a/docs/src/roadmap-continuation.md
+++ b/docs/src/roadmap-continuation.md
@@ -500,10 +500,10 @@ Out of scope:
 
 Acceptance criteria:
 
-- [ ] Every README-level capability claim has a corresponding evidence class.
-- [ ] Unsupported or deferred claims are visible and specific.
-- [ ] Docs route users to preserved artifacts or commands instead of vague confidence language.
-- [ ] MkDocs strict build passes with nav and SUMMARY synchronized.
+- [x] Every README-level capability claim has a corresponding evidence class.
+- [x] Unsupported or deferred claims are visible and specific.
+- [x] Docs route users to preserved artifacts or commands instead of vague confidence language.
+- [x] MkDocs strict build passes with nav and SUMMARY synchronized.
 
 Validation:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -67,6 +67,7 @@ nav:
   - Provider Cohort Selection Record: provider-cohort-selection.md
   - Spatial Scene Artifact Boundary: spatial-scene-artifact-boundary.md
   - Live Smoke Evidence Registry: live-smoke-evidence.md
+  - Claim-To-Evidence Map: claim-evidence-map.md
   - Python API: api/python.md
   - Evaluation: evaluation.md
   - Benchmarking: benchmarking.md

--- a/tests/test_docs_site.py
+++ b/tests/test_docs_site.py
@@ -455,6 +455,59 @@ def test_live_smoke_evidence_registry_docs_cover_issue_144_contract() -> None:
     assert "Live Smoke Evidence Registry: live-smoke-evidence.md" in mkdocs
 
 
+def test_claim_to_evidence_map_covers_issue_140_contract() -> None:
+    claim_map = (ROOT / "docs/src/claim-evidence-map.md").read_text(encoding="utf-8")
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    continuation = (ROOT / "docs/src/roadmap-continuation.md").read_text(encoding="utf-8")
+    summary = (ROOT / "docs/src/SUMMARY.md").read_text(encoding="utf-8")
+    mkdocs = (ROOT / "mkdocs.yml").read_text(encoding="utf-8")
+
+    assert "Issue: [#140]" in claim_map
+    for evidence_class in (
+        "`checkout-tested`",
+        "`fixture-tested`",
+        "`prepared-host smoke-tested`",
+        "`release-gated`",
+        "`deferred`",
+        "`unsupported`",
+    ):
+        assert evidence_class in claim_map
+
+    for capability in (
+        "`predict`",
+        "`score`",
+        "`policy`",
+        "`generate`",
+        "`transfer`",
+        "`reason`",
+        "`embed`",
+        "`plan`",
+    ):
+        assert capability in claim_map
+
+    for non_claim in (
+        "Physical fidelity",
+        "robot safety certification",
+        "Upstream provider SLA",
+        "Training LeWorldModel",
+        "Service-grade persistence",
+    ):
+        assert non_claim in claim_map
+
+    for route in (
+        "uv run worldforge benchmark --preset mock-smoke",
+        "scripts/robotics-showcase --json-only --no-tui --no-rerun",
+        "uv run python scripts/generate_release_evidence.py",
+        "docs/src/live-smoke-evidence.json",
+    ):
+        assert route in claim_map
+
+    assert "claim-to-evidence map" in readme
+    assert "[Claim-To-Evidence Map](./claim-evidence-map.md)" in summary
+    assert "Claim-To-Evidence Map: claim-evidence-map.md" in mkdocs
+    assert "- [x] Every README-level capability claim" in continuation
+
+
 def test_genie_scaffold_docs_record_runtime_contract_defer_decision() -> None:
     provider_page = (ROOT / "docs/src/providers/genie.md").read_text(encoding="utf-8")
     provider_index = (ROOT / "docs/src/providers/README.md").read_text(encoding="utf-8")


### PR DESCRIPTION
## Problem

Public docs make capability, provider, runtime, benchmark, and quality claims across the README and docs, but there was no single page mapping those claims to concrete evidence, limitations, and non-claims.

## Solution

- Add `docs/src/claim-evidence-map.md` with evidence classes for checkout-tested, fixture-tested, prepared-host smoke-tested, release-gated, deferred, and unsupported claims.
- Map README-level capability, provider/runtime, workflow, artifact, and quality claims to tests, commands, artifacts, and boundaries.
- Link the page from the README and wire it into MkDocs navigation and `SUMMARY.md`.
- Mark WF-B4 complete in the roadmap continuation page and add docs-site regression coverage.

## Validation

```bash
uv run pytest tests/test_docs_site.py
uv run mkdocs build --strict
uv run ruff check src tests examples scripts
uv run ruff format --check src tests examples scripts
uv run python scripts/generate_provider_docs.py --check
uv run pytest
git diff --check
```

`uv run pytest` passed with 743 tests.

Closes #140