### PR TITLE
Expand reference host deployment recipes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ releases may still include breaking changes when the public API needs to tighten
 
 ### Added
 
+- Added reference host deployment recipes for the stdlib service, batch evaluation, and robotics
+  operator hosts. The recipes cover env templates, process/readiness/smoke/logging/evidence
+  commands, expected success signals, first triage and rollback steps, and the checkout-safe,
+  prepared-host, credentialed, GPU-bound, and robotics-lab ownership boundaries.
 - Added issue-ready bundles for preserved run workspaces. `worldforge runs bundle <run-id>` now
   exports one run to `evidence_manifest.json`, `summary.md`, and `issue.md`, prints a short issue
   template, preserves SHA-256 digests and `safe_to_attach` flags, and marks unsafe or host-local

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -158,6 +158,224 @@ hook in code, all checklist items are true, and dry-run approval is recorded. Wo
 produces typed policy, score, event, replay, and run-manifest artifacts; it does not certify robot
 hardware, task safety, emergency stops, workspace readiness, or controller behavior.
 
+## Reference Host Deployment Recipes
+
+These recipes are for embedding WorldForge in a host process, not for deploying WorldForge as a
+managed service. WorldForge owns provider contracts, typed validation, local run manifests, report
+rendering, and sanitized evidence helpers. The host owns deployment, authentication, queueing,
+durable storage, controller integration, alerting, rollback, uptime, and provider or robot safety
+policy.
+
+Path taxonomy:
+
+| Path | When to use it | Success signal | Host-owned boundary |
+| --- | --- | --- | --- |
+| checkout-safe | `mock` provider, deterministic examples, no credentials | command exits `0`, `/readyz` is `ready`, or a run manifest is written | no physical-fidelity, uptime, or durability claim |
+| prepared-host | optional provider/runtime already installed by the host | provider health is healthy and the smoke writes evidence | dependency install, checkpoints, cache directories, and runtime patches |
+| credentialed | Cosmos, Runway, or another remote provider with secrets loaded outside the repo | `provider info` shows redacted config and health passes | secret storage, credential rotation, upstream SLA, and network egress |
+| GPU-bound | LeWorldModel, LeRobot, GR00T, or another device-bound runtime | host preflight names the device and the smoke records a manifest | CUDA/Metal drivers, device scheduling, model assets, and memory pressure |
+| robotics-lab | operator review around task-specific policy/action translation | dry-run review records approval and no controller calls by default | workspace safety, interlocks, controller hooks, operator approval, and safety certification |
+
+No new provider environment variables are introduced by these recipes, so `.env.example` stays
+unchanged unless a future provider adds real configuration.
+
+### Stdlib Service Host Recipe
+
+Owned boundary: WorldForge maps provider diagnostics to `/readyz`, emits typed public errors, and
+can run deterministic mock or generate workflows. The embedding service owns HTTP deployment,
+request authentication, routing, queueing, durable state, log shipping, alerting, upstream SLA
+policy, and rollback.
+
+Env template:
+
+```bash
+export WORLDFORGE_SERVICE_PROVIDER=mock
+export WORLDFORGE_SERVICE_STATE_DIR=.worldforge/service-worlds
+export WORLDFORGE_SERVICE_PORT=8080
+# Credentialed path only: export COSMOS_BASE_URL=... or RUNWAYML_API_SECRET=...
+```
+
+Process command:
+
+```bash
+mkdir -p .worldforge/service/logs
+PYTHONUNBUFFERED=1 uv run python examples/hosts/service/app.py \
+  --provider "${WORLDFORGE_SERVICE_PROVIDER:-mock}" \
+  --state-dir "${WORLDFORGE_SERVICE_STATE_DIR:-.worldforge/service-worlds}" \
+  --port "${WORLDFORGE_SERVICE_PORT:-8080}" \
+  2>&1 | tee .worldforge/service/logs/service.log
+```
+
+Readiness command:
+
+```bash
+curl -fsS http://127.0.0.1:8080/readyz | python -m json.tool
+```
+
+Expected success signal: `status` is `ready`, `traffic` is `accept`, and
+`checks.provider_healthy` is `true`. First failure triage step: if the status is
+`provider_unconfigured` or `provider_unhealthy`, run
+`uv run worldforge doctor --registered-only` and `uv run worldforge provider health <provider>`,
+then inspect the redacted `checks.provider_health.details` field.
+
+Smoke command:
+
+```bash
+curl -fsS -X POST http://127.0.0.1:8080/workflows/mock-predict \
+  -H 'content-type: application/json' \
+  -H 'x-request-id: service-smoke-001' \
+  -d '{}' | python -m json.tool
+```
+
+Logging command:
+
+```bash
+tail -f .worldforge/service/logs/service.log
+```
+
+Evidence export command:
+
+```bash
+mkdir -p .worldforge/service/evidence
+curl -fsS http://127.0.0.1:8080/readyz > .worldforge/service/evidence/readyz.json
+curl -fsS http://127.0.0.1:8080/providers > .worldforge/service/evidence/providers.json
+```
+
+First rollback step: drain this host in the embedding service, restart it with the last known good
+provider configuration or `WORLDFORGE_SERVICE_PROVIDER=mock`, and keep upstream traffic disabled
+until `/readyz` returns `ready`.
+
+### Batch Eval Host Recipe
+
+Owned boundary: WorldForge runs deterministic evaluation and benchmark contracts, writes
+`run_manifest.json`, report artifacts, and budget verdicts. The batch platform owns scheduling,
+queueing, retries above the process, credentials, long-term artifact storage, budget-change review,
+alerting, and rollback.
+
+Env template:
+
+```bash
+export WORLDFORGE_BATCH_WORKSPACE=.worldforge/batch-eval
+export WORLDFORGE_BATCH_STATE_DIR=.worldforge/batch-eval/worlds
+# Prepared-host or credentialed path only: load provider-specific env from .env.example.
+```
+
+Readiness command:
+
+```bash
+uv run worldforge doctor --registered-only
+uv run worldforge doctor --capability generate
+uv run worldforge provider health mock
+```
+
+Process command:
+
+```bash
+uv run python examples/hosts/batch-eval/app.py \
+  --workspace "${WORLDFORGE_BATCH_WORKSPACE:-.worldforge/batch-eval}" \
+  --state-dir "${WORLDFORGE_BATCH_STATE_DIR:-.worldforge/batch-eval/worlds}" \
+  benchmark --provider mock --operation generate --iterations 1 \
+  --input-file examples/benchmark-inputs.json \
+  --budget-file examples/benchmark-budget.json
+```
+
+Smoke command: use the same checkout-safe benchmark command with `--provider mock`; it exercises
+report rendering, budget evaluation, manifest preservation, and the batch host exit code without
+live credentials.
+
+Expected success signal: JSON stdout contains `status: "passed"`, `exit_code: 0`,
+`run_manifest`, and a `budget.passed` value of `true` when a budget file is supplied. Budget
+violations exit `1` only after the failed run workspace is preserved.
+
+Logging command:
+
+```bash
+uv run worldforge runs list \
+  --workspace-dir "${WORLDFORGE_BATCH_WORKSPACE:-.worldforge/batch-eval}" \
+  --format markdown
+```
+
+Evidence export command:
+
+```bash
+uv run worldforge runs bundle <run-id> \
+  --workspace-dir "${WORLDFORGE_BATCH_WORKSPACE:-.worldforge/batch-eval}"
+```
+
+First failure triage step: open `<workspace>/runs/<run-id>/run_manifest.json`, then export the
+bundle before deleting or retrying the run. First rollback step: stop the scheduler queue, restore
+the last known good input or budget file, rerun the checkout-safe `mock` benchmark, and only then
+reenable prepared-host or credentialed provider jobs.
+
+### Robotics Operator Host Recipe
+
+Owned boundary: WorldForge runs an offline policy-plus-score review, preserves selected action
+chunks, score rationale, provider events, dry-run approval, replay artifacts, and a manifest. The
+lab host owns task observations, action translators, workspace readiness, emergency stops,
+operator approval, controller hooks, robot hardware, and safety certification.
+
+Env template:
+
+```bash
+export WORLDFORGE_ROBOTICS_WORKSPACE=.worldforge/robotics-operator
+export WORLDFORGE_ROBOTICS_STATE_DIR=.worldforge/robotics-operator/worlds
+# Prepared-host, GPU-bound, or robotics-lab path only:
+# export LEROBOT_POLICY_PATH=...
+# export LEROBOT_DEVICE=cuda
+# export LEWORLDMODEL_DEVICE=cuda
+```
+
+Readiness command:
+
+```bash
+uv run worldforge provider health mock
+scripts/robotics-showcase --health-only
+```
+
+Use the first command for the checkout-safe operator recipe. Use the `--health-only` showcase
+preflight on prepared-host, GPU-bound, or robotics-lab paths before any real LeRobot or
+LeWorldModel run.
+
+Process command:
+
+```bash
+uv run python examples/hosts/robotics-operator/app.py \
+  --workspace "${WORLDFORGE_ROBOTICS_WORKSPACE:-.worldforge/robotics-operator}" \
+  --state-dir "${WORLDFORGE_ROBOTICS_STATE_DIR:-.worldforge/robotics-operator/worlds}" \
+  review --sample-translator --approve-dry-run \
+  --check workspace_clear \
+  --check emergency_stop_available \
+  --check operator_present \
+  --check controller_isolated
+```
+
+Smoke command: use the same checkout-safe review command with the sample translator. It records a
+dry-run review and keeps controller execution disabled.
+
+Expected success signal: JSON stdout contains `status: "passed"`, `exit_code: 0`,
+`run_manifest`, `controller_executed: false`, and paths for `approval`, `action_chunks`,
+`score_rationale`, `provider_events`, and `replay`.
+
+Logging command:
+
+```bash
+tail -n +1 \
+  "${WORLDFORGE_ROBOTICS_WORKSPACE:-.worldforge/robotics-operator}"/runs/<run-id>/logs/provider-events.jsonl
+```
+
+Evidence export command:
+
+```bash
+uv run worldforge runs bundle <run-id> \
+  --workspace-dir "${WORLDFORGE_ROBOTICS_WORKSPACE:-.worldforge/robotics-operator}"
+```
+
+First failure triage step: inspect `results/approval.json` and
+`logs/provider-events.jsonl` before changing translator or controller code. First rollback step:
+keep controller execution disabled, discard the produced action chunks, return to the last approved
+translator/checklist bundle, and rerun the offline review before any lab controller hook is
+reenabled.
+
 ## Optional Runtime Smoke
 
 | Example | Command | Runtime boundary |

