### PR TITLE
Tighten harness preserved-run workflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ releases may still include breaking changes when the public API needs to tighten
   exports one run to `evidence_manifest.json`, `summary.md`, and `issue.md`, prints a short issue
   template, preserves SHA-256 digests and `safe_to_attach` flags, and marks unsafe or host-local
   artifacts before attachment.
+- Added preserved-run history actions to TheWorldHarness. The Runs screen and
+  `worldforge harness --runs` can filter run workspaces by provider, capability, status, date, and
+  safe artifact type; rows expose sanitized rerun commands plus issue-bundle and comparison actions,
+  with failed/skipped/cancelled runs surfacing the recovery bundle command first.
 - Provider scaffolding now generates a fuller fail-closed contract pack: an explicit
   `--implementation-status scaffold` maturity claim, provider/profile tests for disabled
   capability calls, placeholder fixtures marked as non-evidence, an incomplete `.json.stub`

--- a/docs/src/cli.md
+++ b/docs/src/cli.md
@@ -91,15 +91,17 @@ uv run --extra harness worldforge-harness
 uv run --extra harness worldforge-harness --flow leworldmodel
 uv run --extra harness worldforge-harness --flow lerobot
 uv run --extra harness worldforge-harness --flow diagnostics
+uv run --extra harness worldforge-harness --flow runs
 uv run worldforge harness --list
 uv run worldforge harness --connectors --format json
+uv run worldforge harness --runs --status failed --artifact-type json
 ```
 
 TheWorldHarness is optional and Textual-backed. It keeps Textual out of the base package while
 providing a visual workspace for checkout-safe flows, provider diagnostics, local worlds, evals, and
-benchmarks. The connector metadata command is checkout-safe and works without Textual; it reports
-provider readiness categories, missing env-var names, optional runtime dependencies, and first smoke
-commands without printing secret values.
+benchmarks. The connector and run-history metadata commands are checkout-safe and work without
+Textual; they report provider readiness, preserved-run filters, sanitized rerun commands, and first
+recovery actions without printing secret values.
 
 ## Packaged Demos
 

--- a/docs/src/operations.md
+++ b/docs/src/operations.md
@@ -164,6 +164,7 @@ operator evidence bundles, not a database.
 uv run worldforge eval --suite planning --provider mock --run-workspace .worldforge
 uv run worldforge benchmark --provider mock --operation predict --run-workspace .worldforge
 uv run worldforge runs list
+uv run worldforge harness --runs --provider mock --status failed --artifact-type json
 uv run worldforge runs bundle <run-id>
 uv run worldforge runs cleanup --keep 20
 ```
@@ -178,6 +179,12 @@ command writes `.worldforge/issue-bundles/<run-id>/evidence_manifest.json`, `sum
 manifest clearly lists excluded/local-only files with a reason. First triage step after export:
 open `evidence_manifest.json`; if anything is excluded or local-only, remove or replace the unsafe
 artifact before attaching the bundle.
+
+For repeated local operations, use `worldforge harness --runs` or the TheWorldHarness Runs screen
+before opening individual artifacts. It reads preserved manifests without optional model runtimes,
+filters by provider, capability, status, created date, and safe artifact type, and prints sanitized
+rerun, comparison, and issue-bundle commands. Failed, skipped, and cancelled rows surface the
+`worldforge runs bundle <run-id>` recovery command first.
 
 Retention is host-owned. `worldforge runs cleanup --keep <n>` keeps the newest run IDs and removes
 older directories; use `--dry-run` before deleting evidence attached to an incident or release gate.

--- a/docs/src/playbooks.md
+++ b/docs/src/playbooks.md
@@ -261,15 +261,18 @@ that can be attached to an issue, release bundle, or incident note.
 For one failed preserved run, export the issue-ready bundle before posting:
 
 ```bash
+uv run worldforge harness --runs --status failed --artifact-type json
 uv run worldforge runs bundle <run-id> \
   --workspace-dir .worldforge \
   --output .worldforge/issue-bundles/<run-id>
 ```
 
-Success signal: the command writes `evidence_manifest.json`, `summary.md`, and `issue.md`, then
-prints a short issue template with the command, expected signal, observed failure, artifact list,
-`safe_to_attach` status, and first triage step. If `safe_to_attach` is `false`, inspect the
-manifest's excluded and `local_only` entries before attaching anything.
+Success signal: `worldforge harness --runs` lists the failed run with a sanitized rerun command and
+the same `worldforge runs bundle <run-id>` recovery command shown in the Runs screen. The bundle
+command writes `evidence_manifest.json`, `summary.md`, and `issue.md`, then prints a short issue
+template with the command, expected signal, observed failure, artifact list, `safe_to_attach`
+status, and first triage step. If `safe_to_attach` is `false`, inspect the manifest's excluded and
+`local_only` entries before attaching anything.
 
 ```python
 from pathlib import Path

--- a/docs/src/roadmap-continuation.md
+++ b/docs/src/roadmap-continuation.md
@@ -793,10 +793,10 @@ Out of scope:
 
 Acceptance criteria:
 
-- [ ] Harness can filter and open preserved runs without optional model runtimes.
-- [ ] Rerun commands are generated from sanitized manifests and omit secret values.
-- [ ] Failed runs show recovery command and issue-bundle export path.
-- [ ] Tests cover flow logic without importing Textual outside `worldforge.harness.tui`.
+- [x] Harness can filter and open preserved runs without optional model runtimes.
+- [x] Rerun commands are generated from sanitized manifests and omit secret values.
+- [x] Failed runs show recovery command and issue-bundle export path.
+- [x] Tests cover flow logic without importing Textual outside `worldforge.harness.tui`.
 
 Validation:
 

--- a/docs/src/theworldharness.md
+++ b/docs/src/theworldharness.md
@@ -24,10 +24,12 @@ uv run --extra harness worldforge-harness --flow lerobot
 uv run --extra harness worldforge-harness --flow diagnostics
 uv run --extra harness worldforge-harness --flow eval
 uv run --extra harness worldforge-harness --flow benchmark
+uv run --extra harness worldforge-harness --flow runs
 uv run worldforge harness --list
 uv run worldforge harness --list --format json
 uv run worldforge harness --connectors
 uv run worldforge harness --connectors --format json
+uv run worldforge harness --runs --provider mock --status failed --artifact-type json
 ```
 
 Installed package:
@@ -158,11 +160,24 @@ uv run worldforge benchmark --provider mock --operation predict --run-workspace 
 uv run worldforge runs list
 uv run worldforge runs compare .worldforge/runs/<run-a> .worldforge/runs/<run-b>
 uv run worldforge runs cleanup --keep 20
+uv run worldforge harness --runs --provider mock --capability predict --status failed
 ```
 
 Completed eval and benchmark TUI screens still write JSON under `.worldforge/reports/` relative to
 the active state directory for the Home screen and `Ctrl+P` recent-report index. Use the run
 workspace when a full issue attachment needs manifest, reports, logs, and result summaries together.
+The Runs screen and `worldforge harness --runs` read the preserved run manifests directly without
+optional model runtimes. They filter by provider, capability, status, created date, and safe
+artifact type; each row exposes a sanitized rerun command, issue-bundle export command, and
+comparison command where the run type supports comparison. Failed, skipped, and cancelled rows show
+the recovery command first:
+
+```bash
+uv run --extra harness worldforge-harness --flow runs
+uv run worldforge harness --runs --status failed --artifact-type json --format json
+uv run worldforge runs bundle <run-id> --workspace-dir .worldforge
+```
+
 Use `runs compare --format json|markdown|csv` to export attachment-safe comparisons across
 preserved eval runs or preserved benchmark runs. The CLI and harness comparison path share one
 report model: compatible cross-provider runs keep metric deltas, event counts, budget status,
@@ -194,7 +209,9 @@ provider health, benchmark latency, benchmark throughput, and provider event pha
 - `g p`: jump to Providers.
 - `g e`: jump to Eval.
 - `g b`: jump to Benchmark.
-- `Ctrl+P`: search static commands plus worlds, providers, and recent report files.
+- `g u`: jump to Runs.
+- `Ctrl+P`: search static commands plus worlds, providers, recent report files, and preserved run
+  workspaces.
 - `Ctrl+T`: cycle `worldforge-dark`, `worldforge-light`, and `worldforge-high-contrast`.
 - `q`: quit.
 

--- a/src/worldforge/cli.py
+++ b/src/worldforge/cli.py
@@ -1026,7 +1026,15 @@ def _build_parser() -> argparse.ArgumentParser:
     harness = subparsers.add_parser("harness", help="Launch TheWorldHarness TUI.")
     harness.add_argument(
         "--flow",
-        choices=("leworldmodel", "lerobot", "diagnostics"),
+        choices=(
+            "leworldmodel",
+            "lerobot",
+            "diagnostics",
+            "workbench",
+            "eval",
+            "benchmark",
+            "runs",
+        ),
         default="leworldmodel",
         help="Harness flow to open.",
     )
@@ -1047,10 +1055,27 @@ def _build_parser() -> argparse.ArgumentParser:
         help="List provider connector readiness without launching the TUI.",
     )
     harness.add_argument(
+        "--runs",
+        action="store_true",
+        help="List preserved run history without launching the TUI.",
+    )
+    harness.add_argument(
+        "--workspace-dir",
+        type=Path,
+        default=Path(".worldforge"),
+        help="Workspace root for --runs. Defaults to .worldforge.",
+    )
+    harness.add_argument("--provider", help="Filter --runs output by provider substring.")
+    harness.add_argument("--capability", help="Filter --runs output by capability.")
+    harness.add_argument("--status", help="Filter --runs output by run status.")
+    harness.add_argument("--created-from", help="Filter --runs output from YYYY-MM-DD.")
+    harness.add_argument("--created-to", help="Filter --runs output through YYYY-MM-DD.")
+    harness.add_argument("--artifact-type", help="Filter --runs output by safe artifact type.")
+    harness.add_argument(
         "--format",
         choices=("markdown", "json"),
         default="markdown",
-        help="Output format for --list and --connectors.",
+        help="Output format for --list, --connectors, and --runs.",
     )
     harness.add_argument("--no-animation", action="store_true", help="Disable step reveal delays.")
 
