### PR TITLE
Add local state preflight checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ releases may still include breaking changes when the public API needs to tighten
 
 ### Added
 
+- Added read-only local state preflight through `worldforge world preflight`. It checks world state
+  directories, file-safe requested IDs, corrupted world JSON, invalid histories, object bounding
+  boxes, preserved run manifests, stale run workspaces, unsafe artifact paths, and retention
+  pressure while returning safe-to-attach diagnostics and explicit quarantine or dry-run recovery
+  commands.
 - Added checkout-safe operator failure drills through `worldforge drills`. The drills cover missing
   credentials, missing optional dependencies, malformed provider output, benchmark budget
   violations, corrupted local world state, expired artifacts, and unsafe event metadata while

--- a/README.md
+++ b/README.md
@@ -305,6 +305,7 @@ uv run worldforge world predict <world-id> --object-id <object-id> --x 0.4 --y 0
 uv run worldforge world list                                            # persisted worlds
 uv run worldforge world objects <world-id>                              # scene objects
 uv run worldforge world history <world-id>                              # object edits + predictions
+uv run worldforge world preflight                                       # read-only local state diagnostics
 uv run worldforge world export <world-id> --output world.json           # portable state JSON
 uv run worldforge world delete <world-id>                               # remove local JSON state
 uv run worldforge provider list                                         # registered providers

--- a/docs/src/cli.md
+++ b/docs/src/cli.md
@@ -49,6 +49,7 @@ uv run worldforge world list
 uv run worldforge world show <world-id>
 uv run worldforge world objects <world-id>
 uv run worldforge world history <world-id>
+uv run worldforge world preflight --state-dir .worldforge/worlds --workspace-dir .worldforge
 uv run worldforge world export <world-id> --output world.json
 uv run worldforge world import world.json --new-id --name imported-lab
 uv run worldforge world fork <world-id> --name forked-lab
@@ -57,6 +58,11 @@ uv run worldforge world delete <world-id>
 
 World IDs are local JSON file stems. Values with path separators or traversal-shaped input are
 rejected before filesystem access.
+
+`world preflight` is read-only. It checks the world state directory, requested `--world-id` values,
+corrupted world JSON, invalid history entries, object bounding-box coherence, preserved run
+manifests, stale run directories, unsafe artifact paths, and run-retention pressure. JSON output is
+safe to attach by default; the command exits non-zero when it finds error-severity state.
 
 ## Scene Mutations And Prediction
 

--- a/docs/src/operations.md
+++ b/docs/src/operations.md
@@ -129,6 +129,7 @@ uv run worldforge world predict <world-id> --object-id cube-1 --x 0.4 --y 0.5 --
 uv run worldforge world list
 uv run worldforge world objects <world-id>
 uv run worldforge world history <world-id>
+uv run worldforge world preflight --state-dir .worldforge/worlds --workspace-dir .worldforge
 uv run worldforge world export <world-id> --output world.json
 uv run worldforge world import world.json --new-id --name lab-copy
 uv run worldforge world fork <world-id> --history-index 0 --name lab-start
@@ -164,9 +165,33 @@ Supported persistence invariants:
   summaries, malformed serialized actions, and invalid historical snapshot states.
 - `save_world(...)` validates the serialized world before writing and replaces the destination file
   atomically through a temporary file in the same directory.
+- `world preflight` is read-only and does not create, rewrite, delete, or silently coerce state. It
+  reports missing state directories, unsafe requested IDs, corrupted worlds, invalid histories,
+  incoherent object bounding boxes, stale run workspaces, unsafe run artifact paths, and retention
+  pressure.
 - README and operations docs state that multi-writer persistence is host-owned.
 - Any future built-in persistence backend must be introduced as an explicit adapter with its own
   locking, migration, and recovery documentation.
+
+Local state preflight is the first operator command before quarantining user data:
+
+```bash
+uv run worldforge world preflight \
+  --state-dir .worldforge/worlds \
+  --workspace-dir .worldforge \
+  --world-id <world-id> \
+  --retention-keep 20 \
+  --format json > worldforge-state-preflight.json
+```
+
+Success signal: `status` is `passed`, `safe_to_attach` is `true`, and `error_count` is `0`. Warning
+status is allowed for absent local state or retention pressure; failed status means at least one
+world file, requested ID, run manifest, or artifact reference needs operator action.
+
+Recovery commands in the report export diagnostics before moving invalid files into
+`.worldforge/quarantine/`. They do not run `rm` or silently delete user data. For retention pressure,
+the first command is `uv run worldforge runs cleanup --workspace-dir .worldforge --keep 20 --dry-run`;
+remove `--dry-run` only after the preserved evidence is no longer needed.
 
 ## Run Workspaces
 

--- a/docs/src/playbooks.md
+++ b/docs/src/playbooks.md
@@ -247,6 +247,7 @@ uv run worldforge world list
 uv run worldforge world objects <world-id>
 uv run worldforge world show <world-id>
 uv run worldforge world history <world-id>
+uv run worldforge world preflight --state-dir .worldforge/worlds --workspace-dir .worldforge
 uv run worldforge world export <world-id> --output world.json
 uv run worldforge world import world.json --new-id --name lab-copy
 uv run worldforge world fork <world-id> --history-index 0 --name lab-start
@@ -282,10 +283,20 @@ Success signal:
   prediction without replacing the local JSON file.
 - imported state rejects malformed scene objects, invalid history, negative steps, and traversal
   shaped IDs.
+- `world preflight` reports corrupted world JSON, traversal-shaped requested IDs, invalid history
+  entries, incoherent object bounding boxes, stale run workspaces, unsafe artifact paths, and
+  retention pressure without mutating local files.
 
 Recovery guidance:
 
+- run `uv run worldforge world preflight --state-dir .worldforge/worlds --workspace-dir .worldforge
+  --format json > worldforge-state-preflight.json` before moving or deleting any local state.
 - if local JSON is corrupted, restore from the host application's backup of exported world JSON.