--- a/docs/src/operations.md
+++ b/docs/src/operations.md
@@ -24,6 +24,14 @@ uv run worldforge doctor --registered-only
 uv run worldforge provider health
 ```
 
+The [Reference Host Deployment Recipes](./examples.md#reference-host-deployment-recipes) cover the
+stdlib service host, batch evaluation host, and robotics operator host with env templates, process
+commands, readiness checks, smoke commands, logging commands, evidence export commands, expected
+success signals, first triage or rollback steps, and owned boundaries. The recipes distinguish
+checkout-safe, prepared-host, credentialed, GPU-bound, and robotics-lab paths without moving
+deployment, auth, queueing, durable storage, controller integration, alerting, uptime, or safety
+certification into WorldForge.
+
 ## Health And Readiness
 
 Host applications should expose liveness separately from readiness. Liveness answers whether the

--- a/docs/src/playbooks.md
+++ b/docs/src/playbooks.md
@@ -176,6 +176,29 @@ The stdlib service reference uses the same model: `/healthz` is process-only liv
 decision of `accept` or `drain`. Alert routing, paging policy, retry orchestration outside a single
 provider call, and upstream SLA ownership remain host responsibilities.
 
+## 4b. Deploy Reference Hosts
+
+Use this before handing the stdlib service host, batch evaluation host, or robotics operator host to
+another host process owner.
+
+```bash
+uv run python examples/hosts/service/app.py --provider mock --port 8080
+uv run python examples/hosts/batch-eval/app.py benchmark --provider mock --operation generate --iterations 1
+uv run python examples/hosts/robotics-operator/app.py review --sample-translator --approve-dry-run \
+  --check workspace_clear --check emergency_stop_available --check operator_present --check controller_isolated
+```
+
+Success signal: the service host returns `/readyz` with `status: ready` and `traffic: accept`; the
+batch host prints `status: passed` and a `run_manifest`; the robotics operator host prints
+`status: passed`, a `run_manifest`, and `controller_executed: false`.
+
+If it fails: use the [Reference Host Deployment Recipes](./examples.md#reference-host-deployment-recipes)
+first. They include env templates, process commands, readiness commands, smoke commands, logging
+commands, evidence export commands, and first rollback or triage steps for checkout-safe,
+prepared-host, credentialed, GPU-bound, and robotics-lab paths. Deployment, auth, queueing,
+durable storage, controller integration, alerting, uptime, and safety certification stay
+host-owned.
+
 ## 5. Operate Local JSON Persistence
 
 Use this for local jobs, demos, tests, and single-writer workflows.

--- a/docs/src/roadmap-continuation.md
+++ b/docs/src/roadmap-continuation.md
@@ -827,12 +827,12 @@ Out of scope:
 
 Acceptance criteria:
 
-- [ ] Each recipe includes command, expected success signal, first failure triage step, and owned
+- [x] Each recipe includes command, expected success signal, first failure triage step, and owned
       boundary.
-- [ ] Recipes distinguish checkout-safe, prepared-host, credentialed, GPU-bound, and robotics-lab
+- [x] Recipes distinguish checkout-safe, prepared-host, credentialed, GPU-bound, and robotics-lab
       paths.
-- [ ] `.env.example` changes are tracked only when new provider variables are introduced.
-- [ ] Docs do not imply WorldForge owns uptime, safety certification, or durable storage.
+- [x] `.env.example` changes are tracked only when new provider variables are introduced.
+- [x] Docs do not imply WorldForge owns uptime, safety certification, or durable storage.
 
 Validation:
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -82,6 +82,12 @@ writes selected action chunks, score rationale, provider events, and a replay ar
 `.worldforge/robotics-operator/runs/<run-id>/`. Controller execution is only an application hook:
 WorldForge does not certify robot safety, controller semantics, interlocks, or deployment readiness.
 
+Deployment recipes for the service host, batch evaluation host, and robotics operator host live in
+the public examples documentation. Each recipe includes an env template, process command, readiness
+command, smoke command, logging command, evidence export command, expected success signal, first
+triage step, and owned boundary for checkout-safe, prepared-host, credentialed, GPU-bound, and
+robotics-lab paths.
+
 ## Optional Runtime Smoke
 
 | Example | Surface | Command |

--- a/tests/test_docs_site.py
+++ b/tests/test_docs_site.py
@@ -583,6 +583,77 @@ def test_harness_run_history_docs_cover_issue_149_contract() -> None:
     assert "- [x] Rerun commands are generated from sanitized manifests" in continuation
 
 
+def test_reference_host_deployment_recipes_cover_issue_151_contract() -> None:
+    examples = (ROOT / "docs/src/examples.md").read_text(encoding="utf-8")
+    examples_readme = (ROOT / "examples/README.md").read_text(encoding="utf-8")
+    operations = (ROOT / "docs/src/operations.md").read_text(encoding="utf-8")
+    playbooks = (ROOT / "docs/src/playbooks.md").read_text(encoding="utf-8")
+    continuation = (ROOT / "docs/src/roadmap-continuation.md").read_text(encoding="utf-8")
+    changelog = (ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
+
+    for recipe in (
+        "Stdlib Service Host Recipe",
+        "Batch Eval Host Recipe",
+        "Robotics Operator Host Recipe",
+    ):
+        assert recipe in examples
+
+    for signal in (
+        "Env template:",
+        "Process command:",
+        "Readiness command:",
+        "Smoke command:",
+        "Logging command:",
+        "Evidence export command:",
+        "Expected success signal:",
+        "First failure triage step:",
+        "First rollback step:",
+        "Owned boundary:",
+    ):
+        assert signal in examples
+
+    for path in (
+        "checkout-safe",
+        "prepared-host",
+        "credentialed",
+        "GPU-bound",
+        "robotics-lab",
+    ):
+        assert path in examples
+        assert path in examples_readme or path in operations or path in playbooks
+
+    for command in (
+        "uv run python examples/hosts/service/app.py",
+        "curl -fsS http://127.0.0.1:8080/readyz",
+        "uv run python examples/hosts/batch-eval/app.py",
+        "uv run worldforge runs bundle <run-id>",
+        "uv run python examples/hosts/robotics-operator/app.py",
+        "scripts/robotics-showcase --health-only",
+    ):
+        assert command in examples or command in playbooks
+
+    for boundary in (
+        "deployment, authentication, queueing",
+        "durable storage",
+        "alerting",
+        "uptime",
+        "safety certification",
+        "does not certify robot",
+    ):
+        assert boundary in examples or boundary in operations or boundary in playbooks
+
+    assert "No new provider environment variables are introduced" in examples
+    assert "`.env.example` stays" in examples
+    assert "unchanged" in examples
+    assert "reference host deployment recipes" in changelog
+    assert "- [x] Each recipe includes command, expected success signal" in continuation
+    assert "- [x] Recipes distinguish checkout-safe, prepared-host, credentialed" in continuation
+    assert "- [x] `.env.example` changes are tracked only when new provider variables" in (
+        continuation
+    )
+    assert "- [x] Docs do not imply WorldForge owns uptime" in continuation
+
+
 def test_benchmark_budget_calibration_docs_cover_issue_146_contract() -> None:
     benchmarking = (ROOT / "docs/src/benchmarking.md").read_text(encoding="utf-8")
     operations = (ROOT / "docs/src/operations.md").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- add reference host deployment recipes for the stdlib service, batch eval, and robotics operator hosts
- document checkout-safe, prepared-host, credentialed, GPU-bound, and robotics-lab boundaries with success signals, triage, rollback, logging, and evidence export commands
- add a docs contract test and mark WF-C5 complete in the roadmap

## Validation
- `uv run pytest tests/test_docs_site.py tests/test_service_host.py tests/test_batch_eval_host.py tests/test_robotics_operator_host.py`
- `uv run mkdocs build --strict`
- `uv run ruff check src tests examples scripts`
- `uv run ruff format --check src tests examples scripts`
- recipe command smokes for batch eval and robotics operator hosts with temporary workspaces

Closes #151