### PR TITLE
Add checkout-safe operator failure drills

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ releases may still include breaking changes when the public API needs to tighten
 
 ### Added
 
+- Added checkout-safe operator failure drills through `worldforge drills`. The drills cover missing
+  credentials, missing optional dependencies, malformed provider output, benchmark budget
+  violations, corrupted local world state, expired artifacts, and unsafe event metadata while
+  preserving run manifests and optional issue bundles under the requested workspace.
 - Added reference host deployment recipes for the stdlib service, batch evaluation, and robotics
   operator hosts. The recipes cover env templates, process/readiness/smoke/logging/evidence
   commands, expected success signals, first triage and rollback steps, and the checkout-safe,

--- a/docs/src/cli.md
+++ b/docs/src/cli.md
@@ -15,6 +15,18 @@ uv run worldforge examples
 uv run worldforge examples --format json
 ```
 
+Operator failure drills:
+
+```bash
+uv run worldforge drills list
+uv run worldforge drills run missing-credentials --workspace-dir .worldforge/drills
+uv run worldforge drills run unsafe-event-metadata --workspace-dir .worldforge/drills --bundle
+```
+
+The drill command surface is checkout-safe by default. Each run preserves a manifest, records the
+expected failure and recovery command, and confines generated state to the requested temporary or
+documented workspace.
+
 ## Provider Diagnostics
 
 ```bash

--- a/docs/src/operations.md
+++ b/docs/src/operations.md
@@ -32,6 +32,12 @@ checkout-safe, prepared-host, credentialed, GPU-bound, and robotics-lab paths wi
 deployment, auth, queueing, durable storage, controller integration, alerting, uptime, or safety
 certification into WorldForge.
 
+Operator failure drills are available from `worldforge drills`. They rehearse missing credentials,
+missing optional dependencies, malformed provider output, budget violations, corrupted local world
+state, expired artifacts, and unsafe event metadata with mock providers or fixtures. Drill runs
+write manifests under `.worldforge/drills/runs/<run-id>/`, can export an issue bundle with
+`--bundle`, and keep generated state inside the requested temporary or documented workspace.
+
 ## Health And Readiness
 
 Host applications should expose liveness separately from readiness. Liveness answers whether the

--- a/docs/src/playbooks.md
+++ b/docs/src/playbooks.md
@@ -199,6 +199,38 @@ prepared-host, credentialed, GPU-bound, and robotics-lab paths. Deployment, auth
 durable storage, controller integration, alerting, uptime, and safety certification stay
 host-owned.
 
+## 4c. Rehearse Operator Failure Drills
+
+Use this before relying on an incident runbook. The drills are deterministic and checkout-safe; each
+one writes a preserved run manifest under a temporary or documented workspace and records the
+expected failure plus recovery command.
+
+```bash
+uv run worldforge drills list
+uv run worldforge drills run missing-credentials --workspace-dir .worldforge/drills
+uv run worldforge drills run unsafe-event-metadata --workspace-dir .worldforge/drills --bundle
+uv run worldforge drills run all --workspace-dir .worldforge/drills
+```
+
+| Drill | Expected failure | Recovery command |
+| --- | --- | --- |
+| `missing-credentials` | required provider credentials are absent in a value-free config summary | load the required env var, then run `uv run worldforge provider health runway` |
+| `missing-optional-dependency` | optional runtime import is missing | install the provider optional runtime on a prepared host, then rerun its smoke command |
+| `malformed-provider-output` | the Runway task parser rejects a fixture without a task id | attach the sanitized fixture and fix the parser or upstream contract |
+| `budget-violation` | a mock benchmark violates an intentionally impossible latency budget | inspect the run bundle, then rerun `uv run worldforge benchmark --provider mock --operation predict --iterations 1` |
+| `corrupted-world-state` | a malformed local world JSON file raises `WorldStateError` | export diagnostics, quarantine the bad file, then recreate or import a valid world |
+| `expired-artifact` | an artifact descriptor has an expiry timestamp in the past | rerun the provider workflow to refresh the artifact, then export a new issue bundle |
+| `unsafe-event-metadata` | non-JSON-native event metadata is rejected and secret-shaped fields are redacted | remove object or tuple metadata, keep JSON-native fields only, then rerun the workflow |
+
+Success signal: the drill command exits `0`, prints `status: passed`, and writes a run manifest
+whose status is `failed` because the rehearsed incident was observed. With `--bundle`, the command
+also writes `.worldforge/drills/issue-bundles/<run-id>/issue.md`.
+
+If it fails unexpectedly: inspect `<workspace>/runs/<run-id>/results/drill.json` first, then run
+`uv run worldforge runs bundle <run-id> --workspace-dir <workspace>` before changing fixtures.
+Drills must not mutate user worlds; corrupted-state input files are written under the drill run's
+workspace.
+
 ## 5. Operate Local JSON Persistence
 
 Use this for local jobs, demos, tests, and single-writer workflows.

