### PR TITLE
Document contributor triage taxonomy

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -3,6 +3,23 @@ description: Report a reproducible WorldForge bug.
 title: "[Bug]: "
 labels: ["bug"]
 body:
+  - type: markdown
+    attributes:
+      value: |
+        Do not file vulnerabilities, credentials, signed URLs, private endpoints, or host-local
+        artifacts here. Use the private Security tab for security-sensitive reports.
+  - type: dropdown
+    id: triage_stream
+    attributes:
+      label: Triage stream
+      description: Pick the roadmap stream that best matches the bug.
+      options:
+        - Provider evidence or runtime contract
+        - Evidence integrity, evaluation, benchmark, or artifact
+        - Operator workflow, harness, persistence, or adapter authoring
+        - Unsure
+    validations:
+      required: true
   - type: textarea
     id: summary
     attributes:

--- a/.github/ISSUE_TEMPLATE/eval_benchmark.yml
+++ b/.github/ISSUE_TEMPLATE/eval_benchmark.yml
@@ -1,8 +1,14 @@
 name: Evaluation or benchmark issue
 description: Report a problem with eval suites, benchmark inputs, budgets, or reports.
 title: "[Eval/Benchmark]: "
-labels: ["evaluation", "benchmark"]
+labels: ["evaluation", "benchmark", "stream: evidence-integrity"]
 body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for evaluation, benchmark, report, budget, artifact, provenance, or public
+        claim evidence work. Release-candidate or public-claim issues need preserved run evidence,
+        an evidence bundle, or release evidence before closure.
   - type: textarea
     id: command
     attributes:
@@ -15,7 +21,7 @@ body:
     id: artifact
     attributes:
       label: Artifact
-      description: JSON, CSV, Markdown, input file, or budget file involved.
+      description: JSON, CSV, Markdown, input file, budget file, run manifest, or evidence bundle involved.
       render: json
   - type: textarea
     id: claim
@@ -24,6 +30,14 @@ body:
       description: What number, score, gate, or report behavior looks wrong?
     validations:
       required: true
+  - type: checkboxes
+    id: evidence_requirements
+    attributes:
+      label: Evidence requirements
+      options:
+        - label: Preserved run manifest, report artifact, evidence bundle, or release evidence is linked when this affects a public claim or release gate.
+        - label: Provider, capability, suite or preset, budget file, and input fixture are named when relevant.
+        - label: Unsafe host-local artifacts, credentials, signed URLs, and private paths are excluded or redacted.
   - type: textarea
     id: environment
     attributes:

--- a/.github/ISSUE_TEMPLATE/provider_adapter.yml
+++ b/.github/ISSUE_TEMPLATE/provider_adapter.yml
@@ -1,12 +1,31 @@
 name: Provider adapter proposal
 description: Propose or promote a provider adapter.
 title: "[Provider]: "
-labels: ["provider"]
+labels: ["provider", "stream: provider-evidence"]
 body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for provider runtime work. New runtime families or unclear upstream
+        contracts need a provider selection record before implementation. Promotion work should
+        cite the provider authoring guide promotion gate, runtime manifest, fixtures, docs, and
+        live-smoke evidence or explicit blockers.
   - type: input
     id: provider
     attributes:
       label: Provider or runtime
+    validations:
+      required: true
+  - type: dropdown
+    id: triage_path
+    attributes:
+      label: Triage path
+      description: Pick the path that best matches this provider work.
+      options:
+        - New provider/runtime family; needs selection record
+        - Scaffold or experimental adapter
+        - Promotion to beta or stable
+        - Runtime hardening or bug fix
     validations:
       required: true
   - type: checkboxes
@@ -32,9 +51,19 @@ body:
     id: validation
     attributes:
       label: Validation plan
-      description: Contract tests, fixtures, docs, and commands that prove each advertised capability.
+      description: Contract tests, fixtures, docs, smoke evidence, and commands that prove each advertised capability.
     validations:
       required: true