@@ -1102,6 +1127,14 @@ def _cmd_harness(args: argparse.Namespace) -> int:
         state_dir=args.state_dir,
         list_only=args.list,
         connectors=args.connectors,
+        runs=args.runs,
+        workspace_dir=args.workspace_dir,
+        provider=args.provider,
+        capability=args.capability,
+        status=args.status,
+        created_from=args.created_from,
+        created_to=args.created_to,
+        artifact_type=args.artifact_type,
         output_format=args.format,
         animate=not args.no_animation,
     )

--- a/src/worldforge/harness/__init__.py
+++ b/src/worldforge/harness/__init__.py
@@ -4,6 +4,12 @@ from __future__ import annotations
 
 from worldforge.harness.flows import available_flows, flow_index, run_flow
 from worldforge.harness.models import HarnessFlow, HarnessMetric, HarnessRun, HarnessStep
+from worldforge.harness.run_history import (
+    RunHistoryFilter,
+    RunHistoryRecord,
+    list_run_history,
+    preserved_run_from_path,
+)
 from worldforge.harness.workspace import (
     RunWorkspace,
     cleanup_run_workspaces,
@@ -16,11 +22,15 @@ __all__ = [
     "HarnessMetric",
     "HarnessRun",
     "HarnessStep",
+    "RunHistoryFilter",
+    "RunHistoryRecord",
     "RunWorkspace",
     "available_flows",
     "cleanup_run_workspaces",
     "create_run_workspace",
     "flow_index",
+    "list_run_history",
     "list_run_workspaces",
+    "preserved_run_from_path",
     "run_flow",
 ]

--- a/src/worldforge/harness/cli.py
+++ b/src/worldforge/harness/cli.py
@@ -13,6 +13,11 @@ from worldforge.harness.connectors import (
     provider_connector_summary_markdown,
 )
 from worldforge.harness.flows import available_flows, flow_to_dicts
+from worldforge.harness.run_history import (
+    RunHistoryFilter,
+    list_run_history,
+    run_history_markdown,
+)
 
 
 def _parser() -> argparse.ArgumentParser:
@@ -22,11 +27,11 @@ def _parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--flow",
-        choices=[flow.id for flow in available_flows()] + ["eval", "benchmark"],
+        choices=[flow.id for flow in available_flows()] + ["eval", "benchmark", "runs"],
         default=None,
         help=(
             "Harness flow or screen to open. When omitted the harness opens on the Home screen; "
-            "eval and benchmark open those screens directly."
+            "eval, benchmark, and runs open those screens directly."
         ),
     )
     parser.add_argument(
@@ -45,6 +50,23 @@ def _parser() -> argparse.ArgumentParser:
         action="store_true",
         help="List provider connector readiness without launching the TUI.",
     )