--- a/docs/src/roadmap-continuation.md
+++ b/docs/src/roadmap-continuation.md
@@ -863,10 +863,10 @@ Out of scope:
 
 Acceptance criteria:
 
-- [ ] Drill commands run in a clean checkout with mock or fixtures.
-- [ ] Each drill has a documented expected failure and recovery command.
-- [ ] Unsafe metadata drills prove redaction gates fail closed.
-- [ ] Drills do not leave persistent state outside a temporary or documented workspace.
+- [x] Drill commands run in a clean checkout with mock or fixtures.
+- [x] Each drill has a documented expected failure and recovery command.
+- [x] Unsafe metadata drills prove redaction gates fail closed.
+- [x] Drills do not leave persistent state outside a temporary or documented workspace.
 
 Validation:
 

--- a/src/worldforge/cli.py
+++ b/src/worldforge/cli.py
@@ -36,6 +36,7 @@ from worldforge.benchmark_presets import (
 )
 from worldforge.evaluation import EvaluationSuite
 from worldforge.models import CAPABILITY_NAMES
+from worldforge.operator_drills import DRILL_IDS, DRILL_WORKSPACE_DEFAULT
 from worldforge.providers import ProviderError
 from worldforge.providers.catalog import provider_docs_index
 
@@ -63,6 +64,7 @@ CLI_EPILOG = """Common commands:
   worldforge eval --suite planning --provider mock --format json
   worldforge benchmark --provider mock --iterations 5 --format json
   worldforge runs list
+  worldforge drills list
 """
 
 EXAMPLE_COMMANDS: tuple[dict[str, str], ...] = (
@@ -881,6 +883,52 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Output format for cleanup results.",
     )
 
+    drills = subparsers.add_parser(
+        "drills",
+        help="List and run checkout-safe operator failure drills.",
+    )
+    drills_subparsers = drills.add_subparsers(
+        dest="drills_command",
+        required=True,
+        metavar="command",
+    )
+    drills_list = drills_subparsers.add_parser(
+        "list",
+        help="List deterministic operator failure drills.",
+    )
+    drills_list.add_argument(
+        "--format",
+        choices=("json", "markdown"),
+        default="markdown",
+        help="Output format for drill metadata.",
+    )
+    drills_run = drills_subparsers.add_parser(
+        "run",
+        help="Run one drill or all drills and preserve run manifests.",
+    )
+    drills_run.add_argument(
+        "drill",
+        choices=(*DRILL_IDS, "all"),
+        help="Drill id to run, or all.",
+    )
+    drills_run.add_argument(
+        "--workspace-dir",
+        type=Path,
+        default=DRILL_WORKSPACE_DEFAULT,
+        help="Workspace directory for drill run manifests.",
+    )
+    drills_run.add_argument(
+        "--bundle",
+        action="store_true",
+        help="Export an issue bundle for each drill run.",
+    )
+    drills_run.add_argument(
+        "--format",
+        choices=("json", "markdown"),
+        default="json",
+        help="Output format for drill results.",
+    )
+
     doctor = subparsers.add_parser("doctor", help="Inspect the local WorldForge environment.")
     doctor.add_argument("--state-dir", default=".worldforge/worlds", help="World state directory.")
     doctor.add_argument(
@@ -1217,6 +1265,44 @@ def _cmd_runs(args: argparse.Namespace) -> int:
                 }
             )
         return 0
+
+    return 2
+
+
+def _cmd_drills(args: argparse.Namespace) -> int:
+    from worldforge.operator_drills import (
+        list_operator_drills,
+        render_operator_drill_result_markdown,
+        render_operator_drills_markdown,
+        run_all_operator_drills,
+        run_operator_drill,
+    )
+
+    if args.drills_command == "list":
+        drills = list_operator_drills()
+        if args.format == "json":
+            _print_json(drills)
+        else:
+            print(render_operator_drills_markdown(drills))
+        return 0
+
+    if args.drills_command == "run":
+        if args.drill == "all":
+            result = run_all_operator_drills(
+                workspace_dir=args.workspace_dir,
+                bundle=args.bundle,
+            )
+        else:
+            result = run_operator_drill(
+                args.drill,
+                workspace_dir=args.workspace_dir,
+                bundle=args.bundle,
+            )
+        if args.format == "markdown":
+            print(render_operator_drill_result_markdown(result))
+        else:
+            _print_json(result)
+        return 0 if result["status"] == "passed" else 1
 
     return 2
 
@@ -1998,6 +2084,12 @@ def main() -> int:
     if args.command == "runs":
         try:
             return _cmd_runs(args)
+        except (WorldForgeError, ValueError) as exc:
+            parser.exit(2, f"{exc}\n")
+
+    if args.command == "drills":
+        try:
+            return _cmd_drills(args)
         except (WorldForgeError, ValueError) as exc:
             parser.exit(2, f"{exc}\n")
 

