### PR TITLE
Add adapter author workbench flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ releases may still include breaking changes when the public API needs to tighten
 
 ### Added
 
+- Added an adapter author workbench flow for provider promotion evidence. The non-Textual
+  workbench now handles catalog providers, scaffold providers, and the direct-construction
+  `jepa-wms` candidate; reports include runtime manifest status, fixture coverage, docs/catalog
+  drift, redaction checks, promotion gaps by target status, safe artifact references, and validation
+  commands, and `worldforge harness --flow workbench` exposes the same logic through TheWorldHarness.
 - Added cross-provider run comparisons for preserved eval and benchmark workspaces. `worldforge
   runs compare` now exports a shared JSON/Markdown/CSV model with provider rows, capability and
   operation context, fixture digest, suite version, budget status, event counts, missing evidence,

--- a/docs/src/provider-authoring-guide.md
+++ b/docs/src/provider-authoring-guide.md
@@ -48,14 +48,19 @@ Before opening a provider PR, run the non-TUI workbench from a clean checkout:
 ```bash
 uv run worldforge provider workbench mock
 uv run worldforge provider workbench <provider> --format json
+uv run worldforge provider workbench jepa-wms --format markdown
 uv run python scripts/generate_provider_docs.py --check
 ```
 
-The report lists the conformance helper required for every advertised capability, validates
-`tests/fixtures/providers/<provider>_*.json` playback files when they exist, links this guide, and
-prints a pasteable issue summary. It invokes only deterministic local providers by default. Use
-`--live` only on a prepared host when credentials, optional dependencies, injected runtimes, and
-runtime-owned artifacts are intentionally available.
+The report lists the conformance helper required for every advertised capability, planned
+capabilities for scaffold/candidate adapters, runtime manifest status, docs/catalog drift status,
+redaction checks, safe artifact references, and validation commands. It validates
+`tests/fixtures/providers/<provider>_*.json` playback files when they exist, including module-safe
+prefixes such as `jepa_wms_*.json` for direct-construction candidates. It also names missing
+promotion evidence by future status (`experimental`, `beta`, `stable`) so a scaffold gap is visible
+without turning into an accidental capability claim. It invokes only deterministic local providers
+by default. Use `--live` only on a prepared host when credentials, optional dependencies, injected
+runtimes, and runtime-owned artifacts are intentionally available.
 
 ## Adapter Decision Tree
 

--- a/docs/src/roadmap-continuation.md
+++ b/docs/src/roadmap-continuation.md
@@ -693,10 +693,10 @@ Out of scope:
 
 Acceptance criteria:
 
-- [ ] Workbench can run against `mock` and at least one scaffold/candidate in a clean checkout.
-- [ ] Output names missing evidence by promotion status.
-- [ ] Markdown output includes validation commands and safe artifact references.
-- [ ] TUI and CLI workbench views use the same non-Textual flow logic.
+- [x] Workbench can run against `mock` and at least one scaffold/candidate in a clean checkout.
+- [x] Output names missing evidence by promotion status.
+- [x] Markdown output includes validation commands and safe artifact references.
+- [x] TUI and CLI workbench views use the same non-Textual flow logic.
 
 Validation:
 

--- a/docs/src/theworldharness.md
+++ b/docs/src/theworldharness.md
@@ -97,6 +97,7 @@ The diagnostics, eval, and benchmark screens map directly to non-TUI commands:
 uv run worldforge doctor --registered-only
 uv run worldforge provider list
 uv run worldforge provider workbench mock
+uv run worldforge harness --flow workbench
 uv run worldforge benchmark --provider mock --iterations 2 --format json
 uv run worldforge eval --suite planning --provider mock --format json
 ```
@@ -105,23 +106,32 @@ uv run worldforge eval --suite planning --provider mock --format json
 
 `worldforge provider workbench <provider>` is the checkout-safe adapter author loop behind the
 harness provider development workflow. It does not import Textual and does not make live provider
-calls unless `--live` is passed explicitly. The default report is designed to paste into GitHub
-issues: provider profile, required capability conformance helpers, fixture JSON status, docs/catalog
-drift hints, redaction-safe provider event status, and exact follow-up commands.
+calls unless `--live` is passed explicitly. The same non-Textual report model powers the
+`worldforge harness --flow workbench` TUI path. The default report is designed to paste into GitHub
+issues or PR descriptions: provider profile, target source, required capability conformance helpers,
+planned capability surface, runtime manifest status, fixture JSON status, docs/catalog drift hints,
+redaction-safe provider event status, promotion evidence grouped by future status, safe artifact
+references, and exact validation commands.
 
 ```bash
 uv run worldforge provider workbench mock
+uv run worldforge provider workbench jepa-wms --format markdown
+uv run worldforge provider workbench genie --format json
 uv run worldforge provider workbench runway --format json
 uv run worldforge provider workbench runway --live
