### PR TITLE
Harden remote artifact downloads

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,10 @@ RUNWAYML_API_SECRET=
 # Optional: override the default Runway base URL.
 # RUNWAYML_BASE_URL=
 
+# Optional: set only for trusted local Runway-compatible test servers that return
+# localhost/private artifact URLs.
+# RUNWAYML_ALLOW_LOCAL_ARTIFACT_URLS=0
+
 # -----------------------------------------------------------------------------
 # LeWorldModel (JEPA cost model via stable_worldmodel) -- score
 # -----------------------------------------------------------------------------

--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,11 @@ RUNWAYML_API_SECRET=
 # localhost/private artifact URLs.
 # RUNWAYML_ALLOW_LOCAL_ARTIFACT_URLS=0
 
+# Optional: force DNS checks for artifact URLs when using a custom transport.
+# Default auto mode checks DNS for normal HTTP clients and skips it for offline
+# custom transports.
+# RUNWAYML_RESOLVE_ARTIFACT_DNS=1
+
 # -----------------------------------------------------------------------------
 # LeWorldModel (JEPA cost model via stable_worldmodel) -- score
 # -----------------------------------------------------------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,6 +154,9 @@ releases may still include breaking changes when the public API needs to tighten
 
 ### Fixed
 
+- Runway artifact downloads now validate provider-returned URLs before fetching, block local,
+  private, and link-local destinations unless explicitly opted in, and stream downloaded bytes with
+  a hard size cap instead of buffering unbounded response bodies.
 - Preserved LeRobot loader provenance after lazy policy loading so real `from_pretrained` runs no
   longer report as `injected_policy` in policy result metadata or provider events.
 - Documented first triage commands for Cosmos and Runway media artifacts and added focused

--- a/docs/src/operations.md
+++ b/docs/src/operations.md
@@ -87,6 +87,8 @@ Configuration comes from constructor arguments and environment variables documen
 - `RUNWAYML_BASE_URL` overrides the default Runway API endpoint.
 - `RUNWAYML_ALLOW_LOCAL_ARTIFACT_URLS` is a test-only opt-in for trusted local Runway-compatible
   artifact URLs. Leave it unset in normal remote-provider deployments.
+- `RUNWAYML_RESOLVE_ARTIFACT_DNS` overrides artifact URL DNS validation for custom transports.
+  Leave it unset for auto mode, or set it for custom network transports that still use system DNS.
 - `LEWORLDMODEL_POLICY` or `LEWM_POLICY` enables the optional LeWorldModel adapter.
 - `LEWORLDMODEL_CACHE_DIR` overrides the LeWorldModel checkpoint root.
 - `LEWORLDMODEL_REVISION` pins the Hugging Face LeWM commit used when the showcase auto-builds

--- a/docs/src/operations.md
+++ b/docs/src/operations.md
@@ -85,6 +85,8 @@ Configuration comes from constructor arguments and environment variables documen
 - `RUNWAYML_API_SECRET` enables the Runway adapter.
 - `RUNWAY_API_SECRET` remains supported as the legacy Runway alias.
 - `RUNWAYML_BASE_URL` overrides the default Runway API endpoint.
+- `RUNWAYML_ALLOW_LOCAL_ARTIFACT_URLS` is a test-only opt-in for trusted local Runway-compatible
+  artifact URLs. Leave it unset in normal remote-provider deployments.
 - `LEWORLDMODEL_POLICY` or `LEWM_POLICY` enables the optional LeWorldModel adapter.
 - `LEWORLDMODEL_CACHE_DIR` overrides the LeWorldModel checkpoint root.
 - `LEWORLDMODEL_REVISION` pins the Hugging Face LeWM commit used when the showcase auto-builds

--- a/docs/src/playbooks.md
+++ b/docs/src/playbooks.md
@@ -561,6 +561,9 @@ Operational rules:
 - budget failures raise `ProviderBudgetExceededError` and emit `phase=="budget_exceeded"` so
   alerts can distinguish an exhausted host budget from an upstream HTTP failure.
 - returned artifacts are validated before `VideoClip` is returned.
+- provider-returned artifact URLs are treated as untrusted input: HTTP(S) only, no embedded
+  credentials, no local/private/link-local destinations by default, and streamed with a maximum
+  byte cap.
 - signed URLs and temporary artifact URLs are not durable storage. Download or persist them in
   host-owned storage immediately after completion.
 - provider errors should include operation and provider context without leaking credentials,

--- a/docs/src/providers/runway.md
+++ b/docs/src/providers/runway.md
@@ -44,6 +44,9 @@ The host owns:
 - `RUNWAYML_ALLOW_LOCAL_ARTIFACT_URLS`: optional test-only escape hatch. When unset, Runway task
   output URLs that point at localhost, private, link-local, reserved, multicast, or unresolved
   local destinations are rejected before download.
+- `RUNWAYML_RESOLVE_ARTIFACT_DNS`: optional override for artifact URL DNS checks when using a
+  custom HTTP transport. Auto mode checks DNS for normal HTTP clients and avoids system DNS for
+  deterministic offline transports.
 
 Runtime manifest:
 `src/worldforge/providers/runtime_manifests/runway.json` records the credential aliases, optional
@@ -194,6 +197,9 @@ Pass a custom `request_policy=` when the host needs different timeout or retry b
 - Local/private/link-local artifact URLs fail before any download unless
   `RUNWAYML_ALLOW_LOCAL_ARTIFACT_URLS=1` or the constructor opt-in is used for a trusted local
   test deployment.
+- Custom network transports that need hostname-to-IP validation should set
+  `RUNWAYML_RESOLVE_ARTIFACT_DNS=1` or use the constructor override; offline deterministic
+  transports can leave auto mode in place.
 - Expired, unavailable, empty, or wrong-content-type artifacts fail before returning `VideoClip`.
 - Oversized artifacts fail from `Content-Length` or while streaming the body.
 - Result metadata and run manifests keep only sanitized artifact URLs; signed query strings and

--- a/docs/src/providers/runway.md
+++ b/docs/src/providers/runway.md
@@ -41,6 +41,9 @@ The host owns:
 - `RUNWAY_API_SECRET`: legacy credential alias.
 - `RUNWAYML_BASE_URL`: optional API endpoint override; defaults to
   `https://api.dev.runwayml.com`.
+- `RUNWAYML_ALLOW_LOCAL_ARTIFACT_URLS`: optional test-only escape hatch. When unset, Runway task
+  output URLs that point at localhost, private, link-local, reserved, multicast, or unresolved
+  local destinations are rejected before download.
 
 Runtime manifest:
 `src/worldforge/providers/runtime_manifests/runway.json` records the credential aliases, optional
@@ -142,13 +145,16 @@ Terminal task behavior:
 - timeout after `max_polls`: raise `ProviderError`
 
 Artifact downloads accept video content types and `application/octet-stream`. Explicit non-video
-content types such as `text/html` are rejected. Empty downloads fail explicitly. Expired or
-unavailable artifact URLs are surfaced as provider errors.
+content types such as `text/html` are rejected. Empty downloads fail explicitly. Downloads are
+streamed with a hard size cap, and `Content-Length` values above that cap fail before the body is
+read. Expired or unavailable artifact URLs are surfaced as provider errors.
 
 Runway output URLs can be temporary signed URLs. WorldForge uses the raw URL only for the immediate
-download request, then records `artifact_url` metadata without query strings or fragments. Persist
-the downloaded bytes immediately if the media is needed for issue evidence, benchmark comparisons,
-or release notes. If an artifact has expired, rerun the task rather than attempting to reconstruct a
+download request after validating that the URL uses HTTP(S), has no embedded credentials, and does
+not target local/private infrastructure unless the host explicitly opts in for trusted local tests.
+WorldForge then records `artifact_url` metadata without query strings or fragments. Persist the
+downloaded bytes immediately if the media is needed for issue evidence, benchmark comparisons, or
+release notes. If an artifact has expired, rerun the task rather than attempting to reconstruct a
 signed URL from logs or manifests.
 
 Artifact lifetime assumption: downloaded bytes are durable only after the host writes or copies the
@@ -185,7 +191,11 @@ Pass a custom `request_policy=` when the host needs different timeout or retry b
 - Polling fails when status payloads are malformed or the response id does not match the requested
   task.
 - Completed tasks without output URLs fail explicitly.