+  - type: checkboxes
+    id: promotion_evidence
+    attributes:
+      label: Promotion and evidence requirements
+      options:
+        - label: Selection record or existing provider-cohort record is linked when this adds a new runtime family.
+        - label: Provider authoring guide promotion gate is cited for the requested status.
+        - label: Runtime manifest and provider docs are updated or the blocker is explicit.
+        - label: Fixture-backed parser/contract tests are planned for each advertised capability.
+        - label: Prepared-host smoke, live-smoke evidence, or explicit blocker is named when promotion depends on a real runtime.
   - type: textarea
     id: failure_modes
     attributes:
@@ -42,3 +71,8 @@ body:
       description: Expected provider errors, missing dependency behavior, and first triage step.
     validations:
       required: true
+  - type: markdown
+    attributes:
+      value: |
+        Do not include credentials, signed URLs, private endpoints, or host-local artifacts. Use the
+        private Security tab for vulnerabilities or secret exposure.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ releases may still include breaking changes when the public API needs to tighten
 
 ### Added
 
+- Added contributor triage guidance for roadmap stream, capability, severity, and release-scope
+  labels, and routed provider plus evaluation/benchmark issue templates to provider promotion,
+  evidence, and private-security reporting expectations.
 - Added read-only local state preflight through `worldforge world preflight`. It checks world state
   directories, file-safe requested IDs, corrupted world JSON, invalid histories, object bounding
   boxes, preserved run manifests, stale run workspaces, unsafe artifact paths, and retention

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,6 +106,55 @@ Public behavior changes need docs in the same branch. Use this routing:
 - `CHANGELOG.md` for user-visible changes.
 - `AGENTS.md` for repo commands, constraints, gotchas, and agent-facing context.
 
+## Contributor Triage And Labels
+
+Use labels to make the roadmap stream, capability surface, severity, and release scope visible
+before implementation starts.
+
+Roadmap stream labels:
+
+- `stream: provider-evidence`: provider selection, adapter runtime contracts, provider promotion,
+  runtime manifests, provider docs, optional runtime smokes, and upstream research validation.
+- `stream: evidence-integrity`: evaluation suites, benchmarks, budgets, reports, preserved run
+  evidence, release evidence, artifact bundles, provenance, and claim-supporting docs.
+- `stream: ops-authoring`: operator workflows, TheWorldHarness, adapter authoring loops,
+  reference hosts, local persistence, runbooks, drills, and contributor experience.
+
+Capability labels are `predict`, `generate`, `reason`, `embed`, `transfer`, `score`, and `policy`.
+Use them only when the issue touches that public capability surface. Common domain labels include
+`provider`, `research`, `artifacts`, `evaluation`, `benchmark`, `harness`, `operations`,
+`observability`, `persistence`, `security`, `examples`, `developer-experience`, `robotics`, and
+`optional-dependency`.
+
+Severity and release-scope labels:
+
+- `severity: blocking`: blocks release-candidate readiness, a public contract, or operator safety.
+- `severity: quality`: degrades quality or evidence but does not block all development.
+- `type: hardening`: reliability, validation, redaction, recovery, or safety hardening.
+- `release` and `release: provider-hardening-rc`: release process or named release-candidate scope.
+
+Triage rules:
+
+- Provider runtime or promotion work uses the provider template, `stream: provider-evidence`,
+  `provider`, the capability labels it claims, and any relevant `optional-dependency`, `robotics`,
+  `security`, or `research` labels. New runtime families or unclear upstream contracts need a
+  selection record before implementation. Promotion work must cite the provider authoring guide
+  promotion gate, runtime manifest, fixtures, provider docs, and live-smoke or explicit blocker
+  evidence.
+- Evaluation, benchmark, claim, report, budget, or artifact work uses the eval/benchmark template,
+  `stream: evidence-integrity`, and the relevant `evaluation`, `benchmark`, `artifacts`, or
+  `observability` labels. Public claims and release-candidate gates need preserved run evidence or
+  release evidence before the issue can be closed.
+- Operator workflow, local persistence, run workspace, harness, drill, reference host, and adapter
+  authoring workflow work uses `stream: ops-authoring` plus `operations`, `harness`,
+  `developer-experience`, `persistence`, `reliability`, or `examples` as appropriate. These issues
+  should name the command to run, expected success signal, first triage step, and recovery command.
+- Architecture, persistence-boundary, provider-selection, or runtime-ownership changes need a
+  design record or selection record before broad implementation.
+- Security-sensitive reports still route through the private Security tab. Do not open public
+  issues containing vulnerabilities, credentials, signed URLs, private endpoints, or host-local
+  artifacts.
+
 ## Pull Request Checklist
 
 - lint, docs check, tests, coverage, package check, and build pass.