+- if the report names stale run workspaces or unsafe artifact paths, export a run bundle when a
+  manifest is valid; otherwise quarantine the run directory after preserving the preflight report.
+- if retention pressure is the only issue, run `uv run worldforge runs cleanup --workspace-dir
+  .worldforge --keep 20 --dry-run` and remove evidence only after incident or release references
+  no longer need it.
 - if multiple workers need writes, move persistence into host-owned storage with locking,
   migrations, backups, and recovery drills.
 - do not add a lock file, SQLite store, or service adapter to WorldForge without the

--- a/docs/src/roadmap-continuation.md
+++ b/docs/src/roadmap-continuation.md
@@ -896,11 +896,11 @@ Out of scope:
 
 Acceptance criteria:
 
-- [ ] Preflight identifies corrupted worlds, traversal-shaped IDs, invalid history entries, stale
+- [x] Preflight identifies corrupted worlds, traversal-shaped IDs, invalid history entries, stale
       run workspaces, and unsafe artifact paths.
-- [ ] Recovery commands are explicit and do not silently delete user data.
-- [ ] Diagnostics are safe to attach to issues by default.
-- [ ] Existing local JSON behavior remains authoritative.
+- [x] Recovery commands are explicit and do not silently delete user data.
+- [x] Diagnostics are safe to attach to issues by default.
+- [x] Existing local JSON behavior remains authoritative.
 
 Validation:
 