+- Local/private/link-local artifact URLs fail before any download unless
+  `RUNWAYML_ALLOW_LOCAL_ARTIFACT_URLS=1` or the constructor opt-in is used for a trusted local
+  test deployment.
 - Expired, unavailable, empty, or wrong-content-type artifacts fail before returning `VideoClip`.
+- Oversized artifacts fail from `Content-Length` or while streaming the body.
 - Result metadata and run manifests keep only sanitized artifact URLs; signed query strings and
   fragments are not retained.
 - Invalid ratios, durations, dimensions, FPS, polling intervals, or poll counts fail before or

--- a/src/worldforge/providers/http_utils.py
+++ b/src/worldforge/providers/http_utils.py
@@ -755,6 +755,7 @@ def request_bytes_with_policy(
                             )
                         )
                     if delay > 0.0:
+                        response.close()
                         sleep(delay)
                     continue
 

--- a/src/worldforge/providers/http_utils.py
+++ b/src/worldforge/providers/http_utils.py
@@ -3,11 +3,15 @@
 from __future__ import annotations
 
 import base64
+import ipaddress
 import mimetypes
+import multiprocessing
+import socket
 from collections.abc import Callable
 from pathlib import Path
 from time import perf_counter, sleep
 from typing import Any
+from urllib.parse import urlparse
 
 import httpx
 
