### PR TITLE
Add issue-ready run bundles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ releases may still include breaking changes when the public API needs to tighten
 
 ### Added
 
+- Added issue-ready bundles for preserved run workspaces. `worldforge runs bundle <run-id>` now
+  exports one run to `evidence_manifest.json`, `summary.md`, and `issue.md`, prints a short issue
+  template, preserves SHA-256 digests and `safe_to_attach` flags, and marks unsafe or host-local
+  artifacts before attachment.
 - Provider scaffolding now generates a fuller fail-closed contract pack: an explicit
   `--implementation-status scaffold` maturity claim, provider/profile tests for disabled
   capability calls, placeholder fixtures marked as non-evidence, an incomplete `.json.stub`

--- a/docs/src/evaluation.md
+++ b/docs/src/evaluation.md
@@ -62,6 +62,7 @@ generate a checkout-safe evidence bundle:
 ```bash
 uv run worldforge eval --suite planning --provider mock --run-workspace .worldforge
 uv run worldforge benchmark --preset mock-smoke --run-workspace .worldforge
+uv run worldforge runs bundle <run-id>
 uv run python scripts/generate_evidence_bundle.py --workspace-dir .worldforge
 ```
 
@@ -70,6 +71,10 @@ The bundle defaults to `.worldforge/evidence-bundles/<timestamp>/` and writes
 event logs, preset input and budget files, fixture digests, SHA-256 file digests, and
 `safe_to_attach` flags. Unsupported binary artifacts, host-local absolute paths, signed URLs, and
 secret-like text are excluded or marked local-only by default.
+
+Use `worldforge runs bundle <run-id>` for a smaller issue-ready export of one run. It writes
+`issue.md` beside the digest manifest and summary, and the printed issue template includes the
+command, expected signal, observed failure, safe-to-attach notes, and first triage step.
 
 The same built-in suites are available from TheWorldHarness. Launch
 `uv run --extra harness worldforge-harness --flow eval`, pick a suite and provider, and the TUI

--- a/docs/src/operations.md
+++ b/docs/src/operations.md
@@ -164,6 +164,7 @@ operator evidence bundles, not a database.
 uv run worldforge eval --suite planning --provider mock --run-workspace .worldforge
 uv run worldforge benchmark --provider mock --operation predict --run-workspace .worldforge
 uv run worldforge runs list
+uv run worldforge runs bundle <run-id>
 uv run worldforge runs cleanup --keep 20
 ```
 
@@ -171,10 +172,17 @@ Each run directory contains `run_manifest.json`, `inputs/`, `results/`, `reports
 and `logs/`. The manifest stores a sortable file-safe run ID, command, provider, operation, status,
 input summary, result summary, event count, and relative artifact paths.
 
+For public issues, run `worldforge runs bundle <run-id> --workspace-dir .worldforge` first. The
+command writes `.worldforge/issue-bundles/<run-id>/evidence_manifest.json`, `summary.md`, and
+`issue.md`, then prints the issue template. Success signal: `safe_to_attach` is `true` or the
+manifest clearly lists excluded/local-only files with a reason. First triage step after export:
+open `evidence_manifest.json`; if anything is excluded or local-only, remove or replace the unsafe
+artifact before attaching the bundle.
+
 Retention is host-owned. `worldforge runs cleanup --keep <n>` keeps the newest run IDs and removes
 older directories; use `--dry-run` before deleting evidence attached to an incident or release gate.
-For public issues, attach the manifest plus report files and redact any host-created artifacts that
-contain private paths, prompts, credentials, signed URLs, or provider-native payloads.
+Do not attach raw host-created artifacts that contain private paths, prompts, credentials, signed
+URLs, or provider-native payloads.
 
 Candidate benchmark budgets must be generated from preserved benchmark reports and reviewed before
 they replace release budget files:

--- a/docs/src/playbooks.md
+++ b/docs/src/playbooks.md
@@ -258,6 +258,19 @@ in-memory edit buffer stays intact so the user can fix and retry.
 Use this when a CLI job, batch host, service request, or TheWorldHarness run needs provider events
 that can be attached to an issue, release bundle, or incident note.
 