--- a/src/worldforge/cli.py
+++ b/src/worldforge/cli.py
@@ -52,6 +52,7 @@ CLI_EPILOG = """Common commands:
   worldforge world add-object <world-id> cube --x 0 --y 0.5 --z 0
   worldforge world predict <world-id> --object-id <object-id> --x 0.4 --y 0.5 --z 0
   worldforge world list
+  worldforge world preflight
   worldforge world objects <world-id>
   worldforge world history <world-id>
   worldforge world delete <world-id>
@@ -793,6 +794,42 @@ def _build_parser() -> argparse.ArgumentParser:
         choices=("json", "markdown"),
         default="json",
         help="Output format for the forked world summary.",
+    )
+
+    world_preflight = world_subparsers.add_parser(
+        "preflight",
+        help="Check local world JSON state and run workspaces without mutating them.",
+    )
+    world_preflight.add_argument(
+        "--state-dir",
+        type=Path,
+        default=Path(".worldforge/worlds"),
+        help="World state directory.",
+    )
+    world_preflight.add_argument(
+        "--workspace-dir",
+        type=Path,
+        default=Path(".worldforge"),
+        help="WorldForge workspace directory containing runs/.",
+    )
+    world_preflight.add_argument(
+        "--world-id",
+        dest="world_ids",
+        action="append",
+        default=None,
+        help="World identifier to validate without loading. Can be repeated.",
+    )
+    world_preflight.add_argument(
+        "--retention-keep",
+        type=int,
+        default=20,
+        help="Number of newest valid run workspaces to keep before warning.",
+    )
+    world_preflight.add_argument(
+        "--format",
+        choices=("json", "markdown"),
+        default="json",
+        help="Output format for the preflight report.",
     )
 
     runs = subparsers.add_parser("runs", help="List, bundle, compare, and clean preserved runs.")
@@ -1590,6 +1627,25 @@ def _cmd_world_fork(args: argparse.Namespace, forge: WorldForge) -> int:
     return 0
 
 
+def _cmd_world_preflight(args: argparse.Namespace) -> int:
+    from worldforge.persistence_preflight import (
+        preflight_local_state,
+        render_state_preflight_markdown,
+    )
+
+    report = preflight_local_state(
+        state_dir=args.state_dir,
+        workspace_dir=args.workspace_dir,
+        world_ids=tuple(args.world_ids or ()),
+        retention_keep=args.retention_keep,
+    )
+    if args.format == "markdown":
+        print(render_state_preflight_markdown(report))
+    else:
+        _print_json(report)
+    return 1 if report["status"] == "failed" else 0
+
+
 def _cmd_world(args: argparse.Namespace, forge: WorldForge) -> int | None:
     world_dispatch = {
         "list": _cmd_world_list,
@@ -2090,6 +2146,12 @@ def main() -> int:
     if args.command == "drills":
         try:
             return _cmd_drills(args)
+        except (WorldForgeError, ValueError) as exc:
+            parser.exit(2, f"{exc}\n")
+
+    if args.command == "world" and args.world_command == "preflight":
+        try:
+            return _cmd_world_preflight(args)
         except (WorldForgeError, ValueError) as exc:
             parser.exit(2, f"{exc}\n")
 

--- a/src/worldforge/persistence_preflight.py
+++ b/src/worldforge/persistence_preflight.py
@@ -1,0 +1,705 @@
+"""Read-only preflight checks for local JSON state and preserved run workspaces."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+from worldforge.framework import WorldForge, _validate_storage_id
+from worldforge.harness.workspace import runs_dir, validate_run_id, workspace_root_for_state_dir
+from worldforge.models import (
+    BBox,
+    JSONDict,
+    Position,
+    SceneObject,
+    WorldForgeError,
+    WorldStateError,
+)
+
+STATE_PREFLIGHT_SCHEMA_VERSION = 1
+DEFAULT_STATE_DIR_DISPLAY = ".worldforge/worlds"
+DEFAULT_WORKSPACE_DISPLAY = ".worldforge"
+DEFAULT_RETENTION_KEEP = 20
+
+_SECRET_LIKE_PATTERN = re.compile(
+    r"(?:api[_-]?key|authorization|bearer|secret|signature|signed|token|x-amz)",
+    re.IGNORECASE,
+)
+_URL_PATTERN = re.compile(r"^[a-z][a-z0-9+.-]*://", re.IGNORECASE)
+_SAFE_NAME_PATTERN = re.compile(r"^[A-Za-z0-9_.-]+$")
+_VALID_RUN_STATUSES = {"running", "completed", "failed", "skipped", "cancelled"}
+
+
+def preflight_local_state(
+    *,
+    state_dir: Path,
+    workspace_dir: Path | None = None,
+    world_ids: tuple[str, ...] = (),
+    retention_keep: int = DEFAULT_RETENTION_KEEP,
+) -> JSONDict:
+    """Inspect local state without creating, deleting, or rewriting files."""
+
+    if retention_keep < 0:
+        raise WorldForgeError("retention_keep must be greater than or equal to 0.")
+
+    state_root = state_dir.expanduser()
+    workspace_root = (workspace_dir or workspace_root_for_state_dir(state_root)).expanduser()
+    issues: list[JSONDict] = []
+    stats: JSONDict = {
+        "world_files_checked": 0,
+        "run_workspaces_checked": 0,
+        "requested_world_ids_checked": len(world_ids),
+    }
+
+    _check_requested_world_ids(world_ids, issues)
+    _check_world_state_dir(state_root, issues, stats)
+    _check_run_workspaces(
+        workspace_root,
+        issues,
+        stats,
+        retention_keep=retention_keep,
+    )
+
+    error_count = sum(1 for issue in issues if issue["severity"] == "error")
+    warning_count = sum(1 for issue in issues if issue["severity"] == "warning")
+    status = "failed" if error_count else "warning" if warning_count else "passed"
+    return {
+        "schema_version": STATE_PREFLIGHT_SCHEMA_VERSION,
+        "status": status,
+        "safe_to_attach": True,
+        "state_dir": "<state-dir>",
+        "workspace_dir": "<workspace-dir>",
+        "retention_keep": retention_keep,
+        "diagnostic_command": _diagnostic_command(),
+        "recovery_policy": (
+            "Export this preflight report before quarantining invalid files; do not silently "
+            "delete local state."
+        ),
+        "counts": {
+            **stats,
+            "issue_count": len(issues),
+            "error_count": error_count,
+            "warning_count": warning_count,
+        },
+        "issues": issues,
+    }
+
+
+def render_state_preflight_markdown(report: JSONDict) -> str:
+    """Render a local state preflight report for operator runbooks."""
+
+    counts = report.get("counts", {})
+    lines = [
+        "# WorldForge Local State Preflight",
+        "",
+        f"status: `{report.get('status', 'unknown')}`",
+        f"safe_to_attach: `{str(report.get('safe_to_attach', False)).lower()}`",
+        f"state_dir: `{report.get('state_dir', '<state-dir>')}`",
+        f"workspace_dir: `{report.get('workspace_dir', '<workspace-dir>')}`",
+        f"retention_keep: `{report.get('retention_keep', DEFAULT_RETENTION_KEEP)}`",
+        "",
+        f"errors: `{counts.get('error_count', 0)}`",
+        f"warnings: `{counts.get('warning_count', 0)}`",
+        f"world_files_checked: `{counts.get('world_files_checked', 0)}`",
+        f"run_workspaces_checked: `{counts.get('run_workspaces_checked', 0)}`",
+        "",
+        "Diagnostic command:",
+        "",
+        f"```bash\n{report.get('diagnostic_command', _diagnostic_command())}\n```",
+    ]
+    issues = report.get("issues", [])
+    if not isinstance(issues, list) or not issues:
+        lines.extend(["", "No local state issues were found."])
+        return "\n".join(lines)
+
+    lines.extend(
+        [
+            "",
+            "| Severity | Check | Path | Message | Recovery |",
+            "| --- | --- | --- | --- | --- |",
+        ]
+    )
+    for issue in issues:
+        if not isinstance(issue, dict):
+            continue
+        lines.append(
+            "| "
+            f"{_markdown_cell(issue.get('severity'))} | "
+            f"{_markdown_cell(issue.get('check'))} | "
+            f"{_markdown_cell(issue.get('path'))} | "
+            f"{_markdown_cell(issue.get('message'))} | "
+            f"{_markdown_cell(issue.get('recovery_command'))} |"
+        )
+    return "\n".join(lines)
+
+
+def _check_requested_world_ids(world_ids: tuple[str, ...], issues: list[JSONDict]) -> None:
+    for raw_world_id in world_ids:
+        try:
+            _validate_storage_id(raw_world_id, name="world_id")
+        except WorldForgeError:
+            issues.append(
+                _issue(
+                    check="unsafe-world-id",
+                    severity="error",
+                    path="<input:world_id>",
+                    message=(
+                        "Requested world id is traversal-shaped or not file-safe; persistence "
+                        "will reject it before filesystem access."
+                    ),
+                    recovery_command=(
+                        f"{_diagnostic_command()} && use a world id matching "
+                        "[A-Za-z0-9][A-Za-z0-9_.-]*"
+                    ),
+                    details={"world_id": "<unsafe-world-id>"},
+                )
+            )
+
+
+def _check_world_state_dir(state_dir: Path, issues: list[JSONDict], stats: JSONDict) -> None:
+    if not state_dir.exists():
+        issues.append(
+            _issue(
+                check="state-dir-missing",
+                severity="warning",
+                path="<state-dir>",
+                message="World state directory does not exist; no persisted worlds were checked.",
+                recovery_command=(
+                    "uv run worldforge world create lab --provider mock "
+                    f"--state-dir {DEFAULT_STATE_DIR_DISPLAY}"
+                ),
+            )
+        )
+        return
+    if not state_dir.is_dir():
+        issues.append(
+            _issue(
+                check="state-dir-invalid",
+                severity="error",
+                path="<state-dir>",
+                message="World state path exists but is not a directory.",
+                recovery_command=(
+                    f"{_diagnostic_command()} && move the blocking file aside before using "
+                    f"{DEFAULT_STATE_DIR_DISPLAY}"
+                ),
+            )
+        )
+        return
+
+    forge = WorldForge(state_dir=state_dir)
+    roots = ((state_dir, "state-dir"),)
+    for world_file in sorted(state_dir.glob("*.json")):
+        stats["world_files_checked"] += 1
+        world_id = world_file.stem
+        try:
+            _validate_storage_id(world_id, name="world file stem")
+        except WorldForgeError:
+            issues.append(
+                _issue(
+                    check="unsafe-world-file-id",
+                    severity="error",
+                    path=_display_path(world_file, state_dir, "state-dir"),
+                    message="World JSON filename does not map to a file-safe world id.",
+                    recovery_command=_quarantine_world_command(world_file),
+                    details={"world_file": _safe_file_name(world_file.name)},
+                )
+            )
+            continue
+
+        payload = _load_json_object(world_file, state_dir=state_dir, issues=issues)
+        if payload is None:
+            continue
+        payload_id = payload.get("id")
+        if isinstance(payload_id, str) and payload_id != world_id:
+            issues.append(
+                _issue(
+                    check="world-id-mismatch",
+                    severity="warning",
+                    path=_display_path(world_file, state_dir, "state-dir"),
+                    message="World JSON filename does not match the serialized world id.",
+                    recovery_command=(
+                        f"{_diagnostic_command()} && export a valid copy with "
+                        "`uv run worldforge world export <world-id> --output world.json` before "
+                        "renaming or quarantining the mismatched file"
+                    ),
+                    details={"file_world_id": world_id, "payload_world_id": payload_id},
+                )
+            )
+        try:
+            forge.load_world(world_id)
+        except WorldStateError as exc:
+            issues.append(
+                _issue(
+                    check=_world_state_failure_check(str(exc)),
+                    severity="error",
+                    path=_display_path(world_file, state_dir, "state-dir"),
+                    message=(
+                        f"World state validation failed: {_sanitize_message(str(exc), roots=roots)}"
+                    ),
+                    recovery_command=_quarantine_world_command(world_file),
+                    details={"world_id": world_id},
+                )
+            )
+            continue
+        _check_world_bounding_boxes(
+            payload,
+            world_file=world_file,
+            state_dir=state_dir,
+            issues=issues,
+        )
+
+
+def _load_json_object(
+    path: Path,
+    *,
+    state_dir: Path,
+    issues: list[JSONDict],
+) -> JSONDict | None:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        issues.append(
+            _issue(
+                check="corrupted-world-json",
+                severity="error",
+                path=_display_path(path, state_dir, "state-dir"),
+                message=f"World JSON could not be decoded: {_sanitize_message(str(exc))}",
+                recovery_command=_quarantine_world_command(path),
+                details={"world_file": _safe_file_name(path.name)},
+            )
+        )
+        return None
+    if not isinstance(payload, dict):
+        issues.append(
+            _issue(
+                check="corrupted-world-json",
+                severity="error",
+                path=_display_path(path, state_dir, "state-dir"),
+                message="World JSON must decode to an object.",
+                recovery_command=_quarantine_world_command(path),
+                details={"world_file": _safe_file_name(path.name)},
+            )
+        )
+        return None
+    return payload
+
+
+def _check_world_bounding_boxes(
+    state: JSONDict,
+    *,
+    world_file: Path,
+    state_dir: Path,
+    issues: list[JSONDict],
+) -> None:
+    seen: set[int] = set()
+
+    def visit(payload: JSONDict, *, context: str) -> None:
+        payload_id = id(payload)
+        if payload_id in seen:
+            return
+        seen.add(payload_id)
+        objects = payload.get("scene", {}).get("objects", {})
+        if isinstance(objects, dict):
+            for object_id, raw_object in sorted(objects.items()):
+                if not isinstance(raw_object, dict):
+                    continue
+                object_payload = dict(raw_object)
+                object_payload.setdefault("id", str(object_id))
+                try:
+                    scene_object = SceneObject.from_dict(object_payload)
+                except WorldForgeError:
+                    continue
+                if not _position_inside_bbox(scene_object.position, scene_object.bbox):
+                    issues.append(
+                        _issue(
+                            check="bbox-incoherent",
+                            severity="error",
+                            path=_display_path(world_file, state_dir, "state-dir"),
+                            message=(
+                                "Scene object position is outside its bounding box; position "
+                                "patches must keep spatial bounds translated with the object pose."
+                            ),
+                            recovery_command=_quarantine_world_command(world_file),
+                            details={
+                                "world_id": str(state.get("id", world_file.stem)),
+                                "object_id": scene_object.id,
+                                "context": context,
+                            },
+                        )
+                    )
+        history = payload.get("history", [])
+        if isinstance(history, list):
+            for index, entry in enumerate(history):
+                if isinstance(entry, dict) and isinstance(entry.get("state"), dict):
+                    visit(entry["state"], context=f"{context}.history[{index}].state")
+
+    visit(state, context="state")
+
+
+def _check_run_workspaces(
+    workspace_dir: Path,
+    issues: list[JSONDict],
+    stats: JSONDict,
+    *,
+    retention_keep: int,
+) -> None:
+    root = runs_dir(workspace_dir)
+    if not root.exists():
+        return
+    if not root.is_dir():
+        issues.append(
+            _issue(
+                check="runs-dir-invalid",
+                severity="error",
+                path="<workspace-dir>/runs",
+                message="Run workspace path exists but is not a directory.",
+                recovery_command=f"{_diagnostic_command()} && move the blocking file aside",
+            )
+        )
+        return
+
+    valid_run_ids: list[str] = []
+    for run_path in sorted(root.iterdir(), key=lambda item: item.name, reverse=True):
+        stats["run_workspaces_checked"] += 1
+        if not run_path.is_dir():
+            issues.append(
+                _issue(
+                    check="stale-run-workspace",
+                    severity="warning",
+                    path=_display_path(run_path, workspace_dir, "workspace-dir"),
+                    message="Non-directory entry under runs/ is ignored by run history tooling.",
+                    recovery_command=_quarantine_run_command(run_path),
+                )
+            )
+            continue
+
+        run_id_valid = _is_valid_run_id(run_path.name)
+        if not run_id_valid:
+            issues.append(
+                _issue(
+                    check="stale-run-workspace",
+                    severity="warning",
+                    path=_display_path(run_path, workspace_dir, "workspace-dir"),
+                    message="Run workspace directory name is not a valid sortable run id.",
+                    recovery_command=_quarantine_run_command(run_path),
+                    details={"run_id": "<invalid-run-id>"},
+                )
+            )
+
+        manifest_path = run_path / "run_manifest.json"
+        if not manifest_path.is_file():
+            issues.append(
+                _issue(
+                    check="stale-run-workspace",
+                    severity="warning",
+                    path=_display_path(run_path, workspace_dir, "workspace-dir"),
+                    message="Run workspace has no run_manifest.json and cannot be bundled safely.",
+                    recovery_command=_quarantine_run_command(run_path),
+                    details={"run_id": run_path.name if run_id_valid else "<invalid-run-id>"},
+                )
+            )
+            continue
+
+        manifest = _load_manifest(manifest_path, workspace_dir=workspace_dir, issues=issues)
+        if manifest is None:
+            continue
+        if _check_run_manifest(
+            manifest,
+            run_path=run_path,
+            workspace_dir=workspace_dir,
+            issues=issues,
+        ):
+            valid_run_ids.append(str(manifest["run_id"]))
+
+    valid_run_ids.sort(reverse=True)
+    if len(valid_run_ids) > retention_keep:
+        stale_ids = valid_run_ids[retention_keep:]
+        issues.append(
+            _issue(
+                check="retention-pressure",
+                severity="warning",
+                path="<workspace-dir>/runs",
+                message=(
+                    f"{len(valid_run_ids)} valid run workspaces exceed retention_keep="
+                    f"{retention_keep}."
+                ),
+                recovery_command=(
+                    "uv run worldforge runs cleanup --workspace-dir "
+                    f"{DEFAULT_WORKSPACE_DISPLAY} --keep {retention_keep} --dry-run"
+                ),
+                details={"candidate_run_ids": stale_ids[:10], "candidate_count": len(stale_ids)},
+            )
+        )
+
+
+def _load_manifest(
+    path: Path,
+    *,
+    workspace_dir: Path,
+    issues: list[JSONDict],
+) -> JSONDict | None:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        issues.append(
+            _issue(
+                check="invalid-run-manifest",
+                severity="error",
+                path=_display_path(path, workspace_dir, "workspace-dir"),
+                message=f"Run manifest could not be decoded: {_sanitize_message(str(exc))}",
+                recovery_command=_quarantine_run_command(path.parent),
+            )
+        )
+        return None
+    if not isinstance(payload, dict):
+        issues.append(
+            _issue(
+                check="invalid-run-manifest",
+                severity="error",
+                path=_display_path(path, workspace_dir, "workspace-dir"),
+                message="Run manifest must decode to an object.",
+                recovery_command=_quarantine_run_command(path.parent),
+            )
+        )
+        return None
+    return payload
+
+
+def _check_run_manifest(
+    manifest: JSONDict,
+    *,
+    run_path: Path,
+    workspace_dir: Path,
+    issues: list[JSONDict],
+) -> bool:
+    valid = True
+    raw_run_id = manifest.get("run_id")
+    if not isinstance(raw_run_id, str) or not _is_valid_run_id(raw_run_id):
+        valid = False
+        issues.append(
+            _issue(
+                check="invalid-run-manifest",
+                severity="error",
+                path=_display_path(run_path / "run_manifest.json", workspace_dir, "workspace-dir"),
+                message="Run manifest run_id is missing or invalid.",
+                recovery_command=_quarantine_run_command(run_path),
+                details={"run_id": "<invalid-run-id>"},
+            )
+        )
+    elif raw_run_id != run_path.name:
+        valid = False
+        issues.append(
+            _issue(
+                check="invalid-run-manifest",
+                severity="error",
+                path=_display_path(run_path / "run_manifest.json", workspace_dir, "workspace-dir"),
+                message="Run manifest run_id does not match its workspace directory.",
+                recovery_command=_quarantine_run_command(run_path),
+                details={"run_id": raw_run_id},
+            )
+        )
+
+    if manifest.get("schema_version") != 1:
+        valid = False
+        issues.append(
+            _issue(
+                check="invalid-run-manifest",
+                severity="error",
+                path=_display_path(run_path / "run_manifest.json", workspace_dir, "workspace-dir"),
+                message="Run manifest schema_version must be 1.",
+                recovery_command=_quarantine_run_command(run_path),
+                details={"run_id": raw_run_id if isinstance(raw_run_id, str) else "<unknown>"},
+            )
+        )
+    if str(manifest.get("status", "")) not in _VALID_RUN_STATUSES:
+        valid = False
+        issues.append(
+            _issue(
+                check="invalid-run-manifest",
+                severity="error",
+                path=_display_path(run_path / "run_manifest.json", workspace_dir, "workspace-dir"),
+                message="Run manifest status is missing or unknown.",
+                recovery_command=_quarantine_run_command(run_path),
+                details={"run_id": raw_run_id if isinstance(raw_run_id, str) else "<unknown>"},
+            )
+        )
+
+    artifact_paths = manifest.get("artifact_paths", {})
+    if not isinstance(artifact_paths, dict):
+        valid = False
+        issues.append(
+            _issue(
+                check="invalid-run-manifest",
+                severity="error",
+                path=_display_path(run_path / "run_manifest.json", workspace_dir, "workspace-dir"),
+                message="Run manifest artifact_paths must be an object.",
+                recovery_command=_quarantine_run_command(run_path),
+                details={"run_id": raw_run_id if isinstance(raw_run_id, str) else "<unknown>"},
+            )
+        )
+        return valid
+
+    for label, raw_path in sorted(artifact_paths.items()):
+        reason = _unsafe_artifact_reason(raw_path, run_path=run_path)
+        if reason is None:
+            continue
+        issues.append(
+            _issue(
+                check="unsafe-artifact-path",
+                severity="error",
+                path=_display_path(run_path / "run_manifest.json", workspace_dir, "workspace-dir"),
+                message=f"Run manifest artifact path for label '{label}' is unsafe: {reason}.",
+                recovery_command=_artifact_recovery_command(
+                    raw_run_id if isinstance(raw_run_id, str) else None
+                ),
+                details={
+                    "run_id": raw_run_id if isinstance(raw_run_id, str) else "<unknown>",
+                    "artifact_label": str(label),
+                    "artifact_path": "<redacted-unsafe-reference>",
+                },
+            )
+        )
+    return valid
+
+
+def _unsafe_artifact_reason(raw_path: Any, *, run_path: Path) -> str | None:
+    if not isinstance(raw_path, str) or not raw_path.strip():
+        return "reference is not a non-empty relative path"
+    value = raw_path.strip()
+    if _URL_PATTERN.match(value):
+        return "reference is a URL instead of a workspace-relative artifact path"
+    if _SECRET_LIKE_PATTERN.search(value):
+        return "reference contains secret-like or signed URL material"
+    candidate = Path(value)
+    if candidate.is_absolute():
+        return "reference is an absolute host path"
+    if ".." in candidate.parts:
+        return "reference contains traversal"
+    resolved = (run_path / candidate).resolve()
+    run_root = run_path.resolve()
+    if resolved != run_root and run_root not in resolved.parents:
+        return "reference escapes the run workspace"
+    return None
+
+
+def _position_inside_bbox(position: Position, bbox: BBox) -> bool:
+    return (
+        bbox.min.x <= position.x <= bbox.max.x
+        and bbox.min.y <= position.y <= bbox.max.y
+        and bbox.min.z <= position.z <= bbox.max.z
+    )
+
+
+def _world_state_failure_check(message: str) -> str:
+    if "history" in message:
+        return "invalid-world-history"
+    if "scene object" in message or "bbox" in message:
+        return "invalid-world-object"
+    return "invalid-world-state"
+
+
+def _is_valid_run_id(value: str) -> bool:
+    try:
+        validate_run_id(value)
+    except ValueError:
+        return False
+    return True
+
+
+def _issue(
+    *,
+    check: str,
+    severity: str,
+    path: str,
+    message: str,
+    recovery_command: str,
+    details: JSONDict | None = None,
+) -> JSONDict:
+    return {
+        "check": check,
+        "severity": severity,
+        "path": path,
+        "message": message,
+        "recovery_command": recovery_command,
+        "safe_to_attach": True,
+        "details": details or {},
+    }
+
+
+def _display_path(path: Path, root: Path, label: str) -> str:
+    try:
+        relative = path.relative_to(root)
+    except ValueError:
+        try:
+            relative = path.resolve().relative_to(root.resolve())
+        except ValueError:
+            return f"<{label}>/{_safe_file_name(path.name)}"
+    if relative == Path("."):
+        return f"<{label}>"
+    return f"<{label}>/{relative.as_posix()}"
+
+
+def _safe_file_name(value: str) -> str:
+    return value if _SAFE_NAME_PATTERN.fullmatch(value) else "<unsafe-name>"
+
+
+def _diagnostic_command() -> str:
+    return (
+        "uv run worldforge world preflight "
+        f"--state-dir {DEFAULT_STATE_DIR_DISPLAY} "
+        f"--workspace-dir {DEFAULT_WORKSPACE_DISPLAY} "
+        "--format json > worldforge-state-preflight.json"
+    )
+
+
+def _quarantine_world_command(world_file: Path) -> str:
+    name = _safe_file_name(world_file.name)
+    return (
+        f"{_diagnostic_command()} && mkdir -p {DEFAULT_WORKSPACE_DISPLAY}/quarantine/worlds && "
+        f"mv {DEFAULT_STATE_DIR_DISPLAY}/{name} "
+        f"{DEFAULT_WORKSPACE_DISPLAY}/quarantine/worlds/{name}"
+    )
+
+
+def _quarantine_run_command(run_path: Path) -> str:
+    name = _safe_file_name(run_path.name)
+    return (
+        f"{_diagnostic_command()} && mkdir -p {DEFAULT_WORKSPACE_DISPLAY}/quarantine/runs && "
+        f"mv {DEFAULT_WORKSPACE_DISPLAY}/runs/{name} "
+        f"{DEFAULT_WORKSPACE_DISPLAY}/quarantine/runs/{name}"
+    )
+
+
+def _artifact_recovery_command(run_id: str | None) -> str:
+    if run_id and _is_valid_run_id(run_id):
+        return (
+            f"uv run worldforge runs bundle {run_id} "
+            f"--workspace-dir {DEFAULT_WORKSPACE_DISPLAY} --format markdown "
+            "> worldforge-run-issue.md && regenerate the run manifest with relative artifact "
+            "paths under the run workspace"
+        )
+    return (
+        f"{_diagnostic_command()} && regenerate the run manifest with relative artifact paths "
+        "under the run workspace"
+    )
+
+
+def _sanitize_message(
+    message: str,
+    *,
+    roots: tuple[tuple[Path, str], ...] = (),
+) -> str:
+    sanitized = message
+    for root, label in roots:
+        sanitized = sanitized.replace(str(root.resolve()), f"<{label}>")
+        sanitized = sanitized.replace(str(root), f"<{label}>")
+    if _SECRET_LIKE_PATTERN.search(sanitized):
+        sanitized = _SECRET_LIKE_PATTERN.sub("<redacted>", sanitized)
+    return sanitized
+
+
+def _markdown_cell(value: object) -> str:
+    text = str(value if value is not None else "")
+    return text.replace("|", "\\|").replace("\n", " ")