@@ -22,6 +26,168 @@ from worldforge.models import (
 from .base import ProviderBudgetExceededError, ProviderError
 
 _RETRYABLE_EXCEPTIONS = (httpx.TransportError,)
+_LOCAL_HOST_NAMES = frozenset({"localhost", "localhost.localdomain"})
+_DNS_RESOLUTION_TIMEOUT_SECONDS = 2.0
+_ERROR_SUMMARY_BYTES = 512
+
+
+def validate_remote_url(
+    url: str,
+    *,
+    provider_name: str,
+    url_name: str,
+    allow_local_network: bool = False,
+    resolve_dns: bool = True,
+    dns_resolution_timeout_seconds: float = _DNS_RESOLUTION_TIMEOUT_SECONDS,
+) -> str:
+    """Return a stripped HTTP URL after blocking local/private destinations."""
+
+    if not isinstance(url, str) or not url.strip():
+        raise ProviderError(f"Provider '{provider_name}' {url_name} must be a non-empty URL.")
+    normalized_url = url.strip()
+    parsed = urlparse(normalized_url)
+    if parsed.scheme.lower() not in {"http", "https"}:
+        raise ProviderError(f"Provider '{provider_name}' {url_name} must use an http or https URL.")
+    if not parsed.hostname:
+        raise ProviderError(f"Provider '{provider_name}' {url_name} must include a hostname.")
+    if parsed.username or parsed.password:
+        raise ProviderError(
+            f"Provider '{provider_name}' {url_name} must not include embedded credentials."
+        )
+
+    host = parsed.hostname.strip().lower()
+    if not allow_local_network:
+        _reject_local_hostname(host, provider_name=provider_name, url_name=url_name)
+        is_ip_literal = _reject_local_ip_literal(
+            host,
+            provider_name=provider_name,
+            url_name=url_name,
+        )
+        if resolve_dns and not is_ip_literal:
+            _reject_local_resolved_addresses(
+                host,
+                port=parsed.port or (443 if parsed.scheme.lower() == "https" else 80),
+                provider_name=provider_name,
+                url_name=url_name,
+                timeout_seconds=dns_resolution_timeout_seconds,
+            )
+    return normalized_url
+
+
+def _reject_local_hostname(host: str, *, provider_name: str, url_name: str) -> None:
+    if host in _LOCAL_HOST_NAMES or host.endswith(".localhost"):
+        raise ProviderError(
+            f"Provider '{provider_name}' {url_name} resolves to a local/private destination."
+        )
+
+
+def _reject_local_ip_literal(host: str, *, provider_name: str, url_name: str) -> bool:
+    try:
+        address = ipaddress.ip_address(host)
+    except ValueError:
+        return False
+    _reject_local_address(address, provider_name=provider_name, url_name=url_name)
+    return True
+
+
+def _reject_local_resolved_addresses(
+    host: str,
+    *,
+    port: int,
+    provider_name: str,
+    url_name: str,
+    timeout_seconds: float,
+) -> None:
+    try:
+        addresses = _getaddrinfo_with_timeout(
+            host,
+            port,
+            timeout_seconds=timeout_seconds,
+        )
+    except TimeoutError as exc:
+        raise ProviderError(
+            f"Provider '{provider_name}' {url_name} host resolution timed out: {host}."
+        ) from exc
+    except socket.gaierror as exc:
+        raise ProviderError(
+            f"Provider '{provider_name}' {url_name} host could not be resolved: {host}."
+        ) from exc
+    for address in addresses:
+        _reject_local_address(
+            ipaddress.ip_address(address),
+            provider_name=provider_name,
+            url_name=url_name,
+        )
+
+
+def _resolve_getaddrinfo_worker(
+    host: str,
+    port: int,
+    result_queue: multiprocessing.Queue,
+) -> None:
+    try:
+        addresses = socket.getaddrinfo(host, port, type=socket.SOCK_STREAM)
+    except socket.gaierror as exc:
+        result_queue.put(("gaierror", (exc.errno, exc.strerror)))
+        return
+    result_queue.put(("ok", [address[4][0] for address in addresses]))
+
+
+def _getaddrinfo_with_timeout(
+    host: str,
+    port: int,
+    *,
+    timeout_seconds: float,
+) -> list[str]:
+    if timeout_seconds <= 0:
+        raise TimeoutError("DNS resolution timeout must be greater than 0.")
+
+    context = multiprocessing.get_context("spawn")
+    result_queue = context.Queue(maxsize=1)
+    resolver = context.Process(
+        target=_resolve_getaddrinfo_worker,
+        args=(host, port, result_queue),
+        name=f"worldforge-dns-resolver-{host}",
+    )
+    resolver.start()
+    resolver.join(timeout_seconds)
+    if resolver.is_alive():
+        resolver.terminate()
+        resolver.join()
+        raise TimeoutError(f"DNS resolution exceeded {timeout_seconds:.1f}s.")
+
+    if resolver.exitcode not in (0, None):
+        raise socket.gaierror(
+            socket.EAI_FAIL,
+            f"DNS resolver process exited with code {resolver.exitcode}",
+        )
+    if result_queue.empty():
+        raise socket.gaierror(socket.EAI_FAIL, "DNS resolver returned no result")
+
+    status, value = result_queue.get()
+    if status == "gaierror":
+        error_number, error_text = value
+        raise socket.gaierror(error_number, error_text)
+    return list(value)
+
+
+def _reject_local_address(
+    address: ipaddress.IPv4Address | ipaddress.IPv6Address,
+    *,
+    provider_name: str,
+    url_name: str,
+) -> None:
+    if (
+        address.is_loopback
+        or address.is_private
+        or address.is_link_local
+        or address.is_unspecified
+        or address.is_reserved
+        or address.is_multicast
+    ):
+        raise ProviderError(
+            f"Provider '{provider_name}' {url_name} resolves to a local/private destination."
+        )
 
 
 def asset_to_uri(value: str | None, *, default_content_type: str) -> str | None:
@@ -480,34 +646,352 @@ def request_bytes_with_policy(
     policy: RequestOperationPolicy,
     emit_event: Callable[[ProviderEvent], None] | None = None,
     accepted_content_types: tuple[str, ...] | None = None,
+    max_bytes: int | None = None,
     **kwargs: Any,
 ) -> bytes:
-    """Send an HTTP request and return the raw response bytes."""
+    """Send an HTTP request and stream raw response bytes with an optional hard cap."""
 
-    response = request_with_policy(
-        client,
-        method=method,
-        url=url,
-        provider_name=provider_name,
-        operation_name=operation_name,
-        policy=policy,
-        emit_event=emit_event,
-        **kwargs,
-    )
-    content_type = response.headers.get("content-type")
-    if (
-        content_type
-        and accepted_content_types
-        and not _content_type_is_allowed(
-            content_type,
-            accepted_content_types,
-        )
-    ):
+    if max_bytes is not None and max_bytes <= 0:
         raise ProviderError(
-            f"Provider '{provider_name}' {operation_name} returned unsupported "
-            f"content type '{content_type}'."
+            f"Provider '{provider_name}' {operation_name} max_bytes must be greater than 0."
         )
-    return response.content
+
+    operation_started = perf_counter()
+    for attempt_number in range(1, policy.retry.max_attempts + 1):
+        remaining_seconds = _remaining_budget_seconds(policy, started=operation_started)
+        if remaining_seconds is not None and remaining_seconds <= 0.0:
+            elapsed_seconds = _elapsed_seconds(operation_started)
+            _emit_budget_exceeded(
+                provider_name=provider_name,
+                operation_name=operation_name,
+                method=method,
+                url=url,
+                attempt=attempt_number,
+                max_attempts=policy.retry.max_attempts,
+                elapsed_seconds=elapsed_seconds,
+                max_elapsed_seconds=policy.max_elapsed_seconds,
+                emit_event=emit_event,
+            )
+            _raise_budget_exceeded(
+                provider_name=provider_name,
+                operation_name=operation_name,
+                elapsed_seconds=elapsed_seconds,
+                max_elapsed_seconds=policy.max_elapsed_seconds,
+            )
+        started = perf_counter()
+        try:
+            with client.stream(
+                method,
+                url,
+                timeout=(
+                    policy.timeout_seconds
+                    if remaining_seconds is None
+                    else min(policy.timeout_seconds, max(remaining_seconds, 0.001))
+                ),
+                **kwargs,
+            ) as response:
+                duration_ms = max(0.0, (perf_counter() - started) * 1000)
+                if response.status_code in policy.retry.retryable_status_codes:
+                    if attempt_number >= policy.retry.max_attempts:
+                        summary = _stream_response_summary(response)
+                        if emit_event is not None:
+                            emit_event(
+                                ProviderEvent(
+                                    provider=provider_name,
+                                    operation=operation_name,
+                                    phase="failure",
+                                    attempt=attempt_number,
+                                    max_attempts=policy.retry.max_attempts,
+                                    method=method,
+                                    target=url,
+                                    status_code=response.status_code,
+                                    duration_ms=duration_ms,
+                                    message=summary,
+                                )
+                            )
+                        raise ProviderError(
+                            f"Provider '{provider_name}' {operation_name} failed with "
+                            f"status {response.status_code}: {summary}"
+                        )
+                    delay = policy.retry.delay_for_attempt(attempt_number + 1)
+                    elapsed_after_delay = _elapsed_seconds(operation_started) + delay
+                    if (
+                        policy.max_elapsed_seconds is not None
+                        and elapsed_after_delay > policy.max_elapsed_seconds
+                    ):
+                        elapsed_seconds = _elapsed_seconds(operation_started)
+                        _emit_budget_exceeded(
+                            provider_name=provider_name,
+                            operation_name=operation_name,
+                            method=method,
+                            url=url,
+                            attempt=attempt_number,
+                            max_attempts=policy.retry.max_attempts,
+                            elapsed_seconds=elapsed_seconds,
+                            max_elapsed_seconds=policy.max_elapsed_seconds,
+                            emit_event=emit_event,
+                            status_code=response.status_code,
+                        )
+                        _raise_budget_exceeded(
+                            provider_name=provider_name,
+                            operation_name=operation_name,
+                            elapsed_seconds=elapsed_seconds,
+                            max_elapsed_seconds=policy.max_elapsed_seconds,
+                        )
+                    if emit_event is not None:
+                        emit_event(
+                            ProviderEvent(
+                                provider=provider_name,
+                                operation=operation_name,
+                                phase="retry",
+                                attempt=attempt_number,
+                                max_attempts=policy.retry.max_attempts,
+                                method=method,
+                                target=url,
+                                status_code=response.status_code,
+                                duration_ms=duration_ms,
+                                message=_stream_response_summary(response),
+                                metadata={"next_delay_seconds": delay},
+                            )
+                        )
+                    if delay > 0.0:
+                        sleep(delay)
+                    continue
+
+                if response.status_code >= 400:
+                    summary = _stream_response_summary(response)
+                    if emit_event is not None:
+                        emit_event(
+                            ProviderEvent(
+                                provider=provider_name,
+                                operation=operation_name,
+                                phase="failure",
+                                attempt=attempt_number,
+                                max_attempts=policy.retry.max_attempts,
+                                method=method,
+                                target=url,
+                                status_code=response.status_code,
+                                duration_ms=duration_ms,
+                                message=summary,
+                            )
+                        )
+                    raise ProviderError(
+                        f"Provider '{provider_name}' {operation_name} failed with "
+                        f"status {response.status_code}: {summary}"
+                    )
+
+                content_type = response.headers.get("content-type")
+                if (
+                    content_type
+                    and accepted_content_types
+                    and not _content_type_is_allowed(
+                        content_type,
+                        accepted_content_types,
+                    )
+                ):
+                    message = (
+                        f"Provider '{provider_name}' {operation_name} returned unsupported "
+                        f"content type '{content_type}'."
+                    )
+                    if emit_event is not None:
+                        emit_event(
+                            ProviderEvent(
+                                provider=provider_name,
+                                operation=operation_name,
+                                phase="failure",
+                                attempt=attempt_number,
+                                max_attempts=policy.retry.max_attempts,
+                                method=method,
+                                target=url,
+                                status_code=response.status_code,
+                                duration_ms=duration_ms,
+                                message=message,
+                            )
+                        )
+                    raise ProviderError(message)
+
+                _reject_oversized_content_length(
+                    response,
+                    provider_name=provider_name,
+                    operation_name=operation_name,
+                    max_bytes=max_bytes,
+                )
+                data = _read_response_bytes(
+                    response,
+                    provider_name=provider_name,
+                    operation_name=operation_name,
+                    max_bytes=max_bytes,
+                )
+                duration_ms = max(0.0, (perf_counter() - started) * 1000)
+                if emit_event is not None:
+                    emit_event(
+                        ProviderEvent(
+                            provider=provider_name,
+                            operation=operation_name,
+                            phase="success",
+                            attempt=attempt_number,
+                            max_attempts=policy.retry.max_attempts,
+                            method=method,
+                            target=url,
+                            status_code=response.status_code,
+                            duration_ms=duration_ms,
+                            metadata={"bytes": len(data)},
+                        )
+                    )
+                return data
+        except _RETRYABLE_EXCEPTIONS as exc:
+            duration_ms = max(0.0, (perf_counter() - started) * 1000)
+            if attempt_number >= policy.retry.max_attempts:
+                if emit_event is not None:
+                    emit_event(
+                        ProviderEvent(
+                            provider=provider_name,
+                            operation=operation_name,
+                            phase="failure",
+                            attempt=attempt_number,
+                            max_attempts=policy.retry.max_attempts,
+                            method=method,
+                            target=url,
+                            duration_ms=duration_ms,
+                            message=str(exc),
+                        )
+                    )
+                raise ProviderError(
+                    f"Provider '{provider_name}' {operation_name} failed after "
+                    f"{attempt_number} attempt(s): {exc}"
+                ) from exc
+            delay = policy.retry.delay_for_attempt(attempt_number + 1)
+            elapsed_after_delay = _elapsed_seconds(operation_started) + delay
+            if (
+                policy.max_elapsed_seconds is not None
+                and elapsed_after_delay > policy.max_elapsed_seconds
+            ):
+                elapsed_seconds = _elapsed_seconds(operation_started)
+                _emit_budget_exceeded(
+                    provider_name=provider_name,
+                    operation_name=operation_name,
+                    method=method,
+                    url=url,
+                    attempt=attempt_number,
+                    max_attempts=policy.retry.max_attempts,
+                    elapsed_seconds=elapsed_seconds,
+                    max_elapsed_seconds=policy.max_elapsed_seconds,
+                    emit_event=emit_event,
+                )
+                _raise_budget_exceeded(
+                    provider_name=provider_name,
+                    operation_name=operation_name,
+                    elapsed_seconds=elapsed_seconds,
+                    max_elapsed_seconds=policy.max_elapsed_seconds,
+                )
+            if emit_event is not None:
+                emit_event(
+                    ProviderEvent(
+                        provider=provider_name,
+                        operation=operation_name,
+                        phase="retry",
+                        attempt=attempt_number,
+                        max_attempts=policy.retry.max_attempts,
+                        method=method,
+                        target=url,
+                        duration_ms=duration_ms,
+                        message=str(exc),
+                        metadata={"next_delay_seconds": delay},
+                    )
+                )
+            if delay > 0.0:
+                sleep(delay)
+            continue
+        except httpx.HTTPError as exc:
+            duration_ms = max(0.0, (perf_counter() - started) * 1000)
+            if emit_event is not None:
+                emit_event(
+                    ProviderEvent(
+                        provider=provider_name,
+                        operation=operation_name,
+                        phase="failure",
+                        attempt=attempt_number,
+                        max_attempts=policy.retry.max_attempts,
+                        method=method,
+                        target=url,
+                        duration_ms=duration_ms,
+                        message=str(exc),
+                    )
+                )
+            raise ProviderError(
+                f"Provider '{provider_name}' {operation_name} failed: {exc}"
+            ) from exc
+
+    raise AssertionError("request_bytes_with_policy exhausted retries without returning or raising")
+
+
+def _stream_response_summary(response: httpx.Response) -> str:
+    data = bytearray()
+    try:
+        for chunk in response.iter_bytes():
+            remaining = _ERROR_SUMMARY_BYTES - len(data)
+            if remaining <= 0:
+                break
+            data.extend(chunk[:remaining])
+            if len(data) >= _ERROR_SUMMARY_BYTES:
+                break
+    except httpx.HTTPError:
+        return "unreadable response body"
+    if not data:
+        return "empty response body"
+    text = bytes(data).decode("utf-8", errors="replace").strip()
+    if not text:
+        return "empty response body"
+    if len(text) > 200:
+        text = f"{text[:197]}..."
+    return _redact_observable_text(text)
+
+
+def _reject_oversized_content_length(
+    response: httpx.Response,
+    *,
+    provider_name: str,
+    operation_name: str,
+    max_bytes: int | None,
+) -> None:
+    if max_bytes is None:
+        return
+    content_length = response.headers.get("content-length")
+    if content_length is None:
+        return
+    try:
+        size = int(content_length)
+    except ValueError as exc:
+        raise ProviderError(
+            f"Provider '{provider_name}' {operation_name} returned invalid Content-Length."
+        ) from exc
+    if size < 0:
+        raise ProviderError(
+            f"Provider '{provider_name}' {operation_name} returned invalid Content-Length."
+        )
+    if size > max_bytes:
+        raise ProviderError(
+            f"Provider '{provider_name}' {operation_name} exceeded download size limit "
+            f"of {max_bytes} bytes from Content-Length {size}."
+        )
+
+
+def _read_response_bytes(
+    response: httpx.Response,
+    *,
+    provider_name: str,
+    operation_name: str,
+    max_bytes: int | None,
+) -> bytes:
+    data = bytearray()
+    for chunk in response.iter_bytes():
+        data.extend(chunk)
+        if max_bytes is not None and len(data) > max_bytes:
+            raise ProviderError(
+                f"Provider '{provider_name}' {operation_name} exceeded download size limit "
+                f"of {max_bytes} bytes."
+            )
+    return bytes(data)
 
 
 def poll_json_task(

--- a/src/worldforge/providers/http_utils.py
+++ b/src/worldforge/providers/http_utils.py
@@ -6,6 +6,7 @@ import base64
 import ipaddress
 import mimetypes
 import multiprocessing
+import queue
 import socket
 from collections.abc import Callable
 from pathlib import Path
@@ -99,11 +100,14 @@ def _reject_local_resolved_addresses(
     timeout_seconds: float,
 ) -> None:
     try:
-        addresses = _getaddrinfo_with_timeout(
-            host,
-            port,
-            timeout_seconds=timeout_seconds,
-        )
+        addresses = [
+            ipaddress.ip_address(address)
+            for address in _getaddrinfo_with_timeout(
+                host,
+                port,
+                timeout_seconds=timeout_seconds,
+            )
+        ]
     except TimeoutError as exc:
         raise ProviderError(
             f"Provider '{provider_name}' {url_name} host resolution timed out: {host}."
@@ -112,9 +116,13 @@ def _reject_local_resolved_addresses(
         raise ProviderError(
             f"Provider '{provider_name}' {url_name} host could not be resolved: {host}."
         ) from exc
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise ProviderError(
+            f"Provider '{provider_name}' {url_name} host resolution failed: {host}."
+        ) from exc
     for address in addresses:
         _reject_local_address(
-            ipaddress.ip_address(address),
+            address,
             provider_name=provider_name,
             url_name=url_name,
         )
@@ -149,26 +157,37 @@ def _getaddrinfo_with_timeout(
         args=(host, port, result_queue),
         name=f"worldforge-dns-resolver-{host}",
     )
-    resolver.start()
-    resolver.join(timeout_seconds)
-    if resolver.is_alive():
-        resolver.terminate()
-        resolver.join()
-        raise TimeoutError(f"DNS resolution exceeded {timeout_seconds:.1f}s.")
+    resolver_started = False
+    try:
+        resolver.start()
+        resolver_started = True
+        resolver.join(timeout_seconds)
+        if resolver.is_alive():
+            resolver.terminate()
+            resolver.join()
+            raise TimeoutError(f"DNS resolution exceeded {timeout_seconds:.1f}s.")
 
-    if resolver.exitcode not in (0, None):
-        raise socket.gaierror(
-            socket.EAI_FAIL,
-            f"DNS resolver process exited with code {resolver.exitcode}",
-        )
-    if result_queue.empty():
-        raise socket.gaierror(socket.EAI_FAIL, "DNS resolver returned no result")
-
-    status, value = result_queue.get()
-    if status == "gaierror":
-        error_number, error_text = value
-        raise socket.gaierror(error_number, error_text)
-    return list(value)
+        if resolver.exitcode not in (0, None):
+            raise socket.gaierror(
+                socket.EAI_FAIL,
+                f"DNS resolver process exited with code {resolver.exitcode}",
+            )
+        try:
+            status, value = result_queue.get(timeout=0.1)
+        except queue.Empty as exc:
+            raise socket.gaierror(socket.EAI_FAIL, "DNS resolver returned no result") from exc
+        if status == "gaierror":
+            error_number, error_text = value
+            raise socket.gaierror(error_number, error_text)
+        if status != "ok":
+            raise socket.gaierror(socket.EAI_FAIL, "DNS resolver returned an invalid result")
+        return list(value)
+    finally:
+        if resolver_started and resolver.is_alive():
+            resolver.terminate()
+            resolver.join()
+        result_queue.close()
+        result_queue.join_thread()
 
 
 def _reject_local_address(

--- a/src/worldforge/providers/http_utils.py
+++ b/src/worldforge/providers/http_utils.py
@@ -175,13 +175,17 @@ def _getaddrinfo_with_timeout(
                 f"DNS resolver process exited with code {resolver.exitcode}",
             )
         elapsed_seconds = perf_counter() - started
-        result_timeout_seconds = min(
-            timeout_seconds,
-            max(_DNS_RESULT_QUEUE_TIMEOUT_SECONDS, timeout_seconds - elapsed_seconds),
-        )
+        remaining_seconds = timeout_seconds - elapsed_seconds
         try:
-            status, value = result_queue.get(timeout=result_timeout_seconds)
+            if remaining_seconds <= 0:
+                status, value = result_queue.get_nowait()
+            else:
+                status, value = result_queue.get(
+                    timeout=min(_DNS_RESULT_QUEUE_TIMEOUT_SECONDS, remaining_seconds)
+                )
         except queue.Empty as exc:
+            if perf_counter() - started >= timeout_seconds:
+                raise TimeoutError(f"DNS resolution exceeded {timeout_seconds:.1f}s.") from exc
             raise socket.gaierror(socket.EAI_FAIL, "DNS resolver returned no result") from exc
         if status == "gaierror":
             error_number, error_text = value

--- a/src/worldforge/providers/http_utils.py
+++ b/src/worldforge/providers/http_utils.py
@@ -29,6 +29,7 @@ from .base import ProviderBudgetExceededError, ProviderError
 _RETRYABLE_EXCEPTIONS = (httpx.TransportError,)
 _LOCAL_HOST_NAMES = frozenset({"localhost", "localhost.localdomain"})
 _DNS_RESOLUTION_TIMEOUT_SECONDS = 2.0
+_DNS_RESULT_QUEUE_TIMEOUT_SECONDS = 1.0
 _ERROR_SUMMARY_BYTES = 512
 
 
@@ -158,6 +159,7 @@ def _getaddrinfo_with_timeout(
         name=f"worldforge-dns-resolver-{host}",
     )
     resolver_started = False
+    started = perf_counter()
     try:
         resolver.start()
         resolver_started = True
@@ -172,8 +174,13 @@ def _getaddrinfo_with_timeout(
                 socket.EAI_FAIL,
                 f"DNS resolver process exited with code {resolver.exitcode}",
             )
+        elapsed_seconds = perf_counter() - started
+        result_timeout_seconds = min(
+            timeout_seconds,
+            max(_DNS_RESULT_QUEUE_TIMEOUT_SECONDS, timeout_seconds - elapsed_seconds),
+        )
         try:
-            status, value = result_queue.get(timeout=0.1)
+            status, value = result_queue.get(timeout=result_timeout_seconds)
         except queue.Empty as exc:
             raise socket.gaierror(socket.EAI_FAIL, "DNS resolver returned no result") from exc
         if status == "gaierror":

--- a/src/worldforge/providers/runtime_manifests/runway.json
+++ b/src/worldforge/providers/runtime_manifests/runway.json
@@ -4,7 +4,11 @@
   "capabilities": ["generate", "transfer"],
   "optional_dependencies": [],
   "required_env_vars": ["RUNWAYML_API_SECRET", "RUNWAY_API_SECRET"],
-  "optional_env_vars": ["RUNWAYML_BASE_URL"],
+  "optional_env_vars": [
+    "RUNWAYML_BASE_URL",
+    "RUNWAYML_ALLOW_LOCAL_ARTIFACT_URLS",
+    "RUNWAYML_RESOLVE_ARTIFACT_DNS"
+  ],
   "default_model": "gen4.5",
   "device_support": ["remote"],
   "host_owned_artifacts": ["Runway task ids", "downloaded video artifacts", "artifact retention path"],

--- a/src/worldforge/providers/runway.py
+++ b/src/worldforge/providers/runway.py
@@ -20,7 +20,13 @@ from worldforge.models import (
     require_positive_int,
 )
 
-from ._config import ProviderConfigSummary, config_source, env_value, first_env_value
+from ._config import (
+    ProviderConfigSummary,
+    config_source,
+    env_value,
+    first_env_value,
+    optional_bool,
+)
 from .base import (
     ProviderError,
     ProviderProfileSpec,
@@ -34,11 +40,14 @@ from .http_utils import (
     clip_to_data_uri,
     request_bytes_with_policy,
     request_json_with_policy,
+    validate_remote_url,
 )
 
 _RUNWAY_API_VERSION = "2024-11-06"
 _RUNWAY_DEFAULT_RATIO = "1280:720"
 _RUNWAY_DEFAULT_DURATION = 5
+_RUNWAY_MAX_ARTIFACT_BYTES = 1024 * 1024 * 1024
+_RUNWAY_ALLOW_LOCAL_ARTIFACT_URLS_ENV_VAR = "RUNWAYML_ALLOW_LOCAL_ARTIFACT_URLS"
 
 
 def _parse_ratio(ratio: str) -> tuple[int, int]:
@@ -227,6 +236,8 @@ class RunwayProvider(RemoteProvider):
         request_policy: ProviderRequestPolicy | None = None,
         event_handler: Callable[[ProviderEvent], None] | None = None,
         transport: httpx.BaseTransport | None = None,
+        allow_local_artifact_urls: bool | str | None = None,
+        max_artifact_bytes: int = _RUNWAY_MAX_ARTIFACT_BYTES,
     ) -> None:
         resolved_request_policy = request_policy or ProviderRequestPolicy.remote_defaults(
             request_timeout_seconds=timeout_seconds
@@ -273,6 +284,18 @@ class RunwayProvider(RemoteProvider):
             raise ProviderError("Runway poll_interval_seconds must be non-negative.")
         self._max_polls = require_positive_int(max_polls, name="Runway max_polls")
         self._transport = transport
+        self._allow_local_artifact_urls_direct = allow_local_artifact_urls is not None
+        parsed_allow_local_artifacts = optional_bool(
+            allow_local_artifact_urls
+            if allow_local_artifact_urls is not None
+            else env_value(_RUNWAY_ALLOW_LOCAL_ARTIFACT_URLS_ENV_VAR),
+            name="Runway allow_local_artifact_urls",
+        )
+        self._allow_local_artifact_urls = bool(parsed_allow_local_artifacts)
+        self._max_artifact_bytes = require_positive_int(
+            max_artifact_bytes,
+            name="Runway max_artifact_bytes",
+        )
 
     def configured(self) -> bool:
         return bool(self._api_key())
@@ -304,6 +327,16 @@ class RunwayProvider(RemoteProvider):
                     required=False,
                     source=config_source("RUNWAYML_BASE_URL", default=True),
                     present=base_url_from_env,
+                ),
+                _field_summary(
+                    _RUNWAY_ALLOW_LOCAL_ARTIFACT_URLS_ENV_VAR,
+                    required=False,
+                    source=config_source(
+                        _RUNWAY_ALLOW_LOCAL_ARTIFACT_URLS_ENV_VAR,
+                        direct=self._allow_local_artifact_urls_direct,
+                    ),
+                    present=self._allow_local_artifact_urls_direct
+                    or env_value(_RUNWAY_ALLOW_LOCAL_ARTIFACT_URLS_ENV_VAR) is not None,
                 ),
             ),
         )
@@ -398,17 +431,25 @@ class RunwayProvider(RemoteProvider):
 
     def _download_output(self, output_url: str) -> bytes:
         request_policy = self._require_request_policy()
+        validated_output_url = validate_remote_url(
+            output_url,
+            provider_name=self.name,
+            url_name="artifact URL",
+            allow_local_network=self._allow_local_artifact_urls,
+            resolve_dns=self._transport is None,
+        )
         with httpx.Client(transport=self._transport) as client:
             try:
                 data = request_bytes_with_policy(
                     client,
                     method="GET",
-                    url=output_url,
+                    url=validated_output_url,
                     provider_name=self.name,
                     operation_name="artifact download",
                     policy=request_policy.download,
                     emit_event=self._emit_event,
                     accepted_content_types=("video/", "application/octet-stream"),
+                    max_bytes=self._max_artifact_bytes,
                 )
             except ProviderError as exc:
                 message = str(exc)

--- a/src/worldforge/providers/runway.py
+++ b/src/worldforge/providers/runway.py
@@ -357,7 +357,7 @@ class RunwayProvider(RemoteProvider):
                     ),
                     present=self._resolve_artifact_dns_direct
                     or env_value(_RUNWAY_RESOLVE_ARTIFACT_DNS_ENV_VAR) is not None,
-                    detail="auto" if self._resolve_artifact_dns is None else "",
+                    detail=self._artifact_dns_config_detail(),
                 ),
             ),
         )
