### PR TITLE
Add production quality release gates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,6 +112,8 @@ uv lock --check
 uv run ruff check src tests examples scripts
 uv run ruff format --check src tests examples scripts
 uv run python scripts/generate_provider_docs.py --check
+uv run python scripts/check_docs_commands.py
+uv run python scripts/check_core_performance.py
 uv run mkdocs build --strict
 uv run pytest
 uv run --extra harness pytest --cov=src/worldforge --cov-report=term-missing --cov-fail-under=90
@@ -358,9 +360,11 @@ generated documentation surfaces.
   when adding new provider environment variables.
 - Ruff commands run against `src tests examples scripts` to match CI and the commands documented
   in `README.md`. Do not drop `scripts` from either target.
-- `uv run python scripts/generate_provider_docs.py --check` plus
-  `uv run mkdocs build --strict` checks generated provider docs and builds the MkDocs Material
-  site. A warning in the published docs build is a release blocker.
+- `uv run python scripts/generate_provider_docs.py --check`,
+  `uv run python scripts/check_docs_commands.py`, `uv run python scripts/check_core_performance.py`,
+  and `uv run mkdocs build --strict` check generated provider docs, documented command drift,
+  checkout-safe core performance budgets, and the MkDocs Material site. A warning in the published
+  docs build is a release blocker.
 - `worldforge benchmark --budget-file <path>` evaluates direct provider benchmark results against
   JSON thresholds and exits non-zero on violations. Keep benchmark budgets tied to preserved run
   artifacts when using them for release or paper claims.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ releases may still include breaking changes when the public API needs to tighten
 
 ### Added
 
+- Upgraded the release evidence generator into a release-readiness command that writes Markdown and
+  JSON summaries, can execute checkout-safe gates with `--run-gates`, records skipped and failed
+  gate triage steps, and marks optional live-provider evidence as host-owned unless a prepared-host
+  run manifest is linked.
+- Added a public API stability and deprecation policy covering stable, provisional, experimental,
+  and internal surfaces, with migration expectations for provider capabilities and artifact
+  schemas.
+- Added a troubleshooting matrix for public error families, provider contract failures, benchmark
+  budget exits, and docs-build warnings with owner, command, artifact, and first-triage guidance.
+- Added a documented-command drift checker for README, CLI docs, examples, operations, playbooks,
+  and AGENTS command surfaces, and wired it into the release-readiness gate.
+- Added a checkout-safe core performance budget checker for world persistence, benchmark fixture
+  loading, provider diagnostics, evidence-bundle creation, and report rendering, and wired it into
+  release-readiness documentation.
 - Added a roadmap expansion plan for 30 structured GitHub issues across production-grade
   quality/DevX/docs, demos and end-to-end showcases, and new features, explicitly excluding the
   already assigned Nano World Model work.

--- a/README.md
+++ b/README.md
@@ -481,6 +481,8 @@ uv lock --check
 uv run ruff check src tests examples scripts
 uv run ruff format --check src tests examples scripts
 uv run python scripts/generate_provider_docs.py --check
+uv run python scripts/check_docs_commands.py
+uv run python scripts/check_core_performance.py
 uv run mkdocs build --strict
 uv run pytest
 uv run --extra harness pytest --cov=src/worldforge --cov-report=term-missing --cov-fail-under=90

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -29,6 +29,7 @@
 - [Live Smoke Evidence Registry](./live-smoke-evidence.md)
 - [Claim-To-Evidence Map](./claim-evidence-map.md)
 - [Python API](./api/python.md)
+- [Public API Stability](./api-stability.md)
 - [Evaluation](./evaluation.md)
 - [Benchmarking](./benchmarking.md)
 - [Capability Fixture Corpus](./fixtures.md)

--- a/docs/src/api-stability.md
+++ b/docs/src/api-stability.md
@@ -1,0 +1,69 @@
+# Public API Stability
+
+WorldForge is still pre-1.0, but several surfaces are public enough that contributors need a clear
+change policy. This policy sets review expectations; it is not a 1.0 compatibility promise.
+
+## API Tiers
+
+| Tier | Examples | Change policy |
+| --- | --- | --- |
+| Stable | `WorldForge`, `World`, domain models in `worldforge.models`, capability protocols, `WorldForgeError`, `WorldStateError`, `ProviderError`, generated provider docs, documented CLI commands | Keep source-compatible when practical. Breaking changes need a changelog entry, migration note, and at least one release cycle of deprecation unless a security or correctness issue requires an immediate break. |
+| Provisional | Evaluation report schemas, benchmark input and budget schemas, run workspace manifests, evidence bundles, provider workbench reports, optional host scripts | Schema changes need a version bump or explicit migration note. Keep old fields readable where that does not preserve invalid state. |
+| Experimental | `jepa-wms` direct-construction candidate, scaffold provider reservations, optional robotics wrappers, prepared-host live smokes, Rerun visual artifacts | May change faster, but docs must keep capability and runtime ownership honest. Experimental status does not allow secret leakage or silent coercion. |
+| Internal | Private helpers, generated implementation details, test-only fixtures, non-exported parser helpers, TUI internals outside documented harness APIs | Can change without deprecation. Do not import these from downstream code. |
+
+## Deprecation Rules
+
+Deprecation is required when a change affects a stable public import, constructor argument, model
+field, exception family, CLI command or flag, provider capability, provider profile field, artifact
+schema, or documented file layout. In review notes, call this out explicitly as an artifact schema
+migration.
+
+Every deprecation plan should include:
+
+- the old surface and the replacement surface;
+- the first release where warnings or docs notices appear;
+- the earliest release where removal may happen;
+- the validation command that proves both old and new paths during the transition;
+- the changelog entry that describes user action.
+
+Immediate removal is allowed only for security exposure, persisted-state incoherence, false provider
+capability claims, or behavior that cannot be maintained without corrupting user artifacts. In that
+case, the PR must state the reason, the failure mode, and the migration command or manual recovery
+step.
+
+## Provider And Artifact Migrations
+
+Provider changes must preserve truthful capability advertising. Removing or renaming a capability,
+changing a provider profile status, or changing runtime ownership needs a migration note in the
+provider page and changelog. Scaffold adapters must not be promoted by wording alone; promotion
+requires parser tests, contract tests, runtime evidence, and documentation updates.
+
+Artifact schemas must remain JSON-native and versioned when they leave a single process. This
+includes run manifests, evidence bundles, benchmark inputs, benchmark budgets, evaluation reports,
+failure galleries, release evidence JSON, and future scenario files. Readers should reject malformed
+or unsupported schema versions loudly instead of silently coercing invalid state.
+
+## Changelog Expectations
+
+Use the changelog for any public behavior change, including:
+
+- breaking API, CLI, provider, or artifact-schema changes;
+- new deprecations and removal dates;
+- migration commands or manual recovery steps;
+- changed validation gates;
+- changed optional runtime requirements.
+
+Small typo fixes and internal-only refactors do not need changelog entries unless they affect public
+docs, generated artifacts, or user-visible commands.
+
+## Contributor Checklist
+
+Before merging a public API change, answer these questions in the PR:
+
+- Is the touched surface stable, provisional, experimental, or internal?
+- Does the change need a deprecation notice or schema version bump?
+- Do docs and changelog explain the migration?
+- Do tests cover both the old compatibility path and the new behavior when applicable?
+- Does provider capability advertising remain truthful?
+- Are malformed persisted/provider states rejected explicitly?

--- a/docs/src/api/python.md
+++ b/docs/src/api/python.md
@@ -1,5 +1,8 @@
 # Python API
 
+For compatibility tiers, deprecation expectations, and artifact-schema migration rules, see
+[Public API Stability](../api-stability.md).
+
 ## Entry points
 
 ```python

--- a/docs/src/benchmarking.md
+++ b/docs/src/benchmarking.md
@@ -250,6 +250,25 @@ First triage step for a surprising candidate: open `budget-calibration.md`, conf
 report digest matches the preserved benchmark JSON, then rerun the exact benchmark command on the
 same machine class before changing a release budget.
 
+## Core checkout performance guard
+
+Use the core performance gate to detect regressions in framework paths that should stay cheap in a
+clean checkout:
+
+```bash
+uv run python scripts/check_core_performance.py \
+  --workspace-dir .worldforge/core-performance \
+  --output .worldforge/core-performance/core-performance.json
+```
+
+The command measures world persistence, benchmark input fixture loading, provider catalog
+diagnostics, evidence-bundle creation, and evaluation report rendering against local millisecond
+budgets. Success signal: the JSON report has `passed: true`, result rows include measured
+`duration_ms` and `budget_ms`, and preserved workspaces include artifact paths for each operation.
+First triage step: inspect the failing row, verify the artifact path and changed code path, then fix
+the regression before changing budgets. These budgets are checkout-safe regression guards only; they
+are not a leaderboard, cross-machine claim, or optional-runtime benchmark.
+
 ## Report contents
 
 - per-provider, per-operation success and error counts

--- a/docs/src/cli.md
+++ b/docs/src/cli.md
@@ -72,6 +72,8 @@ uv run worldforge world update-object <world-id> cube-1 --x 0.2 --y 0.5 --z 0
 uv run worldforge world remove-object <world-id> cube-1
 uv run worldforge world predict <world-id> --object-id cube-1 --x 0.4 --y 0.5 --z 0
 uv run worldforge predict kitchen --provider mock --x 0.3 --y 0.8 --z 0.0 --steps 2
+uv run worldforge generate "A cube rolling across a table" --provider mock --duration 1
+uv run worldforge transfer input.mp4 --provider mock --prompt "make it slower"
 ```
 
 Scene mutations append typed history entries. Position patches keep bounding boxes translated with
@@ -155,6 +157,9 @@ uvx --from "rerun-sdk>=0.24,<0.32" rerun /tmp/worldforge-robotics-showcase/real-
 Live GR00T and LeRobot policy smoke helpers:
 
 ```bash
+uv run worldforge-smoke-runway --help
+uv run worldforge-smoke-jepa-wms --help
+uv run worldforge-smoke-lerobot-leworldmodel --help
 uv run python scripts/smoke_gr00t_policy.py --help
 uv run python scripts/smoke_lerobot_policy.py --help
 ```

--- a/docs/src/contributing.md
+++ b/docs/src/contributing.md
@@ -21,6 +21,11 @@ Before tags or package publishing, also run the locked dependency audit from
 in strict mode. `bash scripts/test_package.sh` checks the wheel/sdist contents before installing
 the built wheel and running tests against the installed package.
 
+Before changing public imports, CLI flags, provider capabilities, or artifact schemas, classify the
+surface through [Public API Stability](./api-stability.md). Stable and provisional surfaces need a
+deprecation or migration plan unless the change fixes a security exposure, false capability claim,
+or persisted-state incoherence.
+
 Key directories:
 
 - `src/worldforge/models.py`: public data contracts and validation.

--- a/docs/src/operations.md
+++ b/docs/src/operations.md
@@ -552,6 +552,8 @@ uv lock --check
 uv run ruff check src tests examples scripts
 uv run ruff format --check src tests examples scripts
 uv run python scripts/generate_provider_docs.py --check
+uv run python scripts/check_docs_commands.py
+uv run python scripts/check_core_performance.py
 uv run mkdocs build --strict
 uv run pytest
 uv run --extra harness pytest --cov=src/worldforge --cov-report=term-missing --cov-fail-under=90