--- a/tests/test_cli_help_snapshots.py
+++ b/tests/test_cli_help_snapshots.py
@@ -78,6 +78,27 @@ options:
   --format {json,markdown}
                         Output format for history entries.
 """,
+    ("world", "preflight", "--help"): """\
+usage: worldforge world preflight [-h] [--state-dir STATE_DIR]
+                                  [--workspace-dir WORKSPACE_DIR]
+                                  [--world-id WORLD_IDS]
+                                  [--retention-keep RETENTION_KEEP]
+                                  [--format {json,markdown}]
+
+options:
+  -h, --help            show this help message and exit
+  --state-dir STATE_DIR
+                        World state directory.
+  --workspace-dir WORKSPACE_DIR
+                        WorldForge workspace directory containing runs/.
+  --world-id WORLD_IDS  World identifier to validate without loading. Can be
+                        repeated.
+  --retention-keep RETENTION_KEEP
+                        Number of newest valid run workspaces to keep before
+                        warning.
+  --format {json,markdown}
+                        Output format for the preflight report.
+""",
     ("harness", "--help"): """\
 usage: worldforge harness [-h]
                           [--flow {leworldmodel,lerobot,diagnostics,workbench,eval,benchmark,runs}]
@@ -212,6 +233,7 @@ WORLD_HELP_COMMANDS: tuple[tuple[str, str], ...] = (
     ("export", "Export a persisted world as JSON."),
     ("import", "Import and save exported world JSON."),
     ("fork", "Fork a world from a history entry."),
+    ("preflight", "Check local world JSON state and run workspaces without"),
 )
 
 