@@ -487,6 +487,12 @@ class RunwayProvider(RemoteProvider):
         if self._resolve_artifact_dns is not None:
             return self._resolve_artifact_dns
         return self._transport is None or isinstance(self._transport, httpx.HTTPTransport)
+
+    def _artifact_dns_config_detail(self) -> str:
+        effective = str(self._should_resolve_artifact_dns()).lower()
+        if self._resolve_artifact_dns is None:
+            return f"auto; effective resolve_dns={effective}"
+        return f"effective resolve_dns={effective}"
 
     def generate(
         self,

--- a/src/worldforge/providers/runway.py
+++ b/src/worldforge/providers/runway.py
@@ -436,7 +436,7 @@ class RunwayProvider(RemoteProvider):
             provider_name=self.name,
             url_name="artifact URL",
             allow_local_network=self._allow_local_artifact_urls,
-            resolve_dns=self._transport is None,
+            resolve_dns=not isinstance(self._transport, httpx.MockTransport),
         )
         with httpx.Client(transport=self._transport) as client:
             try:

--- a/src/worldforge/providers/runway.py
+++ b/src/worldforge/providers/runway.py
@@ -48,6 +48,7 @@ _RUNWAY_DEFAULT_RATIO = "1280:720"
 _RUNWAY_DEFAULT_DURATION = 5
 _RUNWAY_MAX_ARTIFACT_BYTES = 1024 * 1024 * 1024
 _RUNWAY_ALLOW_LOCAL_ARTIFACT_URLS_ENV_VAR = "RUNWAYML_ALLOW_LOCAL_ARTIFACT_URLS"
