### PR TITLE
Strengthen provider scaffold contracts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,7 +77,7 @@ evaluation harnesses, and testable prototypes.
   compatibility wrapper with an injected deterministic policy.
 - `scripts/generate_provider_docs.py`: provider catalog documentation generator and drift check.
 - `scripts/scaffold_provider.py`: safe scaffold generator for new provider adapter files,
-  fixture placeholders, tests, and docs stubs.
+  fixture placeholders, tests, runtime manifest stubs, docs stubs, and workbench checklists.
 - `scripts/smoke_leworldmodel.py`: compatibility wrapper for
   `uv run --python 3.13 --with "stable-worldmodel @ git+https://github.com/galilai-group/stable-worldmodel.git" --with "datasets>=2.21" worldforge-smoke-leworldmodel`.
 - `scripts/smoke_gr00t_policy.py`: optional live GR00T PolicyClient smoke for host environments
@@ -148,6 +148,7 @@ Generate a provider scaffold:
 ```bash
 uv run python scripts/scaffold_provider.py "Acme WM" \
   --taxonomy "JEPA latent predictive world model" \
+  --implementation-status scaffold \
   --planned-capability score
 ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ releases may still include breaking changes when the public API needs to tighten
 
 ### Added
 
+- Provider scaffolding now generates a fuller fail-closed contract pack: an explicit
+  `--implementation-status scaffold` maturity claim, provider/profile tests for disabled
+  capability calls, placeholder fixtures marked as non-evidence, an incomplete `.json.stub`
+  runtime manifest, a workbench checklist, and printed validation commands. Existing scaffold
+  files still require `--force` before overwrite.
 - Added an adapter author workbench flow for provider promotion evidence. The non-Textual
   workbench now handles catalog providers, scaffold providers, and the direct-construction
   `jepa-wms` candidate; reports include runtime manifest status, fixture coverage, docs/catalog

--- a/README.md
+++ b/README.md
@@ -495,6 +495,7 @@ Scaffold a new provider:
 ```bash
 uv run python scripts/scaffold_provider.py "Acme WM" \
   --taxonomy "JEPA latent predictive world model" \
+  --implementation-status scaffold \
   --planned-capability score
 ```
 

--- a/docs/src/playbooks.md
+++ b/docs/src/playbooks.md
@@ -91,6 +91,7 @@ Use this for new provider work and for promoting a scaffold to a real adapter.
 ```bash
 uv run python scripts/scaffold_provider.py "Acme WM" \
   --taxonomy "JEPA latent predictive world model" \
+  --implementation-status scaffold \
   --planned-capability score \
   --remote \
   --env-var ACME_WM_API_KEY

--- a/docs/src/provider-authoring-guide.md
+++ b/docs/src/provider-authoring-guide.md
@@ -16,11 +16,12 @@ Related docs:
 ## Scaffold Generator
 
 Use the scaffold generator to create the first draft of a provider adapter, fixture files, test
-file, and provider docs stub:
+file, runtime manifest stub, provider docs stub, and workbench checklist:
 
 ```bash
 uv run python scripts/scaffold_provider.py "Acme WM" \
   --taxonomy "JEPA latent predictive world model" \
+  --implementation-status scaffold \
   --planned-capability score \
   --remote \
   --env-var ACME_WM_API_KEY
@@ -33,13 +34,21 @@ src/worldforge/providers/acme_wm.py
 tests/test_acme_wm_provider.py
 tests/fixtures/providers/acme_wm_success.json
 tests/fixtures/providers/acme_wm_error.json
+src/worldforge/providers/runtime_manifests/acme-wm.json.stub
 docs/src/providers/acme-wm.md
+docs/src/providers/acme-wm-workbench.md
 ```
 
 The generated provider is safe by default: it starts as `implementation_status="scaffold"`,
 advertises no public capabilities, and raises `ProviderError` from generated method stubs. Enable
 capabilities only after the adapter calls the real upstream runtime, validates inputs and outputs,
 and has fixture-driven tests for every documented failure mode.
+
+The generated runtime manifest is deliberately named `.json.stub`; it is not loadable runtime
+evidence and should not be renamed to `.json` until every TODO is replaced, the host-owned smoke
+path writes a sanitized `run_manifest.json`, and `uv run pytest tests/test_provider_runtime_manifests.py`
+passes. The generated workbench checklist records the fail-closed checks, promotion work, and next
+validation commands for the provider.
 
 ## Workbench Loop
 