@@ -251,6 +273,7 @@ def test_top_level_help_lists_command_surface(monkeypatch, capsys) -> None:
         "worldforge examples",
         "worldforge world create lab --provider mock",
         "worldforge world history <world-id>",
+        "worldforge world preflight",
         "worldforge provider list",
         "worldforge provider docs",
         "worldforge provider info mock",

--- a/tests/test_docs_site.py
+++ b/tests/test_docs_site.py
@@ -785,6 +785,35 @@ def test_scaffold_provider_docs_cover_issue_142_contract() -> None:
     assert "- [x] Generated manifest stubs are clearly marked incomplete" in continuation
 
 
+def test_local_state_preflight_docs_cover_issue_153_contract() -> None:
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    cli = (ROOT / "docs/src/cli.md").read_text(encoding="utf-8")
+    operations = (ROOT / "docs/src/operations.md").read_text(encoding="utf-8")
+    playbooks = (ROOT / "docs/src/playbooks.md").read_text(encoding="utf-8")
+    continuation = (ROOT / "docs/src/roadmap-continuation.md").read_text(encoding="utf-8")
+    changelog = (ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
+
+    for signal in (
+        "worldforge world preflight",
+        "corrupted world JSON",
+        "traversal-shaped",
+        "invalid history entries",
+        "object bounding-box coherence",
+        "stale run workspaces",
+        "unsafe artifact paths",
+        "retention pressure",
+        "safe to attach",
+        "--dry-run",
+        ".worldforge/quarantine/",
+    ):
+        assert signal in cli or signal in operations or signal in playbooks or signal in changelog
+
+    assert "read-only local state diagnostics" in readme
+    assert "- [x] Preflight identifies corrupted worlds" in continuation
+    assert "- [x] Recovery commands are explicit" in continuation
+    assert "- [x] Diagnostics are safe to attach" in continuation
+
+
 def test_genie_scaffold_docs_record_runtime_contract_defer_decision() -> None:
     provider_page = (ROOT / "docs/src/providers/genie.md").read_text(encoding="utf-8")
     provider_index = (ROOT / "docs/src/providers/README.md").read_text(encoding="utf-8")

--- a/tests/test_persistence_preflight.py
+++ b/tests/test_persistence_preflight.py
@@ -1,0 +1,240 @@
+from __future__ import annotations
+
+import json
+import sys
+
+from worldforge import BBox, Position, SceneObject, World, WorldForge
+from worldforge.cli import main
+from worldforge.harness.workspace import create_run_workspace, write_run_manifest
+from worldforge.persistence_preflight import preflight_local_state, render_state_preflight_markdown
+
+
+def test_local_state_preflight_passes_for_valid_world_and_run_workspace(tmp_path) -> None:
+    state_dir = tmp_path / "worlds"
+    workspace_dir = tmp_path / "workspace"
+    forge = WorldForge(state_dir=state_dir)
+    world = forge.create_world("preflight-ok", provider="mock")
+    world.add_object(
+        SceneObject(
+            "cube",
+            Position(0.0, 0.5, 0.0),
+            BBox(Position(-0.05, 0.45, -0.05), Position(0.05, 0.55, 0.05)),
+            id="cube-1",
+        )
+    )
+    forge.save_world(world)
+    run = create_run_workspace(
+        workspace_dir,
+        kind="eval",
+        command="worldforge eval",
+        run_id="20260102T000000Z-00000002",
+    )
+    run.write_json("reports/report.json", {"status": "ok"})
+    write_run_manifest(
+        run,
+        kind="eval",
+        command="worldforge eval",
+        status="completed",
+        provider="mock",
+        operation="planning",
+        artifact_paths={"json": "reports/report.json"},
+    )
+
+    report = preflight_local_state(state_dir=state_dir, workspace_dir=workspace_dir)
+
+    assert report["status"] == "passed"
+    assert report["safe_to_attach"] is True
+    assert report["counts"]["world_files_checked"] == 1
+    assert report["counts"]["run_workspaces_checked"] == 1
+    assert report["issues"] == []
+    assert str(tmp_path) not in json.dumps(report)
+
+
+def test_local_state_preflight_reports_corrupt_history_and_bbox_issues(tmp_path) -> None:
+    state_dir = tmp_path / "worlds"
+    workspace_dir = tmp_path / "workspace"
+    forge = WorldForge(state_dir=state_dir)
+
+    valid = World("bbox", provider="mock", forge=forge, world_id="bbox-world")
+    valid.add_object(
+        SceneObject(
+            "cube",
+            Position(0.0, 0.5, 0.0),
+            BBox(Position(-0.05, 0.45, -0.05), Position(0.05, 0.55, 0.05)),
+            id="cube-1",
+        )
+    )
+    forge.save_world(valid)
+    bbox_payload = json.loads((state_dir / "bbox-world.json").read_text(encoding="utf-8"))
+    bbox_payload["scene"]["objects"]["cube-1"]["bbox"] = {
+        "min": {"x": 10.0, "y": 10.0, "z": 10.0},
+        "max": {"x": 11.0, "y": 11.0, "z": 11.0},
+    }
+    (state_dir / "bbox-world.json").write_text(json.dumps(bbox_payload), encoding="utf-8")
+
+    bad_history = World("bad-history", provider="mock", forge=forge, world_id="bad-history")
+    forge.save_world(bad_history)
+    history_payload = json.loads((state_dir / "bad-history.json").read_text(encoding="utf-8"))
+    history_payload["history"][0]["summary"] = ""
+    (state_dir / "bad-history.json").write_text(json.dumps(history_payload), encoding="utf-8")
+    (state_dir / "broken.json").write_text("{not valid json", encoding="utf-8")
+
+    report = preflight_local_state(state_dir=state_dir, workspace_dir=workspace_dir)
+
+    checks = {issue["check"] for issue in report["issues"]}
+    assert report["status"] == "failed"
+    assert {"bbox-incoherent", "invalid-world-history", "corrupted-world-json"} <= checks
+    assert all(issue["safe_to_attach"] is True for issue in report["issues"])
+    assert all("rm " not in issue["recovery_command"] for issue in report["issues"])
+    assert any("preflight" in issue["recovery_command"] for issue in report["issues"])
+    assert str(tmp_path) not in json.dumps(report)
+
+
+def test_local_state_preflight_reports_requested_traversal_world_id(tmp_path) -> None:
+    report = preflight_local_state(
+        state_dir=tmp_path / "worlds",
+        workspace_dir=tmp_path / "workspace",
+        world_ids=("../outside",),
+    )
+
+    assert report["status"] == "failed"
+    issue = report["issues"][0]
+    assert issue["check"] == "unsafe-world-id"
+    assert "traversal-shaped" in issue["message"]
+    assert "../outside" not in json.dumps(report)
+
+
+def test_local_state_preflight_reports_stale_runs_unsafe_artifacts_and_retention(tmp_path) -> None:
+    state_dir = tmp_path / "worlds"
+    workspace_dir = tmp_path / "workspace"
+    state_dir.mkdir()
+    stale_run = workspace_dir / "runs" / "20260101T000000Z-00000001"
+    stale_run.mkdir(parents=True)
+
+    unsafe_run = create_run_workspace(
+        workspace_dir,
+        kind="benchmark",
+        command="worldforge benchmark",
+        run_id="20260102T000000Z-00000002",
+    )
+    write_run_manifest(
+        unsafe_run,
+        kind="benchmark",
+        command="worldforge benchmark",
+        status="failed",
+        provider="mock",
+        operation="predict",
+        artifact_paths={"signed_url": "https://example.test/video.mp4?X-Amz-Signature=secret"},
+    )
+    valid_run = create_run_workspace(
+        workspace_dir,
+        kind="eval",
+        command="worldforge eval",
+        run_id="20260103T000000Z-00000003",
+    )
+    write_run_manifest(
+        valid_run,
+        kind="eval",
+        command="worldforge eval",
+        status="completed",
+        provider="mock",
+        operation="planning",
+        artifact_paths={"json": "reports/report.json"},
+    )
+
+    report = preflight_local_state(
+        state_dir=state_dir,
+        workspace_dir=workspace_dir,
+        retention_keep=1,
+    )
+
+    checks = [issue["check"] for issue in report["issues"]]
+    assert report["status"] == "failed"
+    assert "stale-run-workspace" in checks
+    assert "unsafe-artifact-path" in checks
+    assert "retention-pressure" in checks
+    assert "X-Amz-Signature" not in json.dumps(report)
+    retention = next(issue for issue in report["issues"] if issue["check"] == "retention-pressure")
+    assert "--dry-run" in retention["recovery_command"]
+    unsafe = next(issue for issue in report["issues"] if issue["check"] == "unsafe-artifact-path")
+    assert "worldforge runs bundle 20260102T000000Z-00000002" in unsafe["recovery_command"]
+
+
+def test_world_preflight_cli_does_not_create_missing_state_dir(
+    tmp_path,
+    monkeypatch,
+    capsys,
+) -> None:
+    state_dir = tmp_path / "missing" / "worlds"
+    workspace_dir = tmp_path / "workspace"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "worldforge",
+            "world",
+            "preflight",
+            "--state-dir",
+            str(state_dir),
+            "--workspace-dir",
+            str(workspace_dir),
+            "--format",
+            "json",
+        ],
+    )
+
+    assert main() == 0
+    report = json.loads(capsys.readouterr().out)
+    assert report["status"] == "warning"
+    assert report["issues"][0]["check"] == "state-dir-missing"
+    assert not state_dir.exists()
+
+
+def test_world_preflight_cli_reports_failure_and_markdown(tmp_path, monkeypatch, capsys) -> None:
+    state_dir = tmp_path / "worlds"
+    workspace_dir = tmp_path / "workspace"
+    state_dir.mkdir()
+    (state_dir / "broken.json").write_text("{bad", encoding="utf-8")
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "worldforge",
+            "world",
+            "preflight",
+            "--state-dir",
+            str(state_dir),
+            "--workspace-dir",
+            str(workspace_dir),
+            "--world-id",
+            "../outside",
+            "--format",
+            "markdown",
+        ],
+    )
+
+    assert main() == 1
+    output = capsys.readouterr().out
+    assert "# WorldForge Local State Preflight" in output
+    assert "unsafe-world-id" in output
+    assert "corrupted-world-json" in output
+    assert str(tmp_path) not in output
+
+
+def test_state_preflight_markdown_includes_recovery_table() -> None:
+    report = {
+        "status": "passed",
+        "safe_to_attach": True,
+        "counts": {
+            "error_count": 0,
+            "warning_count": 0,
+            "world_files_checked": 0,
+            "run_workspaces_checked": 0,
+        },
+        "issues": [],
+    }
+
+    rendered = render_state_preflight_markdown(report)
+
+    assert rendered.startswith("# WorldForge Local State Preflight")
+    assert "Diagnostic command:" in rendered


### PR DESCRIPTION
## Summary
- add `worldforge world preflight` for read-only local JSON and preserved-run diagnostics
- report corrupted worlds, unsafe requested IDs, invalid histories, bbox incoherence, stale run workspaces, unsafe artifact paths, and retention pressure with safe-to-attach output
- document recovery commands that export diagnostics before quarantine or dry-run cleanup

## Validation
- `uv run pytest tests/test_world_lifecycle.py tests/test_persistence*.py tests/test_harness_workspace.py`
- `uv run pytest tests/test_cli_help_snapshots.py tests/test_docs_site.py`
- `uv run mkdocs build --strict`
- `uv run ruff check src tests examples scripts`
- `uv run ruff format --check src tests examples scripts`
- `git diff --check`

Closes #153