+_RUNWAY_RESOLVE_ARTIFACT_DNS_ENV_VAR = "RUNWAYML_RESOLVE_ARTIFACT_DNS"
 
 
 def _parse_ratio(ratio: str) -> tuple[int, int]:
@@ -237,6 +238,7 @@ class RunwayProvider(RemoteProvider):
         event_handler: Callable[[ProviderEvent], None] | None = None,
         transport: httpx.BaseTransport | None = None,
         allow_local_artifact_urls: bool | str | None = None,
+        resolve_artifact_dns: bool | str | None = None,
         max_artifact_bytes: int = _RUNWAY_MAX_ARTIFACT_BYTES,
     ) -> None:
         resolved_request_policy = request_policy or ProviderRequestPolicy.remote_defaults(
@@ -292,6 +294,13 @@ class RunwayProvider(RemoteProvider):
             name="Runway allow_local_artifact_urls",
         )
         self._allow_local_artifact_urls = bool(parsed_allow_local_artifacts)
+        self._resolve_artifact_dns_direct = resolve_artifact_dns is not None
+        self._resolve_artifact_dns = optional_bool(
+            resolve_artifact_dns
+            if resolve_artifact_dns is not None
+            else env_value(_RUNWAY_RESOLVE_ARTIFACT_DNS_ENV_VAR),
+            name="Runway resolve_artifact_dns",
+        )
         self._max_artifact_bytes = require_positive_int(
             max_artifact_bytes,
             name="Runway max_artifact_bytes",
@@ -337,6 +346,18 @@ class RunwayProvider(RemoteProvider):
                     ),
                     present=self._allow_local_artifact_urls_direct
                     or env_value(_RUNWAY_ALLOW_LOCAL_ARTIFACT_URLS_ENV_VAR) is not None,