--- a/docs/src/roadmap-continuation.md
+++ b/docs/src/roadmap-continuation.md
@@ -727,10 +727,10 @@ Out of scope:
 
 Acceptance criteria:
 
-- [ ] Scaffold output includes tests for unsupported capability calls and provider profile metadata.
-- [ ] Generated manifest stubs are clearly marked incomplete and not used as real evidence.
-- [ ] Generated docs warn that the provider is not executable until promotion criteria pass.
-- [ ] Running the scaffold command does not overwrite existing files unless explicitly requested.
+- [x] Scaffold output includes tests for unsupported capability calls and provider profile metadata.
+- [x] Generated manifest stubs are clearly marked incomplete and not used as real evidence.
+- [x] Generated docs warn that the provider is not executable until promotion criteria pass.
+- [x] Running the scaffold command does not overwrite existing files unless explicitly requested.
 
 Validation:
 

--- a/scripts/scaffold_provider.py
+++ b/scripts/scaffold_provider.py
@@ -14,6 +14,7 @@ from textwrap import dedent
 
 CAPABILITIES = ("predict", "generate", "transfer", "reason", "embed", "score", "policy")
 DEFAULT_TAXONOMY = "unclassified provider scaffold"
+IMPLEMENTATION_STATUSES = ("scaffold",)
 
 
 @dataclass(frozen=True, slots=True)
@@ -31,6 +32,7 @@ class ScaffoldOptions:
     names: ProviderNames
     taxonomy: str
     planned_capabilities: tuple[str, ...]
+    implementation_status: str
     is_local: bool
     env_var: str | None
     force: bool