+    parser.add_argument(
+        "--runs",
+        action="store_true",
+        help="List preserved run history without launching the TUI.",
+    )
+    parser.add_argument(
+        "--workspace-dir",
+        type=Path,
+        default=Path(".worldforge"),
+        help="Workspace root for --runs. Defaults to .worldforge.",
+    )
+    parser.add_argument("--provider", help="Filter --runs output by provider substring.")
+    parser.add_argument("--capability", help="Filter --runs output by capability.")
+    parser.add_argument("--status", help="Filter --runs output by run status.")
+    parser.add_argument("--created-from", help="Filter --runs output from YYYY-MM-DD.")
+    parser.add_argument("--created-to", help="Filter --runs output through YYYY-MM-DD.")
+    parser.add_argument("--artifact-type", help="Filter --runs output by safe artifact type.")
     parser.add_argument(
         "--format",
         choices=("markdown", "json"),
@@ -89,6 +111,21 @@ def print_connector_index(
     print(provider_connector_summary_markdown(rows))
 
 
+def print_run_history(
+    *,
+    workspace_dir: Path,
+    filters: RunHistoryFilter | None = None,
+    output_format: str = "markdown",
+) -> None:
+    """Print preserved run history without importing the TUI."""
+
+    rows = list_run_history(workspace_dir, filters=filters)
+    if output_format == "json":
+        print(json.dumps([row.to_dict() for row in rows], indent=2))
+        return
+    print(run_history_markdown(rows), end="")
+
+
 def launch_harness(
     *,
     flow_id: str | None = None,
@@ -115,7 +152,7 @@ def launch_harness(
             return 2
         raise
 
-    if flow_id in {"eval", "benchmark"}:
+    if flow_id in {"eval", "benchmark", "runs"}:
         initial_screen = flow_id
         resolved_flow_id = "leworldmodel"
     else:
@@ -169,8 +206,16 @@ def run_from_args(
     state_dir: Path | None,
     list_only: bool,
     connectors: bool,
-    output_format: str,
-    animate: bool,
+    runs: bool = False,
+    workspace_dir: Path = Path(".worldforge"),
+    provider: str | None = None,
+    capability: str | None = None,
+    status: str | None = None,
+    created_from: str | None = None,
+    created_to: str | None = None,
+    artifact_type: str | None = None,
+    output_format: str = "markdown",
+    animate: bool = True,
 ) -> int:
     """Run harness behavior from an already-parsed command namespace."""
 
@@ -179,6 +224,21 @@ def run_from_args(
         return 0
     if connectors:
         print_connector_index(state_dir=state_dir, output_format=output_format)
+        return 0
+    if runs:
+        filters = RunHistoryFilter.from_strings(
+            provider=provider,
+            capability=capability,
+            status=status,
+            created_from=created_from,
+            created_to=created_to,
+            artifact_type=artifact_type,
+        )
+        print_run_history(
+            workspace_dir=workspace_dir,
+            filters=filters,
+            output_format=output_format,
+        )
         return 0
     return launch_harness(flow_id=flow_id, state_dir=state_dir, animate=animate)
 
@@ -190,6 +250,14 @@ def main(argv: list[str] | None = None) -> int:
         state_dir=args.state_dir,
         list_only=args.list,
         connectors=args.connectors,
+        runs=args.runs,
+        workspace_dir=args.workspace_dir,
+        provider=args.provider,
+        capability=args.capability,
+        status=args.status,
+        created_from=args.created_from,
+        created_to=args.created_to,
+        artifact_type=args.artifact_type,
         output_format=args.format,
         animate=not args.no_animation,
     )

--- a/src/worldforge/harness/run_history.py
+++ b/src/worldforge/harness/run_history.py
@@ -1,0 +1,640 @@
+"""Textual-free preserved-run history helpers for TheWorldHarness."""
+
+from __future__ import annotations
+
+import json
+import re
+import shlex
+from dataclasses import dataclass, replace
+from datetime import date, datetime
+from pathlib import Path
+
+from worldforge.harness.models import HarnessFlow, HarnessMetric, HarnessRun, HarnessStep
+from worldforge.harness.workspace import list_run_workspaces
+from worldforge.models import CAPABILITY_NAMES, JSONDict, WorldForgeError
+
+_SAFE_ARTIFACT_SUFFIXES = {"json", "jsonl", "md", "csv", "txt"}
+_SECRET_FLAG_PATTERN = re.compile(
+    r"^(--?.*(api[-_]?key|token|secret|password|signature).*)$",
+    re.IGNORECASE,
+)
+_SECRET_ASSIGNMENT_PATTERN = re.compile(
+    r"^([^=\s]*(api[-_]?key|token|secret|password|signature)[^=\s]*)=.*$",
+    re.IGNORECASE,
+)
+_UNSAFE_URL_PATTERN = re.compile(
+    r"^https?://[^\s\"']+[?&](token|signature|sig|key|api_key)=",
+    re.IGNORECASE,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class RunHistoryFilter:
+    """Filter values for preserved harness run history."""
+
+    provider: str | None = None
+    capability: str | None = None
+    status: str | None = None
+    created_from: date | None = None
+    created_to: date | None = None
+    artifact_type: str | None = None
+
+    @classmethod
+    def from_strings(
+        cls,
+        *,
+        provider: str | None = None,
+        capability: str | None = None,
+        status: str | None = None,
+        created_from: str | None = None,
+        created_to: str | None = None,
+        artifact_type: str | None = None,
+    ) -> RunHistoryFilter:
+        """Build a filter from CLI/TUI string fields."""
+
+        return cls(
+            provider=_clean_filter(provider),
+            capability=_clean_filter(capability),
+            status=_clean_filter(status),
+            created_from=parse_history_date(created_from),
+            created_to=parse_history_date(created_to),
+            artifact_type=_clean_filter(artifact_type),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class RunHistoryRecord:
+    """A checkout-safe preserved-run summary for CLI and TUI views."""
+
+    run_id: str
+    kind: str
+    status: str
+    provider: str
+    operation: str
+    capability: str
+    capabilities: tuple[str, ...]
+    created_at: str
+    created_date: date | None
+    command: str
+    rerun_command: str
+    failure_summary: str
+    safe_artifact_types: tuple[str, ...]
+    artifact_count: int
+    event_count: int
+    path: Path
+    display_path: str
+    issue_bundle_command: str
+    issue_bundle_path: str
+    comparison_command: str | None
+    recovery_command: str | None
+
+    def to_dict(self) -> JSONDict:
+        return {
+            "run_id": self.run_id,
+            "kind": self.kind,
+            "status": self.status,
+            "provider": self.provider,
+            "operation": self.operation,
+            "capability": self.capability,
+            "capabilities": list(self.capabilities),
+            "created_at": self.created_at,
+            "command": self.command,
+            "rerun_command": self.rerun_command,
+            "failure_summary": self.failure_summary,
+            "safe_artifact_types": list(self.safe_artifact_types),
+            "artifact_count": self.artifact_count,
+            "event_count": self.event_count,
+            "path": self.display_path,
+            "issue_bundle_command": self.issue_bundle_command,
+            "issue_bundle_path": self.issue_bundle_path,
+            "comparison_command": self.comparison_command,
+            "recovery_command": self.recovery_command,
+        }
+
+
+def parse_history_date(value: str | None) -> date | None:
+    """Parse an ISO date value used by run-history filters."""
+
+    if value is None or not value.strip():
+        return None
+    try:
+        return date.fromisoformat(value.strip())
+    except ValueError as exc:
+        raise WorldForgeError(f"run history date must use YYYY-MM-DD: {value}") from exc
+
+
+def list_run_history(
+    workspace_dir: Path,
+    *,
+    filters: RunHistoryFilter | None = None,
+    limit: int | None = None,
+) -> tuple[RunHistoryRecord, ...]:
+    """Return preserved run summaries sorted newest first."""
+
+    records = tuple(
+        _record_from_manifest(manifest, workspace_dir=workspace_dir)
+        for manifest in list_run_workspaces(workspace_dir)
+    )
+    active_filter = filters or RunHistoryFilter()
+    filtered = tuple(record for record in records if _matches_filter(record, active_filter))
+    if limit is not None:
+        return filtered[:limit]
+    return filtered
+
+
+def preserved_run_from_path(path: Path, *, state_dir: Path) -> HarnessRun:
+    """Open a preserved run workspace as a ``HarnessRun`` without invoking providers."""
+
+    run_path = _run_path_from_input(path)
+    manifest = _load_manifest(run_path)
+    report_path = _report_json_path(run_path, manifest)
+    if report_path is not None and str(manifest.get("kind", "")) in {"eval", "benchmark"}:
+        from worldforge.harness.flows import report_run_from_path
+
+        return replace(
+            report_run_from_path(report_path, state_dir=state_dir),
+            workspace_path=run_path,
+        )
+
+    workspace_dir = run_path.parent.parent
+    record = _record_from_manifest({**manifest, "path": str(run_path)}, workspace_dir=workspace_dir)
+    inspector = _read_json(run_path / "results" / "inspector.json")
+    flow = _flow_from_record(record, inspector)
+    steps = _steps_from_record(record, inspector)
+    metrics = _metrics_from_record(record, inspector)
+    provider_events = _provider_events_from_inspector(inspector)
+    validation_errors = _validation_errors_from_manifest(manifest)
+    return HarnessRun(
+        flow=flow,
+        state_dir=state_dir,
+        summary={
+            "run_id": record.run_id,
+            "kind": record.kind,
+            "status": record.status,
+            "provider": record.provider,
+            "operation": record.operation,
+            "rerun_command": record.rerun_command,
+            "issue_bundle_command": record.issue_bundle_command,
+            "recovery_command": record.recovery_command,
+            "failure_summary": record.failure_summary,
+        },
+        steps=steps,
+        metrics=metrics,
+        transcript=_transcript_from_record(record),
+        kind="flow" if record.kind == "flow" else record.kind,  # type: ignore[arg-type]
+        workspace_path=run_path,
+        provider_events=provider_events,
+        validation_errors=tuple(validation_errors),
+    )
+
+
+def run_history_markdown(records: tuple[RunHistoryRecord, ...]) -> str:
+    """Render preserved run history as Markdown."""
+
+    lines = [
+        "# TheWorldHarness Run History",
+        "",
+        "| Run | Kind | Status | Provider | Capability | Artifacts | Recovery |",
+        "| --- | --- | --- | --- | --- | --- | --- |",
+    ]
+    for record in records:
+        artifacts = ", ".join(record.safe_artifact_types) or "-"
+        recovery = f"`{record.recovery_command}`" if record.recovery_command else "-"
+        lines.append(
+            "| `{run_id}` | {kind} | {status} | {provider} | {capability} | {artifacts} | "
+            "{recovery} |".format(
+                run_id=record.run_id,
+                kind=record.kind or "-",
+                status=record.status or "-",
+                provider=record.provider or "-",
+                capability=record.capability or "-",
+                artifacts=artifacts,
+                recovery=recovery,
+            )
+        )
+    if not records:
+        lines.append("| - | - | - | - | - | - | - |")
+    lines.extend(
+        [
+            "",
+            "## Rerun Commands",
+            "",
+        ]
+    )
+    if records:
+        lines.extend(f"- `{record.run_id}`: `{record.rerun_command}`" for record in records)
+    else:
+        lines.append("- No preserved runs matched the filter.")
+    return "\n".join(lines) + "\n"
+
+
+def _record_from_manifest(manifest: JSONDict, *, workspace_dir: Path) -> RunHistoryRecord:
+    run_id = str(manifest.get("run_id") or Path(str(manifest.get("path", ""))).name)
+    kind = str(manifest.get("kind") or "")
+    status = str(manifest.get("status") or "")
+    provider = _provider_label(manifest)
+    operation = str(manifest.get("operation") or "")
+    capabilities = _capabilities(manifest)
+    capability = capabilities[0] if capabilities else ""
+    created_at = str(manifest.get("created_at") or "")
+    created_date = _date_from_created_at(created_at)
+    command = str(manifest.get("command") or "").strip()
+    workspace_display = _workspace_display(workspace_dir)
+    display_path = f"{workspace_display}/runs/{run_id}"
+    issue_bundle_command = (
+        f"worldforge runs bundle {shlex.quote(run_id)} --workspace-dir "
+        f"{shlex.quote(workspace_display)}"
+    )
+    comparison_command = None
+    if kind in {"eval", "benchmark"}:
+        comparison_command = f"worldforge runs compare {shlex.quote(display_path)} <other-run>"
+    failure_summary = _failure_summary(manifest)
+    recovery_command = (
+        issue_bundle_command if status in {"failed", "cancelled", "skipped"} else None
+    )
+    run_path = Path(str(manifest.get("path") or Path(workspace_dir) / "runs" / run_id))
+    return RunHistoryRecord(
+        run_id=run_id,
+        kind=kind,
+        status=status,
+        provider=provider,
+        operation=operation,
+        capability=capability,
+        capabilities=capabilities,
+        created_at=created_at,
+        created_date=created_date,
+        command=command,
+        rerun_command=_rerun_command(manifest, workspace_display=workspace_display),
+        failure_summary=failure_summary,
+        safe_artifact_types=_safe_artifact_types(manifest),
+        artifact_count=len(manifest.get("artifact_paths", {}) or {}),
+        event_count=int(manifest.get("event_count", 0) or 0),
+        path=run_path,
+        display_path=display_path,
+        issue_bundle_command=issue_bundle_command,
+        issue_bundle_path=f"{workspace_display}/issue-bundles/{run_id}",
+        comparison_command=comparison_command,
+        recovery_command=recovery_command,
+    )
+
+
+def _matches_filter(record: RunHistoryRecord, filters: RunHistoryFilter) -> bool:
+    if filters.provider and filters.provider.lower() not in record.provider.lower():
+        return False
+    if filters.capability:
+        capability = filters.capability.lower()
+        if capability not in {item.lower() for item in record.capabilities}:
+            return False
+    if filters.status and filters.status.lower() != record.status.lower():
+        return False
+    if filters.created_from and (
+        record.created_date is None or record.created_date < filters.created_from
+    ):
+        return False
+    if filters.created_to and (
+        record.created_date is None or record.created_date > filters.created_to
+    ):
+        return False
+    if filters.artifact_type:
+        artifact_type = filters.artifact_type.lower()
+        if artifact_type not in {item.lower() for item in record.safe_artifact_types}:
+            return False
+    return True
+
+
+def _provider_label(manifest: JSONDict) -> str:
+    provider = manifest.get("provider")
+    if isinstance(provider, str) and provider.strip():
+        return provider.strip()
+    input_summary = manifest.get("input_summary")
+    if isinstance(input_summary, dict):
+        providers = input_summary.get("providers")
+        if isinstance(providers, list):
+            return ", ".join(str(item) for item in providers if str(item).strip())
+    return ""
+
+
+def _capabilities(manifest: JSONDict) -> tuple[str, ...]:
+    input_summary = manifest.get("input_summary")
+    found: list[str] = []
+    if isinstance(input_summary, dict):
+        raw_capabilities = input_summary.get("capabilities")
+        if isinstance(raw_capabilities, list):
+            found.extend(str(item) for item in raw_capabilities if str(item).strip())
+        raw_operations = input_summary.get("operations")
+        if isinstance(raw_operations, list):
+            found.extend(str(item) for item in raw_operations if str(item) in CAPABILITY_NAMES)
+    operation = str(manifest.get("operation") or "")
+    if operation in CAPABILITY_NAMES:
+        found.append(operation)
+    if str(manifest.get("kind") or "") == "flow":
+        from worldforge.harness.flows import flow_index
+
+        flow = flow_index().get(operation)
+        if flow is not None and flow.capability:
+            found.append(flow.capability)
+    if not found and str(manifest.get("kind") or "") in {"eval", "benchmark"}:
+        found.append(str(manifest.get("kind")))
+    return tuple(dict.fromkeys(found))
+
+
+def _safe_artifact_types(manifest: JSONDict) -> tuple[str, ...]:
+    raw_paths = manifest.get("artifact_paths")
+    if not isinstance(raw_paths, dict):
+        return ()
+    found: list[str] = []
+    for label, raw_path in sorted(raw_paths.items()):
+        if not isinstance(raw_path, str) or not raw_path.strip():
+            continue
+        path = Path(raw_path)
+        if path.is_absolute() or ".." in path.parts:
+            continue
+        suffix = path.suffix.lower().removeprefix(".")
+        if suffix in _SAFE_ARTIFACT_SUFFIXES:
+            found.append(str(label))
+            found.append(suffix)
+    return tuple(dict.fromkeys(item for item in found if item))
+
+
+def _failure_summary(manifest: JSONDict) -> str:
+    result_summary = manifest.get("result_summary")
+    if isinstance(result_summary, dict):
+        for key in (
+            "failure_reason",
+            "observed_failure",
+            "error",
+            "error_message",
+            "skip_reason",
+            "reason",
+        ):
+            value = result_summary.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+        errors = result_summary.get("validation_errors")
+        if isinstance(errors, list) and errors:
+            return "; ".join(str(error) for error in errors if str(error).strip())
+    status = str(manifest.get("status") or "unknown")
+    if status == "failed":
+        return "Run failed without a structured failure reason."
+    if status == "cancelled":
+        return "Run was cancelled before completion."
+    if status == "skipped":
+        return "Run was skipped without a structured reason."
+    return ""
+
+
+def _rerun_command(manifest: JSONDict, *, workspace_display: str) -> str:
+    command = str(manifest.get("command") or "").strip() or _synthesized_command(manifest)
+    tokens = _split_command(command)
+    sanitized: list[str] = []
+    skip_next = False
+    for token in tokens:
+        if skip_next:
+            skip_next = False
+            continue
+        if _SECRET_FLAG_PATTERN.match(token) and "=" not in token:
+            sanitized.extend([token, "<redacted>"])
+            skip_next = True
+            continue
+        sanitized.append(_sanitize_token(token))
+    kind = str(manifest.get("kind") or "")
+    if kind in {"eval", "benchmark"} and "--run-workspace" not in sanitized:
+        sanitized.extend(["--run-workspace", workspace_display])
+    return shlex.join(sanitized)
+
+
+def _synthesized_command(manifest: JSONDict) -> str:
+    kind = str(manifest.get("kind") or "")
+    provider = _provider_label(manifest) or "mock"
+    operation = str(manifest.get("operation") or "")
+    if kind == "eval":
+        return f"worldforge eval --suite {operation or 'planning'} --provider {provider}"
+    if kind == "benchmark":
+        return f"worldforge benchmark --provider {provider} --operation {operation or 'predict'}"
+    if kind == "flow" and operation:
+        return f"worldforge harness --flow {operation}"
+    return "worldforge runs list"
+
+
+def _split_command(command: str) -> list[str]:
+    try:
+        return shlex.split(command)
+    except ValueError:
+        return command.split()
+
+
+def _sanitize_token(token: str) -> str:
+    if _UNSAFE_URL_PATTERN.search(token):
+        return "<redacted-url>"
+    assignment = _SECRET_ASSIGNMENT_PATTERN.match(token)
+    if assignment:
+        return f"{assignment.group(1)}=<redacted>"
+    if _SECRET_FLAG_PATTERN.match(token):
+        return token
+    if Path(token).is_absolute() or token.startswith("file://"):
+        return f"<host-local:{Path(token).name or 'path'}>"
+    return token
+
+
+def _workspace_display(workspace_dir: Path) -> str:
+    if not workspace_dir.is_absolute():
+        return workspace_dir.as_posix()
+    if workspace_dir.name == ".worldforge":
+        return ".worldforge"
+    return "<workspace-dir>"
+
+
+def _date_from_created_at(value: str) -> date | None:
+    if not value:
+        return None
+    normalized = value.replace("Z", "+00:00")
+    try:
+        return datetime.fromisoformat(normalized).date()
+    except ValueError:
+        return None
+
+
+def _run_path_from_input(path: Path) -> Path:
+    candidate = path.expanduser()
+    if candidate.name == "run_manifest.json":
+        candidate = candidate.parent
+    if candidate.is_file() and candidate.parent.name == "reports":
+        candidate = candidate.parent.parent
+    manifest = candidate / "run_manifest.json"
+    if not manifest.is_file():
+        raise WorldForgeError(f"Preserved run manifest not found: {manifest}")
+    return candidate.resolve()
+
+
+def _load_manifest(run_path: Path) -> JSONDict:
+    try:
+        payload = json.loads((run_path / "run_manifest.json").read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise WorldForgeError(f"Preserved run manifest contains invalid JSON: {run_path}") from exc
+    if not isinstance(payload, dict):
+        raise WorldForgeError(f"Preserved run manifest must be a JSON object: {run_path}")
+    payload = dict(payload)
+    payload["path"] = str(run_path)
+    return payload
+
+
+def _report_json_path(run_path: Path, manifest: JSONDict) -> Path | None:
+    artifact_paths = manifest.get("artifact_paths")
+    if not isinstance(artifact_paths, dict):
+        return None
+    for label in ("json", "report"):
+        raw = artifact_paths.get(label)
+        if isinstance(raw, str):
+            candidate = (run_path / raw).resolve()
+            if candidate.is_file() and candidate.name.endswith(".json"):
+                return candidate
+    fallback = run_path / "reports" / "report.json"
+    return fallback if fallback.is_file() else None
+
+
+def _flow_from_record(record: RunHistoryRecord, inspector: JSONDict | None) -> HarnessFlow:
+    if inspector and isinstance(inspector.get("flow"), dict):
+        flow_payload = inspector["flow"]
+        return HarnessFlow(
+            id=str(flow_payload.get("id") or record.operation or record.run_id),
+            title=str(flow_payload.get("title") or record.operation or record.run_id),
+            short_title=str(flow_payload.get("short_title") or record.operation or record.kind),
+            focus=str(flow_payload.get("focus") or record.kind),
+            provider=str(flow_payload.get("provider") or record.provider),
+            capability=str(flow_payload.get("capability") or record.capability),
+            command=record.rerun_command,
+            accent=str(flow_payload.get("accent") or ""),
+            summary=str(flow_payload.get("summary") or record.failure_summary or record.status),
+        )
+    return HarnessFlow(
+        id=record.operation or record.run_id,
+        title=f"Preserved Run: {record.run_id}",
+        short_title=record.run_id,
+        focus=record.kind or "run",
+        provider=record.provider,
+        capability=record.capability,
+        command=record.rerun_command,
+        accent="",
+        summary=record.failure_summary or f"{record.kind} run is {record.status}.",
+    )
+
+
+def _steps_from_record(
+    record: RunHistoryRecord,
+    inspector: JSONDict | None,
+) -> tuple[HarnessStep, ...]:
+    if inspector and isinstance(inspector.get("steps"), list):
+        steps = [
+            HarnessStep(
+                title=str(item.get("title", "Step")),
+                detail=str(item.get("detail", "")),
+                result=str(item.get("result", "")),
+                artifact=str(item.get("artifact", "")),
+            )
+            for item in inspector["steps"]
+            if isinstance(item, dict)
+        ]
+        if steps:
+            return tuple(steps)
+    recovery = record.recovery_command or record.issue_bundle_command
+    return (
+        HarnessStep(
+            "Load preserved run",
+            "Read run_manifest.json and sanitized result summaries.",
+            f"{record.kind or 'run'} status: {record.status or 'unknown'}",
+            record.display_path,
+        ),
+        HarnessStep(
+            "Prepare recovery action",
+            "Use the issue-ready bundle path before attaching artifacts to a public issue.",
+            recovery,
+            record.issue_bundle_path,
+        ),
+    )
+
+
+def _metrics_from_record(
+    record: RunHistoryRecord,
+    inspector: JSONDict | None,
+) -> tuple[HarnessMetric, ...]:
+    if inspector and isinstance(inspector.get("metrics"), list):
+        metrics = [
+            HarnessMetric(
+                label=str(item.get("label", "Metric")),
+                value=str(item.get("value", "")),
+                detail=str(item.get("detail", "")),
+            )
+            for item in inspector["metrics"]
+            if isinstance(item, dict)
+        ]
+        if metrics:
+            return tuple(metrics)
+    return (
+        HarnessMetric("Status", record.status or "unknown", record.failure_summary),
+        HarnessMetric(
+            "Artifacts",
+            str(record.artifact_count),
+            ", ".join(record.safe_artifact_types),
+        ),
+        HarnessMetric("Events", str(record.event_count), record.capability or record.operation),
+    )
+
+
+def _provider_events_from_inspector(inspector: JSONDict | None) -> tuple[JSONDict, ...]:
+    if not inspector or not isinstance(inspector.get("provider_events"), list):
+        return ()
+    return tuple(dict(item) for item in inspector["provider_events"] if isinstance(item, dict))
+
+
+def _validation_errors_from_manifest(manifest: JSONDict) -> tuple[str, ...]:
+    result_summary = manifest.get("result_summary")
+    if not isinstance(result_summary, dict):
+        return ()
+    errors = result_summary.get("validation_errors")
+    if isinstance(errors, str) and errors.strip():
+        return (errors.strip(),)
+    if isinstance(errors, list):
+        return tuple(str(error).strip() for error in errors if str(error).strip())
+    return ()
+
+
+def _transcript_from_record(record: RunHistoryRecord) -> tuple[str, ...]:
+    lines = [
+        f"run_id: {record.run_id}",
+        f"kind: {record.kind}",
+        f"status: {record.status}",
+        f"provider: {record.provider}",
+        f"capabilities: {', '.join(record.capabilities) or '-'}",
+        f"rerun: {record.rerun_command}",
+        f"issue_bundle: {record.issue_bundle_command}",
+    ]
+    if record.comparison_command:
+        lines.append(f"compare: {record.comparison_command}")
+    if record.failure_summary:
+        lines.append(f"failure: {record.failure_summary}")
+    return tuple(lines)
+
+
+def _read_json(path: Path) -> JSONDict | None:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _clean_filter(value: str | None) -> str | None:
+    if value is None:
+        return None
+    cleaned = value.strip()
+    return cleaned or None
+
+
+__all__ = [
+    "RunHistoryFilter",
+    "RunHistoryRecord",
+    "list_run_history",
+    "parse_history_date",
+    "preserved_run_from_path",
+    "run_history_markdown",
+]

--- a/src/worldforge/harness/tui.py
+++ b/src/worldforge/harness/tui.py
@@ -71,6 +71,12 @@ from worldforge.harness.flows import (
     write_report,
 )
 from worldforge.harness.models import HarnessFlow, HarnessMetric, HarnessRun, HarnessStep
+from worldforge.harness.run_history import (
+    RunHistoryFilter,
+    RunHistoryRecord,
+    list_run_history,
+    preserved_run_from_path,
+)
 from worldforge.harness.theme import (
     FLOW_CAPABILITY_FALLBACKS,
     THEME_NAME_DARK,
@@ -80,6 +86,7 @@ from worldforge.harness.theme import (
     WORLDFORGE_HIGH_CONTRAST_PALETTE,
     WORLDFORGE_LIGHT_PALETTE,
 )
+from worldforge.harness.workspace import workspace_root_for_state_dir
 from worldforge.harness.worlds_view import (
     SceneObjectSpec,
     WorldSpec,
@@ -92,7 +99,7 @@ from worldforge.models import CAPABILITY_NAMES, JSONDict, ProviderEvent
 from worldforge.providers.base import ProviderError
 from worldforge.providers.mock import MockProvider
 
-InitialScreen = Literal["home", "run-inspector", "worlds", "providers", "eval", "benchmark"]
+InitialScreen = Literal["home", "run-inspector", "worlds", "providers", "eval", "benchmark", "runs"]
 
 
 def _build_theme(name: str, palette: dict[str, str], *, dark: bool) -> Theme:
@@ -161,6 +168,20 @@ def _maybe_query(node, selector: str, expected_type):
         return node.query_one(selector, expected_type)
     except NoMatches:
         return None
+
+
+def _input_value(input_widget: Input | None) -> str | None:
+    if input_widget is None:
+        return None
+    value = input_widget.value.strip()
+    return value or None
+
+
+def _select_value(select_widget: Select | None) -> str | None:
+    if select_widget is None or select_widget.value is Select.BLANK:
+        return None
+    value = str(select_widget.value).strip()
+    return value or None
 
 
 class Breadcrumb(Static):
@@ -590,6 +611,7 @@ class HomeScreen(Screen):
         Binding("n", "jump('worlds')", "Create a world", show=True),
         Binding("p", "jump('providers')", "Run a provider", show=True),
         Binding("e", "jump('eval')", "Run an eval", show=True),
+        Binding("u", "jump('runs')", "Review runs", show=True),
     ]
 
     DEFAULT_CSS = """
@@ -665,6 +687,13 @@ class HomeScreen(Screen):
                     description="Execute a deterministic evaluation suite against a provider.",
                     widget_id="jump-run-eval",
                 )
+                yield JumpCard(
+                    target="runs",
+                    title="Review runs",
+                    binding="u",
+                    description="Filter preserved runs and open recovery actions.",
+                    widget_id="jump-review-runs",
+                )
             yield Static(
                 "No recent items yet — jump targets will appear here once you open them.",
                 id="home-recent",
@@ -704,6 +733,9 @@ class HomeScreen(Screen):
         if event.target == "eval":
             self.app.action_switch_screen("eval")
             return
+        if event.target == "runs":
+            self.app.action_switch_screen("runs")
+            return
         self.app.push_screen(
             PlaceholderScreen(target_milestone="?", next_action="Target not yet routed.")
         )
@@ -724,7 +756,8 @@ class HomeScreen(Screen):
             reverse=True,
         )[:5]
         reports = recent_report_paths(forge.state_dir, limit=5)
-        if not world_ids and not reports:
+        runs = list_run_history(workspace_root_for_state_dir(forge.state_dir), limit=5)
+        if not world_ids and not reports and not runs:
             target.update(
                 "No recent worlds or runs — press [b]n[/] to create a world "
                 "or [b]e[/] to run an eval."
@@ -736,10 +769,276 @@ class HomeScreen(Screen):
         else:
             lines.append("Worlds: none yet")
         if reports:
-            lines.append("Runs: " + ", ".join(path.name for path in reports))
+            lines.append("Reports: " + ", ".join(path.name for path in reports))
+        else:
+            lines.append("Reports: none yet")
+        if runs:
+            lines.append("Runs: " + ", ".join(record.run_id for record in runs))
         else:
             lines.append("Runs: none yet")
         target.update("\n".join(lines))
+
+
+class RunsScreen(Screen):
+    """Filter and open preserved run workspaces."""
+
+    BINDINGS: ClassVar[list[Binding]] = [
+        Binding("enter", "open_selected", "Open", show=True),
+        Binding("f", "focus_provider_filter", "Filter", show=True),
+        Binding("escape", "clear_filters", "Clear", show=True),
+    ]
+
+    DEFAULT_CSS = """
+    RunsScreen {
+        background: $background;
+        color: $foreground;
+    }
+
+    #runs-root {
+        padding: 1 2;
+        height: 1fr;
+    }
+
+    #runs-filter-row {
+        height: auto;
+        margin-bottom: 1;
+    }
+
+    #runs-filter-row Input, #runs-filter-row Select {
+        width: 1fr;
+        margin-right: 1;
+    }
+
+    #runs-body {
+        height: 1fr;
+    }
+
+    #runs-table-wrap {
+        width: 2fr;
+        margin-right: 1;
+    }
+
+    #runs-table {
+        height: 1fr;
+    }
+
+    #runs-empty {
+        height: 1fr;
+        align: center middle;
+        color: $text-muted;
+    }
+
+    #runs-empty.hidden {
+        display: none;
+    }
+
+    #runs-table.hidden {
+        display: none;
+    }
+
+    #runs-detail {
+        width: 1fr;
+        padding: 1 2;
+        border: round $panel;
+        background: $surface;
+        color: $foreground;
+    }
+    """
+
+    selected_run_id: reactive[str | None] = reactive(None, init=False)
+
+    def __init__(self, *, state_dir: Path) -> None:
+        super().__init__()
+        self._state_dir = state_dir
+        self._records: dict[str, RunHistoryRecord] = {}
+        self._ordered_ids: list[str] = []
+
+    def compose(self) -> ComposeResult:
+        yield Header(show_clock=True)
+        with Horizontal(id="chrome"):
+            yield Breadcrumb(id="breadcrumb")
+            yield ProviderStatusPill(id="provider-pill")
+        with Container(id="runs-root"):
+            with Horizontal(id="runs-filter-row"):
+                yield Input(placeholder="provider", id="runs-provider-filter")
+                yield Input(placeholder="capability", id="runs-capability-filter")
+                yield Select(
+                    [
+                        ("any status", ""),
+                        ("completed", "completed"),
+                        ("failed", "failed"),
+                        ("skipped", "skipped"),
+                        ("cancelled", "cancelled"),
+                    ],
+                    value="",
+                    allow_blank=False,
+                    id="runs-status-filter",
+                )
+                yield Input(placeholder="from YYYY-MM-DD", id="runs-created-from-filter")
+                yield Input(placeholder="artifact type", id="runs-artifact-filter")
+            with Horizontal(id="runs-body"):
+                with Container(id="runs-table-wrap"):
+                    yield DataTable(zebra_stripes=True, cursor_type="row", id="runs-table")
+                    yield Static("No preserved runs match the active filters.", id="runs-empty")
+                yield Static("Select a run to see recovery commands.", id="runs-detail")
+        yield Footer()
+
+    def on_mount(self) -> None:
+        table = self.query_one("#runs-table", DataTable)
+        table.add_columns("run", "status", "provider", "capability", "artifacts")
+        table.focus()
+        self._update_chrome()
+        self.refresh_runs()
+
+    def on_screen_resume(self) -> None:
+        self._update_chrome()
+        table = _maybe_query(self, "#runs-table", DataTable)
+        if table is not None:
+            table.focus()
+
+    def watch_selected_run_id(self, _old: str | None, _new: str | None) -> None:
+        self._refresh_detail()
+        self._update_chrome()
+
+    def _update_chrome(self) -> None:
+        breadcrumb = _maybe_query(self, "#breadcrumb", Breadcrumb)
+        if breadcrumb is not None:
+            breadcrumb.path = ("worldforge", "runs")
+        pill = _maybe_query(self, "#provider-pill", ProviderStatusPill)
+        if pill is not None:
+            record = self._records.get(self.selected_run_id or "")
+            pill.label = record.provider if record else ""
+
+    def refresh_runs(self) -> None:
+        filters = self._filters()
+        records = list_run_history(
+            workspace_root_for_state_dir(self._state_dir),
+            filters=filters,
+        )
+        self._records = {record.run_id: record for record in records}
+        self._ordered_ids = [record.run_id for record in records]
+        self._rebuild_table_rows()
+
+    def _filters(self) -> RunHistoryFilter:
+        status = _select_value(_maybe_query(self, "#runs-status-filter", Select))
+        try:
+            return RunHistoryFilter.from_strings(
+                provider=_input_value(_maybe_query(self, "#runs-provider-filter", Input)),
+                capability=_input_value(_maybe_query(self, "#runs-capability-filter", Input)),
+                status=status,
+                created_from=_input_value(_maybe_query(self, "#runs-created-from-filter", Input)),
+                artifact_type=_input_value(_maybe_query(self, "#runs-artifact-filter", Input)),
+            )
+        except WorldForgeError as exc:
+            self.notify(str(exc), severity="error", title="Run filter")
+            return RunHistoryFilter()
+
+    def _rebuild_table_rows(self) -> None:
+        table = _maybe_query(self, "#runs-table", DataTable)
+        empty = _maybe_query(self, "#runs-empty", Static)
+        if table is None:
+            return
+        table.clear()
+        for run_id in self._ordered_ids:
+            record = self._records[run_id]
+            table.add_row(
+                record.run_id,
+                record.status or "-",
+                record.provider or "-",
+                record.capability or "-",
+                ", ".join(record.safe_artifact_types) or "-",
+                key=record.run_id,
+            )
+        if not self._ordered_ids:
+            if empty is not None:
+                empty.remove_class("hidden")
+            table.add_class("hidden")
+            self.selected_run_id = None
+        else:
+            if empty is not None:
+                empty.add_class("hidden")
+            table.remove_class("hidden")
+            self.selected_run_id = self._ordered_ids[0]
+
+    def _refresh_detail(self) -> None:
+        detail = _maybe_query(self, "#runs-detail", Static)
+        if detail is None:
+            return
+        record = self._records.get(self.selected_run_id or "")
+        if record is None:
+            detail.update("Select a run to see recovery commands.")
+            return
+        lines = [
+            f"[bold]{record.run_id}[/]",
+            f"status: {record.status or '-'}",
+            f"kind: {record.kind or '-'}",
+            f"provider: {record.provider or '-'}",
+            f"capability: {record.capability or '-'}",
+            f"rerun: [dim]{record.rerun_command}[/]",
+            f"issue bundle: [dim]{record.issue_bundle_command}[/]",
+        ]
+        if record.comparison_command:
+            lines.append(f"compare: [dim]{record.comparison_command}[/]")
+        if record.recovery_command:
+            lines.append(f"recovery: [bold]{record.recovery_command}[/]")
+        if record.failure_summary:
+            lines.append(f"failure: {record.failure_summary}")
+        detail.update("\n".join(lines))
+
+    @on(DataTable.RowHighlighted, "#runs-table")
+    def _on_row_highlighted(self, event: DataTable.RowHighlighted) -> None:
+        key = event.row_key.value if event.row_key else None
+        if isinstance(key, str):
+            self.selected_run_id = key
+
+    @on(DataTable.RowSelected, "#runs-table")
+    def _on_row_selected(self, event: DataTable.RowSelected) -> None:
+        key = event.row_key.value if event.row_key else None
+        if isinstance(key, str):
+            self.selected_run_id = key
+            self.action_open_selected()
+
+    @on(Input.Changed, "#runs-provider-filter")
+    @on(Input.Changed, "#runs-capability-filter")
+    @on(Input.Changed, "#runs-created-from-filter")
+    @on(Input.Changed, "#runs-artifact-filter")
+    def _on_filter_changed(self, event: Input.Changed) -> None:
+        del event
+        self.refresh_runs()
+
+    @on(Select.Changed, "#runs-status-filter")
+    def _on_status_changed(self) -> None:
+        self.refresh_runs()
+
+    def action_focus_provider_filter(self) -> None:
+        provider_filter = _maybe_query(self, "#runs-provider-filter", Input)
+        if provider_filter is not None:
+            provider_filter.focus()
+
+    def action_clear_filters(self) -> None:
+        for selector in (
+            "#runs-provider-filter",
+            "#runs-capability-filter",
+            "#runs-created-from-filter",
+            "#runs-artifact-filter",
+        ):
+            field = _maybe_query(self, selector, Input)
+            if field is not None:
+                field.value = ""
+        status = _maybe_query(self, "#runs-status-filter", Select)
+        if status is not None:
+            status.value = ""
+        self.refresh_runs()
+        table = _maybe_query(self, "#runs-table", DataTable)
+        if table is not None:
+            table.focus()
+
+    def action_open_selected(self) -> None:
+        record = self._records.get(self.selected_run_id or "")
+        if record is None:
+            return
+        if hasattr(self.app, "_open_run_workspace"):
+            self.app._open_run_workspace(record.path)  # type: ignore[attr-defined]
 
 
 class RunInspectorScreen(Screen):
@@ -4042,6 +4341,14 @@ class WorldForgeCommandProvider(  # pragma: no cover - exercised by Pilot/provid
             )
             for path in recent_report_paths(forge.state_dir, limit=50)
         )
+        items.extend(
+            (
+                f"Run workspace: {record.run_id}",
+                "Open the preserved run workspace",
+                lambda path=record.path: app._open_run_workspace(path),  # type: ignore[attr-defined]
+            )
+            for record in list_run_history(workspace_root_for_state_dir(forge.state_dir), limit=50)
+        )
         return items
 
 
@@ -4061,6 +4368,7 @@ class TheWorldHarnessApp(App[None]):
         Binding("g,p", "switch_screen('providers')", "Jump: Providers", show=False),
         Binding("g,e", "switch_screen('eval')", "Jump: Eval", show=False),
         Binding("g,b", "switch_screen('benchmark')", "Jump: Benchmark", show=False),
+        Binding("g,u", "switch_screen('runs')", "Jump: Runs", show=False),
     ]
     SCREENS: ClassVar[dict[str, type[Screen[Any]]]] = {
         "home": HomeScreen,
@@ -4069,6 +4377,7 @@ class TheWorldHarnessApp(App[None]):
         "providers": ProvidersScreen,
         "eval": EvalScreen,
         "benchmark": BenchmarkScreen,
+        "runs": RunsScreen,
     }
     CSS = """
     Header {
@@ -4150,6 +4459,9 @@ class TheWorldHarnessApp(App[None]):
     def _make_benchmark(self) -> BenchmarkScreen:
         return BenchmarkScreen(forge=self._get_forge())
 
+    def _make_runs(self) -> RunsScreen:
+        return RunsScreen(state_dir=self._get_forge().state_dir)
+
     def _record_provider_event(self, event: ProviderEvent) -> None:
         self._provider_event_queue.put(event)
 
@@ -4186,6 +4498,8 @@ class TheWorldHarnessApp(App[None]):
             await self.push_screen(self._make_eval())
         elif self._initial_screen == "benchmark":
             await self.push_screen(self._make_benchmark())
+        elif self._initial_screen == "runs":
+            await self.push_screen(self._make_runs())
         else:
             await self.push_screen(self._make_home())
 
@@ -4232,6 +4546,8 @@ class TheWorldHarnessApp(App[None]):
             self.switch_screen(self._make_eval())
         elif screen_name == "benchmark":
             self.switch_screen(self._make_benchmark())
+        elif screen_name == "runs":
+            self.switch_screen(self._make_runs())
         else:  # pragma: no cover - defensive
             self.switch_screen(screen_name)
 
@@ -4250,6 +4566,8 @@ class TheWorldHarnessApp(App[None]):
             return self._make_eval()
         if screen_name == "benchmark":
             return self._make_benchmark()
+        if screen_name == "runs":
+            return self._make_runs()
         return screen_name
 
     async def _switch_screen_and_wait(  # pragma: no cover - exercised through command callbacks.
@@ -4304,6 +4622,11 @@ class TheWorldHarnessApp(App[None]):
             lambda: self.action_switch_screen("benchmark"),
         )
         yield SystemCommand(
+            "Jump: Runs",
+            "Open preserved run history",
+            lambda: self.action_switch_screen("runs"),
+        )
+        yield SystemCommand(
             "New world",
             "Open the Worlds screen and start a new world",
             self._command_new_world,
@@ -4355,6 +4678,12 @@ class TheWorldHarnessApp(App[None]):
 
     def _open_report_path(self, path: Path) -> None:
         run = report_run_from_path(path, state_dir=self._get_forge().state_dir)
+        while isinstance(self.screen, ModalScreen):
+            self.pop_screen()
+        self.switch_screen(RunInspectorScreen(state_dir=self._get_forge().state_dir, run=run))
+
+    def _open_run_workspace(self, path: Path) -> None:
+        run = preserved_run_from_path(path, state_dir=self._get_forge().state_dir)
         while isinstance(self.screen, ModalScreen):
             self.pop_screen()
         self.switch_screen(RunInspectorScreen(state_dir=self._get_forge().state_dir, run=run))

--- a/tests/test_cli_help_snapshots.py
+++ b/tests/test_cli_help_snapshots.py
@@ -79,13 +79,19 @@ options:
                         Output format for history entries.
 """,
     ("harness", "--help"): """\
-usage: worldforge harness [-h] [--flow {leworldmodel,lerobot,diagnostics}]
+usage: worldforge harness [-h]
+                          [--flow {leworldmodel,lerobot,diagnostics,workbench,eval,benchmark,runs}]
                           [--state-dir STATE_DIR] [--list] [--connectors]
+                          [--runs] [--workspace-dir WORKSPACE_DIR]
+                          [--provider PROVIDER] [--capability CAPABILITY]
+                          [--status STATUS] [--created-from CREATED_FROM]
+                          [--created-to CREATED_TO]
+                          [--artifact-type ARTIFACT_TYPE]
                           [--format {markdown,json}] [--no-animation]
 
 options:
   -h, --help            show this help message and exit
-  --flow {leworldmodel,lerobot,diagnostics}
+  --flow {leworldmodel,lerobot,diagnostics,workbench,eval,benchmark,runs}
                         Harness flow to open.
   --state-dir STATE_DIR
                         Directory for persisted demo worlds. Defaults to a
@@ -94,8 +100,21 @@ options:
                         TUI.
   --connectors          List provider connector readiness without launching
                         the TUI.
+  --runs                List preserved run history without launching the TUI.
+  --workspace-dir WORKSPACE_DIR
+                        Workspace root for --runs. Defaults to .worldforge.
+  --provider PROVIDER   Filter --runs output by provider substring.
+  --capability CAPABILITY
+                        Filter --runs output by capability.
+  --status STATUS       Filter --runs output by run status.
+  --created-from CREATED_FROM
+                        Filter --runs output from YYYY-MM-DD.
+  --created-to CREATED_TO
+                        Filter --runs output through YYYY-MM-DD.
+  --artifact-type ARTIFACT_TYPE
+                        Filter --runs output by safe artifact type.
   --format {markdown,json}
-                        Output format for --list and --connectors.
+                        Output format for --list, --connectors, and --runs.
   --no-animation        Disable step reveal delays.
 """,
     ("predict", "--help"): """\

--- a/tests/test_docs_site.py
+++ b/tests/test_docs_site.py
@@ -559,6 +559,30 @@ def test_issue_bundle_docs_cover_issue_148_contract() -> None:
     assert "- [x] Unsafe metadata causes a clear error or local-only marking" in continuation
 
 
+def test_harness_run_history_docs_cover_issue_149_contract() -> None:
+    harness = (ROOT / "docs/src/theworldharness.md").read_text(encoding="utf-8")
+    operations = (ROOT / "docs/src/operations.md").read_text(encoding="utf-8")
+    playbooks = (ROOT / "docs/src/playbooks.md").read_text(encoding="utf-8")
+    continuation = (ROOT / "docs/src/roadmap-continuation.md").read_text(encoding="utf-8")
+    changelog = (ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
+
+    for signal in (
+        "worldforge harness --runs",
+        "--artifact-type json",
+        "sanitized rerun command",
+        "issue-bundle",
+        "provider, capability, status, created date, and safe artifact type",
+    ):
+        assert signal in harness or signal in operations or signal in playbooks
+
+    assert "Runs screen" in harness
+    assert "preserved-run history actions" in changelog
+    assert "- [x] Harness can filter and open preserved runs without optional model runtimes" in (
+        continuation
+    )
+    assert "- [x] Rerun commands are generated from sanitized manifests" in continuation
+
+
 def test_benchmark_budget_calibration_docs_cover_issue_146_contract() -> None:
     benchmarking = (ROOT / "docs/src/benchmarking.md").read_text(encoding="utf-8")
     operations = (ROOT / "docs/src/operations.md").read_text(encoding="utf-8")

--- a/tests/test_harness_cli.py
+++ b/tests/test_harness_cli.py
@@ -7,6 +7,7 @@ import pytest
 
 from worldforge.cli import main as worldforge_main
 from worldforge.harness.cli import main as harness_main
+from worldforge.harness.workspace import create_run_workspace, write_run_manifest
 
 
 def test_worldforge_harness_lists_flows_without_textual(monkeypatch, capsys) -> None:
@@ -87,6 +88,69 @@ def test_worldforge_harness_lists_connector_readiness_without_textual(monkeypatc
     assert payload["jepa"]["missing_env_vars"] == ["JEPA_MODEL_NAME"]
     assert payload["genie"]["status"] == "scaffold"
     assert "worldforge-smoke-runway" in payload["runway"]["smoke_command"]
+
+
+def test_worldforge_harness_lists_filtered_run_history_without_textual(
+    tmp_path,
+    monkeypatch,
+    capsys,
+) -> None:
+    workspace = create_run_workspace(
+        tmp_path,
+        kind="benchmark",
+        command="worldforge benchmark --provider mock --operation predict --token super-secret",
+        provider="mock",
+        operation="predict",
+        run_id="20260102T000000Z-00000002",
+        input_summary={
+            "providers": ["mock"],
+            "operations": ["predict"],
+            "capabilities": ["predict"],
+        },
+    )
+    workspace.write_json("reports/report.json", {"results": []})
+    write_run_manifest(
+        workspace,
+        kind="benchmark",
+        command="worldforge benchmark --provider mock --operation predict --token super-secret",
+        provider="mock",
+        operation="predict",
+        status="failed",
+        input_summary={
+            "providers": ["mock"],
+            "operations": ["predict"],
+            "capabilities": ["predict"],
+        },
+        result_summary={"failure_reason": "budget failed"},
+        artifact_paths={"json": "reports/report.json"},
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "worldforge",
+            "harness",
+            "--runs",
+            "--workspace-dir",
+            str(tmp_path),
+            "--provider",
+            "mock",
+            "--status",
+            "failed",
+            "--artifact-type",
+            "json",
+            "--format",
+            "json",
+        ],
+    )
+
+    assert worldforge_main() == 0
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload[0]["run_id"] == "20260102T000000Z-00000002"
+    assert payload[0]["recovery_command"].startswith("worldforge runs bundle")
+    assert "super-secret" not in payload[0]["rerun_command"]
+    assert "<redacted>" in payload[0]["rerun_command"]
 
 
 def test_connector_readiness_distinguishes_missing_dependency(monkeypatch, tmp_path) -> None:

--- a/tests/test_harness_flows.py
+++ b/tests/test_harness_flows.py
@@ -141,9 +141,15 @@ def test_eval_run_artifacts_match_canonical_renderer(tmp_path) -> None:
     artifacts, report = eval_run_artifacts(forge, "planning", "mock")
 
     direct = EvaluationSuite.from_builtin("planning").run_report("mock", forge=forge)
-    assert artifacts["json"] == direct.to_json()
+    artifact_payload = json.loads(artifacts["json"])
+    direct_payload = json.loads(direct.to_json())
+    assert artifact_payload["provenance"]["created_at"]
+    assert direct_payload["provenance"]["created_at"]
+    artifact_payload["provenance"]["created_at"] = "<created-at>"
+    direct_payload["provenance"]["created_at"] = "<created-at>"
+    assert artifact_payload == direct_payload
     assert artifacts["markdown"] == report.to_markdown()
-    assert json.loads(artifacts["json"])["suite_id"] == "planning"
+    assert artifact_payload["suite_id"] == "planning"
 
 
 def test_benchmark_run_artifacts_invokes_sample_callback(tmp_path) -> None:

--- a/tests/test_harness_flows.py
+++ b/tests/test_harness_flows.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import importlib
 import json
+import sys
+from pathlib import Path
 
 import pytest
 
@@ -15,6 +18,14 @@ from worldforge.harness.flows import (
     report_run_from_path,
     write_report,
 )
+from worldforge.harness.run_history import (
+    RunHistoryFilter,
+    list_run_history,
+    parse_history_date,
+    preserved_run_from_path,
+    run_history_markdown,
+)
+from worldforge.harness.workspace import create_run_workspace, write_run_manifest
 
 
 def test_harness_flow_metadata_is_available_without_textual() -> None:
@@ -185,7 +196,289 @@ def test_write_benchmark_report_round_trips_canonical_artifacts(tmp_path) -> Non
     assert "operation_metrics_json" in run.artifacts["csv"]
 
 
+def test_run_history_filters_and_generates_safe_recovery_actions(tmp_path: Path) -> None:
+    _preserved_run_history_eval(tmp_path)
+    failed = _preserved_run_history_benchmark(tmp_path)
+
+    records = list_run_history(
+        tmp_path,
+        filters=RunHistoryFilter.from_strings(
+            provider="mock",
+            capability="predict",
+            status="failed",
+            created_from="2026-01-02",
+            artifact_type="json",
+        ),
+    )
+
+    assert [record.run_id for record in records] == ["20260102T000000Z-00000002"]
+    record = records[0]
+    assert record.recovery_command == record.issue_bundle_command
+    assert record.issue_bundle_path.endswith("/issue-bundles/20260102T000000Z-00000002")
+    assert record.comparison_command is not None
+    assert "worldforge runs compare" in record.comparison_command
+    assert "super-secret-value" not in record.rerun_command
+    assert "/tmp/private-worldforge" not in record.rerun_command
+    assert "<redacted>" in record.rerun_command
+    assert "<host-local:private-worldforge>" in record.rerun_command
+    assert record.safe_artifact_types == ("json",)
+
+    opened = preserved_run_from_path(failed.path, state_dir=tmp_path)
+    assert opened.kind == "benchmark"
+    assert opened.workspace_path == failed.path.resolve()
+    assert opened.flow.capability == "benchmark"
+
+
+def test_run_history_markdown_and_filter_boundaries(tmp_path: Path) -> None:
+    _preserved_run_history_eval(tmp_path)
+    _preserved_run_history_benchmark(tmp_path)
+
+    assert parse_history_date(None) is None
+    with pytest.raises(WorldForgeError, match="YYYY-MM-DD"):
+        parse_history_date("2026/01/01")
+
+    all_records = list_run_history(tmp_path, limit=1)
+    assert len(all_records) == 1
+    markdown = run_history_markdown(all_records)
+    assert "# TheWorldHarness Run History" in markdown
+    assert "Rerun Commands" in markdown
+    assert run_history_markdown(()) == (
+        "# TheWorldHarness Run History\n\n"
+        "| Run | Kind | Status | Provider | Capability | Artifacts | Recovery |\n"
+        "| --- | --- | --- | --- | --- | --- | --- |\n"
+        "| - | - | - | - | - | - | - |\n\n"
+        "## Rerun Commands\n\n"
+        "- No preserved runs matched the filter.\n"
+    )
+
+    assert not list_run_history(tmp_path, filters=RunHistoryFilter(provider="runway"))
+    assert not list_run_history(tmp_path, filters=RunHistoryFilter(capability="generate"))
+    assert not list_run_history(tmp_path, filters=RunHistoryFilter(status="cancelled"))
+    assert not list_run_history(
+        tmp_path,
+        filters=RunHistoryFilter.from_strings(created_to="2025-12-31"),
+    )
+    assert not list_run_history(tmp_path, filters=RunHistoryFilter(artifact_type="png"))
+
+
+def test_preserved_flow_run_opens_from_inspector_without_optional_runtime(tmp_path: Path) -> None:
+    run = run_flow("diagnostics", state_dir=tmp_path)
+    assert run.workspace_path is not None
+
+    opened = preserved_run_from_path(run.workspace_path / "run_manifest.json", state_dir=tmp_path)
+
+    assert opened.flow.id == "diagnostics"
+    assert opened.workspace_path == run.workspace_path.resolve()
+    assert opened.steps[0].title == "Create isolated forge"
+    assert opened.metrics[0].label == "Known profiles"
+    assert opened.provider_events
+
+
+def test_preserved_generic_failed_run_uses_recovery_fallbacks(tmp_path: Path) -> None:
+    workspace = create_run_workspace(
+        tmp_path,
+        kind="flow",
+        command="",
+        provider=None,
+        operation="custom-flow",
+        run_id="20260103T000000Z-00000003",
+        input_summary={},
+    )
+    write_run_manifest(
+        workspace,
+        kind="flow",
+        command="",
+        status="failed",
+        operation="custom-flow",
+        result_summary={"validation_errors": ["custom failure"]},
+        artifact_paths={
+            "summary": "results/summary.json",
+            "absolute": "/tmp/private.json",
+            "escape": "../secret.txt",
+        },
+    )
+
+    records = list_run_history(tmp_path)
+    record = records[0]
+    assert record.provider == ""
+    assert record.rerun_command == "worldforge harness --flow custom-flow"
+    assert record.failure_summary == "custom failure"
+    assert record.safe_artifact_types == ("summary", "json")
+    assert record.recovery_command is not None
+
+    opened = preserved_run_from_path(workspace.path, state_dir=tmp_path)
+    assert opened.flow.id == "custom-flow"
+    assert opened.steps[0].title == "Load preserved run"
+    assert opened.metrics[0].value == "failed"
+    assert opened.validation_errors == ("custom failure",)
+    assert "issue_bundle:" in opened.transcript[6]
+
+
+def test_run_history_rejects_missing_or_invalid_manifests(tmp_path: Path) -> None:
+    with pytest.raises(WorldForgeError, match="manifest not found"):
+        preserved_run_from_path(tmp_path / "missing", state_dir=tmp_path)
+
+    bad = tmp_path / "bad" / "run_manifest.json"
+    bad.parent.mkdir()
+    bad.write_text("not-json", encoding="utf-8")
+    with pytest.raises(WorldForgeError, match="invalid JSON"):
+        preserved_run_from_path(bad.parent, state_dir=tmp_path)
+
+    non_object = tmp_path / "non-object" / "run_manifest.json"
+    non_object.parent.mkdir()
+    non_object.write_text("[]", encoding="utf-8")
+    with pytest.raises(WorldForgeError, match="must be a JSON object"):
+        preserved_run_from_path(non_object.parent, state_dir=tmp_path)
+
+
+def test_run_history_sanitizes_assignments_urls_and_synthesizes_commands(tmp_path: Path) -> None:
+    workspace = create_run_workspace(
+        tmp_path,
+        kind="benchmark",
+        command=(
+            "TOKEN=super-secret worldforge benchmark --provider mock --operation predict "
+            "https://example.test/result.json?token=secret"
+        ),
+        provider="",
+        operation="predict",
+        run_id="20260104T000000Z-00000004",
+        input_summary={"providers": ["mock"], "operations": ["predict"]},
+    )
+    write_run_manifest(
+        workspace,
+        kind="benchmark",
+        command=(
+            "TOKEN=super-secret worldforge benchmark --provider mock --operation predict "
+            "https://example.test/result.json?token=secret"
+        ),
+        status="cancelled",
+        operation="predict",
+        input_summary={"providers": ["mock"], "operations": ["predict"]},
+        result_summary={},
+        artifact_paths={},
+    )
+
+    record = list_run_history(tmp_path)[0]
+    assert "super-secret" not in record.rerun_command
+    assert "<redacted-url>" in record.rerun_command
+    assert "TOKEN=<redacted>" in record.rerun_command
+    assert record.failure_summary == "Run was cancelled before completion."
+    assert record.safe_artifact_types == ()
+
+
+def test_run_history_module_imports_without_textual(monkeypatch: pytest.MonkeyPatch) -> None:
+    saved_textual = sys.modules.pop("textual", None)
+    monkeypatch.setitem(sys.modules, "textual", None)
+    try:
+        module = importlib.reload(importlib.import_module("worldforge.harness.run_history"))
+        assert hasattr(module, "list_run_history")
+    finally:
+        if saved_textual is not None:
+            sys.modules["textual"] = saved_textual
+        else:
+            sys.modules.pop("textual", None)
+
+
 def test_eval_capability_mismatch_propagates(tmp_path) -> None:
     forge = WorldForge(state_dir=tmp_path)
     with pytest.raises(WorldForgeError, match="missing required capabilities"):
         eval_run_artifacts(forge, "generation", "leworldmodel")
+
+
+def _preserved_run_history_eval(workspace_dir: Path):
+    workspace = create_run_workspace(
+        workspace_dir,
+        kind="eval",
+        command="worldforge eval --suite planning --provider mock",
+        provider="mock",
+        operation="planning",
+        run_id="20260101T000000Z-00000001",
+        input_summary={"suite_id": "planning", "providers": ["mock"], "capabilities": ["plan"]},
+    )
+    workspace.write_json(
+        "reports/report.json",
+        {
+            "suite_id": "planning",
+            "suite": "Planning Evaluation",
+            "provider_summaries": [],
+            "results": [],
+        },
+    )
+    write_run_manifest(
+        workspace,
+        kind="eval",
+        command="worldforge eval --suite planning --provider mock",
+        provider="mock",
+        operation="planning",
+        status="completed",
+        input_summary={"suite_id": "planning", "providers": ["mock"], "capabilities": ["plan"]},
+        result_summary={"result_count": 0, "passed_count": 0},
+        artifact_paths={"json": "reports/report.json"},
+    )
+    return workspace
+
+
+def _preserved_run_history_benchmark(workspace_dir: Path):
+    workspace = create_run_workspace(
+        workspace_dir,
+        kind="benchmark",
+        command=(
+            "worldforge benchmark --provider mock --operation predict "
+            "--api-key super-secret-value --state-dir /tmp/private-worldforge"
+        ),
+        provider="mock",
+        operation="predict",
+        run_id="20260102T000000Z-00000002",
+        input_summary={
+            "providers": ["mock"],
+            "operations": ["predict"],
+            "capabilities": ["predict"],
+        },
+    )
+    workspace.write_json(
+        "reports/report.json",
+        {
+            "claim_boundary": "test",
+            "run_metadata": {},
+            "results": [
+                {
+                    "provider": "mock",
+                    "operation": "predict",
+                    "iterations": 1,
+                    "concurrency": 1,
+                    "success_count": 0,
+                    "error_count": 1,
+                    "retry_count": 0,
+                    "total_time_ms": 1.0,
+                    "average_latency_ms": 1.0,
+                    "min_latency_ms": 1.0,
+                    "max_latency_ms": 1.0,
+                    "p50_latency_ms": 1.0,
+                    "p95_latency_ms": 1.0,
+                    "throughput_per_second": 1.0,
+                    "operation_metrics": {"events": [{"request_count": 1}]},
+                    "errors": ["budget failed"],
+                }
+            ],
+        },
+    )
+    write_run_manifest(
+        workspace,
+        kind="benchmark",
+        command=(
+            "worldforge benchmark --provider mock --operation predict "
+            "--api-key super-secret-value --state-dir /tmp/private-worldforge"
+        ),
+        provider="mock",
+        operation="predict",
+        status="failed",
+        input_summary={
+            "providers": ["mock"],
+            "operations": ["predict"],
+            "capabilities": ["predict"],
+        },
+        result_summary={"result_count": 1, "error_count": 1, "failure_reason": "budget failed"},
+        artifact_paths={"json": "reports/report.json"},
+        event_count=1,
+    )
+    return workspace

--- a/tests/test_harness_tui.py
+++ b/tests/test_harness_tui.py
@@ -573,6 +573,94 @@ def test_command_palette_lists_screens_and_flows(tmp_path) -> None:
     asyncio.run(scenario())
 
 
+def test_runs_screen_filters_and_opens_preserved_run(tmp_path) -> None:
+    pytest.importorskip("textual")
+
+    from textual.widgets import DataTable, Input
+
+    from worldforge.harness.tui import RunInspectorScreen, RunsScreen, TheWorldHarnessApp
+    from worldforge.harness.workspace import create_run_workspace, write_run_manifest
+
+    workspace = create_run_workspace(
+        tmp_path,
+        kind="benchmark",
+        command="worldforge benchmark --provider mock --operation predict --secret super-secret",
+        provider="mock",
+        operation="predict",
+        run_id="20260102T000000Z-00000002",
+        input_summary={
+            "providers": ["mock"],
+            "operations": ["predict"],
+            "capabilities": ["predict"],
+        },
+    )
+    workspace.write_json(
+        "reports/report.json",
+        {
+            "run_metadata": {},
+            "results": [
+                {
+                    "provider": "mock",
+                    "operation": "predict",
+                    "iterations": 1,
+                    "success_count": 0,
+                    "error_count": 1,
+                    "retry_count": 0,
+                    "total_time_ms": 1.0,
+                    "average_latency_ms": 1.0,
+                    "min_latency_ms": 1.0,
+                    "max_latency_ms": 1.0,
+                    "p50_latency_ms": 1.0,
+                    "p95_latency_ms": 1.0,
+                    "throughput_per_second": 1.0,
+                    "operation_metrics": {"events": [{"request_count": 1}]},
+                    "errors": ["budget failed"],
+                }
+            ],
+        },
+    )
+    write_run_manifest(
+        workspace,
+        kind="benchmark",
+        command="worldforge benchmark --provider mock --operation predict --secret super-secret",
+        provider="mock",
+        operation="predict",
+        status="failed",
+        input_summary={
+            "providers": ["mock"],
+            "operations": ["predict"],
+            "capabilities": ["predict"],
+        },
+        result_summary={"failure_reason": "budget failed"},
+        artifact_paths={"json": "reports/report.json"},
+        event_count=1,
+    )
+
+    async def scenario() -> None:
+        app = TheWorldHarnessApp(state_dir=tmp_path, initial_screen="runs")
+        async with app.run_test(size=(150, 44)) as pilot:
+            await pilot.pause()
+            assert isinstance(app.screen, RunsScreen)
+            table = app.screen.query_one("#runs-table", DataTable)
+            assert table.row_count == 1
+            detail = app.screen.query_one("#runs-detail")
+            assert "worldforge runs bundle" in detail.render().plain  # type: ignore[union-attr]
+            provider_filter = app.screen.query_one("#runs-provider-filter", Input)
+            provider_filter.value = "none"
+            await pilot.pause()
+            assert table.row_count == 0
+            provider_filter.value = "mock"
+            await pilot.pause()
+            assert table.row_count == 1
+            await pilot.press("enter")
+            await pilot.pause()
+            assert isinstance(app.screen, RunInspectorScreen)
+            assert app.screen._fixed_run is not None
+            assert app.screen._fixed_run.workspace_path == workspace.path.resolve()
+
+    asyncio.run(scenario())
+
+
 def test_home_jump_card_keyboard_activation(tmp_path) -> None:
     pytest.importorskip("textual")
 


### PR DESCRIPTION
## Summary

Closes #149.

- add a Textual-free preserved-run history layer for filtering run workspaces by provider, capability, status, date, and safe artifact type
- expose sanitized rerun commands, issue-bundle recovery commands, and comparison actions through `worldforge harness --runs`
- add a TheWorldHarness Runs screen plus command-palette entries for preserved run workspaces
- document the repeated-local-operations workflow and mark the WF-C4 acceptance items complete

## Validation

- `uv lock --check`
- `uv run ruff check src tests examples scripts`
- `uv run ruff format --check src tests examples scripts`
- `uv run python scripts/generate_provider_docs.py --check`
- `uv run pytest tests/test_harness_flows.py tests/test_harness_workspace.py tests/test_harness_report_compare.py`
- `uv run --extra harness pytest tests/test_harness_tui.py`
- `uv run mkdocs build --strict`
- `uv run pytest`
- `uv run --extra harness pytest --cov=src/worldforge --cov-report=term-missing --cov-fail-under=90`
- `bash scripts/test_package.sh`
- `uv build --out-dir dist --clear --no-build-logs`
- `git diff --check`