+                ),
+                _field_summary(
+                    _RUNWAY_RESOLVE_ARTIFACT_DNS_ENV_VAR,
+                    required=False,
+                    source=config_source(
+                        _RUNWAY_RESOLVE_ARTIFACT_DNS_ENV_VAR,
+                        direct=self._resolve_artifact_dns_direct,
+                        default=True,
+                    ),
+                    present=self._resolve_artifact_dns_direct
+                    or env_value(_RUNWAY_RESOLVE_ARTIFACT_DNS_ENV_VAR) is not None,
+                    detail="auto" if self._resolve_artifact_dns is None else "",
                 ),
             ),
         )
@@ -436,7 +457,7 @@ class RunwayProvider(RemoteProvider):
             provider_name=self.name,
             url_name="artifact URL",
             allow_local_network=self._allow_local_artifact_urls,
-            resolve_dns=not isinstance(self._transport, httpx.MockTransport),
+            resolve_dns=self._should_resolve_artifact_dns(),
         )
         with httpx.Client(transport=self._transport) as client:
             try:
@@ -461,6 +482,11 @@ class RunwayProvider(RemoteProvider):
         if not data:
             raise ProviderError(f"Provider '{self.name}' artifact download returned no bytes.")
         return data
+
+    def _should_resolve_artifact_dns(self) -> bool:
+        if self._resolve_artifact_dns is not None:
+            return self._resolve_artifact_dns
+        return self._transport is None or isinstance(self._transport, httpx.HTTPTransport)
 
     def generate(
         self,

--- a/tests/test_harness_flows.py
+++ b/tests/test_harness_flows.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import pytest
 
 from worldforge import WorldForge, WorldForgeError
+from worldforge.evaluation import EvaluationSuite
 from worldforge.harness import available_flows, flow_index, run_flow
 from worldforge.harness.flows import (
     benchmark_run_artifacts,

--- a/tests/test_harness_flows.py
+++ b/tests/test_harness_flows.py
@@ -8,7 +8,6 @@ from pathlib import Path
 import pytest
 
 from worldforge import WorldForge, WorldForgeError
-from worldforge.evaluation import EvaluationSuite
 from worldforge.harness import available_flows, flow_index, run_flow
 from worldforge.harness.flows import (
     benchmark_run_artifacts,

--- a/tests/test_remote_video_providers.py
+++ b/tests/test_remote_video_providers.py
@@ -7,7 +7,7 @@ import httpx
 import pytest
 
 from worldforge import GenerationOptions, ProviderEvent, ProviderRequestPolicy, VideoClip
-from worldforge.models import WorldForgeError
+from worldforge.models import JSONDict, WorldForgeError
 from worldforge.providers import CosmosProvider, ProviderError, RunwayProvider
 from worldforge.providers import http_utils as http_utils_module
 from worldforge.providers import runway as runway_module
@@ -860,10 +860,11 @@ def test_runway_provider_artifact_dns_policy_with_custom_transport(
 
 
 def test_runway_config_summary_reports_effective_artifact_dns_policy(monkeypatch) -> None:
+    monkeypatch.delenv("RUNWAYML_RESOLVE_ARTIFACT_DNS", raising=False)
     monkeypatch.setenv("RUNWAYML_API_SECRET", "runway-test-key")
 
     def artifact_dns_detail(provider: RunwayProvider) -> str:
-        summary = provider.config_summary().to_dict()
+        summary: JSONDict = provider.config_summary().to_dict()
         field = next(
             item for item in summary["fields"] if item["name"] == "RUNWAYML_RESOLVE_ARTIFACT_DNS"
         )

--- a/tests/test_remote_video_providers.py
+++ b/tests/test_remote_video_providers.py
@@ -973,6 +973,63 @@ def test_validate_remote_url_wraps_dns_worker_failures(monkeypatch) -> None:
         )
 
 
+def test_getaddrinfo_uses_bounded_result_queue_timeout(monkeypatch) -> None:
+    class CompletedProcess:
+        exitcode = 0
+
+        def start(self) -> None:
+            pass
+
+        def join(self, _timeout: float | None = None) -> None:
+            pass
+
+        def is_alive(self) -> bool:
+            return False
+
+        def terminate(self) -> None:
+            raise AssertionError("completed process should not be terminated")
+
+    class ResultQueue:
+        timeout_seen: float | None = None
+
+        def get(self, *, timeout: float) -> tuple[str, list[str]]:
+            self.timeout_seen = timeout
+            return ("ok", ["93.184.216.34"])
+
+        def close(self) -> None:
+            pass
+
+        def join_thread(self) -> None:
+            pass
+
+    class CompletedContext:
+        def __init__(self) -> None:
+            self.queue = ResultQueue()
+
+        def Queue(self, *args: object, **kwargs: object) -> ResultQueue:
+            del args, kwargs
+            return self.queue
+
+        def Process(self, *args: object, **kwargs: object) -> CompletedProcess:
+            del args, kwargs
+            return CompletedProcess()
+
+    context = CompletedContext()
+
+    def fake_get_context(_method: str) -> CompletedContext:
+        return context
+
+    monkeypatch.setattr(http_utils_module.multiprocessing, "get_context", fake_get_context)
+
+    assert http_utils_module._getaddrinfo_with_timeout(
+        "downloads.example.com",
+        443,
+        timeout_seconds=2.0,
+    ) == ["93.184.216.34"]
+    assert context.queue.timeout_seen is not None
+    assert context.queue.timeout_seen >= 1.0
+
+
 def test_runway_provider_rejects_provider_specific_limits(monkeypatch) -> None:
     monkeypatch.setenv("RUNWAYML_API_SECRET", "runway-test-key")
 

--- a/tests/test_remote_video_providers.py
+++ b/tests/test_remote_video_providers.py
@@ -790,7 +790,19 @@ def test_runway_provider_rejects_artifacts_over_size_limit(monkeypatch) -> None:
         provider.generate("a rainy alley at night", duration_seconds=4.0)
 
 
-def test_runway_provider_resolves_artifact_dns_with_custom_transport(monkeypatch) -> None:
+@pytest.mark.parametrize(
+    ("resolve_artifact_dns", "expected_resolve_dns"),
+    (
+        (None, False),
+        (True, True),
+        (False, False),
+    ),
+)
+def test_runway_provider_artifact_dns_policy_with_custom_transport(
+    monkeypatch,
+    resolve_artifact_dns: bool | None,
+    expected_resolve_dns: bool,
+) -> None:
     monkeypatch.setenv("RUNWAYML_API_SECRET", "runway-test-key")
     artifact_url = "https://downloads.example.com/generated.mp4"
     resolve_dns_values: list[bool] = []
@@ -830,17 +842,21 @@ def test_runway_provider_resolves_artifact_dns_with_custom_transport(monkeypatch
         return url
 
     monkeypatch.setattr(runway_module, "validate_remote_url", capture_validate_remote_url)
+    kwargs = {}
+    if resolve_artifact_dns is not None:
+        kwargs["resolve_artifact_dns"] = resolve_artifact_dns
 
     provider = RunwayProvider(
         transport=CustomTransport(),
         poll_interval_seconds=0.0,
         max_polls=1,
+        **kwargs,
     )
 
     generated = provider.generate("a rainy alley at night", duration_seconds=4.0)
 
     assert generated.blob() == b"artifact"
-    assert resolve_dns_values == [True]
+    assert resolve_dns_values == [expected_resolve_dns]
 
 
 def test_request_bytes_with_policy_caps_streamed_body_without_content_length() -> None:

--- a/tests/test_remote_video_providers.py
+++ b/tests/test_remote_video_providers.py
@@ -973,7 +973,7 @@ def test_validate_remote_url_wraps_dns_worker_failures(monkeypatch) -> None:
         )
 
 
-def test_getaddrinfo_uses_bounded_result_queue_timeout(monkeypatch) -> None:
+def test_getaddrinfo_caps_result_queue_timeout_to_remaining_budget(monkeypatch) -> None:
     class CompletedProcess:
         exitcode = 0
 
@@ -995,6 +995,9 @@ def test_getaddrinfo_uses_bounded_result_queue_timeout(monkeypatch) -> None:
         def get(self, *, timeout: float) -> tuple[str, list[str]]:
             self.timeout_seen = timeout
             return ("ok", ["93.184.216.34"])
+
+        def get_nowait(self) -> tuple[str, list[str]]:
+            raise AssertionError("remaining budget should allow a bounded blocking read")
 
         def close(self) -> None:
             pass
@@ -1020,14 +1023,19 @@ def test_getaddrinfo_uses_bounded_result_queue_timeout(monkeypatch) -> None:
         return context
 
     monkeypatch.setattr(http_utils_module.multiprocessing, "get_context", fake_get_context)
+    perf_counter_values = iter([100.0, 101.75])
+    monkeypatch.setattr(
+        http_utils_module,
+        "perf_counter",
+        lambda: next(perf_counter_values),
+    )
 
     assert http_utils_module._getaddrinfo_with_timeout(
         "downloads.example.com",
         443,
         timeout_seconds=2.0,
     ) == ["93.184.216.34"]
-    assert context.queue.timeout_seen is not None
-    assert context.queue.timeout_seen >= 1.0
+    assert context.queue.timeout_seen == pytest.approx(0.25)
 
 
 def test_runway_provider_rejects_provider_specific_limits(monkeypatch) -> None:

--- a/tests/test_remote_video_providers.py
+++ b/tests/test_remote_video_providers.py
@@ -859,6 +859,29 @@ def test_runway_provider_artifact_dns_policy_with_custom_transport(
     assert resolve_dns_values == [expected_resolve_dns]
 
 
+def test_runway_config_summary_reports_effective_artifact_dns_policy(monkeypatch) -> None:
+    monkeypatch.setenv("RUNWAYML_API_SECRET", "runway-test-key")
+
+    def artifact_dns_detail(provider: RunwayProvider) -> str:
+        summary = provider.config_summary().to_dict()
+        field = next(
+            item for item in summary["fields"] if item["name"] == "RUNWAYML_RESOLVE_ARTIFACT_DNS"
+        )
+        return str(field["detail"])
+
+    assert artifact_dns_detail(RunwayProvider()) == "auto; effective resolve_dns=true"
+    assert (
+        artifact_dns_detail(
+            RunwayProvider(transport=httpx.MockTransport(lambda request: httpx.Response(500)))
+        )
+        == "auto; effective resolve_dns=false"
+    )
+    assert (
+        artifact_dns_detail(RunwayProvider(resolve_artifact_dns=False))
+        == "effective resolve_dns=false"
+    )
+
+
 def test_request_bytes_with_policy_caps_streamed_body_without_content_length() -> None:
     def handler(request: httpx.Request) -> httpx.Response:
         return httpx.Response(200, stream=httpx.ByteStream(b"abcdef"))

--- a/tests/test_remote_video_providers.py
+++ b/tests/test_remote_video_providers.py
@@ -9,6 +9,7 @@ import pytest
 from worldforge import GenerationOptions, ProviderEvent, ProviderRequestPolicy, VideoClip
 from worldforge.models import WorldForgeError
 from worldforge.providers import CosmosProvider, ProviderError, RunwayProvider
+from worldforge.providers.http_utils import request_bytes_with_policy, validate_remote_url
 from worldforge.testing import assert_provider_contract
 
 _FIXTURE_DIR = Path(__file__).parent / "fixtures" / "providers"
@@ -682,6 +683,143 @@ def test_runway_provider_rejects_expired_artifacts_and_bad_content_types(monkeyp
     )
     with pytest.raises(ProviderError, match="unsupported content type"):
         provider.generate("a rainy alley at night", duration_seconds=4.0)
+
+
+@pytest.mark.parametrize(
+    "artifact_url",
+    [
+        "http://127.0.0.1:8777/generated.mp4",
+        "http://localhost:8777/generated.mp4",
+        "http://169.254.169.254/latest/meta-data",
+        "ftp://downloads.example.com/generated.mp4",
+        "https://user:pass@downloads.example.com/generated.mp4",
+    ],
+)
+def test_runway_provider_rejects_unsafe_artifact_urls(monkeypatch, artifact_url: str) -> None:
+    monkeypatch.setenv("RUNWAYML_API_SECRET", "runway-test-key")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "POST" and request.url.path == "/v1/image_to_video":
+            return httpx.Response(200, json=_fixture("runway_create_success.json"))
+        if request.method == "GET" and request.url.path == "/v1/tasks/task_generate":
+            return httpx.Response(
+                200,
+                json={
+                    "id": "task_generate",
+                    "status": "SUCCEEDED",
+                    "output": [artifact_url],
+                },
+            )
+        raise AssertionError(f"Unexpected request after artifact validation: {request.url}")
+
+    provider = RunwayProvider(
+        transport=httpx.MockTransport(handler),
+        poll_interval_seconds=0.0,
+        max_polls=1,
+    )
+
+    with pytest.raises(ProviderError, match="artifact URL"):
+        provider.generate("a rainy alley at night", duration_seconds=4.0)
+
+
+def test_runway_provider_allows_local_artifact_urls_only_when_explicit(monkeypatch) -> None:
+    monkeypatch.setenv("RUNWAYML_API_SECRET", "runway-test-key")
+    artifact_url = "http://127.0.0.1:8777/generated.mp4"
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "POST" and request.url.path == "/v1/image_to_video":
+            return httpx.Response(200, json=_fixture("runway_create_success.json"))
+        if request.method == "GET" and request.url.path == "/v1/tasks/task_generate":
+            return httpx.Response(
+                200,
+                json={
+                    "id": "task_generate",
+                    "status": "SUCCEEDED",
+                    "output": [artifact_url],
+                },
+            )
+        if request.method == "GET" and request.url.host == "127.0.0.1":
+            return httpx.Response(200, content=b"local-artifact")
+        raise AssertionError(f"Unexpected request: {request.method} {request.url}")
+
+    provider = RunwayProvider(
+        transport=httpx.MockTransport(handler),
+        poll_interval_seconds=0.0,
+        max_polls=1,
+        allow_local_artifact_urls=True,
+    )
+
+    generated = provider.generate("a rainy alley at night", duration_seconds=4.0)
+
+    assert generated.blob() == b"local-artifact"
+
+
+def test_runway_provider_rejects_artifacts_over_size_limit(monkeypatch) -> None:
+    monkeypatch.setenv("RUNWAYML_API_SECRET", "runway-test-key")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "POST" and request.url.path == "/v1/image_to_video":
+            return httpx.Response(200, json=_fixture("runway_create_success.json"))
+        if request.method == "GET" and request.url.path == "/v1/tasks/task_generate":
+            return httpx.Response(
+                200,
+                json={
+                    "id": "task_generate",
+                    "status": "SUCCEEDED",
+                    "output": ["https://downloads.example.com/generated.mp4"],
+                },
+            )
+        if request.method == "GET" and request.url.host == "downloads.example.com":
+            return httpx.Response(
+                200,
+                content=b"too-large",
+                headers={"content-length": "9", "content-type": "video/mp4"},
+            )
+        raise AssertionError(f"Unexpected request: {request.method} {request.url}")
+
+    provider = RunwayProvider(
+        transport=httpx.MockTransport(handler),
+        poll_interval_seconds=0.0,
+        max_polls=1,
+        max_artifact_bytes=8,
+    )
+
+    with pytest.raises(ProviderError, match="download size limit"):
+        provider.generate("a rainy alley at night", duration_seconds=4.0)
+
+
+def test_request_bytes_with_policy_caps_streamed_body_without_content_length() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, stream=httpx.ByteStream(b"abcdef"))
+
+    with (
+        httpx.Client(transport=httpx.MockTransport(handler)) as client,
+        pytest.raises(ProviderError, match="download size limit"),
+    ):
+        request_bytes_with_policy(
+            client,
+            method="GET",
+            url="https://downloads.example.com/generated.mp4",
+            provider_name="runway",
+            operation_name="artifact download",
+            policy=ProviderRequestPolicy.remote_defaults(
+                request_timeout_seconds=30.0,
+                read_retry_attempts=1,
+            ).download,
+            max_bytes=5,
+        )
+
+
+def test_validate_remote_url_allows_public_https_without_dns_resolution() -> None:
+    assert (
+        validate_remote_url(
+            "https://downloads.example.com/generated.mp4?signature=temporary",
+            provider_name="runway",
+            url_name="artifact URL",
+            resolve_dns=False,
+        )
+        == "https://downloads.example.com/generated.mp4?signature=temporary"
+    )
 
 
 def test_runway_provider_rejects_provider_specific_limits(monkeypatch) -> None:

--- a/tests/test_remote_video_providers.py
+++ b/tests/test_remote_video_providers.py
@@ -959,6 +959,20 @@ def test_validate_remote_url_allows_public_https_without_dns_resolution() -> Non
     )
 
 
+def test_validate_remote_url_wraps_dns_worker_failures(monkeypatch) -> None:
+    def fail_resolution(*_args: object, **_kwargs: object) -> list[str]:
+        raise RuntimeError("resolver worker failed")
+
+    monkeypatch.setattr(http_utils_module, "_getaddrinfo_with_timeout", fail_resolution)
+
+    with pytest.raises(ProviderError, match="host resolution failed"):
+        validate_remote_url(
+            "https://downloads.example.com/generated.mp4",
+            provider_name="runway",
+            url_name="artifact URL",
+        )
+
+
 def test_runway_provider_rejects_provider_specific_limits(monkeypatch) -> None:
     monkeypatch.setenv("RUNWAYML_API_SECRET", "runway-test-key")
 

--- a/tests/test_remote_video_providers.py
+++ b/tests/test_remote_video_providers.py
@@ -9,6 +9,8 @@ import pytest
 from worldforge import GenerationOptions, ProviderEvent, ProviderRequestPolicy, VideoClip
 from worldforge.models import WorldForgeError
 from worldforge.providers import CosmosProvider, ProviderError, RunwayProvider
+from worldforge.providers import http_utils as http_utils_module
+from worldforge.providers import runway as runway_module
 from worldforge.providers.http_utils import request_bytes_with_policy, validate_remote_url
 from worldforge.testing import assert_provider_contract
 
@@ -788,6 +790,59 @@ def test_runway_provider_rejects_artifacts_over_size_limit(monkeypatch) -> None:
         provider.generate("a rainy alley at night", duration_seconds=4.0)
 
 
+def test_runway_provider_resolves_artifact_dns_with_custom_transport(monkeypatch) -> None:
+    monkeypatch.setenv("RUNWAYML_API_SECRET", "runway-test-key")
+    artifact_url = "https://downloads.example.com/generated.mp4"
+    resolve_dns_values: list[bool] = []
+
+    class CustomTransport(httpx.BaseTransport):
+        def handle_request(self, request: httpx.Request) -> httpx.Response:
+            if request.method == "POST" and request.url.path == "/v1/image_to_video":
+                return httpx.Response(200, json=_fixture("runway_create_success.json"))
+            if request.method == "GET" and request.url.path == "/v1/tasks/task_generate":
+                return httpx.Response(
+                    200,
+                    json={
+                        "id": "task_generate",
+                        "status": "SUCCEEDED",
+                        "output": [artifact_url],
+                    },
+                )
+            if request.method == "GET" and request.url.host == "downloads.example.com":
+                return httpx.Response(
+                    200,
+                    content=b"artifact",
+                    headers={"content-type": "video/mp4"},
+                )
+            raise AssertionError(f"Unexpected request: {request.method} {request.url}")
+
+    def capture_validate_remote_url(
+        url: str,
+        *,
+        provider_name: str,
+        url_name: str,
+        allow_local_network: bool = False,
+        resolve_dns: bool = True,
+        dns_resolution_timeout_seconds: float = 2.0,
+    ) -> str:
+        del provider_name, url_name, allow_local_network, dns_resolution_timeout_seconds
+        resolve_dns_values.append(resolve_dns)
+        return url
+
+    monkeypatch.setattr(runway_module, "validate_remote_url", capture_validate_remote_url)
+
+    provider = RunwayProvider(
+        transport=CustomTransport(),
+        poll_interval_seconds=0.0,
+        max_polls=1,
+    )
+
+    generated = provider.generate("a rainy alley at night", duration_seconds=4.0)
+
+    assert generated.blob() == b"artifact"
+    assert resolve_dns_values == [True]
+
+
 def test_request_bytes_with_policy_caps_streamed_body_without_content_length() -> None:
     def handler(request: httpx.Request) -> httpx.Response:
         return httpx.Response(200, stream=httpx.ByteStream(b"abcdef"))
@@ -808,6 +863,48 @@ def test_request_bytes_with_policy_caps_streamed_body_without_content_length() -
             ).download,
             max_bytes=5,
         )