@@ -568,21 +570,32 @@ uvx --from pip-audit pip-audit -r "$tmp_req" --no-deps --disable-pip --progress-
 rm -f "$tmp_req"
 ```
 
-Generate the release evidence bundle after local gates and optional smokes finish:
+Generate the release-readiness evidence after local gates and optional smokes finish. The command
+writes both Markdown and JSON summaries by default; use `--run-gates` when the evidence run itself
+should execute the checkout-safe gates instead of recording them as skipped.
 
 ```bash
 uv run python scripts/generate_release_evidence.py \
+  --run-gates \
   --live-smoke-registry docs/src/live-smoke-evidence.json \
   --run-manifest .worldforge/runs/<run-id>/run_manifest.json \
   --benchmark-artifact .worldforge/reports/benchmark-<timestamp>-<run-id>.json \
   --artifact dist/worldforge_ai-<version>-py3-none-any.whl
 ```
 
-The report defaults to `.worldforge/release-evidence/release-evidence.md`. It can be generated
-without credentials; providers without linked live-smoke manifests are recorded as `not configured`
-or `skipped` rather than being silently omitted, and the live-smoke registry records
-missing-runtime and missing-credential skips. Attach the report and linked artifacts when a release
-note or provider promotion claims live-provider coverage.
+The report defaults to `.worldforge/release-evidence/release-evidence.md` and the JSON summary
+defaults to `.worldforge/release-evidence/release-evidence.json`. Gate rows are explicit
+`passed`, `failed`, or `skipped`; each row includes the command, exit code when available, and first
+triage step. Optional live provider evidence is `host-owned` unless a prepared-host
+`run_manifest.json` is linked. Attach the Markdown report, JSON summary, and linked artifacts when a
+release note or provider promotion claims live-provider coverage.
+
+`uv run python scripts/check_core_performance.py` writes a checkout-safe JSON report for world
+persistence, benchmark fixture loading, provider diagnostics, evidence-bundle creation, and report
+rendering. Success signal: `passed` is true and each result row has a preserved artifact path when
+`--workspace-dir <path>` is supplied. First triage step: inspect the failing row's measured path and
+fix the regression before changing a budget. These budgets are local regression guards, not
+cross-machine or optional-runtime performance claims.
 
 When release or issue triage needs the underlying evaluation and benchmark artifacts, generate a
 separate evidence bundle first:

--- a/docs/src/playbooks.md
+++ b/docs/src/playbooks.md
@@ -17,6 +17,7 @@ uv lock --check
 uv run worldforge doctor
 uv run worldforge examples
 uv run python scripts/generate_provider_docs.py --check
+uv run python scripts/check_docs_commands.py
 uv run mkdocs build --strict
 uv run pytest tests/test_cli_help_snapshots.py tests/test_provider_catalog_docs.py
 ```
@@ -158,7 +159,26 @@ If it fails:
 | provider is registered but unhealthy | optional dependency, endpoint, or credential is invalid | run provider-specific docs and health command |
 | provider lacks capability | capability flag is truthful and workflow picked the wrong provider | choose another provider or implement the capability end to end |
 
-### 4a. Map Health And Readiness During Incidents
+### 4a. Troubleshoot Error Families
+
+Use this matrix when an issue, run manifest, or operator log reports a public WorldForge exception.
+Do not catch these errors and continue with coerced state; each family points to a specific owner
+and first artifact.
+
+| Error family | Common symptom | Likely owner | First command | Expected artifact or signal | First triage step |
+| --- | --- | --- | --- | --- | --- |
+| `WorldForgeError` | invalid public input, unknown capability, unsupported output format, non-finite number, unsafe artifact reference | caller or contributor | `uv run worldforge doctor --registered-only` | JSON diagnostics with framework and provider configuration state | fix the caller input or add a regression test for the rejected public boundary |
+| `WorldStateError` | corrupted local world JSON, traversal-shaped world id, invalid history entry, incoherent object bounding box | host operator for local state; contributor if the CLI wrote it | `uv run worldforge world preflight --state-dir .worldforge/worlds --workspace-dir .worldforge --format json` | `worldforge-state-preflight.json` with `status`, `safe_to_attach`, `error_count`, and recovery commands | export diagnostics, then quarantine invalid files only after reviewing the report |
+| `ProviderError` | missing credentials, missing optional dependency, malformed upstream response, unsupported provider capability, expired artifact URL | host runtime owner first; adapter maintainer if parser or docs are wrong | `uv run worldforge provider info <provider>` | redacted config summary, provider profile, capability flags, health, and typed provider details | attach a sanitized run manifest or issue bundle; never paste raw credentials or signed URLs |
+| `AssertionError` from `worldforge.testing` | provider conformance helper reports a contract failure | adapter contributor | `uv run pytest tests/test_provider_contracts.py -q` | explicit helper failure naming the missing capability behavior | fix the adapter or its fixtures; do not replace helper checks with bare `assert` |
+| non-zero benchmark budget exit | benchmark gate failed against a JSON budget | release or performance maintainer | `uv run worldforge benchmark --preset mock-smoke --run-workspace .worldforge --format json` | preserved run workspace with `run_manifest.json`, report JSON, and budget status | inspect the budget row and preserved inputs before changing thresholds |
+| MkDocs strict warning | bad link, nav drift, or generated docs mismatch | docs contributor | `uv run mkdocs build --strict` | strict build output naming the page or link | sync `mkdocs.yml`, `docs/src/SUMMARY.md`, and source page links |
+
+Public issues should attach `worldforge runs bundle <run-id>` or
+`scripts/generate_evidence_bundle.py` output when available. Security-sensitive failures still go
+through the private Security tab.
+
+### 4b. Map Health And Readiness During Incidents
 
 Use this when a service host, batch job, or operator dashboard needs to decide whether to send
 traffic to a provider-backed workflow. Keep process liveness separate from provider readiness.
@@ -176,7 +196,7 @@ The stdlib service reference uses the same model: `/healthz` is process-only liv
 decision of `accept` or `drain`. Alert routing, paging policy, retry orchestration outside a single
 provider call, and upstream SLA ownership remain host responsibilities.
 
-## 4b. Deploy Reference Hosts
+## 4c. Deploy Reference Hosts
 
 Use this before handing the stdlib service host, batch evaluation host, or robotics operator host to
 another host process owner.
@@ -199,7 +219,7 @@ prepared-host, credentialed, GPU-bound, and robotics-lab paths. Deployment, auth
 durable storage, controller integration, alerting, uptime, and safety certification stay
 host-owned.
 
-## 4c. Rehearse Operator Failure Drills
+## 4d. Rehearse Operator Failure Drills
 
 Use this before relying on an incident runbook. The drills are deterministic and checkout-safe; each
 one writes a preserved run manifest under a temporary or documented workspace and records the
@@ -735,6 +755,8 @@ uv lock --check
 uv run ruff check src tests examples scripts
 uv run ruff format --check src tests examples scripts
 uv run python scripts/generate_provider_docs.py --check
+uv run python scripts/check_docs_commands.py
+uv run python scripts/check_core_performance.py
 uv run mkdocs build --strict
 uv run pytest
 uv run --extra harness pytest --cov=src/worldforge --cov-report=term-missing --cov-fail-under=90
@@ -747,6 +769,21 @@ files, the `py.typed` marker, capability protocols, observable capability wrappe
 scripts; the sdist must contain docs, tests, examples, scripts, and release metadata needed to
 rebuild and audit the source package.
 
+Run the core performance budget gate with a preserved workspace before claiming release
+readiness:
+
+```bash
+uv run python scripts/check_core_performance.py \
+  --workspace-dir .worldforge/core-performance \
+  --output .worldforge/core-performance/core-performance.json
+```
+
+Success signal: `core-performance.json` has `passed: true` and result rows for world persistence,
+benchmark fixture loading, provider catalog diagnostics, evidence-bundle creation, and report
+rendering. First triage step: inspect the failing row's artifact path and rerun the single changed
+code path before loosening a budget. The report is a local regression guard, not a public
+performance claim.
+
 Then run the locked dependency audit:
 
 ```bash
@@ -756,13 +793,17 @@ uvx --from pip-audit pip-audit -r "$tmp_req" --no-deps --disable-pip --progress-
 rm -f "$tmp_req"
 ```
 
-Finally generate the release evidence bundle:
+Finally generate the release-readiness evidence. This command writes
+`.worldforge/release-evidence/release-evidence.md` and
+`.worldforge/release-evidence/release-evidence.json`; add `--run-gates` when the evidence run
+should execute the checkout-safe gates itself.
 
 ```bash
 uv run python scripts/generate_evidence_bundle.py \
   --workspace-dir .worldforge \
   --output .worldforge/evidence-bundles/release-candidate
 uv run python scripts/generate_release_evidence.py \
+  --run-gates \
   --live-smoke-registry docs/src/live-smoke-evidence.json \
   --run-manifest .worldforge/runs/<run-id>/run_manifest.json \
   --artifact .worldforge/evidence-bundles/release-candidate/evidence_manifest.json \
@@ -770,18 +811,20 @@ uv run python scripts/generate_release_evidence.py \
   --artifact dist/worldforge_ai-<version>-py3-none-any.whl
 ```
 
-The default report path is `.worldforge/release-evidence/release-evidence.md`. The generator does
-not require provider credentials; absent live smokes are listed explicitly as `not configured` or
-`skipped`, the registry records missing-runtime and missing-credential skips, and
-passed/failed/skipped live runs link back to their preserved `run_manifest.json` files and artifact
-summaries. Use `--known-limitation` for release-scoped caveats that should travel with the bundle.
+The generator does not require provider credentials; optional live smokes without linked manifests
+are listed explicitly as `host-owned`, the registry records missing-runtime and missing-credential
+skips, and passed/failed/skipped live runs link back to their preserved `run_manifest.json` files
+and artifact summaries. Gate rows are explicit `passed`, `failed`, or `skipped` and include the
+first triage step. Use `--known-limitation` for release-scoped caveats that should travel with the
+bundle.
 
 Success signal:
 
 - validation passes from a clean checkout.
 - generated provider docs have no drift and the Pages site builds in strict mode.
 - release evidence links validation expectations, optional live-smoke manifests, benchmark
-  artifacts, generated evidence bundles, distribution artifacts, and known limitations.
+  artifacts, generated evidence bundles, distribution artifacts, JSON summaries, first triage
+  steps, and known limitations.
 - README, docs, changelog, and `AGENTS.md` reflect public behavior.
 - no optional runtime dependency, checkpoint, credential, generated artifact, or `.env` file is
   committed accidentally.

--- a/docs/src/quality.md
+++ b/docs/src/quality.md
@@ -99,6 +99,8 @@ uv lock --check
 uv run ruff check src tests examples scripts
 uv run ruff format --check src tests examples scripts
 uv run python scripts/generate_provider_docs.py --check
+uv run python scripts/check_docs_commands.py
+uv run python scripts/check_core_performance.py
 uv run mkdocs build --strict
 uv run pytest
 uv run --extra harness pytest --cov=src/worldforge --cov-report=term-missing --cov-fail-under=90