@@ -164,7 +166,7 @@ def _capability_stubs(names: ProviderNames, planned_capabilities: tuple[str, ...
 def _provider_source(options: ScaffoldOptions) -> str:
     names = options.names
     env_constant = f"{names.snake.upper()}_ENV_VAR"
-    required_env_vars = f"[{env_constant}]" if options.env_var else "[]"
+    required_env_vars = f"({env_constant},)" if options.env_var else "()"
     planned = ", ".join(options.planned_capabilities)
     stubs = _capability_stubs(names, options.planned_capabilities)
     model_imports = ["ProviderCapabilities", "ProviderEvent", "ProviderHealth"]
@@ -182,7 +184,7 @@ def _provider_source(options: ScaffoldOptions) -> str:
         model_imports.extend(["ActionPolicyResult", "JSONDict"])
 
     deduped_model_imports = sorted(dict.fromkeys(model_imports))
-    base_imports = ["BaseProvider", "ProviderError"]
+    base_imports = ["BaseProvider", "ProviderError", "ProviderProfileSpec"]
     if "predict" in options.planned_capabilities:
         base_imports.insert(1, "PredictionPayload")
 
@@ -230,6 +232,7 @@ def _provider_source(options: ScaffoldOptions) -> str:
             "",
             f"    planned_capabilities = {options.planned_capabilities!r}",
             f"    taxonomy_category = {options.taxonomy!r}",
+            f"    scaffold_implementation_status = {options.implementation_status!r}",
             "",
             "    def __init__(",
             "        self,",
@@ -240,23 +243,25 @@ def _provider_source(options: ScaffoldOptions) -> str:
             "        super().__init__(",
             "            name=name,",
             "            capabilities=ProviderCapabilities(predict=False),",
-            f"            is_local={options.is_local!r},",
-            f'            description="{names.display} provider scaffold.",',
-            '            package="worldforge",',
-            '            implementation_status="scaffold",',
-            "            deterministic=False,",
-            f"            requires_credentials={not options.is_local!r},",
-            f"            required_env_vars={required_env_vars},",
-            "            supported_modalities=[],",
-            "            artifact_types=[],",
-            "            notes=[",
+            "            profile=ProviderProfileSpec(",
+            f"                is_local={options.is_local!r},",
+            f'                description="{names.display} provider scaffold.",',
+            '                package="worldforge",',
+            f"                implementation_status={options.implementation_status!r},",
+            "                deterministic=False,",
+            f"                requires_credentials={not options.is_local!r},",
+            f"                required_env_vars={required_env_vars},",
+            "                supported_modalities=(),",
+            "                artifact_types=(),",
+            "                notes=(",
             (
-                '                "Generated scaffold; do not register as a real provider until '
+                '                    "Generated scaffold; do not register as a real provider until '
                 'implemented.",'
             ),
-            f'                "Taxonomy category: {options.taxonomy}.",',
-            f'                "Planned capabilities: {planned}.",',
-            "            ],",
+            f'                    "Taxonomy category: {options.taxonomy}.",',
+            f'                    "Planned capabilities: {planned}.",',
+            "                ),",
+            "            ),",
             "            event_handler=event_handler,",
             "        )",
             "",
@@ -304,24 +309,17 @@ def _provider_source(options: ScaffoldOptions) -> str:
 
 def _test_source(options: ScaffoldOptions) -> str:
     names = options.names
-    worldforge_imports: list[str] = []
-    if "predict" in options.planned_capabilities:
-        worldforge_imports.append("Action")
-    if "transfer" in options.planned_capabilities:
-        worldforge_imports.append("VideoClip")
-
     lines = [
         "from __future__ import annotations",
         "",
         "import pytest",
         "",
+        "from worldforge import Action, VideoClip",
     ]
-    if worldforge_imports:
-        lines.append(f"from worldforge import {', '.join(worldforge_imports)}")
     lines.extend(
         [
-            "from worldforge.providers.base import ProviderError",
             f"from worldforge.providers.{names.snake} import {names.class_name}",
+            "from worldforge.providers.base import ProviderError",
             "",
             "",
             f"def test_{names.snake}_profile_starts_as_safe_scaffold() -> None:",
@@ -329,10 +327,55 @@ def _test_source(options: ScaffoldOptions) -> str:
             "    profile = provider.profile()",
             "",
             f'    assert profile.name == "{names.slug}"',
-            '    assert profile.implementation_status == "scaffold"',
+            f"    assert profile.implementation_status == {options.implementation_status!r}",
             "    assert profile.supported_tasks == []",
+            "    assert all(",
+            "        profile.capabilities.supports(capability) is False",
+            "        for capability in (",
+            '            "predict",',
+            '            "generate",',
+            '            "transfer",',
+            '            "reason",',
+            '            "embed",',
+            '            "score",',
+            '            "policy",',
+            "        )",
+            "    )",
             f"    assert provider.planned_capabilities == {options.planned_capabilities!r}",
             f"    assert provider.taxonomy_category == {options.taxonomy!r}",
+            "    assert (",
+            f"        provider.scaffold_implementation_status == {options.implementation_status!r}",
+            "    )",
+            '    assert any("do not register" in note for note in profile.notes)',
+            "",
+            "",
+            f"def test_{names.snake}_capability_calls_fail_closed_until_promoted() -> None:",
+            f"    provider = {names.class_name}()",
+            "    clip = VideoClip(",
+            '        frames=[b"frame"],',
+            "        fps=1.0,",
+            "        resolution=(1, 1),",
+            "        duration_seconds=1.0,",
+            "    )",
+            "    calls = {",
+            '        "predict": lambda: provider.predict({}, Action.noop(), 1),',
+            '        "generate": lambda: provider.generate("prompt", 1.0),',
+            '        "transfer": lambda: provider.transfer(',
+            "            clip,",
+            "            width=1,",
+            "            height=1,",
+            "            fps=1.0,",
+            "        ),",
+            '        "reason": lambda: provider.reason("query"),',
+            '        "embed": lambda: provider.embed(text="query"),',
+            '        "score": lambda: provider.score_actions(info={}, action_candidates=[]),',
+            '        "policy": lambda: provider.select_actions(info={}),',
+            "    }",
+            "",
+            "    for capability, call in calls.items():",
+            "        assert provider.profile().capabilities.supports(capability) is False",
+            '        with pytest.raises(ProviderError, match="not implement"):',
+            "            call()",
         ]
     )
     if options.env_var:
@@ -460,22 +503,44 @@ def _docs_source(options: ScaffoldOptions) -> str:
         f"""\
         # {names.display} Provider
 
-        Status: scaffold
+        Status: {options.implementation_status}
 
         Taxonomy category: {options.taxonomy}
 
         This file was generated by `scripts/scaffold_provider.py`. Treat it as a checklist, not as
         proof that the provider is implemented.
 
+        The generated provider is not executable until the promotion criteria pass: every planned
+        capability must call a real runtime, return validated WorldForge models, have
+        fixture-backed parser and failure tests, and advertise only the capabilities implemented
+        end to end.
+
         ## Planned Capabilities
 
         {capability_rows}
+
+        ## Generated Contract Files
+
+        - Provider scaffold: `src/worldforge/providers/{names.snake}.py`
+        - Contract tests: `tests/test_{names.snake}_provider.py`
+        - Placeholder fixtures: `tests/fixtures/providers/{names.snake}_success.json` and
+          `tests/fixtures/providers/{names.snake}_error.json`
+        - Runtime manifest stub:
+          `src/worldforge/providers/runtime_manifests/{names.slug}.json.stub`
+        - Workbench checklist: `docs/src/providers/{names.slug}-workbench.md`
 
         ## Configuration
 
         {env_section}
         - Optional dependencies: document runtime packages, model checkpoints, and cache paths.
         - Registration rule: document the environment variables required before auto-registration.
+
+        ## Runtime Manifest Stub
+
+        The generated `.json.stub` file is intentionally incomplete and must not be renamed to
+        `{names.slug}.json` or treated as smoke evidence until every TODO is replaced with a real
+        host-owned runtime contract and `uv run pytest tests/test_provider_runtime_manifests.py`
+        passes.
 
         ## Contract To Define
 
@@ -499,6 +564,9 @@ def _docs_source(options: ScaffoldOptions) -> str:
 
         - [ ] Provider capabilities are narrow and truthful.
         - [ ] Provider profile metadata is complete.
+        - [ ] Runtime manifest stub is complete, renamed, and validated or intentionally omitted.
+        - [ ] `uv run worldforge provider workbench {names.slug} --format markdown` has no failed
+              checks after a catalog entry or direct workbench target exists.
         - [ ] Public API docs mention new failure modes.
         - [ ] `docs/src/providers/README.md` links this provider page.
         - [ ] `AGENTS.md` documents any new commands, dependencies, or gotchas.
@@ -510,8 +578,12 @@ def _docs_source(options: ScaffoldOptions) -> str:
 def _fixture_payload(options: ScaffoldOptions, *, success: bool) -> str:
     payload = {
         "provider": options.names.slug,
+        "fixture_status": "placeholder",
+        "implementation_status": options.implementation_status,
         "taxonomy_category": options.taxonomy,
         "planned_capabilities": list(options.planned_capabilities),
+        "replace_before_promotion": True,
+        "usable_as_evidence": False,
     }
     if success:
         payload["status"] = "replace-with-real-success-payload"
@@ -521,6 +593,101 @@ def _fixture_payload(options: ScaffoldOptions, *, success: bool) -> str:
             "message": "Replace this scaffold fixture with a real malformed upstream response.",
         }
     return json.dumps(payload, indent=2, sort_keys=True) + "\n"
+
+
+def _runtime_manifest_stub_source(options: ScaffoldOptions) -> str:
+    names = options.names
+    required_env_vars = [options.env_var] if options.env_var is not None else ["TODO_RUNTIME_ENV"]
+    payload = {
+        "_instructions": (
+            f"Incomplete scaffold stub for {names.slug}. Replace every TODO, remove "
+            "stub_status/usable_as_evidence, rename this file to "
+            f"{names.slug}.json, and validate it before using it as runtime evidence."
+        ),
+        "schema_version": 1,
+        "provider": names.slug,
+        "implementation_status": options.implementation_status,
+        "stub_status": "incomplete",
+        "usable_as_evidence": False,
+        "capabilities": list(options.planned_capabilities),
+        "optional_dependencies": ["TODO_RUNTIME_PACKAGE"],
+        "required_env_vars": required_env_vars,
+        "optional_env_vars": [],
+        "default_model": "TODO_MODEL_OR_RUNTIME_ALIAS",
+        "device_support": ["TODO_DEVICE"],
+        "host_owned_artifacts": ["TODO_HOST_OWNED_CHECKPOINT_OR_RUNTIME_ARTIFACT"],
+        "minimum_smoke_command": (
+            "TODO uv run worldforge-smoke-"
+            f"{names.slug} --run-manifest .worldforge/runs/{names.slug}-live/run_manifest.json"
+        ),
+        "expected_success_signal": (
+            "TODO describe the validated provider result and sanitized run_manifest.json signal"
+        ),
+        "setup_hint": "TODO document host-owned install, credentials, cache, and checkpoint setup",
+        "docs_path": f"docs/src/providers/{names.slug}.md",
+    }
+    return json.dumps(payload, indent=2, sort_keys=True) + "\n"
+
+
+def _workbench_checklist_source(options: ScaffoldOptions) -> str:
+    names = options.names
+    planned = ", ".join(f"`{capability}`" for capability in options.planned_capabilities)
+    return dedent(
+        f"""\
+        # {names.display} Provider Workbench Checklist
+
+        Status: {options.implementation_status}
+
+        This checklist was generated by `scripts/scaffold_provider.py`. It is not evidence by
+        itself; it names the contract work required before `{names.slug}` becomes executable.
+
+        ## Scaffold Surface
+
+        - Planned capabilities: {planned}
+        - Provider source: `src/worldforge/providers/{names.snake}.py`
+        - Provider docs: `docs/src/providers/{names.slug}.md`
+        - Placeholder fixtures: `tests/fixtures/providers/{names.snake}_*.json`
+        - Runtime manifest stub:
+          `src/worldforge/providers/runtime_manifests/{names.slug}.json.stub`
+
+        ## Fail-Closed Checks
+
+        - [ ] Generated provider profile reports
+              `implementation_status="{options.implementation_status}"`.
+        - [ ] Generated provider advertises no public capabilities before promotion.
+        - [ ] Every generated capability call raises `ProviderError` until real runtime behavior
+              is implemented.
+        - [ ] Existing files are not overwritten unless `--force` is explicit.
+
+        ## Promotion Work
+
+        - [ ] Replace placeholder fixtures with real success and malformed upstream payloads.
+        - [ ] Replace generated method stubs with real runtime calls and typed WorldForge models.
+        - [ ] Validate provider events do not expose secrets, signed URLs, raw tensors, or local
+              checkpoint paths.
+        - [ ] Replace every runtime manifest TODO, rename `.json.stub` to `.json`, and run
+              `uv run pytest tests/test_provider_runtime_manifests.py`.
+        - [ ] Add catalog registration only after configuration, docs, fixtures, and runtime
+              evidence are ready.
+
+        ## Workbench Target
+
+        Add a catalog entry or direct workbench target before running this command:
+
+        ```bash
+        uv run worldforge provider workbench {names.slug} --format markdown
+        ```
+
+        ## Validation Commands
+
+        ```bash
+        uv run pytest tests/test_{names.snake}_provider.py
+        uv run python scripts/generate_provider_docs.py --check
+        uv run pytest tests/test_provider_catalog_docs.py
+        uv run mkdocs build --strict
+        ```
+        """
+    )
 
 
 def scaffold_files(options: ScaffoldOptions) -> dict[Path, str]:
@@ -536,7 +703,16 @@ def scaffold_files(options: ScaffoldOptions) -> dict[Path, str]:
         options.root / "tests" / "fixtures" / "providers" / f"{names.snake}_error.json": (
             _fixture_payload(options, success=False)
         ),
+        options.root
+        / "src"
+        / "worldforge"
+        / "providers"
+        / "runtime_manifests"
+        / f"{names.slug}.json.stub": _runtime_manifest_stub_source(options),
         options.root / "docs" / "src" / "providers" / f"{names.slug}.md": _docs_source(options),
+        options.root / "docs" / "src" / "providers" / f"{names.slug}-workbench.md": (
+            _workbench_checklist_source(options)
+        ),
     }
 
 
@@ -579,6 +755,12 @@ def parse_args(argv: list[str]) -> ScaffoldOptions:
         help="Capability stub to generate. Repeat for multiple planned capabilities.",
     )
     parser.add_argument(
+        "--implementation-status",
+        choices=IMPLEMENTATION_STATUSES,
+        required=True,
+        help="Explicit provider maturity claim for the generated scaffold.",
+    )
+    parser.add_argument(
         "--env-var",
         help="Optional environment variable required by the provider.",
     )
@@ -604,6 +786,7 @@ def parse_args(argv: list[str]) -> ScaffoldOptions:
         names=names,
         taxonomy=args.taxonomy.strip() or DEFAULT_TAXONOMY,
         planned_capabilities=planned_capabilities,
+        implementation_status=args.implementation_status,
         is_local=is_local,
         env_var=env_var,
         force=bool(args.force),
@@ -623,9 +806,17 @@ def main(argv: list[str] | None = None) -> int:
         print(f"- {path.relative_to(options.root)}")
     print("\nNext steps:")
     print("- implement the TODO methods before advertising capabilities")
+    print("- replace placeholder fixtures and the .json.stub runtime manifest before promotion")
     print("- add the provider to src/worldforge/providers/__init__.py when it is ready")
     print("- register it in src/worldforge/providers/catalog.py only after the adapter is tested")
     print("- link the docs stub from docs/src/providers/README.md")
+    print("\nNext validation commands:")
+    print(f"- uv run pytest tests/test_{options.names.snake}_provider.py")
+    print("- uv run python scripts/generate_provider_docs.py --check")
+    print("- uv run pytest tests/test_provider_catalog_docs.py")
+    print("- uv run mkdocs build --strict")
+    print("\nWorkbench command after adding a catalog or direct target:")
+    print(f"- uv run worldforge provider workbench {options.names.slug} --format markdown")
     return 0
 
 

--- a/tests/test_docs_site.py
+++ b/tests/test_docs_site.py
@@ -641,6 +641,30 @@ def test_adapter_workbench_docs_cover_issue_141_contract() -> None:
     assert "- [x] TUI and CLI workbench views use the same non-Textual flow logic" in continuation
 
 
+def test_scaffold_provider_docs_cover_issue_142_contract() -> None:
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    agents = (ROOT / "AGENTS.md").read_text(encoding="utf-8")
+    playbooks = (ROOT / "docs/src/playbooks.md").read_text(encoding="utf-8")
+    authoring = (ROOT / "docs/src/provider-authoring-guide.md").read_text(encoding="utf-8")
+    continuation = (ROOT / "docs/src/roadmap-continuation.md").read_text(encoding="utf-8")
+    changelog = (ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
+
+    for signal in (
+        "--implementation-status scaffold",
+        "runtime manifest stubs",
+        "workbench checklists",
+        "acme-wm.json.stub",
+        "not loadable runtime",
+        "uv run pytest tests/test_provider_runtime_manifests.py",
+        "validation commands",
+    ):
+        assert signal in readme or signal in agents or signal in playbooks or signal in authoring
+
+    assert "fuller fail-closed contract pack" in changelog
+    assert "- [x] Scaffold output includes tests for unsupported capability calls" in continuation
+    assert "- [x] Generated manifest stubs are clearly marked incomplete" in continuation
+
+
 def test_genie_scaffold_docs_record_runtime_contract_defer_decision() -> None:
     provider_page = (ROOT / "docs/src/providers/genie.md").read_text(encoding="utf-8")
     provider_index = (ROOT / "docs/src/providers/README.md").read_text(encoding="utf-8")

--- a/tests/test_provider_scaffold_script.py
+++ b/tests/test_provider_scaffold_script.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import py_compile
 import subprocess
 import sys
@@ -19,6 +20,8 @@ def test_scaffold_provider_script_generates_safe_adapter_files(tmp_path: Path) -
             str(tmp_path),
             "--taxonomy",
             "JEPA latent predictive world model",
+            "--implementation-status",
+            "scaffold",
             "--planned-capability",
             "score",
             "--planned-capability",
@@ -38,33 +41,67 @@ def test_scaffold_provider_script_generates_safe_adapter_files(tmp_path: Path) -
     test_path = tmp_path / "tests" / "test_acme_wm_provider.py"
     success_fixture = tmp_path / "tests" / "fixtures" / "providers" / "acme_wm_success.json"
     error_fixture = tmp_path / "tests" / "fixtures" / "providers" / "acme_wm_error.json"
+    runtime_manifest_stub = (
+        tmp_path / "src" / "worldforge" / "providers" / "runtime_manifests" / "acme-wm.json.stub"
+    )
     docs_path = tmp_path / "docs" / "src" / "providers" / "acme-wm.md"
+    workbench_path = tmp_path / "docs" / "src" / "providers" / "acme-wm-workbench.md"
 
     assert "Generated provider scaffold for Acme WM" in result.stdout
+    assert "Next validation commands:" in result.stdout
+    assert "uv run worldforge provider workbench acme-wm --format markdown" in result.stdout
     assert provider_path.exists()
     assert test_path.exists()
     assert success_fixture.exists()
     assert error_fixture.exists()
+    assert runtime_manifest_stub.exists()
+    assert not runtime_manifest_stub.with_suffix("").exists()
     assert docs_path.exists()
+    assert workbench_path.exists()
 
     provider_source = provider_path.read_text(encoding="utf-8")
     assert "class AcmeWMProvider(BaseProvider)" in provider_source
+    assert "from .base import BaseProvider, ProviderError, ProviderProfileSpec" in provider_source
     assert "capabilities=ProviderCapabilities(predict=False)" in provider_source
+    assert "profile=ProviderProfileSpec(" in provider_source
     assert "planned_capabilities = ('score', 'generate', 'policy')" in provider_source
+    assert "scaffold_implementation_status = 'scaffold'" in provider_source
+    assert "implementation_status='scaffold'" in provider_source
     assert 'ACME_WM_ENV_VAR = "ACME_WM_API_KEY"' in provider_source
     assert "healthy=False" in provider_source
     assert "no runtime adapter implemented" in provider_source
 
     test_source = test_path.read_text(encoding="utf-8")
+    assert "capability_calls_fail_closed_until_promoted" in test_source
+    assert "profile.capabilities.supports(capability) is False" in test_source
     assert "score_actions_is_not_implemented_yet" in test_source
     assert "generate_is_not_implemented_yet" in test_source
     assert "select_actions_is_not_implemented_yet" in test_source
     assert "profile.supported_tasks == []" in test_source
 
+    fixture_payload = json.loads(success_fixture.read_text(encoding="utf-8"))
+    assert fixture_payload["fixture_status"] == "placeholder"
+    assert fixture_payload["usable_as_evidence"] is False
+    assert fixture_payload["replace_before_promotion"] is True
+
+    manifest_payload = json.loads(runtime_manifest_stub.read_text(encoding="utf-8"))
+    assert manifest_payload["stub_status"] == "incomplete"
+    assert manifest_payload["usable_as_evidence"] is False
+    assert manifest_payload["implementation_status"] == "scaffold"
+    assert manifest_payload["required_env_vars"] == ["ACME_WM_API_KEY"]
+    assert "rename" in manifest_payload["_instructions"].lower()
+
     docs_source = docs_path.read_text(encoding="utf-8")
     assert "Taxonomy category: JEPA latent predictive world model" in docs_source
+    assert "not executable until the promotion criteria pass" in docs_source
+    assert "acme-wm.json.stub" in docs_source
     assert "`score` implemented, advertised, and tested" in docs_source
     assert "`policy` implemented, advertised, and tested" in docs_source
+
+    workbench_source = workbench_path.read_text(encoding="utf-8")
+    assert "Provider Workbench Checklist" in workbench_source
+    assert "uv run pytest tests/test_acme_wm_provider.py" in workbench_source
+    assert "uv run pytest tests/test_provider_runtime_manifests.py" in workbench_source
 
     py_compile.compile(str(provider_path), doraise=True)
     py_compile.compile(str(test_path), doraise=True)
@@ -77,6 +114,8 @@ def test_scaffold_provider_script_refuses_to_overwrite_files(tmp_path: Path) -> 
         "Acme WM",
         "--root",
         str(tmp_path),
+        "--implementation-status",
+        "scaffold",
         "--planned-capability",
         "score",
     ]

--- a/tests/test_scaffold_provider.py
+++ b/tests/test_scaffold_provider.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "scaffold_provider.py"
+
+
+def _run_scaffold(tmp_path: Path, *extra_args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "Acme WM",
+            "--root",
+            str(tmp_path),
+            "--taxonomy",
+            "JEPA latent predictive world model",
+            "--implementation-status",
+            "scaffold",
+            "--planned-capability",
+            "score",
+            *extra_args,
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_scaffold_provider_requires_explicit_implementation_status(tmp_path: Path) -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "Acme WM",
+            "--root",
+            str(tmp_path),
+            "--planned-capability",
+            "score",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 2
+    assert "--implementation-status" in result.stderr
+
+
+def test_scaffold_provider_writes_full_contract_pack(tmp_path: Path) -> None:
+    result = _run_scaffold(tmp_path, "--remote", "--env-var", "ACME_WM_API_KEY")
+
+    provider_path = tmp_path / "src/worldforge/providers/acme_wm.py"
+    test_path = tmp_path / "tests/test_acme_wm_provider.py"
+    manifest_stub_path = tmp_path / "src/worldforge/providers/runtime_manifests/acme-wm.json.stub"
+    docs_path = tmp_path / "docs/src/providers/acme-wm.md"
+    workbench_path = tmp_path / "docs/src/providers/acme-wm-workbench.md"
+
+    for path in (provider_path, test_path, manifest_stub_path, docs_path, workbench_path):
+        assert path.exists(), path
+
+    assert "uv run pytest tests/test_acme_wm_provider.py" in result.stdout
+    assert "uv run mkdocs build --strict" in result.stdout
+    assert "worldforge provider workbench acme-wm" in result.stdout
+
+    provider_source = provider_path.read_text(encoding="utf-8")
+    assert "planned_capabilities = ('score',)" in provider_source
+    assert "implementation_status='scaffold'" in provider_source
+    assert "profile=ProviderProfileSpec(" in provider_source
+    assert "capabilities=ProviderCapabilities(predict=False)" in provider_source
+
+    test_source = test_path.read_text(encoding="utf-8")
+    assert "profile.capabilities.supports(capability) is False" in test_source
+    assert "capability_calls_fail_closed_until_promoted" in test_source
+    assert "ProviderError" in test_source
+
+    docs_source = docs_path.read_text(encoding="utf-8")
+    assert "not executable until the promotion criteria pass" in docs_source
+    assert "acme-wm.json.stub" in docs_source
+    assert "uv run worldforge provider workbench acme-wm --format markdown" in docs_source
+
+    workbench_source = workbench_path.read_text(encoding="utf-8")
+    assert "not evidence by\nitself" in workbench_source
+    assert "Existing files are not overwritten unless `--force` is explicit" in workbench_source
+
+
+def test_scaffold_provider_manifest_stub_cannot_be_loaded_as_evidence(tmp_path: Path) -> None:
+    _run_scaffold(tmp_path)
+
+    manifest_stub_path = tmp_path / "src/worldforge/providers/runtime_manifests/acme-wm.json.stub"
+    manifest_path = tmp_path / "src/worldforge/providers/runtime_manifests/acme-wm.json"
+    payload = json.loads(manifest_stub_path.read_text(encoding="utf-8"))
+
+    assert manifest_stub_path.exists()
+    assert not manifest_path.exists()
+    assert payload["stub_status"] == "incomplete"
+    assert payload["usable_as_evidence"] is False
+    assert "TODO" in json.dumps(payload)


### PR DESCRIPTION
## Problem

Provider scaffolds were still too thin for adapter authors. They generated adapter, fixture, test, and docs placeholders, but did not create a runtime-manifest stub or workbench checklist, and the generated provider source had drifted from the current `BaseProvider` profile contract.

Closes #142.

## Solution

- Require an explicit `--implementation-status scaffold` argument when generating a provider scaffold.
- Generate a fuller fail-closed contract pack: provider source, tests, placeholder fixtures, docs stub, incomplete `.json.stub` runtime manifest, and provider workbench checklist.
- Mark fixture and runtime-manifest placeholders as non-evidence until TODOs are replaced and promotion validation passes.
- Generate provider source through `ProviderProfileSpec(...)` so new scaffolds match the current provider base-class API.
- Document the new scaffold files, validation commands, non-evidence manifest behavior, and later workbench target requirement.

## Validation

- `uv lock --check`
- `uv run ruff check src tests examples scripts`
- `uv run ruff format --check src tests examples scripts`
- `uv run python scripts/generate_provider_docs.py --check`
- `uv run pytest tests/test_scaffold_provider.py tests/test_provider_catalog_docs.py`
- `uv run mkdocs build --strict`
- `uv run pytest`
- `uv run --extra harness pytest --cov=src/worldforge --cov-report=term-missing --cov-fail-under=90`
- `bash scripts/test_package.sh`
- `uv build --out-dir dist --clear --no-build-logs`
- `git diff --check`

## Caveats

The generated workbench command is documented as a post-target check. A newly generated provider is still not auto-registered, so authors must add a catalog or direct workbench target before expecting `worldforge provider workbench <provider>` to run.