+For one failed preserved run, export the issue-ready bundle before posting:
+
+```bash
+uv run worldforge runs bundle <run-id> \
+  --workspace-dir .worldforge \
+  --output .worldforge/issue-bundles/<run-id>
+```
+
+Success signal: the command writes `evidence_manifest.json`, `summary.md`, and `issue.md`, then
+prints a short issue template with the command, expected signal, observed failure, artifact list,
+`safe_to_attach` status, and first triage step. If `safe_to_attach` is `false`, inspect the
+manifest's excluded and `local_only` entries before attaching anything.
+
 ```python
 from pathlib import Path
 

--- a/docs/src/roadmap-continuation.md
+++ b/docs/src/roadmap-continuation.md
@@ -761,10 +761,10 @@ Out of scope:
 
 Acceptance criteria:
 
-- [ ] Export succeeds for successful, failed, skipped, and cancelled mock runs.
-- [ ] Unsafe metadata causes a clear error or local-only marking.
-- [ ] Bundle manifest contains digests and safe-to-attach flags.
-- [ ] Docs explain the first triage step after export.
+- [x] Export succeeds for successful, failed, skipped, and cancelled mock runs.
+- [x] Unsafe metadata causes a clear error or local-only marking.
+- [x] Bundle manifest contains digests and safe-to-attach flags.
+- [x] Docs explain the first triage step after export.
 
 Validation:
 

--- a/src/worldforge/cli.py
+++ b/src/worldforge/cli.py
@@ -793,7 +793,7 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Output format for the forked world summary.",
     )
 
-    runs = subparsers.add_parser("runs", help="List and clean preserved run workspaces.")
+    runs = subparsers.add_parser("runs", help="List, bundle, compare, and clean preserved runs.")
     runs_subparsers = runs.add_subparsers(dest="runs_command", required=True, metavar="command")
     runs_list = runs_subparsers.add_parser("list", help="List preserved run manifests.")
     runs_list.add_argument(
@@ -828,6 +828,33 @@ def _build_parser() -> argparse.ArgumentParser:
         "--output",
         type=Path,
         help="Optional path to write the comparison artifact instead of stdout.",
+    )
+    runs_bundle = runs_subparsers.add_parser(
+        "bundle",
+        help="Export an issue-ready bundle for one preserved run.",
+    )
+    runs_bundle.add_argument("run_id", help="Run id under .worldforge/runs/.")
+    runs_bundle.add_argument(
+        "--workspace-dir",
+        type=Path,
+        default=Path(".worldforge"),
+        help="WorldForge workspace directory containing runs/.",
+    )
+    runs_bundle.add_argument(
+        "--output",
+        type=Path,
+        help="Bundle output directory. Defaults to <workspace-dir>/issue-bundles/<run-id>.",
+    )
+    runs_bundle.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Replace an existing output directory.",
+    )
+    runs_bundle.add_argument(
+        "--format",
+        choices=("json", "markdown"),
+        default="markdown",
+        help="Output format for the issue bundle summary.",
     )
     runs_cleanup = runs_subparsers.add_parser("cleanup", help="Remove old preserved runs.")
     runs_cleanup.add_argument(
@@ -1107,6 +1134,36 @@ def _cmd_runs(args: argparse.Namespace) -> int:
             )
             return 0
         print(rendered)
+        return 0
+
+    if args.runs_command == "bundle":
+        from worldforge.evidence_bundle import generate_issue_bundle
+
+        output_dir = args.output or args.workspace_dir / "issue-bundles" / args.run_id
+        result = generate_issue_bundle(
+            workspace_dir=args.workspace_dir,
+            run_id=args.run_id,
+            output_dir=output_dir,
+            overwrite=args.overwrite,
+        )
+        if args.format == "json":
+            _print_json(
+                {
+                    "run_id": args.run_id,
+                    "output_dir": str(result.output_dir),
+                    "manifest_path": str(result.manifest_path),
+                    "summary_path": str(result.summary_path),
+                    "issue_template_path": str(result.issue_template_path),
+                    "safe_to_attach": result.manifest["safe_to_attach"],
+                    "included_count": result.manifest["included_count"],
+                    "excluded_count": result.manifest["excluded_count"],
+                    "first_triage_step": result.manifest["first_triage_step"],
+                }
+            )
+        else:
+            if result.issue_template_path is None:
+                raise WorldForgeError("Issue bundle did not produce issue.md.")
+            print(result.issue_template_path.read_text(encoding="utf-8"))
         return 0
 
     if args.runs_command == "cleanup":

--- a/src/worldforge/evidence_bundle.py
+++ b/src/worldforge/evidence_bundle.py
@@ -36,6 +36,7 @@ class BundleResult:
     manifest_path: Path
     summary_path: Path
     manifest: JSONDict
+    issue_template_path: Path | None = None
 
 
 def generate_evidence_bundle(
@@ -73,7 +74,10 @@ def generate_evidence_bundle(
             "command": str(manifest.get("command", "")),
             "provider": manifest.get("provider"),
             "operation": manifest.get("operation"),
+            "expected_signal": _expected_signal(manifest),
+            "observed_failure": _observed_failure(manifest),
             "skip_reason": _skip_reason(manifest),
+            "validation_errors": _validation_errors(manifest),
             "source_path": _display_path(run_path),
         }
         runs.append(run_record)
@@ -121,6 +125,45 @@ def generate_evidence_bundle(
         output_dir=output,
         manifest_path=manifest_path,
         summary_path=summary_path,
+        manifest=manifest,
+    )
+
+
+def generate_issue_bundle(
+    *,
+    workspace_dir: Path,
+    run_id: str,
+    output_dir: Path,
+    overwrite: bool = False,
+) -> BundleResult:
+    """Generate a small issue-ready bundle for one preserved run."""
+
+    result = generate_evidence_bundle(
+        workspace_dir=workspace_dir,
+        output_dir=output_dir,
+        run_ids=(run_id,),
+        overwrite=overwrite,
+        include_fixture_digests=False,
+    )
+    manifest = {
+        **result.manifest,
+        "bundle_kind": "issue-run",
+        "issue_template": "issue.md",
+        "first_triage_step": _first_triage_step(result.manifest),
+    }
+    dump_json(manifest)
+    issue_path = result.output_dir / "issue.md"
+    result.manifest_path.write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    result.summary_path.write_text(render_evidence_bundle_summary(manifest), encoding="utf-8")
+    issue_path.write_text(render_issue_bundle_template(manifest), encoding="utf-8")
+    return BundleResult(
+        output_dir=result.output_dir,
+        manifest_path=result.manifest_path,
+        summary_path=result.summary_path,
+        issue_template_path=issue_path,
         manifest=manifest,
     )
 
@@ -200,6 +243,64 @@ def render_evidence_bundle_summary(manifest: JSONDict) -> str:
             "This bundle copies checkout-safe evidence from preserved WorldForge run workspaces. "
             "Excluded files are listed with reasons. The bundle does not upload artifacts, execute "
             "live providers, include raw secrets, or claim physical fidelity.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def render_issue_bundle_template(manifest: JSONDict) -> str:
+    """Render a short GitHub issue body from an issue-run bundle manifest."""
+
+    runs = manifest.get("runs", [])
+    run = runs[0] if isinstance(runs, list) and runs else {}
+    if not isinstance(run, dict):
+        run = {}
+    safe = bool(manifest.get("safe_to_attach"))
+    validation_errors = run.get("validation_errors")
+    lines = [
+        f"## WorldForge Run Issue: `{run.get('run_id', '-')}`",
+        "",
+        "### Command",
+        "",
+        f"`{run.get('command') or '-'}`",
+        "",
+        "### Expected Signal",
+        "",
+        str(run.get("expected_signal") or "-"),
+        "",
+        "### Observed Failure",
+        "",
+        str(run.get("observed_failure") or "-"),
+    ]
+    if isinstance(validation_errors, list) and validation_errors:
+        lines.extend(["", "Validation errors:"])
+        lines.extend(f"- {error}" for error in validation_errors)
+    lines.extend(
+        [
+            "",
+            "### Artifacts",
+            "",
+            "- `evidence_manifest.json`",
+            "- `summary.md`",
+            "- `issue.md`",
+            f"- included files: {manifest.get('included_count', 0)}",
+            f"- excluded files: {manifest.get('excluded_count', 0)}",
+            "",
+            "### Safe-To-Attach Notes",
+            "",
+            f"- safe_to_attach: `{str(safe).lower()}`",
+            (
+                "- Attach the bundle contents from this directory."
+                if safe
+                else "- Review `evidence_manifest.json` before attaching; at least one file was "
+                "excluded or marked local-only."
+            ),
+            "- Excluded files remain listed with reason, digest when available, and `local_only`.",
+            "",
+            "### First Triage Step",
+            "",
+            str(manifest.get("first_triage_step") or _first_triage_step(manifest)),
             "",
         ]
     )
@@ -550,7 +651,7 @@ def _record_excluded(
     context.files.append(
         {
             "path": destination.as_posix(),
-            "source": source,
+            "source": _safe_source_display(source),
             "kind": kind,
             "included": False,
             "safe_to_attach": False,
@@ -641,6 +742,69 @@ def _skip_reason(manifest: JSONDict) -> str | None:
     return None
 
 
+def _expected_signal(manifest: JSONDict) -> str:
+    result_summary = manifest.get("result_summary", {})
+    if isinstance(result_summary, dict):
+        expected = result_summary.get("expected_signal")
+        if isinstance(expected, str) and expected.strip():
+            return expected.strip()
+    return "The preserved command completes and writes a non-failed run_manifest.json."
+
+
+def _observed_failure(manifest: JSONDict) -> str:
+    status = str(manifest.get("status", "") or "unknown")
+    result_summary = manifest.get("result_summary", {})
+    if isinstance(result_summary, dict):
+        for key in (
+            "observed_failure",
+            "failure_reason",
+            "error",
+            "error_message",
+            "message",
+            "skip_reason",
+            "reason",
+        ):
+            value = result_summary.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+        validation_errors = _validation_errors(manifest)
+        if validation_errors:
+            return "; ".join(validation_errors)
+    if status == "passed":
+        return "No failure recorded; bundle captures a successful preserved run."
+    if status == "skipped":
+        return _skip_reason(manifest) or "Run was skipped without a structured reason."
+    if status == "cancelled":
+        return "Run was cancelled before completion."
+    if status == "failed":
+        return "Run failed without a structured failure reason."
+    return f"Run status is {status}."
+
+
+def _validation_errors(manifest: JSONDict) -> list[str]:
+    result_summary = manifest.get("result_summary", {})
+    if not isinstance(result_summary, dict):
+        return []
+    raw_errors = result_summary.get("validation_errors") or result_summary.get("validation_error")
+    if isinstance(raw_errors, str) and raw_errors.strip():
+        return [raw_errors.strip()]
+    if isinstance(raw_errors, list):
+        return [str(error).strip() for error in raw_errors if str(error).strip()]
+    return []
+
+
+def _first_triage_step(manifest: JSONDict) -> str:
+    if not bool(manifest.get("safe_to_attach")):
+        return (
+            "Open evidence_manifest.json, inspect excluded files and local_only entries, and "
+            "remove or replace unsafe artifacts before attaching the bundle."
+        )
+    return (
+        "Open summary.md, then inspect the copied run_manifest.json and report artifacts for the "
+        "preserved run."
+    )
+
+
 def _sha256_file(path: Path) -> str:
     digest = hashlib.sha256()
     with path.open("rb") as handle:
@@ -661,7 +825,13 @@ def _display_path(path: Path) -> str:
     try:
         return path.resolve().relative_to(_ROOT.resolve()).as_posix()
     except ValueError:
-        return str(path)
+        return f"<host-local:{path.name}>"
+
+
+def _safe_source_display(source: str) -> str:
+    if _HOST_PATH_PATTERN.search(source):
+        return f"<host-local:{Path(source).name or 'path'}>"
+    return source
 
 
 def _is_relative_to(path: Path, root: Path) -> bool:
@@ -676,5 +846,7 @@ __all__ = [
     "EVIDENCE_BUNDLE_SCHEMA_VERSION",
     "BundleResult",
     "generate_evidence_bundle",
+    "generate_issue_bundle",
     "render_evidence_bundle_summary",
+    "render_issue_bundle_template",
 ]

--- a/src/worldforge/evidence_bundle.py
+++ b/src/worldforge/evidence_bundle.py
@@ -829,7 +829,7 @@ def _display_path(path: Path) -> str:
 
 
 def _safe_source_display(source: str) -> str:
-    if _HOST_PATH_PATTERN.search(source):
+    if Path(source).is_absolute() or _HOST_PATH_PATTERN.search(source):
         return f"<host-local:{Path(source).name or 'path'}>"
     return source
 

--- a/tests/test_docs_site.py
+++ b/tests/test_docs_site.py
@@ -534,6 +534,31 @@ def test_evidence_bundle_docs_cover_issue_145_contract() -> None:
     assert "- [x] Bundle generation succeeds" in continuation
 
 
+def test_issue_bundle_docs_cover_issue_148_contract() -> None:
+    evaluation = (ROOT / "docs/src/evaluation.md").read_text(encoding="utf-8")
+    operations = (ROOT / "docs/src/operations.md").read_text(encoding="utf-8")
+    playbooks = (ROOT / "docs/src/playbooks.md").read_text(encoding="utf-8")
+    continuation = (ROOT / "docs/src/roadmap-continuation.md").read_text(encoding="utf-8")
+    changelog = (ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
+
+    for signal in (
+        "worldforge runs bundle <run-id>",
+        "issue.md",
+        "expected signal",
+        "observed failure",
+        "safe_to_attach",
+        "first triage step",
+        "local_only",
+    ):
+        assert signal in evaluation or signal in operations or signal in playbooks
+
+    assert "issue-ready bundles" in changelog
+    assert "- [x] Export succeeds for successful, failed, skipped, and cancelled mock runs" in (
+        continuation
+    )
+    assert "- [x] Unsafe metadata causes a clear error or local-only marking" in continuation
+
+
 def test_benchmark_budget_calibration_docs_cover_issue_146_contract() -> None:
     benchmarking = (ROOT / "docs/src/benchmarking.md").read_text(encoding="utf-8")
     operations = (ROOT / "docs/src/operations.md").read_text(encoding="utf-8")

--- a/tests/test_issue_bundle_export.py
+++ b/tests/test_issue_bundle_export.py
@@ -132,6 +132,7 @@ def test_issue_bundle_marks_unsafe_metadata_local_only(tmp_path: Path) -> None:
         artifact_paths={
             "events": "logs/provider-events.jsonl",
             "local": str(local_path),
+            "linux_tmp": "/tmp/worldforge-local-result.json",
         },
     )
 
@@ -149,7 +150,9 @@ def test_issue_bundle_marks_unsafe_metadata_local_only(tmp_path: Path) -> None:
         "signed or credentialed URL detected",
     }
     assert excluded["runs/20260105T000000Z-00000005/artifacts/local"]["local_only"] is True
+    assert excluded["runs/20260105T000000Z-00000005/artifacts/linux_tmp"]["local_only"] is True
     assert str(tmp_path) not in json.dumps(manifest)
+    assert "/tmp/worldforge-local-result.json" not in json.dumps(manifest)
     assert result.issue_template_path is not None
     assert (
         "Review `evidence_manifest.json` before attaching"

--- a/tests/test_issue_bundle_export.py
+++ b/tests/test_issue_bundle_export.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+from worldforge.cli import main
+from worldforge.evidence_bundle import generate_issue_bundle
+from worldforge.harness.workspace import create_run_workspace, write_run_manifest
+
+
+def _mock_run(workspace_dir: Path, *, run_id: str, status: str) -> None:
+    workspace = create_run_workspace(
+        workspace_dir,
+        kind="eval",
+        command=f"worldforge eval --suite planning --provider mock --status {status}",
+        provider="mock",
+        operation="planning",
+        run_id=run_id,
+        input_summary={"suite_id": "planning", "providers": ["mock"]},
+    )
+    workspace.write_json(
+        "reports/report.json",
+        {
+            "suite_id": "planning",
+            "provider_summaries": [{"provider": "mock", "status": status}],
+            "run_metadata": {},
+        },
+    )
+    workspace.write_json("results/result-summary.json", {"status": status, "provider": "mock"})
+    workspace.write_text(
+        "logs/provider-events.jsonl",
+        '{"provider":"mock","operation":"planning","phase":"success","metadata":{}}',
+    )
+    result_summary = {
+        "expected_signal": "planning evaluation writes a preserved report and run manifest",
+    }
+    if status == "failed":
+        result_summary["validation_errors"] = ["score was below threshold"]
+    if status == "skipped":
+        result_summary["skip_reason"] = "fixture requested skip"
+    if status == "cancelled":
+        result_summary["failure_reason"] = "operator cancelled run"
+    write_run_manifest(
+        workspace,
+        kind="eval",
+        command=f"worldforge eval --suite planning --provider mock --status {status}",
+        provider="mock",
+        operation="planning",
+        status=status,
+        input_summary={"suite_id": "planning", "providers": ["mock"]},
+        result_summary=result_summary,
+        artifact_paths={
+            "report": "reports/report.json",
+            "result": "results/result-summary.json",
+            "events": "logs/provider-events.jsonl",
+        },
+        event_count=1,
+    )
+
+
+def test_issue_bundle_exports_mock_run_statuses(tmp_path: Path) -> None:
+    run_ids = {
+        "passed": "20260101T000000Z-00000001",
+        "failed": "20260102T000000Z-00000002",
+        "skipped": "20260103T000000Z-00000003",
+        "cancelled": "20260104T000000Z-00000004",
+    }
+    for status, run_id in run_ids.items():
+        _mock_run(tmp_path, run_id=run_id, status=status)
+
+    for status, run_id in run_ids.items():
+        result = generate_issue_bundle(
+            workspace_dir=tmp_path,
+            run_id=run_id,
+            output_dir=tmp_path / "issue-bundles" / status,
+        )
+
+        manifest = result.manifest
+        assert manifest["bundle_kind"] == "issue-run"
+        assert manifest["run_count"] == 1
+        assert manifest["runs"][0]["run_id"] == run_id
+        assert manifest["runs"][0]["status"] == status
+        assert manifest["runs"][0]["expected_signal"].startswith("planning evaluation")
+        assert manifest["safe_to_attach"] is True
+        assert all(item["sha256"].startswith("sha256:") for item in manifest["files"])
+        assert result.issue_template_path is not None
+        issue = result.issue_template_path.read_text(encoding="utf-8")
+        assert "### Command" in issue
+        assert "### Expected Signal" in issue
+        assert "### Observed Failure" in issue
+        assert "### Safe-To-Attach Notes" in issue
+        assert "### First Triage Step" in issue
+        assert "safe_to_attach: `true`" in issue
+
+    failed = json.loads(
+        (tmp_path / "issue-bundles" / "failed" / "evidence_manifest.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert failed["runs"][0]["validation_errors"] == ["score was below threshold"]
+    assert "score was below threshold" in (
+        tmp_path / "issue-bundles" / "failed" / "issue.md"
+    ).read_text(encoding="utf-8")
+
+
+def test_issue_bundle_marks_unsafe_metadata_local_only(tmp_path: Path) -> None:
+    workspace = create_run_workspace(
+        tmp_path,
+        kind="eval",
+        command="worldforge eval --suite planning --provider mock",
+        provider="mock",
+        operation="planning",
+        run_id="20260105T000000Z-00000005",
+        input_summary={"suite_id": "planning", "providers": ["mock"]},
+    )
+    workspace.write_text(
+        "logs/provider-events.jsonl",
+        '{"target":"https://example.test/artifact.json?token=secret"}',
+    )
+    local_path = tmp_path / "local-result.json"
+    local_path.write_text("{}", encoding="utf-8")
+    write_run_manifest(
+        workspace,
+        kind="eval",
+        command="worldforge eval --suite planning --provider mock",
+        provider="mock",
+        operation="planning",
+        status="failed",
+        input_summary={"suite_id": "planning", "providers": ["mock"]},
+        result_summary={"failure_reason": "provider event was unsafe"},
+        artifact_paths={
+            "events": "logs/provider-events.jsonl",
+            "local": str(local_path),
+        },
+    )
+
+    result = generate_issue_bundle(
+        workspace_dir=tmp_path,
+        run_id="20260105T000000Z-00000005",
+        output_dir=tmp_path / "issue-bundles" / "unsafe",
+    )
+
+    manifest = result.manifest
+    assert manifest["safe_to_attach"] is False
+    excluded = {item["path"]: item for item in manifest["files"] if not item["included"]}
+    assert excluded["runs/20260105T000000Z-00000005/logs/provider-events.jsonl"]["reason"] in {
+        "secret-like material detected",
+        "signed or credentialed URL detected",
+    }
+    assert excluded["runs/20260105T000000Z-00000005/artifacts/local"]["local_only"] is True
+    assert str(tmp_path) not in json.dumps(manifest)
+    assert result.issue_template_path is not None
+    assert (
+        "Review `evidence_manifest.json` before attaching"
+        in result.issue_template_path.read_text(encoding="utf-8")
+    )
+
+
+def test_runs_bundle_cli_prints_issue_template_and_json(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    run_id = "20260106T000000Z-00000006"
+    _mock_run(tmp_path, run_id=run_id, status="failed")
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "worldforge",
+            "runs",
+            "bundle",
+            run_id,
+            "--workspace-dir",
+            str(tmp_path),
+            "--output",
+            str(tmp_path / "bundle-md"),
+        ],
+    )
+    assert main() == 0
+    markdown = capsys.readouterr().out
+    assert "## WorldForge Run Issue" in markdown
+    assert "score was below threshold" in markdown
+    assert (tmp_path / "bundle-md" / "issue.md").exists()
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "worldforge",
+            "runs",
+            "bundle",
+            run_id,
+            "--workspace-dir",
+            str(tmp_path),
+            "--output",
+            str(tmp_path / "bundle-json"),
+            "--format",
+            "json",
+        ],
+    )
+    assert main() == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["run_id"] == run_id
+    assert payload["safe_to_attach"] is True
+    assert payload["issue_template_path"].endswith("issue.md")


### PR DESCRIPTION
## Problem

Preserved run workspaces could already feed release evidence bundles, but operators still lacked a run-scoped issue export that prints the command context, expected signal, observed failure, artifacts, and safe-to-attach notes for a single run.

Closes #148.

## Solution

- Add `worldforge runs bundle <run-id>` for one-run issue bundles under `.worldforge/issue-bundles/<run-id>/` by default.
- Reuse the existing safe evidence-copying path while writing `evidence_manifest.json`, `summary.md`, and a new `issue.md` template.
- Record expected signal, observed failure, validation errors, digests, `safe_to_attach`, excluded files, and first triage step in the generated manifest/template.
- Redact host-local source paths from generated manifests and mark unsafe or local-only artifacts before attachment.
- Document the operator flow in evaluation, operations, and playbook docs.

## Validation

- `uv lock --check`
- `uv run ruff check src tests examples scripts`
- `uv run ruff format --check src tests examples scripts`
- `uv run python scripts/generate_provider_docs.py --check`
- `uv run pytest tests/test_issue_bundle_export.py tests/test_harness_workspace.py tests/test_observability.py`
- `uv run pytest tests/test_evidence_bundle.py tests/test_issue_bundle_export.py tests/test_provider_catalog_docs.py`
- `uv run pytest tests/test_cli_help_snapshots.py tests/test_docs_site.py`
- `uv run mkdocs build --strict`
- `uv run pytest`
- `uv run --extra harness pytest --cov=src/worldforge --cov-report=term-missing --cov-fail-under=90`
- `bash scripts/test_package.sh`
- `uv build --out-dir dist --clear --no-build-logs`
- `git diff --check`

## Caveats

This only packages local preserved run workspaces. It does not create GitHub issues, upload artifacts, store bundles remotely, or make unsafe host-owned artifacts attachable.