@@ -106,9 +108,12 @@ bash scripts/test_package.sh
 uv build --out-dir dist --clear --no-build-logs
 ```
 
-The local gate runs the lock check, Ruff, generated-provider-doc drift check, strict MkDocs build,
-full pytest, harness coverage gate, wheel/sdist package contract, and distribution build. Before a
-release tag, also run:
+The local gate runs the lock check, Ruff, generated-provider-doc drift check, documented-command
+drift check, checkout-safe core performance budgets, strict MkDocs build, full pytest, harness
+coverage gate, wheel/sdist package contract, and distribution build. The core performance budget
+gate writes JSON with measured local paths and a claim boundary; it detects regressions in checkout
+paths and is not a cross-machine benchmark or optional-runtime performance claim. Before a release
+tag, also run:
 
 ```bash
 tmp_req="$(mktemp requirements-audit.XXXXXX)"

--- a/docs/src/security.md
+++ b/docs/src/security.md
@@ -19,5 +19,10 @@ Provider events and health details redact common bearer/API key/password/signatu
 query strings from URLs before serialization. Hosts should still avoid putting raw secrets into
 custom exception messages, artifact metadata, or issue attachments.
 
+Redaction regressions are guarded by the shared corpus at
+`tests/fixtures/redaction/provider_event_corpus.json`. New provider event sinks, run manifests,
+issue bundles, Rerun layers, metrics exporters, and OpenTelemetry bridges should exercise that
+corpus before their output is considered safe to attach.
+
 For scope, response targets, and supported versions, see the canonical
 [Security Policy](https://github.com/AbdelStark/worldforge/blob/main/SECURITY.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -69,6 +69,7 @@ nav:
   - Live Smoke Evidence Registry: live-smoke-evidence.md
   - Claim-To-Evidence Map: claim-evidence-map.md
   - Python API: api/python.md
+  - Public API Stability: api-stability.md
   - Evaluation: evaluation.md
   - Benchmarking: benchmarking.md
   - Capability Fixture Corpus: fixtures.md

--- a/scripts/check_core_performance.py
+++ b/scripts/check_core_performance.py
@@ -1,0 +1,223 @@
+"""Run checkout-safe performance budgets for core WorldForge paths."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import tempfile
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from time import perf_counter
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from worldforge import WorldForge  # noqa: E402
+from worldforge.benchmark import load_benchmark_inputs  # noqa: E402
+from worldforge.evaluation import EvaluationSuite  # noqa: E402
+from worldforge.evidence_bundle import generate_evidence_bundle  # noqa: E402
+from worldforge.harness.workspace import create_run_workspace, write_run_manifest  # noqa: E402
+
+DEFAULT_BUDGETS_MS = {
+    "world_persistence": 250.0,
+    "benchmark_fixture_loading": 100.0,
+    "provider_catalog_diagnostics": 250.0,
+    "evidence_bundle_creation": 500.0,
+    "report_rendering": 250.0,
+}
+
+
+@dataclass(frozen=True, slots=True)
+class CorePerformanceResult:
+    name: str
+    duration_ms: float
+    budget_ms: float | None
+    passed: bool
+    artifact_path: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "duration_ms": self.duration_ms,
+            "budget_ms": self.budget_ms,
+            "passed": self.passed,
+            "artifact_path": self.artifact_path,
+        }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--budget-file", type=Path, help="JSON file mapping operation to max ms.")
+    parser.add_argument("--output", type=Path, help="Optional JSON output path.")
+    parser.add_argument(
+        "--workspace-dir",
+        type=Path,
+        help="Preserve run artifacts under this workspace instead of a temporary directory.",
+    )
+    args = parser.parse_args(argv)
+    budgets = _load_budgets(args.budget_file) if args.budget_file else DEFAULT_BUDGETS_MS
+    payload = run_core_performance_budgets(budgets=budgets, workspace_dir=args.workspace_dir)
+    rendered = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(rendered, encoding="utf-8")
+    else:
+        print(rendered, end="")
+    return 0 if payload["passed"] else 1
+
+
+def run_core_performance_budgets(
+    *,
+    budgets: dict[str, float] | None = None,
+    workspace_dir: Path | None = None,
+) -> dict[str, Any]:
+    """Measure checkout-safe core paths against optional millisecond budgets."""
+
+    resolved_budgets = budgets or DEFAULT_BUDGETS_MS
+    if workspace_dir is None:
+        with tempfile.TemporaryDirectory(prefix="worldforge-core-perf-") as tmp:
+            return _run(Path(tmp), budgets=resolved_budgets, preserve=False)
+    workspace = workspace_dir.expanduser().resolve()
+    workspace.mkdir(parents=True, exist_ok=True)
+    return _run(workspace, budgets=resolved_budgets, preserve=True)
+
+
+def _run(workspace: Path, *, budgets: dict[str, float], preserve: bool) -> dict[str, Any]:
+    results = [
+        _measure("world_persistence", budgets, lambda: _world_persistence(workspace)),
+        _measure("benchmark_fixture_loading", budgets, _benchmark_fixture_loading),
+        _measure("provider_catalog_diagnostics", budgets, lambda: _provider_catalog(workspace)),
+        _measure("evidence_bundle_creation", budgets, lambda: _evidence_bundle(workspace)),
+        _measure("report_rendering", budgets, lambda: _report_rendering(workspace)),
+    ]
+    payload = {
+        "schema_version": 1,
+        "passed": all(result.passed for result in results),
+        "preserved_workspace": str(workspace) if preserve else None,
+        "results": [result.to_dict() for result in results],
+        "claim_boundary": (
+            "These checkout-safe budgets detect local regressions only. They are not a public "
+            "leaderboard, cross-machine performance claim, or optional-runtime benchmark."
+        ),
+    }
+    if preserve:
+        (workspace / "core-performance.json").write_text(
+            json.dumps(payload, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+    return payload
+
+
+def _measure(
+    name: str,
+    budgets: dict[str, float],
+    operation: Callable[[], str | None],
+) -> CorePerformanceResult:
+    started = perf_counter()
+    artifact_path = operation()
+    duration_ms = round((perf_counter() - started) * 1000, 3)
+    budget = budgets.get(name)
+    return CorePerformanceResult(
+        name=name,
+        duration_ms=duration_ms,
+        budget_ms=budget,
+        passed=budget is None or duration_ms <= budget,
+        artifact_path=artifact_path,
+    )
+
+
+def _world_persistence(workspace: Path) -> str | None:
+    forge = WorldForge(state_dir=workspace / "worlds", auto_register_remote=False)
+    world = forge.create_world_from_prompt("A table with one cube", provider="mock", name="perf")
+    forge.save_world(world)
+    reloaded = forge.load_world(world.id)
+    if reloaded.id != world.id:
+        raise RuntimeError("world persistence reload mismatch")
+    return str((workspace / "worlds" / f"{world.id}.json").resolve())
+
+
+def _benchmark_fixture_loading() -> str | None:
+    input_file = ROOT / "examples/benchmark-inputs.json"
+    inputs = load_benchmark_inputs(
+        json.loads(input_file.read_text(encoding="utf-8")),
+        base_path=input_file.parent,
+    )
+    if inputs.embedding_text == "":
+        raise RuntimeError("benchmark fixture did not load")
+    return "examples/benchmark-inputs.json"
+
+
+def _provider_catalog(workspace: Path) -> str | None:
+    forge = WorldForge(state_dir=workspace / "doctor-worlds", auto_register_remote=False)
+    report = forge.doctor(registered_only=True)
+    if report.provider_count < 1:
+        raise RuntimeError("doctor returned no providers")
+    path = workspace / "doctor-report.json"
+    path.write_text(report.to_json(), encoding="utf-8")
+    return str(path)
+
+
+def _evidence_bundle(workspace: Path) -> str | None:
+    run_workspace = create_run_workspace(
+        workspace,
+        kind="benchmark",
+        command="worldforge benchmark --provider mock",
+        provider="mock",
+        operation="benchmark",
+        input_summary={"provider": "mock"},
+    )
+    run_workspace.write_json("reports/report.json", {"schema_version": 1, "status": "passed"})
+    write_run_manifest(
+        run_workspace,
+        kind="benchmark",
+        command="worldforge benchmark --provider mock",
+        provider="mock",
+        operation="benchmark",
+        status="passed",
+        input_summary={"provider": "mock"},
+        result_summary={"status": "passed"},
+    )
+    result = generate_evidence_bundle(
+        workspace_dir=workspace,
+        output_dir=workspace / "evidence-bundle",
+        overwrite=True,
+        include_fixture_digests=False,
+    )
+    return str(result.manifest_path)
+
+
+def _report_rendering(workspace: Path) -> str | None:
+    forge = WorldForge(state_dir=workspace / "report-worlds", auto_register_remote=False)
+    report = EvaluationSuite.from_builtin("planning").run_report(["mock"], forge=forge)
+    markdown = report.to_markdown()
+    if "# Evaluation Report" not in markdown:
+        raise RuntimeError("evaluation report renderer returned unexpected Markdown")
+    path = workspace / "report.md"
+    path.write_text(markdown, encoding="utf-8")
+    return str(path)
+
+
+def _load_budgets(path: Path) -> dict[str, float]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise SystemExit("core performance budget file must be a JSON object")
+    budgets: dict[str, float] = {}
+    for key, value in payload.items():
+        if (
+            not isinstance(key, str)
+            or isinstance(value, bool)
+            or not isinstance(value, int | float)
+            or value < 0
+        ):
+            raise SystemExit("core performance budgets must map operation names to non-negative ms")
+        budgets[key] = float(value)
+    return budgets
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_docs_commands.py
+++ b/scripts/check_docs_commands.py
@@ -1,0 +1,297 @@
+"""Check documented WorldForge commands for CLI and entry-point drift."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from worldforge.cli import _build_parser  # noqa: E402
+
+DEFAULT_DOCS = (
+    "README.md",
+    "docs/src/cli.md",
+    "docs/src/examples.md",
+    "docs/src/operations.md",
+    "docs/src/playbooks.md",
+    "AGENTS.md",
+)
+IGNORED_EXECUTABLES = {"uv", "uvx", "pytest", "bash", "curl", "jq", "python", "python3", "rm"}
+WORLD_FORGE_COMMAND = re.compile(
+    r"(?<![A-Za-z0-9_./-])(worldforge(?:-[A-Za-z0-9_-]+)?)(?!/)([^\n`|]*)"
+)
+SCRIPT_COMMAND = re.compile(r"(?<![A-Za-z0-9_./-])(scripts/[A-Za-z0-9_.-]+)([^\n`|]*)")
+
+
+@dataclass(frozen=True, slots=True)
+class DocumentedCommand:
+    executable: str
+    args: tuple[str, ...]
+    source: str
+    line: int
+    raw: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "executable": self.executable,
+            "args": list(self.args),
+            "source": self.source,
+            "line": self.line,
+            "raw": self.raw,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class DocsCommandCheck:
+    documented: tuple[DocumentedCommand, ...]
+    missing_entry_points: tuple[str, ...]
+    stale_commands: tuple[str, ...]
+    undocumented_worldforge_subcommands: tuple[str, ...]
+
+    @property
+    def passed(self) -> bool:
+        return not (
+            self.missing_entry_points
+            or self.stale_commands
+            or self.undocumented_worldforge_subcommands
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "passed": self.passed,
+            "documented_count": len(self.documented),
+            "missing_entry_points": list(self.missing_entry_points),
+            "stale_commands": list(self.stale_commands),
+            "undocumented_worldforge_subcommands": list(self.undocumented_worldforge_subcommands),
+            "documented": [command.to_dict() for command in self.documented],
+        }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--doc",
+        action="append",
+        default=[],
+        help="Documentation file to scan. Can be repeated. Defaults to public command docs.",
+    )
+    parser.add_argument(
+        "--format",
+        choices=("json", "markdown"),
+        default="markdown",
+        help="Output format for the drift report.",
+    )
+    args = parser.parse_args(argv)
+    docs = tuple(args.doc or DEFAULT_DOCS)
+    report = check_docs_commands(ROOT, docs=docs)
+    if args.format == "json":
+        print(json.dumps(report.to_dict(), indent=2, sort_keys=True))
+    else:
+        print(render_markdown(report))
+    return 0 if report.passed else 1
+
+
+def check_docs_commands(
+    root: Path = ROOT,
+    *,
+    docs: tuple[str, ...] = DEFAULT_DOCS,
+) -> DocsCommandCheck:
+    """Check docs for stale command references and undocumented public entry points."""
+
+    project_scripts = _project_scripts(root)
+    script_paths = _script_paths(root)
+    worldforge_subcommands = _worldforge_subcommands()
+    documented = tuple(
+        command for doc in docs for command in _documented_commands(root / doc, root=root)
+    )
+    documented_executables = {command.executable for command in documented}
+    documented_worldforge_subcommands = {
+        command.args[0]
+        for command in documented
+        if command.executable == "worldforge" and command.args
+    }
+    stale = tuple(
+        sorted(
+            _stale_message(command, project_scripts, script_paths, worldforge_subcommands)
+            for command in documented
+            if _stale_message(command, project_scripts, script_paths, worldforge_subcommands)
+        )
+    )
+    missing_entry_points = tuple(
+        sorted(
+            name
+            for name in project_scripts
+            if name.startswith("worldforge") and name not in documented_executables
+        )
+    )
+    undocumented_worldforge_subcommands = tuple(
+        sorted(worldforge_subcommands - documented_worldforge_subcommands)
+    )
+    return DocsCommandCheck(
+        documented=documented,
+        missing_entry_points=missing_entry_points,
+        stale_commands=stale,
+        undocumented_worldforge_subcommands=undocumented_worldforge_subcommands,
+    )
+
+
+def render_markdown(report: DocsCommandCheck) -> str:
+    lines = [
+        "# Docs Command Drift Check",
+        "",
+        f"- Status: `{'passed' if report.passed else 'failed'}`",
+        f"- Documented commands scanned: {len(report.documented)}",
+        "",
+        "## Missing Entry Points",
+        "",
+    ]
+    lines.extend(f"- `{item}`" for item in report.missing_entry_points)
+    if not report.missing_entry_points:
+        lines.append("- none")
+    lines.extend(["", "## Undocumented `worldforge` Subcommands", ""])
+    lines.extend(f"- `worldforge {item}`" for item in report.undocumented_worldforge_subcommands)
+    if not report.undocumented_worldforge_subcommands:
+        lines.append("- none")
+    lines.extend(["", "## Stale Commands", ""])
+    lines.extend(f"- {item}" for item in report.stale_commands)
+    if not report.stale_commands:
+        lines.append("- none")
+    return "\n".join(lines)
+
+
+def _project_scripts(root: Path) -> set[str]:
+    payload = tomllib.loads((root / "pyproject.toml").read_text(encoding="utf-8"))
+    scripts = payload.get("project", {}).get("scripts", {})
+    return {str(name) for name in scripts}
+
+
+def _script_paths(root: Path) -> set[str]:
+    scripts_dir = root / "scripts"
+    if not scripts_dir.exists():
+        return set()
+    return {
+        str(path.relative_to(root))
+        for path in scripts_dir.iterdir()
+        if path.is_file() and not path.name.startswith(".")
+    }
+
+
+def _worldforge_subcommands() -> set[str]:
+    parser = _build_parser()
+    subcommands: set[str] = set()
+    for action in parser._actions:
+        if isinstance(action, argparse._SubParsersAction):
+            subcommands.update(action.choices)
+            break
+    subcommands.discard("providers")
+    return subcommands
+
+
+def _documented_commands(path: Path, *, root: Path) -> tuple[DocumentedCommand, ...]:
+    if not path.exists():
+        return ()
+    commands: list[DocumentedCommand] = []
+    for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        commands.extend(
+            _commands_from_matches(
+                WORLD_FORGE_COMMAND.finditer(line),
+                path=path,
+                root=root,
+                line_number=line_number,
+            )
+        )
+        commands.extend(
+            _commands_from_matches(
+                SCRIPT_COMMAND.finditer(line),
+                path=path,
+                root=root,
+                line_number=line_number,
+            )
+        )
+    return tuple(commands)
+
+
+def _commands_from_matches(
+    matches: Any,
+    *,
+    path: Path,
+    root: Path,
+    line_number: int,
+) -> list[DocumentedCommand]:
+    commands: list[DocumentedCommand] = []
+    for match in matches:
+        executable = match.group(1)
+        args = tuple(_split_command_args(match.group(2)))
+        commands.append(
+            DocumentedCommand(
+                executable=executable,
+                args=args,
+                source=str(path.relative_to(root)),
+                line=line_number,
+                raw=(executable + match.group(2)).strip(),
+            )
+        )
+    return commands
+
+
+def _split_command_args(value: str) -> list[str]:
+    tokens = []
+    for token in value.strip().split():
+        cleaned = token.strip("`'\",;:()[]")
+        if not cleaned or cleaned.startswith(("-", "<")):
+            break
+        if cleaned in {"|", "&&", "\\"}:
+            break
+        tokens.append(cleaned)
+    return tokens
+
+
+def _stale_message(
+    command: DocumentedCommand,
+    project_scripts: set[str],
+    script_paths: set[str],
+    worldforge_subcommands: set[str],
+) -> str:
+    if _is_python_reference(command):
+        return ""
+    if command.executable in project_scripts:
+        if command.executable == "worldforge" and command.args:
+            subcommand = command.args[0]
+            if subcommand not in worldforge_subcommands and subcommand != "providers":
+                return (
+                    f"{command.source}:{command.line} references unknown `worldforge {subcommand}`"
+                )
+        return ""
+    if command.executable in script_paths:
+        return ""
+    if command.executable in IGNORED_EXECUTABLES:
+        return ""
+    if command.executable.startswith("worldforge-"):
+        return ""
+    return f"{command.source}:{command.line} references unknown `{command.executable}`"
+
+
+def _is_python_reference(command: DocumentedCommand) -> bool:
+    first_arg = command.args[0] if command.args else ""
+    return bool(
+        command.executable == "worldforge"
+        and (
+            first_arg.startswith((".", "_"))
+            or first_arg == "import"
+            or command.raw.startswith(("worldforge.", "worldforge_"))
+        )
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/generate_release_evidence.py
+++ b/scripts/generate_release_evidence.py
@@ -9,7 +9,9 @@ import subprocess
 import sys
 from dataclasses import dataclass
 from datetime import UTC, datetime
+from hashlib import sha256
 from pathlib import Path
+from time import monotonic
 from typing import Any
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -30,26 +32,119 @@ DEFAULT_REPORTS_DIR = ROOT / ".worldforge" / "reports"
 DEFAULT_DIST_DIR = ROOT / "dist"
 DEFAULT_EVIDENCE_BUNDLES_DIR = ROOT / ".worldforge" / "evidence-bundles"
 
-VALIDATION_COMMANDS = (
-    ("Lockfile", "uv lock --check"),
-    ("Lint", "uv run ruff check src tests examples scripts"),
-    ("Format", "uv run ruff format --check src tests examples scripts"),
-    ("Provider catalog drift", "uv run python scripts/generate_provider_docs.py --check"),
-    ("Docs", "uv run mkdocs build --strict"),
-    ("Tests", "uv run pytest"),
-    (
+MAX_CAPTURE_CHARS = 4_000
+
+
+@dataclass(frozen=True, slots=True)
+class ReleaseGate:
+    """Checkout-safe validation gate included in release-readiness evidence."""
+
+    name: str
+    command: str
+    triage_step: str
+
+
+@dataclass(frozen=True, slots=True)
+class ReleaseGateResult:
+    """Result for one release-readiness validation gate."""
+
+    name: str
+    command: str
+    status: str
+    triage_step: str
+    exit_code: int | None = None
+    duration_ms: float | None = None
+    started_at: str | None = None
+    finished_at: str | None = None
+    stdout_tail: str = ""
+    stderr_tail: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "command": self.command,
+            "status": self.status,
+            "exit_code": self.exit_code,
+            "duration_ms": self.duration_ms,
+            "started_at": self.started_at,
+            "finished_at": self.finished_at,
+            "stdout_tail": self.stdout_tail,
+            "stderr_tail": self.stderr_tail,
+            "triage_step": self.triage_step,
+        }
+
+
+CHECKOUT_SAFE_GATES = (
+    ReleaseGate(
+        "Lockfile",
+        "uv lock --check",
+        "Refresh dependency metadata intentionally, then rerun `uv lock --check`.",
+    ),
+    ReleaseGate(
+        "Lint",
+        "uv run ruff check src tests examples scripts",
+        "Run Ruff locally, fix the named file and rule, then rerun the lint gate.",
+    ),
+    ReleaseGate(
+        "Format",
+        "uv run ruff format --check src tests examples scripts",
+        "Run `uv run ruff format src tests examples scripts` and inspect the diff.",
+    ),
+    ReleaseGate(
+        "Provider catalog drift",
+        "uv run python scripts/generate_provider_docs.py --check",
+        "Run the provider docs generator without `--check`, inspect generated docs, then rerun.",
+    ),
+    ReleaseGate(
+        "Docs command drift",
+        "uv run python scripts/check_docs_commands.py",
+        "Fix stale command references or document the missing public entry point, then rerun.",
+    ),
+    ReleaseGate(
+        "Core performance budgets",
+        "uv run python scripts/check_core_performance.py",
+        "Inspect the JSON report row, confirm the measured path, and fix regressions before "
+        "changing budgets.",
+    ),
+    ReleaseGate(
+        "Docs",
+        "uv run mkdocs build --strict",
+        "Fix the reported page, link, or navigation warning before release.",
+    ),
+    ReleaseGate(
+        "Tests",
+        "uv run pytest",
+        "Reproduce the failing test directly and add or repair the focused regression.",
+    ),
+    ReleaseGate(
         "Coverage",
         "uv run --extra harness pytest --cov=src/worldforge --cov-report=term-missing "
         "--cov-fail-under=90",
+        "Add focused tests for uncovered behavior instead of weakening the coverage gate.",
     ),
-    ("Package contract", "bash scripts/test_package.sh"),
-    ("Build", "uv build --out-dir dist --clear --no-build-logs"),
-    (
+    ReleaseGate(
+        "Package contract",
+        "bash scripts/test_package.sh",
+        "Inspect the isolated package-contract output for missing files, scripts, or metadata.",
+    ),
+    ReleaseGate(
+        "Build",
+        "uv build --out-dir dist --clear --no-build-logs",
+        "Fix build backend or package metadata errors, then rebuild into a clean dist directory.",
+    ),
+    ReleaseGate(
         "Dependency audit",
-        "uv export --all-groups --no-emit-project --no-hashes -o requirements-ci.txt && "
-        "uvx --from pip-audit pip-audit -r requirements-ci.txt",
+        (
+            'tmp_req="$(mktemp requirements-audit.XXXXXX)" && '
+            'uv export --frozen --all-groups --no-emit-project --no-hashes -o "$tmp_req" '
+            ">/dev/null && "
+            'uvx --from pip-audit pip-audit -r "$tmp_req" --no-deps --disable-pip '
+            '--progress-spinner off; status=$?; rm -f "$tmp_req"; exit $status'
+        ),
+        "Inspect the advisory, update or document the dependency decision, then rerun the audit.",
     ),
 )
+VALIDATION_COMMANDS = tuple((gate.name, gate.command) for gate in CHECKOUT_SAFE_GATES)
 
 LIVE_PROVIDER_ENV = {
     "cosmos": ("COSMOS_BASE_URL",),
@@ -81,6 +176,37 @@ def _parser() -> argparse.ArgumentParser:
         type=Path,
         default=DEFAULT_OUTPUT,
         help="Markdown report path. Defaults to .worldforge/release-evidence/release-evidence.md.",
+    )
+    parser.add_argument(
+        "--json-output",
+        help=(
+            "JSON report path. Defaults to the Markdown output path with a .json suffix. "
+            "Use '-' to print JSON to stdout after writing Markdown."
+        ),
+    )
+    parser.add_argument(
+        "--run-gates",
+        action="store_true",
+        help="Execute checkout-safe release gates before rendering evidence.",
+    )
+    parser.add_argument(
+        "--gate",
+        choices=tuple(gate.name for gate in CHECKOUT_SAFE_GATES),
+        action="append",
+        default=[],
+        help="Limit --run-gates to one named gate. Can be repeated.",
+    )
+    parser.add_argument(
+        "--skip-gate",
+        choices=tuple(gate.name for gate in CHECKOUT_SAFE_GATES),
+        action="append",
+        default=[],
+        help="Mark one release gate skipped with an explicit reason. Can be repeated.",
+    )
+    parser.add_argument(
+        "--skip-reason",
+        default="operator skipped this gate for the current evidence run",
+        help="Reason recorded for gates named by --skip-gate.",
     )
     parser.add_argument(
         "--run-manifest",
@@ -124,6 +250,14 @@ def _parser() -> argparse.ArgumentParser:
 def main(argv: list[str] | None = None) -> int:
     args = _parser().parse_args(argv)
     output = args.output.expanduser().resolve()
+    json_output = _json_output_path(output, args.json_output)
+    selected_gates = _selected_gates(tuple(args.gate or ()))
+    gate_results = release_gate_results(
+        selected_gates,
+        run=args.run_gates,
+        skip_gates=tuple(args.skip_gate or ()),
+        skip_reason=args.skip_reason,
+    )
     manifests = _collect_manifests(args.run_manifest)
     live_smoke_registry = _load_live_smoke_registry(args.live_smoke_registry)
     benchmark_artifacts = _dedupe_paths(
@@ -143,10 +277,141 @@ def main(argv: list[str] | None = None) -> int:
         benchmark_artifacts=benchmark_artifacts,
         artifacts=artifacts,
         known_limitations=tuple(args.known_limitation),
+        gate_results=gate_results,
+    )
+    payload = release_evidence_payload(
+        manifests=manifests,
+        live_smoke_registry=live_smoke_registry,
+        benchmark_artifacts=benchmark_artifacts,
+        artifacts=artifacts,
+        known_limitations=tuple(args.known_limitation),
+        gate_results=gate_results,
     )
     output.parent.mkdir(parents=True, exist_ok=True)
     output.write_text(report, encoding="utf-8")
     print(f"wrote {output.relative_to(ROOT) if output.is_relative_to(ROOT) else output}")
+    if json_output == "-":
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    elif json_output is not None:
+        json_path = Path(json_output).expanduser().resolve()
+        json_path.parent.mkdir(parents=True, exist_ok=True)
+        json_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        display = json_path.relative_to(ROOT) if json_path.is_relative_to(ROOT) else json_path
+        print(f"wrote {display}")
+    failed = [result for result in gate_results if result.status == "failed"]
+    return 1 if failed else 0
+
+
+def release_gate_results(
+    gates: tuple[ReleaseGate, ...] = CHECKOUT_SAFE_GATES,
+    *,
+    run: bool,
+    skip_gates: tuple[str, ...] = (),
+    skip_reason: str = "",
+    runner: Any = subprocess.run,
+) -> tuple[ReleaseGateResult, ...]:
+    """Return release-readiness gate results, optionally executing commands."""
+
+    skip_gate_names = set(skip_gates)
+    results: list[ReleaseGateResult] = []
+    for gate in gates:
+        if gate.name in skip_gate_names:
+            results.append(
+                ReleaseGateResult(
+                    name=gate.name,
+                    command=gate.command,
+                    status="skipped",
+                    triage_step=skip_reason or gate.triage_step,
+                )
+            )
+            continue
+        if not run:
+            results.append(
+                ReleaseGateResult(
+                    name=gate.name,
+                    command=gate.command,
+                    status="skipped",
+                    triage_step="Run with `--run-gates` to execute this checkout-safe gate.",
+                )
+            )
+            continue
+
+        started_at = datetime.now(UTC).replace(microsecond=0).isoformat()
+        start = monotonic()
+        completed = runner(
+            gate.command,
+            shell=True,
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+        )
+        finished_at = datetime.now(UTC).replace(microsecond=0).isoformat()
+        duration_ms = round((monotonic() - start) * 1000, 3)
+        return_code = int(completed.returncode)
+        results.append(
+            ReleaseGateResult(
+                name=gate.name,
+                command=gate.command,
+                status="passed" if return_code == 0 else "failed",
+                exit_code=return_code,
+                duration_ms=duration_ms,
+                started_at=started_at,
+                finished_at=finished_at,
+                stdout_tail=_capture_tail(completed.stdout),
+                stderr_tail=_capture_tail(completed.stderr),
+                triage_step=gate.triage_step,
+            )
+        )
+    unknown_skips = skip_gate_names - {gate.name for gate in gates}
+    if unknown_skips:
+        unknown = ", ".join(sorted(unknown_skips))
+        raise SystemExit(f"Unknown --skip-gate value for selected gates: {unknown}")
+    return tuple(results)
+
+
+def release_evidence_payload(
+    *,
+    manifests: tuple[ManifestEvidence, ...],
+    benchmark_artifacts: tuple[Path, ...],
+    artifacts: tuple[Path, ...],
+    gate_results: tuple[ReleaseGateResult, ...],
+    live_smoke_registry: dict[str, Any] | None = None,
+    known_limitations: tuple[str, ...] = (),
+) -> dict[str, Any]:
+    """Return a JSON-native release-readiness evidence payload."""
+
+    generated_at = datetime.now(UTC).replace(microsecond=0).isoformat()
+    return {
+        "schema_version": 1,
+        "generated_at": generated_at,
+        "git": {
+            "branch": _git_output("branch", "--show-current") or "unknown",
+            "commit": _git_output("rev-parse", "--short", "HEAD") or "unknown",
+        },
+        "validation_gates": [result.to_dict() for result in gate_results],
+        "validation_summary": _gate_summary(gate_results),
+        "live_provider_evidence": [
+            _provider_evidence(provider, manifests) for provider in sorted(LIVE_PROVIDER_ENV)
+        ],
+        "extra_live_provider_evidence": [
+            _provider_evidence(provider, manifests)
+            for provider in sorted(
+                {
+                    manifest.provider
+                    for manifest in manifests
+                    if manifest.provider not in LIVE_PROVIDER_ENV
+                }
+            )
+        ],
+        "live_smoke_registry": live_smoke_registry,
+        "benchmark_artifacts": [_path_record(path) for path in benchmark_artifacts],
+        "release_artifacts": [_path_record(path) for path in artifacts],
+        "known_limitations": list(known_limitations),
+        "claim_boundary": (
+            "Checkout-safe gates do not prove live provider availability, model quality, "
+            "physical fidelity, or robot safety unless a matching live-smoke manifest is linked."
+        ),
+    }
     return 0
 
 
@@ -158,24 +423,31 @@ def render_release_evidence(
     artifacts: tuple[Path, ...],
     live_smoke_registry: dict[str, Any] | None = None,
     known_limitations: tuple[str, ...] = (),
+    gate_results: tuple[ReleaseGateResult, ...] | None = None,
 ) -> str:
     commit = _git_output("rev-parse", "--short", "HEAD") or "unknown"
     branch = _git_output("branch", "--show-current") or "unknown"
     generated_at = datetime.now(UTC).replace(microsecond=0).isoformat()
+    resolved_gate_results = gate_results or release_gate_results(run=False)
     lines = [
         "# WorldForge Release Evidence",
         "",
         f"- Generated at: `{generated_at}`",
         f"- Git branch: `{branch}`",
         f"- Git commit: `{commit}`",
+        f"- Validation status: `{_overall_gate_status(resolved_gate_results)}`",
         "",
         "## Validation Gates",
         "",
-        "| Gate | Command | Evidence status |",
-        "| --- | --- | --- |",
+        "| Gate | Command | Status | Exit | First triage step |",
+        "| --- | --- | --- | ---: | --- |",
     ]
-    for name, command in VALIDATION_COMMANDS:
-        lines.append(f"| {name} | `{command}` | not run by evidence generator |")
+    for result in resolved_gate_results:
+        exit_code = "-" if result.exit_code is None else str(result.exit_code)
+        lines.append(
+            f"| {result.name} | `{result.command}` | {result.status} | "
+            f"{exit_code} | {result.triage_step} |"
+        )
 
     lines.extend(
         [
@@ -266,6 +538,93 @@ def _collect_manifests(paths: list[Path]) -> tuple[ManifestEvidence, ...]:
     return tuple(evidence)
 
 
+def _json_output_path(markdown_output: Path, raw_json_output: Path | str | None) -> Path | str:
+    if raw_json_output == "-":
+        return "-"
+    if raw_json_output is not None:
+        return Path(raw_json_output)
+    return markdown_output.with_suffix(".json")
+
+
+def _selected_gates(names: tuple[str, ...]) -> tuple[ReleaseGate, ...]:
+    if not names:
+        return CHECKOUT_SAFE_GATES
+    selected_names = set(names)
+    return tuple(gate for gate in CHECKOUT_SAFE_GATES if gate.name in selected_names)
+
+
+def _capture_tail(value: str | None) -> str:
+    if not value:
+        return ""
+    stripped = value.strip()
+    if len(stripped) <= MAX_CAPTURE_CHARS:
+        return stripped
+    return stripped[-MAX_CAPTURE_CHARS:]
+
+
+def _gate_summary(results: tuple[ReleaseGateResult, ...]) -> dict[str, int]:
+    summary = {"passed": 0, "failed": 0, "skipped": 0, "host-owned": 0}
+    for result in results:
+        summary[result.status] = summary.get(result.status, 0) + 1
+    return summary
+
+
+def _overall_gate_status(results: tuple[ReleaseGateResult, ...]) -> str:
+    summary = _gate_summary(results)
+    if summary["failed"]:
+        return "failed"
+    if summary["passed"] and not summary["skipped"]:
+        return "passed"
+    return "skipped"
+
+
+def _provider_evidence(provider: str, manifests: tuple[ManifestEvidence, ...]) -> dict[str, Any]:
+    matching = [manifest for manifest in manifests if manifest.provider == provider]
+    if matching:
+        return {
+            "provider": provider,
+            "status": _combined_manifest_status(matching),
+            "manifests": [
+                {
+                    "path": _display_path(manifest.path),
+                    "status": manifest.status,
+                    "capability": manifest.payload["capability"],
+                    "artifact_paths": manifest.payload.get("artifact_paths", {}),
+                }
+                for manifest in matching
+            ],
+            "reason": "",
+        }
+    env_vars = LIVE_PROVIDER_ENV.get(provider, ())
+    configured = any(os.environ.get(name, "").strip() for name in env_vars)
+    env_summary = ", ".join(env_vars) or "no known env gate"
+    return {
+        "provider": provider,
+        "status": "host-owned",
+        "manifests": [],
+        "reason": (
+            "configured but no run manifest linked"
+            if configured
+            else f"missing host-owned configuration: {env_summary}"
+        ),
+    }
+
+
+def _path_record(path: Path) -> dict[str, str | int | None]:
+    resolved = path.expanduser().resolve()
+    digest = None
+    size = None
+    if resolved.is_file():
+        data = resolved.read_bytes()
+        digest = "sha256:" + sha256(data).hexdigest()
+        size = len(data)
+    return {
+        "path": _display_path(resolved),
+        "sha256": digest,
+        "size_bytes": size,
+    }
+
+
 def _load_live_smoke_registry(path: Path | None) -> dict[str, Any] | None:
     if path is None:
         return None
@@ -287,9 +646,13 @@ def _render_provider_row(
 
     env_vars = LIVE_PROVIDER_ENV.get(provider, ())
     configured = any(os.environ.get(name, "").strip() for name in env_vars)
-    status = "skipped" if configured else "not configured"
     env_summary = ", ".join(f"`{name}`" for name in env_vars) or "no known env gate"
-    reason = "configured but no run manifest linked" if configured else f"missing {env_summary}"
+    reason = (
+        "configured but no run manifest linked"
+        if configured
+        else f"missing host-owned configuration: {env_summary}"
+    )
+    status = "host-owned"
     return f"| `{provider}` | {status} | {reason} |"
 
 
@@ -326,12 +689,17 @@ def _artifact_lines(paths: tuple[Path, ...], output: Path, *, empty: str) -> lis
 
 def _markdown_link(path: Path, output: Path) -> str:
     resolved = path.expanduser().resolve()
-    try:
-        display = resolved.relative_to(ROOT)
-    except ValueError:
-        display = resolved
+    display = _display_path(resolved)
     link = os.path.relpath(resolved, start=output.parent).replace(os.sep, "/")
     return f"[`{display}`]({link})"
+
+
+def _display_path(path: Path) -> str:
+    resolved = path.expanduser().resolve()
+    try:
+        return str(resolved.relative_to(ROOT))
+    except ValueError:
+        return str(resolved)
 
 
 def _glob_existing(directory: Path, pattern: str) -> tuple[Path, ...]:

--- a/src/worldforge/observability.py
+++ b/src/worldforge/observability.py
@@ -16,6 +16,7 @@ from worldforge.models import (
     ProviderEvent,
     WorldForgeError,
     _redact_observable_value,
+    _sanitize_observable_id,
     dump_json,
     require_json_dict,
 )
@@ -144,7 +145,12 @@ class RunJsonLogSink:
     def __post_init__(self) -> None:
         if not isinstance(self.run_id, str) or not self.run_id.strip():
             raise WorldForgeError("RunJsonLogSink run_id must be a non-empty string.")
-        self.run_id = self.run_id.strip()
+        self.run_id = _sanitize_observable_id(
+            self.run_id,
+            name="RunJsonLogSink run_id",
+        )
+        if self.run_id is None:
+            raise WorldForgeError("RunJsonLogSink run_id must be a non-empty string.")
         self._path = Path(self.path)
         self.extra_fields = _redacted_extra_fields(
             self.extra_fields,

--- a/tests/fixtures/redaction/provider_event_corpus.json
+++ b/tests/fixtures/redaction/provider_event_corpus.json
@@ -1,0 +1,72 @@
+{
+  "schema_version": 1,
+  "cases": [
+    {
+      "id": "signed_url_and_bearer",
+      "event": {
+        "provider": "runway",
+        "operation": "artifact download",
+        "phase": "failure",
+        "method": "get",
+        "target": "https://user:pass@downloads.example.test/video.mp4?X-Amz-Signature=wf-signature-secret&token=wf-token-secret#fragment",
+        "status_code": 403,
+        "duration_ms": 12.5,
+        "message": "download failed with Authorization=wf-auth-secret and Bearer wf-bearer-secret",
+        "metadata": {
+          "capability": "generate",
+          "api_token": "wf-metadata-token",
+          "nested": {
+            "signed_url": "https://downloads.example.test/video.mp4?signature=wf-nested-signature",
+            "safe_url": "https://downloads.example.test/video.mp4?signature=wf-safe-signature"
+          },
+          "request_headers": {
+            "Authorization": "Bearer wf-header-secret"
+          }
+        },
+        "request_id": "token=wf-request-secret",
+        "artifact_id": "https://downloads.example.test/video.mp4?token=wf-artifact-secret"
+      },
+      "forbidden": [
+        "wf-signature-secret",
+        "wf-token-secret",
+        "wf-auth-secret",
+        "wf-bearer-secret",
+        "wf-metadata-token",
+        "wf-nested-signature",
+        "wf-safe-signature",
+        "wf-header-secret",
+        "wf-request-secret",
+        "wf-artifact-secret",
+        "user:pass"
+      ]
+    },
+    {
+      "id": "private_endpoint_and_json_text",
+      "event": {
+        "provider": "cosmos",
+        "operation": "task poll",
+        "phase": "retry",
+        "method": "post",
+        "target": "https://internal.example.test/tasks/123?api_key=wf-query-key",
+        "status_code": 429,
+        "duration_ms": 27.0,
+        "message": "retrying password=wf-password-secret for {\"api_key\":\"wf-json-key\"}",
+        "metadata": {
+          "capability": "generate",
+          "private_endpoint": "https://internal.example.test/tasks/123?token=wf-private-token",
+          "json_text": "{\"secret\":\"wf-json-secret\",\"token\":\"wf-json-token\"}"
+        },
+        "trace_id": "Bearer wf-trace-secret"
+      },
+      "forbidden": [
+        "wf-query-key",
+        "wf-password-secret",
+        "wf-json-key",
+        "wf-private-token",
+        "wf-json-secret",
+        "wf-json-token",
+        "wf-trace-secret"
+      ]
+    }
+  ]
+}

--- a/tests/test_core_performance.py
+++ b/tests/test_core_performance.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "check_core_performance.py"
+SPEC = importlib.util.spec_from_file_location("check_core_performance", SCRIPT)
+assert SPEC is not None
+check_core_performance = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+sys.modules["check_core_performance"] = check_core_performance
+SPEC.loader.exec_module(check_core_performance)
+
+
+def test_core_performance_budgets_emit_checkout_safe_report(tmp_path: Path) -> None:
+    payload = check_core_performance.run_core_performance_budgets(
+        budgets=dict.fromkeys(check_core_performance.DEFAULT_BUDGETS_MS, 10_000.0),
+        workspace_dir=tmp_path,
+    )
+
+    assert payload["schema_version"] == 1
+    assert payload["passed"] is True
+    assert payload["preserved_workspace"] == str(tmp_path.resolve())
+    assert (tmp_path / "core-performance.json").exists()
+    assert "not a public leaderboard" in payload["claim_boundary"]
+    assert {result["name"] for result in payload["results"]} == set(
+        check_core_performance.DEFAULT_BUDGETS_MS
+    )
+    assert all(result["artifact_path"] for result in payload["results"])
+
+
+def test_core_performance_budgets_fail_on_explicit_threshold(tmp_path: Path) -> None:
+    budgets = dict.fromkeys(check_core_performance.DEFAULT_BUDGETS_MS, 0.0)
+
+    payload = check_core_performance.run_core_performance_budgets(
+        budgets=budgets,
+        workspace_dir=tmp_path,
+    )
+
+    assert payload["passed"] is False
+    assert any(not result["passed"] for result in payload["results"])
+
+
+def test_core_performance_preserved_workspace_can_be_reused(tmp_path: Path) -> None:
+    budgets = dict.fromkeys(check_core_performance.DEFAULT_BUDGETS_MS, 10_000.0)
+
+    first = check_core_performance.run_core_performance_budgets(
+        budgets=budgets,
+        workspace_dir=tmp_path,
+    )
+    second = check_core_performance.run_core_performance_budgets(
+        budgets=budgets,
+        workspace_dir=tmp_path,
+    )
+
+    assert first["passed"] is True
+    assert second["passed"] is True
+    assert len(list((tmp_path / "runs").iterdir())) == 2
+
+
+def test_core_performance_script_writes_json_and_exits_nonzero_on_violation(
+    tmp_path: Path,
+) -> None:
+    budget_file = tmp_path / "budgets.json"
+    output = tmp_path / "core-performance.json"
+    budget_file.write_text(
+        json.dumps(dict.fromkeys(check_core_performance.DEFAULT_BUDGETS_MS, 0.0)),
+        encoding="utf-8",
+    )
+
+    assert (
+        check_core_performance.main(
+            [
+                "--budget-file",
+                str(budget_file),
+                "--workspace-dir",
+                str(tmp_path / "workspace"),
+                "--output",
+                str(output),
+            ]
+        )
+        == 1
+    )
+
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert payload["passed"] is False

--- a/tests/test_docs_command_drift.py
+++ b/tests/test_docs_command_drift.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "check_docs_commands.py"
+SPEC = importlib.util.spec_from_file_location("check_docs_commands", SCRIPT)
+assert SPEC is not None
+check_docs_commands = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+sys.modules["check_docs_commands"] = check_docs_commands
+SPEC.loader.exec_module(check_docs_commands)
+
+
+def test_docs_command_checker_passes_current_public_docs(capsys) -> None:
+    assert check_docs_commands.main(["--format", "json"]) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload["passed"] is True
+    assert payload["missing_entry_points"] == []
+    assert payload["stale_commands"] == []
+    assert payload["undocumented_worldforge_subcommands"] == []
+    assert payload["documented_count"] > 20
+
+
+def test_docs_command_checker_reports_stale_and_missing_commands(tmp_path: Path) -> None:
+    (tmp_path / "scripts").mkdir()
+    (tmp_path / "scripts" / "known-smoke").write_text("#!/usr/bin/env bash\n", encoding="utf-8")
+    (tmp_path / "pyproject.toml").write_text(
+        """
+[project]
+name = "example"
+
+[project.scripts]
+worldforge = "worldforge.cli:main"
+worldforge-demo-known = "worldforge.demo:main"
+worldforge-demo-missing = "worldforge.missing:main"
+""".lstrip(),
+        encoding="utf-8",
+    )
+    doc = tmp_path / "README.md"
+    doc.write_text(
+        """
+```bash
+uv run worldforge doctor
+uv run worldforge missing-subcommand
+uv run worldforge-demo-known
+scripts/known-smoke
+scripts/missing-smoke
+```
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    report = check_docs_commands.check_docs_commands(tmp_path, docs=("README.md",))
+
+    assert report.passed is False
+    assert report.missing_entry_points == ("worldforge-demo-missing",)
+    assert any("worldforge missing-subcommand" in item for item in report.stale_commands)
+    assert any("scripts/missing-smoke" in item for item in report.stale_commands)

--- a/tests/test_docs_site.py
+++ b/tests/test_docs_site.py
@@ -905,6 +905,209 @@ def test_roadmap_expansion_documents_three_streams_and_thirty_issues() -> None:
         assert expansion.count(section) >= 30
 
 
+def test_release_readiness_evidence_docs_cover_issue_179_contract() -> None:
+    operations = (ROOT / "docs/src/operations.md").read_text(encoding="utf-8")
+    playbooks = (ROOT / "docs/src/playbooks.md").read_text(encoding="utf-8")
+    release_script = (ROOT / "scripts/generate_release_evidence.py").read_text(encoding="utf-8")
+
+    for signal in (
+        "--run-gates",
+        ".worldforge/release-evidence/release-evidence.md",
+        ".worldforge/release-evidence/release-evidence.json",
+        "`passed`, `failed`, or `skipped`",
+        "first triage step",
+        "`host-owned`",
+    ):
+        assert signal in operations or signal in playbooks
+
+    for implementation_signal in (
+        "class ReleaseGateResult",
+        "release_evidence_payload",
+        "validation_summary",
+        "stdout_tail",
+        "stderr_tail",
+    ):
+        assert implementation_signal in release_script
+
+
+def test_public_api_stability_docs_cover_issue_180_contract() -> None:
+    policy = (ROOT / "docs/src/api-stability.md").read_text(encoding="utf-8")
+    python_api = (ROOT / "docs/src/api/python.md").read_text(encoding="utf-8")
+    contributing = (ROOT / "docs/src/contributing.md").read_text(encoding="utf-8")
+    summary = (ROOT / "docs/src/SUMMARY.md").read_text(encoding="utf-8")
+    mkdocs = (ROOT / "mkdocs.yml").read_text(encoding="utf-8")
+    changelog = (ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
+
+    for tier in ("Stable", "Provisional", "Experimental", "Internal"):
+        assert f"| {tier} |" in policy
+
+    for signal in (
+        "WorldForgeError",
+        "ProviderError",
+        "CLI command or flag",
+        "provider capability",
+        "artifact schema",
+        "schema version bump",
+        "changelog entry",
+        "earliest release where removal may happen",
+        "truthful capability advertising",
+    ):
+        assert signal in policy
+
+    assert "[Public API Stability](../api-stability.md)" in python_api
+    assert "[Public API Stability](./api-stability.md)" in contributing
+    assert "[Public API Stability](./api-stability.md)" in summary
+    assert "Public API Stability: api-stability.md" in mkdocs
+    assert "public API stability and deprecation policy" in changelog
+
+
+def test_redaction_corpus_docs_cover_issue_181_contract() -> None:
+    security = (ROOT / "docs/src/security.md").read_text(encoding="utf-8")
+    corpus = (ROOT / "tests/fixtures/redaction/provider_event_corpus.json").read_text(
+        encoding="utf-8"
+    )
+    redaction_tests = (ROOT / "tests/test_redaction_corpus.py").read_text(encoding="utf-8")
+
+    assert "tests/fixtures/redaction/provider_event_corpus.json" in security
+    for sink in (
+        "provider event sinks",
+        "run manifests",
+        "issue bundles",
+        "Rerun layers",
+        "metrics exporters",
+        "OpenTelemetry bridges",
+    ):
+        assert sink in security
+
+    for secret_shape in (
+        "X-Amz-Signature",
+        "Bearer wf-bearer-secret",
+        "Authorization",
+        "api_key",
+        "token=wf-request-secret",
+    ):
+        assert secret_shape in corpus
+
+    for covered_path in (
+        "JsonLoggerSink",
+        "RunJsonLogSink",
+        "provider_event_metric_labels",
+        "provider_event_span_attributes",
+        "OpenTelemetryProviderEventSink",
+        "RerunEventSink",
+        "build_run_manifest",
+        "validate_run_manifest",
+        "generate_issue_bundle",
+    ):
+        assert covered_path in redaction_tests
+
+
+def test_troubleshooting_matrix_docs_cover_issue_182_contract() -> None:
+    playbooks = (ROOT / "docs/src/playbooks.md").read_text(encoding="utf-8")
+
+    assert "### 4a. Troubleshoot Error Families" in playbooks
+    assert (
+        "| Error family | Common symptom | Likely owner | First command | "
+        "Expected artifact or signal | First triage step |"
+    ) in playbooks
+
+    for error_family in (
+        "`WorldForgeError`",
+        "`WorldStateError`",
+        "`ProviderError`",
+        "`AssertionError` from `worldforge.testing`",
+    ):
+        assert error_family in playbooks
+
+    for command in (
+        "uv run worldforge doctor --registered-only",
+        "uv run worldforge world preflight --state-dir .worldforge/worlds",
+        "uv run worldforge provider info <provider>",
+        "uv run pytest tests/test_provider_contracts.py -q",
+        "uv run worldforge benchmark --preset mock-smoke",
+        "uv run mkdocs build --strict",
+        "worldforge runs bundle <run-id>",
+        "scripts/generate_evidence_bundle.py",
+    ):
+        assert command in playbooks
+
+    for signal in (
+        "safe_to_attach",
+        "run_manifest.json",
+        "budget status",
+        "private Security tab",
+        "do not replace helper checks with bare `assert`",
+    ):
+        assert signal in playbooks
+
+
+def test_docs_command_drift_checker_docs_cover_issue_183_contract() -> None:
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    agents = (ROOT / "AGENTS.md").read_text(encoding="utf-8")
+    quality = (ROOT / "docs/src/quality.md").read_text(encoding="utf-8")
+    operations = (ROOT / "docs/src/operations.md").read_text(encoding="utf-8")
+    playbooks = (ROOT / "docs/src/playbooks.md").read_text(encoding="utf-8")
+    release_script = (ROOT / "scripts/generate_release_evidence.py").read_text(encoding="utf-8")
+    checker = (ROOT / "scripts/check_docs_commands.py").read_text(encoding="utf-8")
+    changelog = (ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
+
+    for doc in (readme, agents, quality, operations, playbooks):
+        assert "uv run python scripts/check_docs_commands.py" in doc
+
+    assert "Docs command drift" in release_script
+    assert "documented-command drift checker" in changelog
+
+    for implementation_signal in (
+        "DEFAULT_DOCS",
+        "README.md",
+        "docs/src/cli.md",
+        "docs/src/examples.md",
+        "docs/src/operations.md",
+        "docs/src/playbooks.md",
+        "AGENTS.md",
+        "missing_entry_points",
+        "stale_commands",
+        "undocumented_worldforge_subcommands",
+    ):
+        assert implementation_signal in checker
+
+
+def test_core_performance_budget_docs_cover_issue_184_contract() -> None:
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    agents = (ROOT / "AGENTS.md").read_text(encoding="utf-8")
+    quality = (ROOT / "docs/src/quality.md").read_text(encoding="utf-8")
+    operations = (ROOT / "docs/src/operations.md").read_text(encoding="utf-8")
+    playbooks = (ROOT / "docs/src/playbooks.md").read_text(encoding="utf-8")
+    benchmarking = (ROOT / "docs/src/benchmarking.md").read_text(encoding="utf-8")
+    release_script = (ROOT / "scripts/generate_release_evidence.py").read_text(encoding="utf-8")
+    checker = (ROOT / "scripts/check_core_performance.py").read_text(encoding="utf-8")
+    changelog = (ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
+
+    for doc in (readme, agents, quality, operations, playbooks):
+        assert "uv run python scripts/check_core_performance.py" in doc
+
+    assert "Core performance budgets" in release_script
+    assert "checkout-safe core performance budget checker" in changelog
+
+    for doc in (quality, operations, playbooks, benchmarking):
+        assert "regression" in doc
+        assert "not" in doc
+        assert "performance claim" in doc
+
+    for implementation_signal in (
+        "DEFAULT_BUDGETS_MS",
+        "world_persistence",
+        "benchmark_fixture_loading",
+        "provider_catalog_diagnostics",
+        "evidence_bundle_creation",
+        "report_rendering",
+        "claim_boundary",
+        "--workspace-dir",
+        "--budget-file",
+    ):
+        assert implementation_signal in checker
+
+
 def test_genie_scaffold_docs_record_runtime_contract_defer_decision() -> None:
     provider_page = (ROOT / "docs/src/providers/genie.md").read_text(encoding="utf-8")
     provider_index = (ROOT / "docs/src/providers/README.md").read_text(encoding="utf-8")

--- a/tests/test_redaction_corpus.py
+++ b/tests/test_redaction_corpus.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+import json
+import logging
+from contextlib import AbstractContextManager
+from dataclasses import dataclass, field
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+from worldforge import ProviderEvent
+from worldforge.evidence_bundle import generate_issue_bundle
+from worldforge.harness.workspace import create_run_workspace, write_run_manifest
+from worldforge.observability import (
+    JsonLoggerSink,
+    OpenTelemetryProviderEventSink,
+    RunJsonLogSink,
+    provider_event_metric_labels,
+    provider_event_span_attributes,
+)
+from worldforge.rerun import RerunEventSink, RerunRecordingConfig, RerunSession
+from worldforge.smoke.run_manifest import build_run_manifest, validate_run_manifest
+
+ROOT = Path(__file__).resolve().parents[1]
+CORPUS = ROOT / "tests/fixtures/redaction/provider_event_corpus.json"
+
+
+@dataclass
+class _FakeSpan:
+    name: str
+    attributes: dict[str, Any] = field(default_factory=dict)
+
+    def set_attribute(self, key: str, value: object) -> None:
+        self.attributes[key] = value
+
+
+@dataclass
+class _SpanContext(AbstractContextManager[_FakeSpan]):
+    span: _FakeSpan
+
+    def __enter__(self) -> _FakeSpan:
+        return self.span
+
+    def __exit__(self, *exc_info: object) -> None:
+        return None
+
+
+@dataclass
+class _FakeTracer:
+    spans: list[_FakeSpan] = field(default_factory=list)
+
+    def start_as_current_span(
+        self,
+        name: str,
+        *,
+        attributes: dict[str, object] | None = None,
+    ) -> _SpanContext:
+        span = _FakeSpan(name=name, attributes=dict(attributes or {}))
+        self.spans.append(span)
+        return _SpanContext(span)
+
+
+class _FakeRerun:
+    TextLogLevel = SimpleNamespace(ERROR="ERROR", WARN="WARN", INFO="INFO")
+
+    def __init__(self) -> None:
+        self.logs: list[tuple[str, dict[str, Any]]] = []
+
+    def init(self, *args: Any, **kwargs: Any) -> None:
+        return None
+
+    def set_time(self, timeline: str, *, sequence: int) -> None:
+        return None
+
+    def log(self, entity_path: str, entity: dict[str, Any]) -> None:
+        self.logs.append((entity_path, entity))
+
+    def TextLog(self, text: str, *, level: object | None = None) -> dict[str, Any]:
+        return {"kind": "TextLog", "text": text, "level": level}
+
+    def TextDocument(self, text: str, *, media_type: str | None = None) -> dict[str, Any]:
+        return {"kind": "TextDocument", "text": text, "media_type": media_type}
+
+    def Scalar(self, scalar: float) -> dict[str, Any]:
+        return {"kind": "Scalar", "scalar": scalar}
+
+    def AnyValues(self, **kwargs: Any) -> dict[str, Any]:
+        return {"kind": "AnyValues", **kwargs}
+
+
+def _corpus_cases() -> list[dict[str, Any]]:
+    payload = json.loads(CORPUS.read_text(encoding="utf-8"))
+    assert payload["schema_version"] == 1
+    return list(payload["cases"])
+
+
+def _assert_forbidden_absent(rendered: str, forbidden: list[str]) -> None:
+    for value in forbidden:
+        assert value not in rendered
+
+
+def test_provider_event_redaction_corpus_covers_event_sinks_and_manifests(
+    caplog,
+    tmp_path: Path,
+) -> None:
+    logger = logging.getLogger("worldforge.tests.redaction-corpus")
+
+    for index, case in enumerate(_corpus_cases(), start=1):
+        event = ProviderEvent(**case["event"])
+        forbidden = list(case["forbidden"])
+
+        event_payload = json.dumps(event.to_dict(), sort_keys=True)
+        _assert_forbidden_absent(event_payload, forbidden)
+        assert "[redacted]" in event_payload
+
+        caplog.clear()
+        with caplog.at_level(logging.INFO, logger=logger.name):
+            JsonLoggerSink(logger=logger, extra_fields={"api_key": "wf-extra-secret"})(event)
+        json_logger_payload = "\n".join(record.message for record in caplog.records)
+        _assert_forbidden_absent(json_logger_payload, [*forbidden, "wf-extra-secret"])
+
+        run_log = tmp_path / f"{case['id']}.jsonl"
+        RunJsonLogSink(run_log, run_id="run-token=wf-run-secret")(event)
+        run_log_payload = run_log.read_text(encoding="utf-8")
+        _assert_forbidden_absent(run_log_payload, [*forbidden, "wf-run-secret"])
+
+        metric_payload = json.dumps(provider_event_metric_labels(event), sort_keys=True)
+        _assert_forbidden_absent(metric_payload, forbidden)
+
+        otel_payload = json.dumps(provider_event_span_attributes(event), sort_keys=True)
+        _assert_forbidden_absent(otel_payload, forbidden)
+
+        tracer = _FakeTracer()
+        OpenTelemetryProviderEventSink(tracer=tracer)(event)
+        _assert_forbidden_absent(json.dumps(tracer.spans[0].attributes), forbidden)
+
+        fake_rerun = _FakeRerun()
+        rerun_sink = RerunEventSink(
+            session=RerunSession(
+                config=RerunRecordingConfig(recording_name="redaction corpus"),
+                sdk=fake_rerun,
+            )
+        )
+        rerun_sink(event)
+        _assert_forbidden_absent(json.dumps(fake_rerun.logs, sort_keys=True), forbidden)
+
+        manifest = build_run_manifest(
+            run_id=f"{case['id']}-run",
+            provider_profile=event.provider,
+            capability=str(event.metadata["capability"]),
+            status="failed",
+            env_vars=("RUNWAYML_API_SECRET",),
+            command_argv=("worldforge-smoke", "--provider", event.provider),
+            result=event.to_dict(),
+            artifact_paths={"artifact": str(case["event"]["target"])},
+        ).to_dict()
+        validated_manifest = validate_run_manifest(manifest)
+        _assert_forbidden_absent(json.dumps(validated_manifest, sort_keys=True), forbidden)
+
+        issue_run_id = f"20260101T00000{index}Z-0000000{index}"
+        workspace = create_run_workspace(
+            tmp_path,
+            kind="provider-diagnostic",
+            command=f"worldforge provider workbench {event.provider}",
+            provider=event.provider,
+            operation=event.operation,
+            run_id=issue_run_id,
+            input_summary={"case": case["id"]},
+        )
+        workspace.write_text("logs/provider-events.jsonl", event_payload)
+        write_run_manifest(
+            workspace,
+            kind="provider-diagnostic",
+            command=f"worldforge provider workbench {event.provider}",
+            provider=event.provider,
+            operation=event.operation,
+            status="failed",
+            input_summary={"case": case["id"]},
+            result_summary={"event": event.to_dict()},
+            event_count=1,
+        )
+        issue_bundle = generate_issue_bundle(
+            workspace_dir=tmp_path,
+            run_id=issue_run_id,
+            output_dir=tmp_path / f"{case['id']}-bundle",
+            overwrite=True,
+        )
+        _assert_forbidden_absent(json.dumps(issue_bundle.manifest, sort_keys=True), forbidden)
+        _assert_forbidden_absent(
+            issue_bundle.issue_template_path.read_text(encoding="utf-8"),
+            forbidden,
+        )

--- a/tests/test_release_evidence.py
+++ b/tests/test_release_evidence.py
@@ -4,6 +4,7 @@ import importlib.util
 import json
 import sys
 from pathlib import Path
+from subprocess import CompletedProcess
 
 from worldforge.smoke.run_manifest import build_run_manifest, write_run_manifest
 
@@ -16,8 +17,10 @@ assert SPEC.loader is not None
 sys.modules["generate_release_evidence"] = generate_release_evidence
 SPEC.loader.exec_module(generate_release_evidence)
 ManifestEvidence = generate_release_evidence.ManifestEvidence
+ReleaseGate = generate_release_evidence.ReleaseGate
 main = generate_release_evidence.main
 render_release_evidence = generate_release_evidence.render_release_evidence
+release_gate_results = generate_release_evidence.release_gate_results
 
 
 def test_release_evidence_renders_without_credentials(
@@ -47,12 +50,11 @@ def test_release_evidence_renders_without_credentials(
         known_limitations=("No prepared-host smokes were run for this branch.",),
     )
 
-    assert (
-        "| `runway` | not configured | missing `RUNWAYML_API_SECRET`, `RUNWAY_API_SECRET` |"
-        in report
-    )
+    assert "| `runway` | host-owned |" in report
+    assert "missing host-owned configuration: `RUNWAYML_API_SECRET`, `RUNWAY_API_SECRET`" in report
     assert "uv run python scripts/generate_provider_docs.py --check" in report
     assert "uv run --extra harness pytest --cov=src/worldforge" in report
+    assert "Run with `--run-gates` to execute this checkout-safe gate." in report
     assert "[`" in report
     assert "benchmark.json" in report
     assert "No prepared-host smokes were run for this branch." in report
@@ -97,8 +99,66 @@ def test_release_evidence_main_writes_default_shape(tmp_path: Path) -> None:
     assert main(["--output", str(output), "--known-limitation", "Release candidate only."]) == 0
 
     report = output.read_text(encoding="utf-8")
+    payload = json.loads(output.with_suffix(".json").read_text(encoding="utf-8"))
     assert report.startswith("# WorldForge Release Evidence")
     assert "Release candidate only." in report
+    assert payload["schema_version"] == 1
+    assert payload["validation_summary"]["skipped"] >= 1
+    assert payload["live_provider_evidence"][0]["status"] == "host-owned"
+
+
+def test_release_evidence_gate_runner_records_pass_fail_and_skip() -> None:
+    gates = (
+        ReleaseGate("Pass", "pass-command", "inspect pass"),
+        ReleaseGate("Fail", "fail-command", "inspect fail"),
+        ReleaseGate("Skip", "skip-command", "inspect skip"),
+    )
+
+    def runner(command: str, **kwargs) -> CompletedProcess[str]:
+        assert kwargs["shell"] is True
+        if command == "fail-command":
+            return CompletedProcess(command, 7, stdout="ok", stderr="broken\n" * 2000)
+        return CompletedProcess(command, 0, stdout="passed", stderr="")
+
+    results = release_gate_results(
+        gates,
+        run=True,
+        skip_gates=("Skip",),
+        skip_reason="host skipped intentionally",
+        runner=runner,
+    )
+
+    assert [result.status for result in results] == ["passed", "failed", "skipped"]
+    assert results[0].exit_code == 0
+    assert results[1].exit_code == 7
+    assert len(results[1].stderr_tail) <= generate_release_evidence.MAX_CAPTURE_CHARS
+    assert results[2].triage_step == "host skipped intentionally"
+
+
+def test_release_evidence_json_payload_contains_gate_and_host_owned_statuses() -> None:
+    gate_results = release_gate_results(
+        (ReleaseGate("Docs", "uv run mkdocs build --strict", "fix docs"),),
+        run=False,
+    )
+
+    payload = generate_release_evidence.release_evidence_payload(
+        manifests=(),
+        benchmark_artifacts=(),
+        artifacts=(),
+        gate_results=gate_results,
+        known_limitations=("No live smokes.",),
+    )
+
+    assert payload["validation_gates"][0]["status"] == "skipped"
+    assert payload["validation_gates"][0]["triage_step"].startswith("Run with")
+    assert payload["validation_summary"] == {
+        "passed": 0,
+        "failed": 0,
+        "skipped": 1,
+        "host-owned": 0,
+    }
+    assert {item["status"] for item in payload["live_provider_evidence"]} == {"host-owned"}
+    assert payload["known_limitations"] == ["No live smokes."]
 
 
 def test_release_evidence_main_discovers_evidence_bundle_manifest(


### PR DESCRIPTION
## Summary

Implements the first production-quality roadmap batch:

- release-readiness evidence command with Markdown and JSON output, runnable checkout-safe gates, skipped/failed triage, and host-owned optional live evidence status
- public API stability and deprecation policy with docs navigation
- shared provider-event redaction corpus covering JSON logs, run logs, metrics, OpenTelemetry, Rerun, manifests, and issue bundles
- troubleshooting matrix for public error families and docs/build/benchmark failures
- documented-command drift checker for README, CLI docs, examples, operations, playbooks, and AGENTS
- checkout-safe core performance budget checker for world persistence, benchmark fixture loading, provider diagnostics, evidence-bundle creation, and report rendering

Fixes #179
Fixes #180
Fixes #181
Fixes #182
Fixes #183
Fixes #184

## Validation

- `uv lock --check`
- `uv run ruff check src tests examples scripts`
- `uv run ruff format --check src tests examples scripts`
- `uv run python scripts/generate_provider_docs.py --check`
- `uv run python scripts/check_docs_commands.py --format json`
- `uv run python scripts/check_core_performance.py --workspace-dir /tmp/worldforge-core-perf-focused --output /tmp/worldforge-core-performance-focused.json`
- `uv run mkdocs build --strict`
- `uv run pytest`
- `uv run --extra harness pytest --cov=src/worldforge --cov-report=term-missing --cov-fail-under=90`
- `bash scripts/test_package.sh`
- `uv build --out-dir dist --clear --no-build-logs`
- `git diff --check`