--- a/docs/src/contributing.md
+++ b/docs/src/contributing.md
@@ -57,6 +57,40 @@ report = assert_provider_contract(
 )
 ```
 
+## Contributor Triage And Labels
+
+Use labels to make an issue's roadmap stream and evidence contract clear before work starts.
+
+| Axis | Labels | Use when |
+| --- | --- | --- |
+| Roadmap stream | `stream: provider-evidence` | provider selection, runtime contracts, provider promotion, runtime manifests, upstream validation |
+| Roadmap stream | `stream: evidence-integrity` | evals, benchmarks, budgets, preserved run evidence, release evidence, provenance, public claims |
+| Roadmap stream | `stream: ops-authoring` | operator workflows, TheWorldHarness, adapter authoring loops, reference hosts, persistence, runbooks |
+| Capability | `predict`, `generate`, `reason`, `embed`, `transfer`, `score`, `policy` | the issue changes or validates that public capability surface |
+| Severity | `severity: blocking`, `severity: quality`, `type: hardening` | release blockers, quality regressions, validation/redaction/recovery hardening |
+| Release scope | `release`, `release: provider-hardening-rc` | release process or named release-candidate scope |
+
+Provider runtime issues should use the provider adapter template, `stream: provider-evidence`,
+`provider`, the claimed capability labels, and any relevant `optional-dependency`, `robotics`,
+`security`, or `research` labels. New runtime families or unclear upstream contracts need a
+selection record before implementation. Provider promotion work must cite the provider authoring
+guide promotion gate, runtime manifest, fixtures, docs, and live-smoke or explicit blocker
+evidence.
+
+Evaluation, benchmark, artifact, budget, report, or claim issues should use the eval/benchmark
+template with `stream: evidence-integrity`. Release-candidate or public-claim issues need preserved
+run evidence, an evidence bundle, or release evidence before closure.
+
+Operator workflow issues should use `stream: ops-authoring` plus `operations`, `harness`,
+`developer-experience`, `persistence`, `reliability`, or `examples` as appropriate. The issue should
+name the command to run, expected success signal, first triage step, and recovery command.
+
+Architecture, persistence-boundary, provider-selection, or runtime-ownership changes need a design
+record or selection record before broad implementation.
+
+Security-sensitive reports still route through the private Security tab. Do not open public issues
+containing vulnerabilities, credentials, signed URLs, private endpoints, or host-local artifacts.
+
 Before publishing a branch:
 
 - run the full release gate from [User And Operator Playbooks](./playbooks.md).

--- a/docs/src/roadmap-continuation.md
+++ b/docs/src/roadmap-continuation.md
@@ -930,10 +930,10 @@ Out of scope:
 
 Acceptance criteria:
 
-- [ ] Labels exist for the three roadmap streams or existing labels are explicitly mapped to them.
-- [ ] Contributor docs explain how to classify provider, evidence, and operator workflow issues.
-- [ ] Issue templates route provider runtime work to promotion criteria and evidence requirements.
-- [ ] Security-sensitive reports still route privately, not to public issues.
+- [x] Labels exist for the three roadmap streams or existing labels are explicitly mapped to them.
+- [x] Contributor docs explain how to classify provider, evidence, and operator workflow issues.
+- [x] Issue templates route provider runtime work to promotion criteria and evidence requirements.
+- [x] Security-sensitive reports still route privately, not to public issues.
 
 Validation:
 

--- a/tests/test_docs_site.py
+++ b/tests/test_docs_site.py
@@ -814,6 +814,52 @@ def test_local_state_preflight_docs_cover_issue_153_contract() -> None:
     assert "- [x] Diagnostics are safe to attach" in continuation
 
 
+def test_contributor_triage_docs_cover_issue_131_contract() -> None:
+    contributing = (ROOT / "CONTRIBUTING.md").read_text(encoding="utf-8")
+    docs_contributing = (ROOT / "docs/src/contributing.md").read_text(encoding="utf-8")
+    provider_template = (ROOT / ".github/ISSUE_TEMPLATE/provider_adapter.yml").read_text(
+        encoding="utf-8"
+    )
+    eval_template = (ROOT / ".github/ISSUE_TEMPLATE/eval_benchmark.yml").read_text(encoding="utf-8")
+    bug_template = (ROOT / ".github/ISSUE_TEMPLATE/bug_report.yml").read_text(encoding="utf-8")
+    config_template = (ROOT / ".github/ISSUE_TEMPLATE/config.yml").read_text(encoding="utf-8")
+    continuation = (ROOT / "docs/src/roadmap-continuation.md").read_text(encoding="utf-8")
+    changelog = (ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
+
+    for stream in (
+        "stream: provider-evidence",
+        "stream: evidence-integrity",
+        "stream: ops-authoring",
+    ):
+        assert stream in contributing
+        assert stream in docs_contributing
+
+    for signal in (
+        "capability labels",
+        "severity: blocking",
+        "release: provider-hardening-rc",
+        "selection record",
+        "promotion gate",
+        "release evidence",
+        "Security tab",
+    ):
+        assert signal in contributing or signal in docs_contributing
+
+    assert 'labels: ["provider", "stream: provider-evidence"]' in provider_template
+    assert "Triage path" in provider_template
+    assert "Promotion and evidence requirements" in provider_template
+    assert "Selection record or existing provider-cohort record" in provider_template
+    assert 'labels: ["evaluation", "benchmark", "stream: evidence-integrity"]' in eval_template
+    assert "Evidence requirements" in eval_template
+    assert "Triage stream" in bug_template
+    assert "private Security tab" in bug_template
+    assert "Report vulnerabilities privately" in config_template
+    assert "contributor triage guidance" in changelog
+    assert "- [x] Labels exist for the three roadmap streams" in continuation
+    assert "- [x] Issue templates route provider runtime work" in continuation
+    assert "- [x] Security-sensitive reports still route privately" in continuation
+
+
 def test_genie_scaffold_docs_record_runtime_contract_defer_decision() -> None:
     provider_page = (ROOT / "docs/src/providers/genie.md").read_text(encoding="utf-8")
     provider_index = (ROOT / "docs/src/providers/README.md").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- document roadmap stream, capability, severity, and release-scope label taxonomy in contributor docs
- route provider adapter issues to provider-evidence promotion/evidence requirements
- route eval/benchmark issues to evidence-integrity requirements and keep security-sensitive reports on the private Security path

## Validation
- `gh label list --limit 200` confirmed `stream: provider-evidence`, `stream: evidence-integrity`, and `stream: ops-authoring` exist
- `uv run pytest tests/test_docs_site.py`
- `uv run mkdocs build --strict`
- `uv run ruff check src tests examples scripts`
- `uv run ruff format --check src tests examples scripts`
- `git diff --check`

Closes #131