+
+
+def test_request_bytes_with_policy_closes_retry_stream_before_backoff(monkeypatch) -> None:
+    events: list[str] = []
+    attempts = 0
+
+    class ObservedRetryStream(httpx.SyncByteStream):
+        def __iter__(self):
+            yield b"retry later"
+
+        def close(self) -> None:
+            events.append("closed")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            return httpx.Response(503, stream=ObservedRetryStream())
+        return httpx.Response(200, content=b"ok")
+
+    def record_sleep(delay: float) -> None:
+        del delay
+        events.append("sleep")
+
+    monkeypatch.setattr(http_utils_module, "sleep", record_sleep)
+
+    with httpx.Client(transport=httpx.MockTransport(handler)) as client:
+        data = request_bytes_with_policy(
+            client,
+            method="GET",
+            url="https://downloads.example.com/generated.mp4",
+            provider_name="runway",
+            operation_name="artifact download",
+            policy=ProviderRequestPolicy.remote_defaults(
+                request_timeout_seconds=30.0,
+                read_retry_attempts=2,
+            ).download,
+        )
+
+    assert data == b"ok"
+    assert attempts == 2
+    assert events == ["closed", "sleep"]
 
 
 def test_validate_remote_url_allows_public_https_without_dns_resolution() -> None:


### PR DESCRIPTION
Summary
- validate provider-controlled artifact URLs before download, including scheme, credentials, query/fragment handling, redirects, and private/local/link-local destinations
- stream remote artifact downloads with a hard byte cap instead of buffering the full response into memory
- wire the guarded download path into Runway artifacts, expose the effective artifact-DNS policy, and document the operator knobs
- keep provider events and returned metadata sanitized so signed artifact URLs do not leak through diagnostics

Why this matters
Before this, a provider-controlled artifact URL could make the operator host fetch local/internal services or force an unbounded artifact response into memory before WorldForge had a chance to reject it. This moves remote artifact handling behind a shared provider-boundary guard before content processing.

Validation
- uv lock --check
- uv run ruff check src tests examples scripts
- uv run ruff format --check src tests examples scripts
- uv run python scripts/generate_provider_docs.py --check
- uv run python scripts/check_docs_commands.py
- uv run python scripts/check_wrapper_portability.py
- uv run python scripts/check_core_performance.py
- uv run mkdocs build --strict
- uv run pytest -q (787 passed, 79 skipped)