+uv run worldforge harness --flow workbench
 ```
 
 For deterministic local providers such as `mock`, the workbench invokes the advertised capability
-helpers. For HTTP adapters it validates matching `tests/fixtures/providers/<provider>_*.json`
-playback files and lists the capability helpers that the provider test module must cover. For
-host-owned local runtimes such as LeRobot and LeWorldModel, the default path inspects profile,
-health, docs, and fixtures while leaving injected-runtime/live smoke execution to prepared hosts.
-Run `uv run python scripts/generate_provider_docs.py --check` before opening a provider PR so
-profile metadata and generated catalog tables stay in sync.
+helpers. For scaffold or direct-construction candidates such as `genie` and `jepa-wms`, it names
+missing evidence by promotion status instead of implying the provider is ready. For HTTP adapters it
+validates matching `tests/fixtures/providers/<provider>_*.json` or Python module-safe fixture
+prefixes such as `jepa_wms_*.json`, and lists the capability helpers that the provider test module
+must cover. For host-owned local runtimes such as LeRobot and LeWorldModel, the default path
+inspects profile, health, docs, runtime manifests, and fixtures while leaving injected-runtime/live
+smoke execution to prepared hosts. Run
+`uv run python scripts/generate_provider_docs.py --check` before opening a provider PR so profile
+metadata and generated catalog tables stay in sync.
 
 Completed checkout-safe flows also preserve a sanitized run workspace:
 

--- a/src/worldforge/harness/flows.py
+++ b/src/worldforge/harness/flows.py
@@ -67,6 +67,21 @@ FLOWS: tuple[HarnessFlow, ...] = (
             "mock provider benchmark matrix, and compare latency, throughput, and emitted events."
         ),
     ),
+    HarnessFlow(
+        id="workbench",
+        title="Adapter Author Workbench",
+        short_title="Workbench",
+        focus="adapter authoring evidence",
+        provider="Provider workbench",
+        capability="authoring",
+        command="uv run worldforge provider workbench mock",
+        accent="#f0a35e",
+        summary=(
+            "Run the checkout-safe provider workbench against the stable mock provider and the "
+            "direct-construction jepa-wms candidate, then collect promotion evidence, safe "
+            "artifact references, and validation commands."
+        ),
+    ),
 )
 
 
@@ -126,6 +141,50 @@ def _run_diagnostics_demo(*, state_dir: Path, emit: bool = False) -> JSONDict:
     return summary
 
 
+def _run_workbench_demo(*, state_dir: Path, emit: bool = False) -> JSONDict:
+    from worldforge.harness.workbench import (
+        provider_workbench_markdown,
+        provider_workbench_report,
+    )
+
+    reports = [
+        provider_workbench_report("mock", docs_root=Path.cwd()),
+        provider_workbench_report("jepa-wms", docs_root=Path.cwd()),
+    ]
+    providers = [str(report["provider"]) for report in reports]
+    passed = sum(1 for report in reports if report.get("status") == "passed")
+    safe_artifacts = [
+        artifact
+        for report in reports
+        for artifact in report.get("safe_artifacts", [])
+        if isinstance(artifact, dict)
+    ]
+    validation_commands = sorted(
+        {str(command) for report in reports for command in report.get("validation_commands", [])}
+    )
+    missing_by_provider = {
+        str(report["provider"]): report["promotion"]["missing_evidence_by_status"]
+        for report in reports
+    }
+    summary: JSONDict = {
+        "demo_kind": "provider_workbench",
+        "state_dir": str(state_dir),
+        "providers": providers,
+        "report_count": len(reports),
+        "passed_count": passed,
+        "failed_count": len(reports) - passed,
+        "reports": reports,
+        "safe_artifact_count": len(safe_artifacts),
+        "safe_artifacts": safe_artifacts,
+        "validation_commands": validation_commands,
+        "missing_evidence_by_provider": missing_by_provider,
+        "provider_events": [],
+    }
+    if emit:
+        print("\n\n".join(provider_workbench_markdown(report) for report in reports))
+    return summary
+
+
 # Demo modules import the optional-runtime provider classes at module scope, so
 # keep these imports lazy: loading the harness should not pull LeRobot/LeWorldModel
 # adapters into the base cold-start path.
@@ -145,6 +204,7 @@ _RUNNERS: dict[str, FlowRunner] = {
     "leworldmodel": _run_leworldmodel_demo,
     "lerobot": _run_lerobot_demo,
     "diagnostics": _run_diagnostics_demo,
+    "workbench": _run_workbench_demo,
 }
 
 
@@ -806,6 +866,43 @@ def _steps_for(flow_id: str, summary: JSONDict) -> tuple[HarnessStep, ...]:
                 "artifact=benchmark report json/markdown/csv",
             ),
         )
+    if flow_id == "workbench":
+        candidate_missing = summary["missing_evidence_by_provider"]["jepa-wms"]
+        return (
+            HarnessStep(
+                "Select authoring targets",
+                "Use one stable catalog provider and one direct-construction candidate.",
+                f"{', '.join(summary['providers'])} selected.",
+                "providers=mock,jepa-wms",
+            ),
+            HarnessStep(
+                "Run checkout-safe workbench",
+                "Invoke non-Textual provider_workbench_report without live provider calls.",
+                f"{summary['passed_count']}/{summary['report_count']} reports passed.",
+                "live=false",
+            ),
+            HarnessStep(
+                "Inspect promotion evidence",
+                "Group missing evidence by target promotion status.",
+                (
+                    "jepa-wms stable gaps: "
+                    f"{', '.join(candidate_missing.get('stable', [])) or 'none'}."
+                ),
+                "promotion=experimental,beta,stable",
+            ),
+            HarnessStep(
+                "Check runtime and fixtures",
+                "Read runtime manifest status and provider fixture coverage.",
+                f"{summary['safe_artifact_count']} safe artifact references collected.",
+                "fixtures=tests/fixtures/providers",
+            ),
+            HarnessStep(
+                "Render issue output",
+                "Preserve validation commands and safe artifact references for PRs or issues.",
+                f"{len(summary['validation_commands'])} validation commands listed.",
+                "format=markdown,json",
+            ),
+        )
     raise ValueError(f"unknown harness flow '{flow_id}'")
 
 
@@ -844,6 +941,36 @@ def _metrics_for(flow_id: str, summary: JSONDict) -> tuple[HarnessMetric, ...]:
                 "Events",
                 str(summary["benchmark_event_count"]),
                 "provider events captured during benchmark samples",
+            ),
+        )
+    if flow_id == "workbench":
+        candidate_missing = summary["missing_evidence_by_provider"]["jepa-wms"]
+        stable_missing = candidate_missing.get("stable", [])
+        return (
+            HarnessMetric(
+                "Targets",
+                str(summary["report_count"]),
+                ", ".join(summary["providers"]),
+            ),
+            HarnessMetric(
+                "Passed",
+                f"{summary['passed_count']}/{summary['report_count']}",
+                "checkout-safe reports",
+            ),
+            HarnessMetric(
+                "Candidate gaps",
+                str(len(stable_missing)),
+                ", ".join(stable_missing) or "none",
+            ),
+            HarnessMetric(
+                "Artifacts",
+                str(summary["safe_artifact_count"]),
+                "safe issue references",
+            ),
+            HarnessMetric(
+                "Commands",
+                str(len(summary["validation_commands"])),
+                "validation commands",
             ),
         )
 
@@ -885,6 +1012,16 @@ def _transcript_for(flow_id: str, summary: JSONDict) -> tuple[str, ...]:
             f"highest_throughput_operation: {summary['highest_throughput_operation']}",
             f"benchmark_event_count: {summary['benchmark_event_count']}",
             f"commands: {' | '.join(summary['commands'])}",
+        )
+    if flow_id == "workbench":
+        candidate_missing = summary["missing_evidence_by_provider"]["jepa-wms"]
+        return (
+            "flow: workbench",
+            f"providers: {', '.join(summary['providers'])}",
+            f"passed: {summary['passed_count']}/{summary['report_count']}",
+            f"jepa-wms_missing_stable: {', '.join(candidate_missing.get('stable', [])) or 'none'}",
+            f"safe_artifacts: {summary['safe_artifact_count']}",
+            f"validation_commands: {' | '.join(summary['validation_commands'])}",
         )
 
     lines = [

--- a/src/worldforge/harness/workbench.py
+++ b/src/worldforge/harness/workbench.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 import json
 from collections.abc import Callable
+from dataclasses import dataclass
 from pathlib import Path
 from time import perf_counter
 
 from worldforge.models import JSONDict, ProviderEvent, WorldForgeError
 from worldforge.providers import BaseProvider, ProviderError
 from worldforge.providers.catalog import DOC_CAPABILITY_ORDER, PROVIDER_CATALOG
+from worldforge.providers.runtime_manifest import load_runtime_manifest
 from worldforge.testing import (
     assert_embed_conformance,
     assert_generate_conformance,
@@ -22,6 +24,9 @@ from worldforge.testing import (
 AUTHORING_DOC = "docs/src/provider-authoring-guide.md"
 CATALOG_CHECK_COMMAND = "uv run python scripts/generate_provider_docs.py --check"
 FIXTURE_DOC = "tests/fixtures/providers/<provider>_*.json"
+PROVIDER_INDEX_DOC = "docs/src/providers/README.md"
+PROVIDER_COHORT_DOC = "docs/src/provider-cohort-selection.md"
+LIVE_SMOKE_EVIDENCE_DOC = "docs/src/live-smoke-evidence.json"
 
 _CONFORMANCE_HELPERS: dict[str, str] = {
     "predict": "assert_predict_conformance",
@@ -32,6 +37,43 @@ _CONFORMANCE_HELPERS: dict[str, str] = {
     "score": "assert_score_conformance",
     "policy": "assert_policy_conformance",
 }
+
+_PROMOTION_REQUIREMENTS: dict[str, tuple[str, ...]] = {
+    "experimental": (
+        "selection_record",
+        "docs_page",
+        "catalog_or_candidate_index",
+        "runtime_manifest",
+        "fixture_coverage",
+        "conformance_helpers",
+        "redaction_checks",
+    ),
+    "beta": (
+        "runtime_manifest",
+        "fixture_coverage",
+        "conformance_helpers",
+        "redaction_checks",
+        "prepared_host_smoke_record",
+    ),
+    "stable": (
+        "runtime_manifest",
+        "fixture_coverage",
+        "conformance_helpers",
+        "redaction_checks",
+        "prepared_host_smoke_artifact",
+        "release_evidence",
+    ),
+}
+
+_STATUS_ORDER = ("scaffold", "experimental", "beta", "stable")
+
+
+@dataclass(frozen=True, slots=True)
+class _WorkbenchTarget:
+    provider: BaseProvider
+    source: str
+    catalog_registered: bool
+    docs_page: str
 
 
 def provider_workbench_report(
@@ -49,45 +91,77 @@ def provider_workbench_report(
     """
 
     events: list[ProviderEvent] = []
-    provider = _create_catalog_provider(provider_name, events.append)
+    target = _create_workbench_target(provider_name, events.append)
+    provider = target.provider
     profile = provider.profile()
     docs_base = docs_root or Path.cwd()
     started = perf_counter()
 
     required_tests = _required_tests(provider)
+    planned_capabilities = _planned_capabilities(provider)
     health_report = _health_report(provider)
     invocation = _run_safe_conformance(provider, live=live)
     fixture_report = _fixture_report(provider.name, fixtures_dir=fixtures_dir)
-    docs_report = _docs_report(provider, docs_root=docs_base)
+    runtime_manifest_report = _runtime_manifest_report(provider.name)
+    docs_report = _docs_report(provider, docs_root=docs_base, target=target)
+    catalog_report = _catalog_report(provider.name, docs_root=docs_base, target=target)
     event_report = _event_report(events, provider=provider.name)
-
     checks = [
         _status_check(
             "profile",
             "passed",
-            f"{provider.name} advertises {', '.join(required_tests) or 'no'} capability tests.",
+            (
+                f"{provider.name} advertises {', '.join(required_tests) or 'no'} capability "
+                f"tests; planned capabilities: {', '.join(planned_capabilities) or 'none'}."
+            ),
         ),
         health_report,
         invocation,
         fixture_report,
+        runtime_manifest_report,
         docs_report,
+        catalog_report,
         event_report,
     ]
+    promotion_report = _promotion_report(
+        provider,
+        checks=checks,
+        docs_root=docs_base,
+        target=target,
+        required_tests=required_tests,
+        planned_capabilities=planned_capabilities,
+    )
+    checks.append(
+        _status_check(
+            "promotion_evidence",
+            "passed",
+            _promotion_detail(promotion_report),
+        )
+    )
+
     status = (
         "passed" if all(check["status"] in {"passed", "skipped"} for check in checks) else "failed"
     )
     return {
         "provider": provider.name,
+        "target_source": target.source,
+        "catalog_registered": target.catalog_registered,
         "status": status,
         "live": live,
         "duration_ms": round((perf_counter() - started) * 1000, 3),
         "profile": profile.to_dict(),
         "required_tests": required_tests,
+        "planned_capabilities": planned_capabilities,
+        "promotion": promotion_report,
         "checks": checks,
+        "safe_artifacts": _safe_artifacts(provider.name, checks=checks, target=target),
+        "validation_commands": _validation_commands(provider.name, docs_root=docs_base),
         "docs": {
             "authoring_guide": AUTHORING_DOC,
             "catalog_check": CATALOG_CHECK_COMMAND,
             "fixture_pattern": FIXTURE_DOC,
+            "provider_index": PROVIDER_INDEX_DOC,
+            "selection_record": PROVIDER_COHORT_DOC,
         },
         "issue_summary": _issue_summary(provider.name, checks),
     }
@@ -100,6 +174,8 @@ def provider_workbench_markdown(report: JSONDict) -> str:
         f"# Provider Workbench: `{report['provider']}`",
         "",
         f"- status: `{report['status']}`",
+        f"- target source: `{report['target_source']}`",
+        f"- catalog registered: `{str(report['catalog_registered']).lower()}`",
         f"- live calls: `{str(report['live']).lower()}`",
         f"- duration_ms: `{report['duration_ms']}`",
         "",
@@ -111,10 +187,47 @@ def provider_workbench_markdown(report: JSONDict) -> str:
         lines.extend(f"- `{test}`" for test in required_tests)
     else:
         lines.append("- none advertised")
+    planned_capabilities = report.get("planned_capabilities", [])
+    lines.extend(["", "## Planned Capability Surface", ""])
+    if isinstance(planned_capabilities, list) and planned_capabilities:
+        lines.extend(f"- `{capability}`" for capability in planned_capabilities)
+    else:
+        lines.append("- none declared")
     lines.extend(["", "## Checks", ""])
     lines.extend(
         f"- `{check['status']}` `{check['name']}`: {check['detail']}" for check in report["checks"]
     )
+    promotion = report["promotion"]
+    lines.extend(
+        [
+            "",
+            "## Promotion Evidence",
+            "",
+            f"- current status: `{promotion['current_status']}`",
+        ]
+    )
+    missing_by_status = promotion["missing_evidence_by_status"]
+    if isinstance(missing_by_status, dict) and missing_by_status:
+        lines.extend(
+            f"- missing for `{status}`: {', '.join(f'`{item}`' for item in missing) or 'none'}"
+            for status, missing in missing_by_status.items()
+        )
+    else:
+        lines.append("- no promotion gaps for the current status")
+    lines.extend(["", "## Safe Artifacts", ""])
+    safe_artifacts = report.get("safe_artifacts", [])
+    if isinstance(safe_artifacts, list) and safe_artifacts:
+        lines.extend(
+            f"- `{artifact['path']}`: {artifact['note']}"
+            for artifact in safe_artifacts
+            if isinstance(artifact, dict)
+        )
+    else:
+        lines.append("- no local artifacts were referenced")
+    lines.extend(["", "## Validation Commands", ""])
+    validation_commands = report.get("validation_commands", [])
+    if isinstance(validation_commands, list):
+        lines.extend(f"- `{command}`" for command in validation_commands)
     docs = report["docs"]
     lines.extend(
         [
@@ -133,15 +246,31 @@ def provider_workbench_markdown(report: JSONDict) -> str:
     return "\n".join(lines)
 
 
-def _create_catalog_provider(
+def _create_workbench_target(
     provider_name: str,
     event_handler: Callable[[ProviderEvent], None],
-) -> BaseProvider:
+) -> _WorkbenchTarget:
     for entry in PROVIDER_CATALOG:
         if entry.name == provider_name:
-            return entry.create(event_handler=event_handler)
+            return _WorkbenchTarget(
+                provider=entry.create(event_handler=event_handler),
+                source="provider_catalog",
+                catalog_registered=True,
+                docs_page=entry.docs_page or "README.md",
+            )
+    if provider_name == "jepa-wms":
+        from worldforge.providers.jepa_wms import JEPAWMSProvider
+
+        return _WorkbenchTarget(
+            provider=JEPAWMSProvider(event_handler=event_handler),
+            source="direct_construction_candidate",
+            catalog_registered=False,
+            docs_page="jepa-wms.md",
+        )
     valid = ", ".join(entry.name for entry in PROVIDER_CATALOG)
-    raise ProviderError(f"Provider '{provider_name}' is unknown. Valid providers: {valid}.")
+    raise ProviderError(
+        f"Provider '{provider_name}' is unknown. Valid providers: {valid}, jepa-wms."
+    )
 
 
 def _required_tests(provider: BaseProvider) -> list[str]:
@@ -150,6 +279,15 @@ def _required_tests(provider: BaseProvider) -> list[str]:
         _CONFORMANCE_HELPERS[capability]
         for capability in DOC_CAPABILITY_ORDER
         if profile.capabilities.supports(capability) and capability in _CONFORMANCE_HELPERS
+    ]
+
+
+def _planned_capabilities(provider: BaseProvider) -> list[str]:
+    planned = getattr(provider, "planned_capabilities", ())
+    return [
+        capability
+        for capability in DOC_CAPABILITY_ORDER
+        if isinstance(planned, tuple | list) and capability in planned
     ]
 
 
@@ -214,12 +352,14 @@ def _fixture_report(provider: str, *, fixtures_dir: Path | None) -> JSONDict:
     if not resolved_dir.exists():
         return _status_check("fixtures", "skipped", f"{resolved_dir} does not exist.")
 
-    fixture_paths = sorted(resolved_dir.glob(f"{provider}_*.json"))
+    patterns = _fixture_patterns(provider)
+    fixture_paths = sorted({path for pattern in patterns for path in resolved_dir.glob(pattern)})
     if not fixture_paths:
+        rendered_patterns = ", ".join(str(resolved_dir / pattern) for pattern in patterns)
         return _status_check(
             "fixtures",
             "skipped",
-            f"no fixture playback files matched {resolved_dir}/{provider}_*.json.",
+            f"no fixture playback files matched {rendered_patterns}.",
         )
 
     try:
@@ -237,13 +377,44 @@ def _fixture_report(provider: str, *, fixtures_dir: Path | None) -> JSONDict:
             f"validated {len(fixture_paths)} provider fixture JSON file(s).",
         ),
         "paths": [str(path) for path in fixture_paths],
+        "patterns": [str(resolved_dir / pattern) for pattern in patterns],
     }
 
 
-def _docs_report(provider: BaseProvider, *, docs_root: Path) -> JSONDict:
+def _fixture_patterns(provider: str) -> tuple[str, ...]:
+    prefixes = [provider]
+    module_prefix = provider.replace("-", "_")
+    if module_prefix not in prefixes:
+        prefixes.append(module_prefix)
+    return tuple(f"{prefix}_*.json" for prefix in prefixes)
+
+
+def _runtime_manifest_report(provider: str) -> JSONDict:
+    try:
+        manifest = load_runtime_manifest(provider)
+    except WorldForgeError as exc:
+        return _status_check("runtime_manifest", "skipped", str(exc))
+    return {
+        **_status_check(
+            "runtime_manifest",
+            "passed",
+            (
+                f"{provider}:schema-{manifest.schema_version}; capabilities "
+                f"{', '.join(manifest.capabilities)}; minimum smoke "
+                f"`{manifest.minimum_smoke_command}`."
+            ),
+        ),
+        "manifest_id": f"{provider}:schema-{manifest.schema_version}",
+        "path": f"src/worldforge/providers/runtime_manifests/{provider}.json",
+        "minimum_smoke_command": manifest.minimum_smoke_command,
+        "expected_success_signal": manifest.expected_success_signal,
+    }
+
+
+def _docs_report(provider: BaseProvider, *, docs_root: Path, target: _WorkbenchTarget) -> JSONDict:
     profile = provider.profile()
     docs_paths = [
-        docs_root / f"docs/src/providers/{provider.name}.md",
+        docs_root / f"docs/src/providers/{target.docs_page}",
         docs_root / "docs/src/providers/README.md",
     ]
     docs_path = next((path for path in docs_paths if path.exists()), None)
@@ -274,12 +445,190 @@ def _docs_report(provider: BaseProvider, *, docs_root: Path) -> JSONDict:
     )
 
 
+def _catalog_report(provider: str, *, docs_root: Path, target: _WorkbenchTarget) -> JSONDict:
+    index_path = docs_root / PROVIDER_INDEX_DOC
+    try:
+        text = index_path.read_text(encoding="utf-8").lower()
+    except OSError as exc:
+        return _status_check("catalog", "failed", f"failed to read {index_path}: {exc}")
+    needle = f"`{provider}`"
+    if needle not in text:
+        return _status_check(
+            "catalog",
+            "failed",
+            f"{PROVIDER_INDEX_DOC} does not mention `{provider}`.",
+        )
+    target_kind = (
+        "catalog provider" if target.catalog_registered else "direct-construction candidate"
+    )
+    return _status_check(
+        "catalog",
+        "passed",
+        f"{PROVIDER_INDEX_DOC} indexes `{provider}` as a {target_kind}.",
+    )
+
+
 def _event_report(events: list[ProviderEvent], *, provider: str) -> JSONDict:
     try:
         assert_provider_events_conform(events, provider=provider)
     except AssertionError as exc:
         return _status_check("events", "failed", str(exc))
     return _status_check("events", "passed", f"{len(events)} provider event(s) are issue-safe.")
+
+
+def _promotion_report(
+    provider: BaseProvider,
+    *,
+    checks: list[JSONDict],
+    docs_root: Path,
+    target: _WorkbenchTarget,
+    required_tests: list[str],
+    planned_capabilities: list[str],
+) -> JSONDict:
+    profile = provider.profile()
+    current_status = profile.implementation_status
+    present = _present_evidence(
+        provider.name,
+        checks=checks,
+        docs_root=docs_root,
+        target=target,
+        required_tests=required_tests,
+        planned_capabilities=planned_capabilities,
+    )
+    missing_by_status: dict[str, list[str]] = {}
+    for status in _future_statuses(current_status):
+        required = set(_PROMOTION_REQUIREMENTS[status])
+        missing_by_status[status] = sorted(required.difference(present))
+    next_status = next(iter(missing_by_status), None)
+    return {
+        "current_status": current_status,
+        "next_status": next_status,
+        "present_evidence": sorted(present),
+        "missing_evidence_by_status": missing_by_status,
+        "required_evidence_by_status": {
+            status: list(requirements)
+            for status, requirements in _PROMOTION_REQUIREMENTS.items()
+            if status in missing_by_status
+        },
+    }
+
+
+def _present_evidence(
+    provider: str,
+    *,
+    checks: list[JSONDict],
+    docs_root: Path,
+    target: _WorkbenchTarget,
+    required_tests: list[str],
+    planned_capabilities: list[str],
+) -> set[str]:
+    checks_by_name = {str(check["name"]): check for check in checks}
+    present: set[str] = set()
+    if _doc_mentions(docs_root / PROVIDER_COHORT_DOC, provider):
+        present.add("selection_record")
+    if checks_by_name.get("docs", {}).get("status") == "passed":
+        present.add("docs_page")
+    if checks_by_name.get("catalog", {}).get("status") == "passed":
+        present.add("catalog_or_candidate_index")
+    if checks_by_name.get("runtime_manifest", {}).get("status") == "passed":
+        present.add("runtime_manifest")
+    if checks_by_name.get("fixtures", {}).get("status") == "passed":
+        present.add("fixture_coverage")
+    if required_tests or planned_capabilities:
+        present.add("conformance_helpers")
+    if checks_by_name.get("events", {}).get("status") == "passed":
+        present.add("redaction_checks")
+    if _live_smoke_entry(docs_root / LIVE_SMOKE_EVIDENCE_DOC, provider) is not None:
+        present.add("prepared_host_smoke_record")
+    live_entry = _live_smoke_entry(docs_root / LIVE_SMOKE_EVIDENCE_DOC, provider)
+    if isinstance(live_entry, dict) and live_entry.get("artifact_path"):
+        present.add("prepared_host_smoke_artifact")
+    if target.catalog_registered and _doc_mentions(
+        docs_root / "docs/src/claim-evidence-map.md",
+        provider,
+    ):
+        present.add("release_evidence")
+    return present
+
+
+def _future_statuses(current_status: str) -> tuple[str, ...]:
+    if current_status not in _STATUS_ORDER:
+        return tuple(_PROMOTION_REQUIREMENTS)
+    index = _STATUS_ORDER.index(current_status)
+    return tuple(
+        status for status in _STATUS_ORDER[index + 1 :] if status in _PROMOTION_REQUIREMENTS
+    )
+
+
+def _promotion_detail(promotion: JSONDict) -> str:
+    next_status = promotion.get("next_status")
+    if not next_status:
+        return f"{promotion['current_status']} has no higher promotion status in this workbench."
+    missing_by_status = promotion.get("missing_evidence_by_status", {})
+    missing = []
+    if isinstance(missing_by_status, dict):
+        missing = list(missing_by_status.get(next_status, []))
+    if not missing:
+        return f"{promotion['current_status']} has evidence needed for {next_status}."
+    return (
+        f"{promotion['current_status']} missing for {next_status}: "
+        f"{', '.join(str(item) for item in missing)}."
+    )
+
+
+def _safe_artifacts(
+    provider: str,
+    *,
+    checks: list[JSONDict],
+    target: _WorkbenchTarget,
+) -> list[JSONDict]:
+    artifacts = [
+        _artifact(AUTHORING_DOC, "provider authoring guide"),
+        _artifact(PROVIDER_INDEX_DOC, "generated provider index"),
+        _artifact(f"docs/src/providers/{target.docs_page}", "provider documentation page"),
+        _artifact(PROVIDER_COHORT_DOC, "provider selection record"),
+        _artifact(FIXTURE_DOC.replace("<provider>", provider), "provider fixture pattern"),
+    ]
+    runtime = next((check for check in checks if check["name"] == "runtime_manifest"), None)
+    if isinstance(runtime, dict) and isinstance(runtime.get("path"), str):
+        artifacts.append(_artifact(runtime["path"], "runtime manifest"))
+    return artifacts
+
+
+def _artifact(path: str, note: str) -> JSONDict:
+    return {"path": path, "note": note, "safe_to_attach": True}
+
+
+def _validation_commands(provider: str, *, docs_root: Path) -> list[str]:
+    commands = [
+        "uv run pytest tests/test_provider_workbench.py tests/test_provider_catalog_docs.py",
+        CATALOG_CHECK_COMMAND,
+        "uv run mkdocs build --strict",
+    ]
+    test_path = docs_root / f"tests/test_{provider.replace('-', '_')}_provider.py"
+    if test_path.exists():
+        commands.insert(0, f"uv run pytest {test_path.relative_to(docs_root)}")
+    return commands
+
+
+def _doc_mentions(path: Path, provider: str) -> bool:
+    try:
+        return provider.lower() in path.read_text(encoding="utf-8").lower()
+    except OSError:
+        return False
+
+
+def _live_smoke_entry(path: Path, provider: str) -> JSONDict | None:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(payload, dict) or not isinstance(payload.get("entries"), list):
+        return None
+    for entry in payload["entries"]:
+        if isinstance(entry, dict) and entry.get("provider") == provider:
+            return dict(entry)
+    return None
 
 
 def _status_check(name: str, status: str, detail: str) -> JSONDict:

--- a/tests/test_docs_site.py
+++ b/tests/test_docs_site.py
@@ -618,6 +618,29 @@ def test_cross_provider_comparison_docs_cover_issue_150_contract() -> None:
     )
 
 
+def test_adapter_workbench_docs_cover_issue_141_contract() -> None:
+    harness = (ROOT / "docs/src/theworldharness.md").read_text(encoding="utf-8")
+    authoring = (ROOT / "docs/src/provider-authoring-guide.md").read_text(encoding="utf-8")
+    continuation = (ROOT / "docs/src/roadmap-continuation.md").read_text(encoding="utf-8")
+    changelog = (ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
+
+    for signal in (
+        "worldforge harness --flow workbench",
+        "worldforge provider workbench jepa-wms",
+        "promotion evidence",
+        "runtime manifest status",
+        "safe artifact references",
+        "validation commands",
+        "missing evidence by promotion status",
+        "jepa_wms_*.json",
+    ):
+        assert signal in harness or signal in authoring
+
+    assert "adapter author workbench flow" in changelog
+    assert "- [x] Workbench can run against `mock`" in continuation
+    assert "- [x] TUI and CLI workbench views use the same non-Textual flow logic" in continuation
+
+
 def test_genie_scaffold_docs_record_runtime_contract_defer_decision() -> None:
     provider_page = (ROOT / "docs/src/providers/genie.md").read_text(encoding="utf-8")
     provider_index = (ROOT / "docs/src/providers/README.md").read_text(encoding="utf-8")

--- a/tests/test_harness_cli.py
+++ b/tests/test_harness_cli.py
@@ -19,6 +19,7 @@ def test_worldforge_harness_lists_flows_without_textual(monkeypatch, capsys) -> 
     assert "leworldmodel" in output
     assert "lerobot" in output
     assert "diagnostics" in output
+    assert "workbench" in output
 
 
 def test_worldforge_harness_lists_json_without_textual(monkeypatch, capsys) -> None:
@@ -31,7 +32,12 @@ def test_worldforge_harness_lists_json_without_textual(monkeypatch, capsys) -> N
     assert worldforge_main() == 0
     payload = json.loads(capsys.readouterr().out)
 
-    assert [flow["id"] for flow in payload] == ["leworldmodel", "lerobot", "diagnostics"]
+    assert [flow["id"] for flow in payload] == [
+        "leworldmodel",
+        "lerobot",
+        "diagnostics",
+        "workbench",
+    ]
 
 
 def test_worldforge_harness_console_entry_lists_flows(capsys) -> None:

--- a/tests/test_harness_flows.py
+++ b/tests/test_harness_flows.py
@@ -19,13 +19,14 @@ from worldforge.harness.flows import (
 
 def test_harness_flow_metadata_is_available_without_textual() -> None:
     flows = available_flows()
-    assert [flow.id for flow in flows] == ["leworldmodel", "lerobot", "diagnostics"]
+    assert [flow.id for flow in flows] == ["leworldmodel", "lerobot", "diagnostics", "workbench"]
     assert flow_index()["leworldmodel"].provider == "LeWorldModelProvider"
 
     payload = flow_to_dicts()
     assert payload[0]["command"] == "uv run worldforge-demo-leworldmodel"
     assert payload[1]["focus"] == "policy plus score planning"
     assert payload[2]["command"] == "uv run worldforge harness --flow diagnostics"
+    assert payload[3]["command"] == "uv run worldforge provider workbench mock"
 
 
 def test_harness_runs_leworldmodel_flow(tmp_path) -> None:
@@ -101,6 +102,27 @@ def test_harness_runs_diagnostics_flow(tmp_path) -> None:
     ]
     assert run.summary["benchmark_event_count"] >= 10
     assert "benchmark_operations: predict, reason, generate, transfer, embed" in run.transcript
+
+
+def test_harness_runs_workbench_flow(tmp_path) -> None:
+    run = run_flow("workbench", state_dir=tmp_path)
+
+    assert run.flow.id == "workbench"
+    assert len(run.steps) == 5
+    assert len(run.metrics) == 5
+    assert run.summary["providers"] == ["mock", "jepa-wms"]
+    assert run.summary["passed_count"] == 2
+    assert run.summary["missing_evidence_by_provider"]["jepa-wms"]["experimental"] == []
+    assert run.summary["missing_evidence_by_provider"]["jepa-wms"]["stable"] == [
+        "prepared_host_smoke_artifact",
+        "release_evidence",
+    ]
+    assert "jepa-wms_missing_stable: prepared_host_smoke_artifact, release_evidence" in (
+        run.transcript
+    )
+    assert run.workspace_path is not None
+    inspector = json.loads((run.workspace_path / "results" / "inspector.json").read_text())
+    assert inspector["steps"][0]["title"] == "Select authoring targets"
 
 
 def test_eval_run_artifacts_match_canonical_renderer(tmp_path) -> None:

--- a/tests/test_provider_workbench.py
+++ b/tests/test_provider_workbench.py
@@ -48,12 +48,54 @@ def test_provider_workbench_skips_live_runway_but_validates_fixtures() -> None:
     assert checks["fixtures"]["paths"]
 
 
+def test_provider_workbench_runs_scaffold_and_names_promotion_gaps() -> None:
+    report = provider_workbench_report("genie")
+
+    assert report["status"] == "passed"
+    assert report["target_source"] == "provider_catalog"
+    assert report["profile"]["implementation_status"] == "scaffold"
+    checks = {check["name"]: check for check in report["checks"]}
+    assert checks["runtime_manifest"]["status"] == "skipped"
+    assert checks["fixtures"]["status"] == "skipped"
+    assert report["promotion"]["missing_evidence_by_status"]["experimental"] == [
+        "conformance_helpers",
+        "fixture_coverage",
+        "runtime_manifest",
+    ]
+
+    markdown = provider_workbench_markdown(report)
+    assert "missing for `experimental`" in markdown
+    assert "`runtime_manifest`" in markdown
+    assert "## Validation Commands" in markdown
+    assert "uv run mkdocs build --strict" in markdown
+
+
+def test_provider_workbench_runs_direct_candidate_in_clean_checkout() -> None:
+    report = provider_workbench_report("jepa-wms")
+
+    assert report["status"] == "passed"
+    assert report["target_source"] == "direct_construction_candidate"
+    assert report["catalog_registered"] is False
+    assert report["planned_capabilities"] == ["score"]
+    checks = {check["name"]: check for check in report["checks"]}
+    assert checks["runtime_manifest"]["status"] == "passed"
+    assert checks["fixtures"]["status"] == "passed"
+    assert "tests/fixtures/providers/jepa_wms_success.json" in checks["fixtures"]["paths"]
+    assert report["promotion"]["missing_evidence_by_status"]["experimental"] == []
+    assert report["promotion"]["missing_evidence_by_status"]["stable"] == [
+        "prepared_host_smoke_artifact",
+        "release_evidence",
+    ]
+
+
 def test_provider_workbench_markdown_is_issue_ready() -> None:
     markdown = provider_workbench_markdown(provider_workbench_report("mock"))
 
     assert markdown.startswith("# Provider Workbench: `mock`")
     assert "`passed` `conformance`" in markdown
     assert "generated catalog check" in markdown
+    assert "Safe Artifacts" in markdown
+    assert "Validation Commands" in markdown
     assert "Issue Summary" in markdown
 
 
@@ -69,3 +111,19 @@ def test_provider_workbench_cli_outputs_json(monkeypatch, capsys) -> None:
 
     assert payload["provider"] == "mock"
     assert payload["status"] == "passed"
+    assert payload["validation_commands"]
+
+
+def test_provider_workbench_cli_outputs_candidate_json(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["worldforge", "provider", "workbench", "jepa-wms", "--format", "json"],
+    )
+
+    assert worldforge_main() == 0
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload["provider"] == "jepa-wms"
+    assert payload["target_source"] == "direct_construction_candidate"
+    assert payload["promotion"]["missing_evidence_by_status"]["experimental"] == []


### PR DESCRIPTION
## Problem

Provider authors need one checkout-safe loop that can inspect a stable provider, a scaffold, or a direct-construction candidate without making live calls or hiding promotion gaps. The existing workbench covered the basic provider checks but did not model promotion evidence, runtime manifests, direct candidates, safe artifact references, or the TUI-visible harness flow.

## Solution

- Extend the non-Textual provider workbench report with target source, planned capabilities, runtime manifest status, catalog/docs status, safe artifact references, validation commands, and promotion evidence grouped by future status.
- Support the direct-construction `jepa-wms` candidate in addition to catalog providers and accept module-safe fixture prefixes such as `jepa_wms_*.json`.
- Add a TheWorldHarness `workbench` flow that reuses `provider_workbench_report()` for `mock` and `jepa-wms`, preserving the same logic for CLI and TUI paths.
- Update provider-authoring and harness docs, changelog, roadmap checklist, and regression coverage.

Closes #141

## Validation

- `uv lock --check`
- `uv run ruff check src tests examples scripts`
- `uv run ruff format --check src tests examples scripts`
- `uv run python scripts/generate_provider_docs.py --check`
- `uv run pytest tests/test_provider_workbench.py tests/test_harness_flows.py tests/test_harness_cli.py`
- `uv run --extra harness pytest tests/test_harness_tui.py`
- `uv run pytest tests/test_docs_site.py tests/test_provider_workbench.py tests/test_harness_flows.py tests/test_harness_cli.py -q`
- `uv run mkdocs build --strict`
- `uv run pytest`
- `uv run --extra harness pytest --cov=src/worldforge --cov-report=term-missing --cov-fail-under=90`
- `bash scripts/test_package.sh`
- `uv build --out-dir dist --clear --no-build-logs`
- `git diff --check`