--- a/src/worldforge/operator_drills.py
+++ b/src/worldforge/operator_drills.py
@@ -1,0 +1,572 @@
+"""Checkout-safe operator failure drills for WorldForge runbooks."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+from worldforge import WorldForge
+from worldforge.benchmark import ProviderBenchmarkHarness, load_benchmark_budgets
+from worldforge.evidence_bundle import generate_issue_bundle
+from worldforge.harness.workspace import RunWorkspace, create_run_workspace, write_run_manifest
+from worldforge.models import JSONDict, ProviderEvent, WorldForgeError, WorldStateError, dump_json
+from worldforge.providers import ProviderError
+from worldforge.providers.runtime_manifest import load_runtime_manifest
+from worldforge.providers.runway import RunwayTaskCreationResponse
+
+DRILL_WORKSPACE_DEFAULT = Path(".worldforge/drills")
+DRILL_IDS = (
+    "missing-credentials",
+    "missing-optional-dependency",
+    "malformed-provider-output",
+    "budget-violation",
+    "corrupted-world-state",
+    "expired-artifact",
+    "unsafe-event-metadata",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class OperatorDrillSpec:
+    """Metadata for a checkout-safe operator failure drill."""
+
+    id: str
+    title: str
+    failure_mode: str
+    expected_failure: str
+    recovery_command: str
+    description: str
+    checkout_safe: bool = True
+    prepared_host: bool = False
+
+    def to_dict(self) -> JSONDict:
+        return {
+            "id": self.id,
+            "title": self.title,
+            "failure_mode": self.failure_mode,
+            "expected_failure": self.expected_failure,
+            "recovery_command": self.recovery_command,
+            "description": self.description,
+            "checkout_safe": self.checkout_safe,
+            "prepared_host": self.prepared_host,
+            "command": f"uv run worldforge drills run {self.id} --workspace-dir .worldforge/drills",
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class _DrillOutcome:
+    failure_signal: str
+    details: JSONDict
+    artifacts: dict[str, str]
+    event_count: int = 0
+
+
+_SPECS: dict[str, OperatorDrillSpec] = {
+    "missing-credentials": OperatorDrillSpec(
+        id="missing-credentials",
+        title="Missing provider credentials",
+        failure_mode="missing_credentials",
+        expected_failure="runtime manifest reports required provider credentials absent",
+        recovery_command=(
+            "load the required provider env var, then run "
+            "`uv run worldforge provider health runway`"
+        ),
+        description=(
+            "Uses the Runway runtime manifest with an empty environment so operators can rehearse "
+            "a credential-missing path without touching local shell secrets."
+        ),
+    ),
+    "missing-optional-dependency": OperatorDrillSpec(
+        id="missing-optional-dependency",
+        title="Missing optional dependency",
+        failure_mode="missing_optional_dependency",
+        expected_failure="optional runtime import is absent",
+        recovery_command=(
+            "install the provider optional runtime on a prepared host, then rerun its smoke command"
+        ),
+        description=(
+            "Checks for a deliberately absent module name and records the same shape of failure an "
+            "optional provider would surface when host-owned runtime packages are missing."
+        ),
+    ),
+    "malformed-provider-output": OperatorDrillSpec(
+        id="malformed-provider-output",
+        title="Malformed provider output",
+        failure_mode="malformed_provider_output",
+        expected_failure="Runway task creation parser rejects a missing task id",
+        recovery_command=(
+            "capture the sanitized payload fixture, then fix the parser or upstream contract"
+        ),
+        description=(
+            "Feeds a fixture-shaped malformed response through the real Runway parser so parser "
+            "failure triage is repeatable without a live provider call."
+        ),
+    ),
+    "budget-violation": OperatorDrillSpec(
+        id="budget-violation",
+        title="Benchmark budget violation",
+        failure_mode="budget_violation",
+        expected_failure="benchmark budget gate reports at least one violation",
+        recovery_command=(
+            "inspect the run bundle, then rerun "
+            "`uv run worldforge benchmark --provider mock --operation predict --iterations 1`"
+        ),
+        description=(
+            "Runs a one-iteration mock benchmark against an intentionally impossible latency "
+            "budget so operators can rehearse budget-gate failure handling."
+        ),
+    ),
+    "corrupted-world-state": OperatorDrillSpec(
+        id="corrupted-world-state",
+        title="Corrupted local world state",
+        failure_mode="corrupted_world_state",
+        expected_failure="local JSON world load raises WorldStateError",
+        recovery_command=(
+            "export diagnostics, quarantine the bad file, then recreate or import a valid world"
+        ),
+        description=(
+            "Writes a malformed world JSON file inside the drill workspace and attempts to load it "
+            "through the normal WorldForge persistence path."
+        ),
+    ),
+    "expired-artifact": OperatorDrillSpec(
+        id="expired-artifact",
+        title="Expired remote artifact",
+        failure_mode="expired_artifact",
+        expected_failure="artifact expiry timestamp is already in the past",
+        recovery_command=(
+            "rerun the provider workflow to refresh the artifact, then export a new issue bundle"
+        ),
+        description=(
+            "Records a sanitized expired artifact descriptor so operators can rehearse refresh and "
+            "evidence-export handling without downloading remote media."
+        ),
+    ),
+    "unsafe-event-metadata": OperatorDrillSpec(
+        id="unsafe-event-metadata",
+        title="Unsafe provider-event metadata",
+        failure_mode="unsafe_event_metadata",
+        expected_failure=(
+            "non-JSON-native metadata is rejected and secret-shaped fields are redacted"
+        ),
+        recovery_command=(
+            "remove object or tuple metadata, keep JSON-native fields only, then rerun the "
+            "event-producing workflow"
+        ),
+        description=(
+            "Exercises ProviderEvent validation and redaction with fixture metadata so event logs "
+            "fail closed before unsafe values reach sinks."
+        ),
+    ),
+}
+
+_RUNNERS: dict[str, Callable[[RunWorkspace], _DrillOutcome]] = {}
+
+
+def list_operator_drills() -> tuple[JSONDict, ...]:
+    """Return drill metadata in stable display order."""
+
+    return tuple(_SPECS[drill_id].to_dict() for drill_id in DRILL_IDS)
+
+
+def get_operator_drill(drill_id: str) -> OperatorDrillSpec:
+    """Return one drill spec or raise a clear error."""
+
+    try:
+        return _SPECS[drill_id]
+    except KeyError as exc:
+        raise WorldForgeError(f"Unknown operator drill: {drill_id}") from exc
+
+
+def run_operator_drill(
+    drill_id: str,
+    *,
+    workspace_dir: Path = DRILL_WORKSPACE_DEFAULT,
+    bundle: bool = False,
+) -> JSONDict:
+    """Run one deterministic operator drill and preserve the observed failure."""
+
+    spec = get_operator_drill(drill_id)
+    workspace = create_run_workspace(
+        workspace_dir,
+        kind="operator_drill",
+        command=f"uv run worldforge drills run {drill_id} --workspace-dir <workspace-dir>",
+        provider="fixture",
+        operation=spec.failure_mode,
+        input_summary={
+            "drill_id": drill_id,
+            "checkout_safe": spec.checkout_safe,
+            "prepared_host": spec.prepared_host,
+        },
+    )
+    outcome = _RUNNERS[drill_id](workspace)
+    result_summary: JSONDict = {
+        "drill_id": drill_id,
+        "drill_passed": True,
+        "expected_failure_observed": True,
+        "expected_failure": spec.expected_failure,
+        "expected_signal": spec.expected_failure,
+        "observed_failure": outcome.failure_signal,
+        "failure_signal": outcome.failure_signal,
+        "recovery_command": spec.recovery_command,
+    }
+    drill_payload: JSONDict = {
+        "schema_version": 1,
+        "status": "passed",
+        "run_id": workspace.run_id,
+        "drill": spec.to_dict(),
+        "expected_failure_observed": True,
+        "failure_signal": outcome.failure_signal,
+        "recovery_command": spec.recovery_command,
+        "details": outcome.details,
+        "run_workspace": f"<workspace-dir>/runs/{workspace.run_id}",
+        "run_manifest": f"<workspace-dir>/runs/{workspace.run_id}/run_manifest.json",
+    }
+    dump_json(drill_payload)
+    outcome_artifacts = dict(outcome.artifacts)
+    outcome_artifacts["drill_json"] = "results/drill.json"
+    outcome_artifacts["drill_markdown"] = "reports/drill.md"
+    workspace.write_json("results/drill.json", drill_payload)
+    workspace.write_text("reports/drill.md", _render_drill_markdown(drill_payload))
+    write_run_manifest(
+        workspace,
+        kind="operator_drill",
+        command=f"uv run worldforge drills run {drill_id} --workspace-dir <workspace-dir>",
+        provider="fixture",
+        operation=spec.failure_mode,
+        status="failed",
+        input_summary={
+            "drill_id": drill_id,
+            "checkout_safe": spec.checkout_safe,
+            "prepared_host": spec.prepared_host,
+        },
+        result_summary=result_summary,
+        artifact_paths=outcome_artifacts,
+        event_count=outcome.event_count,
+    )
+    result: JSONDict = {
+        **drill_payload,
+        "artifact_paths": outcome_artifacts,
+        "run_workspace": str(workspace.path),
+        "run_manifest": str(workspace.manifest_path),
+    }
+    if bundle:
+        bundle_result = generate_issue_bundle(
+            workspace_dir=workspace_dir,
+            run_id=workspace.run_id,
+            output_dir=workspace_dir / "issue-bundles" / workspace.run_id,
+            overwrite=True,
+        )
+        result["issue_bundle"] = {
+            "output_dir": str(bundle_result.output_dir),
+            "manifest_path": str(bundle_result.manifest_path),
+            "summary_path": str(bundle_result.summary_path),
+            "issue_template_path": (
+                str(bundle_result.issue_template_path)
+                if bundle_result.issue_template_path is not None
+                else None
+            ),
+            "safe_to_attach": bundle_result.manifest["safe_to_attach"],
+        }
+    dump_json(result)
+    return result
+
+
+def run_all_operator_drills(
+    *,
+    workspace_dir: Path = DRILL_WORKSPACE_DEFAULT,
+    bundle: bool = False,
+) -> JSONDict:
+    """Run every checkout-safe operator drill."""
+
+    runs = [
+        run_operator_drill(drill_id, workspace_dir=workspace_dir, bundle=bundle)
+        for drill_id in DRILL_IDS
+    ]
+    return {
+        "status": "passed",
+        "run_count": len(runs),
+        "runs": runs,
+    }
+
+
+def render_operator_drills_markdown(drills: tuple[JSONDict, ...]) -> str:
+    """Render drill metadata as Markdown."""
+
+    lines = [
+        "# Operator Failure Drills",
+        "",
+        "| Drill | Failure mode | Checkout-safe | Expected failure | Recovery command |",
+        "| --- | --- | --- | --- | --- |",
+    ]
+    lines.extend(
+        (
+            "| `{id}` | {mode} | {safe} | {expected} | {recovery} |".format(
+                id=drill["id"],
+                mode=drill["failure_mode"],
+                safe=str(drill["checkout_safe"]).lower(),
+                expected=drill["expected_failure"],
+                recovery=drill["recovery_command"],
+            )
+        )
+        for drill in drills
+    )
+    return "\n".join(lines)
+
+
+def render_operator_drill_result_markdown(result: JSONDict) -> str:
+    """Render one drill result or an aggregate run result as Markdown."""
+
+    if "runs" in result:
+        lines = ["# Operator Drill Run", "", f"Status: `{result['status']}`", ""]
+        lines.extend(f"- `{run['drill']['id']}`: {run['failure_signal']}" for run in result["runs"])
+        return "\n".join(lines)
+    return _render_drill_markdown(result)
+
+
+def _render_drill_markdown(payload: JSONDict) -> str:
+    drill = payload["drill"]
+    return "\n".join(
+        [
+            f"# Operator Drill: {drill['title']}",
+            "",
+            f"- Drill id: `{drill['id']}`",
+            f"- Failure mode: `{drill['failure_mode']}`",
+            f"- Status: `{payload['status']}`",
+            f"- Expected failure observed: `{str(payload['expected_failure_observed']).lower()}`",
+            f"- Failure signal: {payload['failure_signal']}",
+            f"- Recovery command: `{payload['recovery_command']}`",
+            f"- Run manifest: `{payload['run_manifest']}`",
+            "",
+        ]
+    )
+
+
+def _missing_credentials(workspace: RunWorkspace) -> _DrillOutcome:
+    manifest = load_runtime_manifest("runway")
+    summary = manifest.config_summary(environ={}).to_dict()
+    if summary["configured"]:
+        raise WorldForgeError("missing credentials drill expected configured=false.")
+    workspace.write_json("results/config-summary.json", summary)
+    return _DrillOutcome(
+        failure_signal="Provider config summary configured=false for RUNWAYML_API_SECRET",
+        details={"provider": "runway", "config_summary": summary},
+        artifacts={"config_summary": "results/config-summary.json"},
+    )
+
+
+def _missing_optional_dependency(workspace: RunWorkspace) -> _DrillOutcome:
+    dependency = "worldforge_operator_drill_missing_dependency"
+    spec = importlib.util.find_spec(dependency)
+    if spec is not None:
+        raise WorldForgeError(f"missing optional dependency drill unexpectedly found {dependency}.")
+    details = {
+        "provider": "fixture-optional-runtime",
+        "dependency": dependency,
+        "importable": False,
+        "prepared_host": False,
+    }
+    workspace.write_json("results/dependency-check.json", details)
+    return _DrillOutcome(
+        failure_signal=f"missing optional dependency {dependency}",
+        details=details,
+        artifacts={"dependency_check": "results/dependency-check.json"},
+    )
+
+
+def _malformed_provider_output(workspace: RunWorkspace) -> _DrillOutcome:
+    fixture = {"status": "SUCCEEDED", "output": []}
+    workspace.write_json("inputs/malformed-runway-task.json", fixture)
+    try:
+        RunwayTaskCreationResponse.from_payload(
+            fixture,
+            provider_name="runway-drill",
+            operation_name="task create",
+        )
+    except ProviderError as exc:
+        details = {
+            "provider": "runway-drill",
+            "parser": "RunwayTaskCreationResponse",
+            "error": str(exc),
+        }
+        workspace.write_json("results/parser-error.json", details)
+        return _DrillOutcome(
+            failure_signal=str(exc),
+            details=details,
+            artifacts={
+                "fixture": "inputs/malformed-runway-task.json",
+                "parser_error": "results/parser-error.json",
+            },
+        )
+    raise WorldForgeError("malformed provider output drill expected ProviderError.")
+
+
+def _budget_violation(workspace: RunWorkspace) -> _DrillOutcome:
+    forge = WorldForge(state_dir=workspace.inputs_dir / "worlds")
+    report = ProviderBenchmarkHarness(forge=forge).run(
+        ["mock"],
+        operations=["predict"],
+        iterations=1,
+        concurrency=1,
+    )
+    budget_payload = {
+        "budgets": [
+            {
+                "provider": "mock",
+                "operation": "predict",
+                "max_average_latency_ms": 0.0,
+                "max_error_count": 0,
+                "max_retry_count": 0,
+                "min_success_rate": 1.0,
+            }
+        ]
+    }
+    gate = report.evaluate_budgets(load_benchmark_budgets(budget_payload))
+    if gate.passed:
+        raise WorldForgeError("budget violation drill expected a failed budget gate.")
+    workspace.write_json("inputs/budget.json", budget_payload)
+    workspace.write_text("reports/benchmark.json", report.to_json())
+    workspace.write_text("reports/benchmark.md", report.to_markdown())
+    workspace.write_text("reports/benchmark.csv", report.to_csv())
+    workspace.write_json("results/budget-gate.json", gate.to_dict())
+    return _DrillOutcome(
+        failure_signal=f"benchmark budget violation count={len(gate.violations)}",
+        details={
+            "budget_passed": gate.passed,
+            "violation_count": len(gate.violations),
+            "violations": [violation.to_dict() for violation in gate.violations],
+        },
+        artifacts={
+            "budget": "inputs/budget.json",
+            "benchmark_json": "reports/benchmark.json",
+            "benchmark_markdown": "reports/benchmark.md",
+            "benchmark_csv": "reports/benchmark.csv",
+            "budget_gate": "results/budget-gate.json",
+        },
+    )
+
+
+def _corrupted_world_state(workspace: RunWorkspace) -> _DrillOutcome:
+    state_dir = workspace.inputs_dir / "worlds"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    corrupt_path = state_dir / "corrupted.json"
+    corrupt_path.write_text('{"id": "corrupted", "state": ', encoding="utf-8")
+    try:
+        WorldForge(state_dir=state_dir).load_world("corrupted")
+    except WorldStateError as exc:
+        error = _relative_workspace_text(workspace, str(exc))
+        details = {
+            "world_id": "corrupted",
+            "state_file": "inputs/worlds/corrupted.json",
+            "error": error,
+        }
+        workspace.write_json("results/world-state-error.json", details)
+        return _DrillOutcome(
+            failure_signal=error,
+            details=details,
+            artifacts={
+                "corrupted_world": "inputs/worlds/corrupted.json",
+                "world_state_error": "results/world-state-error.json",
+            },
+        )
+    raise WorldForgeError("corrupted world state drill expected WorldStateError.")
+
+
+def _expired_artifact(workspace: RunWorkspace) -> _DrillOutcome:
+    expires_at = "2000-01-01T00:00:00Z"
+    parsed = datetime.fromisoformat(expires_at.replace("Z", "+00:00"))
+    expired = parsed < datetime.now(UTC)
+    if not expired:
+        raise WorldForgeError("expired artifact drill expected a past expiry timestamp.")
+    descriptor = {
+        "artifact_id": "drill-expired-artifact",
+        "artifact_url": "https://artifacts.example.invalid/worldforge/drill-output.json",
+        "expires_at": expires_at,
+        "expired": True,
+        "safe_to_attach": False,
+    }
+    workspace.write_json("artifacts/expired-artifact.json", descriptor)
+    return _DrillOutcome(
+        failure_signal=f"artifact expired at {expires_at}",
+        details=descriptor,
+        artifacts={"expired_artifact": "artifacts/expired-artifact.json"},
+    )
+
+
+def _unsafe_event_metadata(workspace: RunWorkspace) -> _DrillOutcome:
+    try:
+        ProviderEvent(
+            provider="runway",
+            operation="artifact download",
+            phase="failure",
+            metadata={"shape": (1, 2, 3)},
+        )
+    except WorldForgeError as exc:
+        rejection = str(exc)
+    else:
+        raise WorldForgeError("unsafe event metadata drill expected WorldForgeError.")
+
+    redacted_event = ProviderEvent(
+        provider="runway",
+        operation="artifact download",
+        phase="failure",
+        target="https://downloads.example.invalid/generated.mp4?token=drill-secret",
+        message="download failed with Authorization=drill-secret",
+        metadata={
+            "api_token": "drill-secret",
+            "safe_note": "metadata redaction drill",
+        },
+    ).to_dict()
+    serialized = json.dumps(redacted_event, sort_keys=True)
+    if "drill-secret" in serialized:
+        raise WorldForgeError("unsafe event metadata drill leaked a secret-shaped value.")
+    workspace.write_text("logs/provider-events.jsonl", json.dumps(redacted_event, sort_keys=True))
+    details = {
+        "rejection": rejection,
+        "redacted_event": redacted_event,
+        "secret_leaked": False,
+    }
+    workspace.write_json("results/event-redaction.json", details)
+    return _DrillOutcome(
+        failure_signal=rejection,
+        details=details,
+        artifacts={
+            "provider_events": "logs/provider-events.jsonl",
+            "event_redaction": "results/event-redaction.json",
+        },
+        event_count=1,
+    )
+
+
+_RUNNERS.update(
+    {
+        "missing-credentials": _missing_credentials,
+        "missing-optional-dependency": _missing_optional_dependency,
+        "malformed-provider-output": _malformed_provider_output,
+        "budget-violation": _budget_violation,
+        "corrupted-world-state": _corrupted_world_state,
+        "expired-artifact": _expired_artifact,
+        "unsafe-event-metadata": _unsafe_event_metadata,
+    }
+)
+
+
+def _relative_workspace_text(workspace: RunWorkspace, value: str) -> str:
+    return value.replace(str(workspace.path), "<run-workspace>")
+
+
+__all__ = [
+    "DRILL_IDS",
+    "DRILL_WORKSPACE_DEFAULT",
+    "OperatorDrillSpec",
+    "get_operator_drill",
+    "list_operator_drills",
+    "render_operator_drill_result_markdown",
+    "render_operator_drills_markdown",
+    "run_all_operator_drills",
+    "run_operator_drill",
+]

--- a/tests/test_cli_help_snapshots.py
+++ b/tests/test_cli_help_snapshots.py
@@ -244,6 +244,7 @@ def test_top_level_help_lists_command_surface(monkeypatch, capsys) -> None:
         "benchmark",
         "harness",
         "runs",
+        "drills",
     ):
         assert command in output
     for common_command in (
@@ -256,6 +257,7 @@ def test_top_level_help_lists_command_surface(monkeypatch, capsys) -> None:
         "worldforge harness --list",
         "worldforge eval --suite planning --provider mock --format json",
         "worldforge runs list",
+        "worldforge drills list",
     ):
         assert common_command in output
 

--- a/tests/test_operator_drills.py
+++ b/tests/test_operator_drills.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from worldforge.cli import main
+from worldforge.operator_drills import (
+    DRILL_IDS,
+    list_operator_drills,
+    render_operator_drills_markdown,
+    run_all_operator_drills,
+    run_operator_drill,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_operator_drill_catalog_documents_failure_and_recovery_commands() -> None:
+    drills = list_operator_drills()
+
+    assert tuple(drill["id"] for drill in drills) == DRILL_IDS
+    assert len(drills) == 7
+    for drill in drills:
+        assert drill["checkout_safe"] is True
+        assert drill["prepared_host"] is False
+        assert drill["expected_failure"]
+        assert drill["recovery_command"]
+        assert drill["command"].endswith(
+            f"worldforge drills run {drill['id']} --workspace-dir .worldforge/drills"
+        )
+
+    markdown = render_operator_drills_markdown(drills)
+    assert "Operator Failure Drills" in markdown
+    assert "missing-credentials" in markdown
+    assert "unsafe-event-metadata" in markdown
+
+
+@pytest.mark.parametrize("drill_id", DRILL_IDS)
+def test_operator_drills_preserve_expected_failures_under_workspace(
+    tmp_path: Path,
+    drill_id: str,
+) -> None:
+    result = run_operator_drill(drill_id, workspace_dir=tmp_path)
+
+    assert result["status"] == "passed"
+    assert result["expected_failure_observed"] is True
+    assert result["recovery_command"]
+    assert tmp_path.resolve() in Path(result["run_workspace"]).resolve().parents
+
+    manifest = json.loads(Path(result["run_manifest"]).read_text(encoding="utf-8"))
+    assert manifest["kind"] == "operator_drill"
+    assert manifest["status"] == "failed"
+    assert manifest["operation"] == result["drill"]["failure_mode"]
+    assert manifest["result_summary"]["drill_passed"] is True
+    assert manifest["result_summary"]["expected_failure_observed"] is True
+    assert manifest["artifact_paths"]["drill_json"] == "results/drill.json"
+    assert (Path(result["run_workspace"]) / "results" / "drill.json").exists()
+    assert (Path(result["run_workspace"]) / "reports" / "drill.md").exists()
+
+    serialized = json.dumps(result, sort_keys=True)
+    assert "drill-secret" not in serialized
+
+
+def test_operator_drill_issue_bundle_exports_safe_manifest(tmp_path: Path) -> None:
+    result = run_operator_drill("budget-violation", workspace_dir=tmp_path, bundle=True)
+
+    bundle = result["issue_bundle"]
+    assert bundle["safe_to_attach"] is True
+    manifest = json.loads(Path(bundle["manifest_path"]).read_text(encoding="utf-8"))
+    issue = Path(bundle["issue_template_path"]).read_text(encoding="utf-8")
+
+    assert manifest["bundle_kind"] == "issue-run"
+    assert manifest["safe_to_attach"] is True
+    assert manifest["runs"][0]["status"] == "failed"
+    assert manifest["runs"][0]["operation"] == "budget_violation"
+    assert "benchmark budget violation" in manifest["runs"][0]["observed_failure"]
+    assert "budget-violation" in issue
+    assert "drill-secret" not in json.dumps(manifest, sort_keys=True)
+
+
+def test_unsafe_event_metadata_drill_bundle_fails_closed(tmp_path: Path) -> None:
+    result = run_operator_drill("unsafe-event-metadata", workspace_dir=tmp_path, bundle=True)
+
+    bundle = result["issue_bundle"]
+    manifest = json.loads(Path(bundle["manifest_path"]).read_text(encoding="utf-8"))
+
+    assert bundle["safe_to_attach"] is False
+    assert manifest["safe_to_attach"] is False
+    assert manifest["excluded_count"] > 0
+    assert any(file["reason"] == "secret-like material detected" for file in manifest["files"])
+    assert "drill-secret" not in json.dumps(manifest, sort_keys=True)
+    assert result["details"]["secret_leaked"] is False
+
+
+def test_operator_drills_all_runs_every_checkout_safe_drill(tmp_path: Path) -> None:
+    result = run_all_operator_drills(workspace_dir=tmp_path)
+
+    assert result["status"] == "passed"
+    assert result["run_count"] == len(DRILL_IDS)
+    assert {run["drill"]["id"] for run in result["runs"]} == set(DRILL_IDS)
+    assert len(list((tmp_path / "runs").glob("*/run_manifest.json"))) == len(DRILL_IDS)
+
+
+def test_operator_drill_docs_cover_issue_152_contract() -> None:
+    playbooks = (ROOT / "docs/src/playbooks.md").read_text(encoding="utf-8")
+    operations = (ROOT / "docs/src/operations.md").read_text(encoding="utf-8")
+    cli_docs = (ROOT / "docs/src/cli.md").read_text(encoding="utf-8")
+    continuation = (ROOT / "docs/src/roadmap-continuation.md").read_text(encoding="utf-8")
+    changelog = (ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
+
+    for drill_id in DRILL_IDS:
+        assert drill_id in playbooks
+    for signal in (
+        "worldforge drills list",
+        "worldforge drills run unsafe-event-metadata",
+        "expected failure",
+        "recovery command",
+        "temporary or documented workspace",
+        "issue bundle",
+    ):
+        assert signal in playbooks or signal in operations or signal in cli_docs
+    assert "operator failure drills" in changelog
+    assert "- [x] Drill commands run in a clean checkout" in continuation
+    assert "- [x] Unsafe metadata drills prove redaction gates fail closed" in continuation
+
+
+def test_worldforge_drills_cli_lists_and_runs(tmp_path: Path, monkeypatch, capsys) -> None:
+    monkeypatch.setattr(sys, "argv", ["worldforge", "drills", "list", "--format", "json"])
+    assert main() == 0
+    drills = json.loads(capsys.readouterr().out)
+    assert [drill["id"] for drill in drills] == list(DRILL_IDS)
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "worldforge",
+            "drills",
+            "run",
+            "missing-credentials",
+            "--workspace-dir",
+            str(tmp_path),
+            "--format",
+            "json",
+        ],
+    )
+    assert main() == 0
+    result = json.loads(capsys.readouterr().out)
+    assert result["drill"]["id"] == "missing-credentials"
+    assert Path(result["run_manifest"]).exists()


### PR DESCRIPTION
## Summary
- add `worldforge drills list` and `worldforge drills run` for deterministic operator failure drills
- cover missing credentials, missing optional dependency, malformed provider output, budget violation, corrupted world state, expired artifact, and unsafe event metadata
- preserve run manifests, support optional issue-bundle export, and document expected failure plus recovery commands

## Validation
- `uv run pytest tests/test_operator_drills.py tests/test_provider_config.py tests/test_observability.py`
- `uv run mkdocs build --strict`
- `uv run ruff check src tests examples scripts`
- `uv run ruff format --check src tests examples scripts`
- `uv run pytest tests/test_cli_help_snapshots.py`
- `uv run worldforge drills run all --workspace-dir <temp> --format json`

Closes #152