### PR TITLE
Add Cosmos-Policy harness flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,8 +62,8 @@ evaluation harnesses, and testable prototypes.
   failure lab, and cookbook workflows.
 - `src/worldforge/harness/`: optional TheWorldHarness TUI package. Keep flow metadata and runners
   independent from Textual; `tui.py` is the only Textual-dependent module. Current flows cover
-  LeWorldModel score planning, LeRobot policy-plus-score planning, and provider diagnostics plus
-  benchmark comparison.
+  LeWorldModel score planning, LeRobot policy-plus-score planning, Cosmos-Policy ALOHA replay,
+  provider diagnostics plus benchmark comparison, and the adapter author workbench.
 - `src/worldforge/smoke/`: packaged optional-runtime smoke entry points exposed through `uv run`
   console scripts.
 - `src/worldforge/smoke/lerobot_leworldmodel.py`: optional host-owned real robotics showcase that

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ world editing, and saved report previews through the `harness` extra.
 ```bash
 uv run --extra harness worldforge-harness
 uv run --extra harness worldforge-harness --flow lerobot
+uv run --extra harness worldforge-harness --flow cosmos-policy
 uv run --extra harness worldforge-harness --flow diagnostics
 ```
 

--- a/docs/src/cli.md
+++ b/docs/src/cli.md
@@ -127,7 +127,9 @@ paper, or public claim.
 uv run --extra harness worldforge-harness
 uv run --extra harness worldforge-harness --flow leworldmodel
 uv run --extra harness worldforge-harness --flow lerobot
+uv run --extra harness worldforge-harness --flow cosmos-policy
 uv run --extra harness worldforge-harness --flow diagnostics
+uv run --extra harness worldforge-harness --flow workbench
 uv run --extra harness worldforge-harness --flow runs
 uv run worldforge harness --list
 uv run worldforge harness --connectors --format json

--- a/docs/src/cli.md
+++ b/docs/src/cli.md
@@ -142,6 +142,13 @@ benchmarks. The connector and run-history metadata commands are checkout-safe an
 Textual; they report provider readiness, preserved-run filters, sanitized rerun commands, and first
 recovery actions without printing secret values.
 
+Expected success signal: the selected flow reaches a completed run workspace and the inspector
+shows its saved artifact paths. For `cosmos-policy`, the replay should report
+`raw_action_shape: [50, 14]`, `translated_actions: 50`, and
+`saved_replay_artifact: artifacts/cosmos-policy-replay.json`. First triage step: open the saved
+run workspace and inspect `logs/provider-events.jsonl` plus `artifacts/cosmos-policy-replay.json`;
+for live-provider readiness checks, run `uv run worldforge harness --connectors --format json`.
+
 ## Packaged Demos
 
 Checkout-safe demos use injected deterministic runtimes:

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -39,7 +39,9 @@ provider workflows.
 ```bash
 uv run --extra harness worldforge-harness
 uv run --extra harness worldforge-harness --flow lerobot
+uv run --extra harness worldforge-harness --flow cosmos-policy
 uv run --extra harness worldforge-harness --flow diagnostics
+uv run --extra harness worldforge-harness --flow workbench
 uv run worldforge harness --list
 ```
 
@@ -52,7 +54,9 @@ Available flows:
 | --- | --- |
 | `leworldmodel` | Visual score-planning path through the LeWorldModel provider surface. |
 | `lerobot` | Visual policy-plus-score path through the LeRobot provider surface. |
+| `cosmos-policy` | Visual saved ALOHA `/act` replay through the Cosmos-Policy provider surface. |
 | `diagnostics` | Visual provider diagnostics and benchmark comparison path. |
+| `workbench` | Visual provider-authoring evidence path for adapter promotion work. |
 
 ## Rerun Recording
 

--- a/docs/src/theworldharness.md
+++ b/docs/src/theworldharness.md
@@ -64,6 +64,13 @@ dependencies at package import time.
 | `diagnostics` | provider catalog plus benchmark harness | `doctor()` provider scan, registered/unregistered provider status, mock benchmark matrix across predict/reason/generate/transfer/embed, latency/throughput comparison, provider events. |
 | `workbench` | provider authoring | Checkout-safe provider workbench evidence for stable and candidate adapters, promotion gaps, safe artifacts, and validation commands. |
 
+For the Cosmos replay, run
+`uv run --extra harness worldforge-harness --flow cosmos-policy`. A good run reports
+`raw_action_shape: [50, 14]`, `translated_actions: 50`, and
+`saved_replay_artifact: artifacts/cosmos-policy-replay.json`. If it fails, start with the preserved
+run workspace: inspect `logs/provider-events.jsonl` for the provider phase and
+`artifacts/cosmos-policy-replay.json` for the saved request/response/translated-action artifact.
+
 ## Provider Connector Workspace
 
 The Providers screen and `worldforge harness --connectors --format json` use the same

--- a/docs/src/theworldharness.md
+++ b/docs/src/theworldharness.md
@@ -21,7 +21,9 @@ Textual is optional. The base package keeps `httpx` as its only runtime dependen
 ```bash
 uv run --extra harness worldforge-harness
 uv run --extra harness worldforge-harness --flow lerobot
+uv run --extra harness worldforge-harness --flow cosmos-policy
 uv run --extra harness worldforge-harness --flow diagnostics
+uv run --extra harness worldforge-harness --flow workbench
 uv run --extra harness worldforge-harness --flow eval
 uv run --extra harness worldforge-harness --flow benchmark
 uv run --extra harness worldforge-harness --flow runs
@@ -58,7 +60,9 @@ dependencies at package import time.
 | --- | --- | --- |
 | `leworldmodel` | `score` | Deterministic LeWorldModel-shaped cost runtime, candidate scoring, score planning, execution, persistence, reload, provider events. |
 | `lerobot` | `policy` plus score provider | Deterministic LeRobot-shaped policy, action translation, policy candidate ranking, execution, persistence, reload, provider events. |
+| `cosmos-policy` | `policy` | Saved Cosmos-Policy ALOHA `/act` replay through the real provider adapter, json_numpy 50 x 14 action validation, action translation, provider events, and a sanitized replay artifact. |
 | `diagnostics` | provider catalog plus benchmark harness | `doctor()` provider scan, registered/unregistered provider status, mock benchmark matrix across predict/reason/generate/transfer/embed, latency/throughput comparison, provider events. |
+| `workbench` | provider authoring | Checkout-safe provider workbench evidence for stable and candidate adapters, promotion gaps, safe artifacts, and validation commands. |
 
 ## Provider Connector Workspace
 
@@ -204,7 +208,9 @@ provider health, benchmark latency, benchmark throughput, and provider event pha
 - `r`: run the selected flow.
 - `1`: select LeWorldModel score planning.
 - `2`: select LeRobot policy-plus-score planning.
-- `3`: select provider diagnostics and benchmark comparison.
+- `3`: select Cosmos-Policy ALOHA replay.
+- `4`: select provider diagnostics and benchmark comparison.
+- `5`: select adapter author workbench.
 - `g w`: jump to Worlds.
 - `g p`: jump to Providers.
 - `g e`: jump to Eval.

--- a/src/worldforge/harness/flows.py
+++ b/src/worldforge/harness/flows.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import base64
 import json
+import struct
 import tempfile
 from collections.abc import Callable, Sequence
 from datetime import UTC, datetime
@@ -54,6 +56,21 @@ FLOWS: tuple[HarnessFlow, ...] = (
         ),
     ),
     HarnessFlow(
+        id="cosmos-policy",
+        title="Cosmos-Policy ALOHA Replay",
+        short_title="Cosmos",
+        focus="saved ALOHA /act replay",
+        provider="CosmosPolicyProvider",
+        capability="policy",
+        command="uv run --extra harness worldforge-harness --flow cosmos-policy",
+        accent="#74d7f7",
+        summary=(
+            "Replay a sanitized NVIDIA Cosmos-Policy ALOHA /act response through the real "
+            "provider boundary, decode 50 x 14 json_numpy actions, translate them, and preserve "
+            "an inspectable run artifact without requiring a live GPU."
+        ),
+    ),
+    HarnessFlow(
         id="diagnostics",
         title="Provider Diagnostics + Benchmark",
         short_title="Diagnostics",
@@ -82,6 +99,20 @@ FLOWS: tuple[HarnessFlow, ...] = (
             "artifact references, and validation commands."
         ),
     ),
+)
+
+_COSMOS_POLICY_REPLAY_BASE_URL = "http://93.184.216.34"
+_COSMOS_POLICY_MODEL = "nvidia/Cosmos-Policy-ALOHA-Predict2-2B"
+_COSMOS_POLICY_ACTION_HORIZON = 50
+_COSMOS_POLICY_ACTION_DIM = 14
+_COSMOS_POLICY_VALUE_PREDICTION = 0.190714
+_COSMOS_POLICY_PREVIEW_ROWS = (
+    (0.01227, -0.02509, -0.00844, -0.04266, 0.05760, 0.01356),
+    (0.00180, -0.02080, -0.01734, -0.03035, 0.05673, 0.00983),
+    (0.01250, -0.02521, -0.00710, -0.04928, 0.05478, 0.01556),
+    (0.00418, -0.02012, -0.01506, -0.03610, 0.06206, 0.01546),
+    (0.01023, -0.02691, -0.01081, -0.05677, 0.06027, 0.01551),
+    (0.00377, -0.02269, -0.01370, -0.04925, 0.06735, 0.01213),
 )
 
 
@@ -185,6 +216,181 @@ def _run_workbench_demo(*, state_dir: Path, emit: bool = False) -> JSONDict:
     return summary
 
 
+def _run_cosmos_policy_demo(*, state_dir: Path, emit: bool = False) -> JSONDict:
+    import httpx
+
+    from worldforge.models import Action
+    from worldforge.providers import CosmosPolicyProvider
+
+    events: list[ProviderEvent] = []
+    request_count = 0
+    raw_rows = _cosmos_policy_action_rows()
+    encoded_rows = [_json_numpy_action_row(row) for row in raw_rows]
+    policy_info = _cosmos_policy_policy_info()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal request_count
+        request_count += 1
+        payload = json.loads(request.content.decode("utf-8"))
+        assert request.method == "POST"
+        assert request.url.path == "/act"
+        assert payload.get("action_horizon") == _COSMOS_POLICY_ACTION_HORIZON
+        return httpx.Response(
+            200,
+            json={
+                "actions": encoded_rows,
+                "value_prediction": _COSMOS_POLICY_VALUE_PREDICTION,
+                "future_image_predictions": {
+                    "summary": "omitted from checkout-safe replay artifact",
+                    "source": "sanitized-live-shape",
+                },
+            },
+        )
+
+    def translator(raw_actions: object, _info: JSONDict, _provider_info: JSONDict):
+        assert isinstance(raw_actions, dict)
+        matrix = raw_actions.get("actions")
+        assert isinstance(matrix, list)
+        return [
+            Action.move_to(float(row[0]), float(row[1]), float(row[2]))
+            for row in matrix
+            if isinstance(row, list)
+        ]
+
+    provider = CosmosPolicyProvider(
+        base_url=_COSMOS_POLICY_REPLAY_BASE_URL,
+        model=_COSMOS_POLICY_MODEL,
+        transport=httpx.MockTransport(handler),
+        action_translator=translator,
+        event_handler=events.append,
+    )
+    forge = WorldForge(state_dir=state_dir, auto_register_remote=False)
+    forge.register_provider(provider)
+    health = provider.health()
+    result = forge.select_actions("cosmos-policy", info=policy_info)
+    metadata = result.metadata
+    provider_info = metadata.get("provider_info", {})
+    raw_action_summary = metadata.get("raw_action_summary", {})
+    raw_actions = result.raw_actions.get("actions", [])
+    raw_action_shape = list(raw_action_summary.get("actions_shape", []))
+    selected_action_preview = [action.to_dict() for action in result.actions[:6]]
+    raw_action_preview = _preview_action_rows(raw_actions)
+    replay_artifact = {
+        "schema_version": 1,
+        "source": "sanitized Cosmos-Policy smoke shape replay",
+        "provider": result.provider,
+        "model": metadata.get("model"),
+        "server_path": metadata.get("server_path"),
+        "runtime": metadata.get("runtime"),
+        "task_description": metadata.get("task_description"),
+        "request": {
+            "observation_fields": sorted(policy_info["observation"]),
+            "proprio_dim": len(policy_info["observation"]["proprio"]),
+            "action_horizon": policy_info["action_horizon"],
+            "embodiment_tag": policy_info["embodiment_tag"],
+        },
+        "response": {
+            "json_numpy_rows": True,
+            "raw_action_shape": raw_action_shape,
+            "value_prediction": provider_info.get("value_prediction"),
+            "translated_action_count": len(result.actions),
+            "raw_action_preview": raw_action_preview,
+            "selected_action_preview": selected_action_preview,
+        },
+    }
+    summary: JSONDict = {
+        "demo_kind": "cosmos_policy_saved_replay",
+        "state_dir": str(state_dir),
+        "providers": [result.provider],
+        "model": metadata.get("model"),
+        "task_description": metadata.get("task_description"),
+        "runtime": metadata.get("runtime"),
+        "server_path": metadata.get("server_path"),
+        "runtime_contract": "saved /act replay through CosmosPolicyProvider",
+        "health": health.to_dict(),
+        "request_count": request_count,
+        "raw_action_shape": raw_action_shape,
+        "translated_action_count": len(result.actions),
+        "action_horizon": result.action_horizon,
+        "selected_candidate_index": metadata.get("selected_candidate_index"),
+        "candidate_count": metadata.get("candidate_count"),
+        "value_prediction": provider_info.get("value_prediction"),
+        "selected_actions": [action.to_dict() for action in result.actions],
+        "selected_action_preview": selected_action_preview,
+        "raw_action_preview": raw_action_preview,
+        "event_phases": [event.phase for event in events],
+        "provider_events": [event.to_dict() for event in events],
+        "harness_artifacts": {
+            "cosmos_policy_replay": {
+                "path": "artifacts/cosmos-policy-replay.json",
+                "payload": replay_artifact,
+            },
+        },
+    }
+    if emit:
+        print("\n".join(_transcript_for("cosmos-policy", summary)))
+    return summary
+
+
+def _cosmos_policy_policy_info() -> JSONDict:
+    return {
+        "observation": {
+            "primary_image": [[[[0, 0, 0]]]],
+            "left_wrist_image": [[[[1, 1, 1]]]],
+            "right_wrist_image": [[[[2, 2, 2]]]],
+            "proprio": [0.0 for _ in range(_COSMOS_POLICY_ACTION_DIM)],
+        },
+        "task_description": "fold shirt",
+        "embodiment_tag": "aloha",
+        "action_horizon": _COSMOS_POLICY_ACTION_HORIZON,
+    }
+
+
+def _cosmos_policy_action_rows() -> list[list[float]]:
+    rows: list[list[float]] = []
+    for index in range(_COSMOS_POLICY_ACTION_HORIZON):
+        if index < len(_COSMOS_POLICY_PREVIEW_ROWS):
+            prefix = list(_COSMOS_POLICY_PREVIEW_ROWS[index])
+        else:
+            prefix = [
+                _bounded_action_value(index, dimension)
+                for dimension in range(len(_COSMOS_POLICY_PREVIEW_ROWS[0]))
+            ]
+        row = list(prefix)
+        row.extend(
+            _bounded_action_value(index, dimension)
+            for dimension in range(len(prefix), _COSMOS_POLICY_ACTION_DIM)
+        )
+        rows.append(row)
+    return rows
+
+
+def _bounded_action_value(index: int, dimension: int) -> float:
+    magnitude = ((index * 17 + dimension * 31) % 90 + 5) / 1500.0
+    sign = -1.0 if dimension in {1, 2, 3, 6, 8, 11, 13} else 1.0
+    return round(sign * magnitude, 5)
+
+
+def _json_numpy_action_row(row: Sequence[float]) -> JSONDict:
+    raw = struct.pack(f"<{_COSMOS_POLICY_ACTION_DIM}f", *row)
+    return {
+        "__numpy__": base64.b64encode(raw).decode("ascii"),
+        "dtype": "<f4",
+        "shape": [_COSMOS_POLICY_ACTION_DIM],
+    }
+
+
+def _preview_action_rows(rows: object, *, limit: int = 6, columns: int = 6) -> list[list[float]]:
+    if not isinstance(rows, list):
+        return []
+    preview: list[list[float]] = []
+    for row in rows[:limit]:
+        if not isinstance(row, list):
+            continue
+        preview.append([round(float(value), 5) for value in row[:columns]])
+    return preview
+
+
 # Demo modules import the optional-runtime provider classes at module scope, so
 # keep these imports lazy: loading the harness should not pull LeRobot/LeWorldModel
 # adapters into the base cold-start path.
@@ -203,6 +409,7 @@ def _run_lerobot_demo(**kwargs: object) -> JSONDict:
 _RUNNERS: dict[str, FlowRunner] = {
     "leworldmodel": _run_leworldmodel_demo,
     "lerobot": _run_lerobot_demo,
+    "cosmos-policy": _run_cosmos_policy_demo,
     "diagnostics": _run_diagnostics_demo,
     "workbench": _run_workbench_demo,
 }
@@ -665,6 +872,7 @@ def _write_flow_workspace(workspace: RunWorkspace, run: HarnessRun) -> None:
         "transcript": str(transcript_path.relative_to(workspace.path)),
         "inspector": str(inspector_path.relative_to(workspace.path)),
     }
+    artifact_paths.update(_write_flow_artifacts(workspace, run.summary))
     write_run_manifest(
         workspace,
         kind="flow",
@@ -694,6 +902,25 @@ def _inspector_payload(run: HarnessRun) -> JSONDict:
         "validation_errors": list(run.validation_errors),
         "workspace_path": str(run.workspace_path) if run.workspace_path is not None else None,
     }
+
+
+def _write_flow_artifacts(workspace: RunWorkspace, summary: JSONDict) -> dict[str, str]:
+    descriptors = summary.get("harness_artifacts")
+    if not isinstance(descriptors, dict):
+        return {}
+    paths: dict[str, str] = {}
+    for name, descriptor in descriptors.items():
+        if not isinstance(name, str) or not name.strip():
+            raise ValueError("harness artifact names must be non-empty strings")
+        if not isinstance(descriptor, dict):
+            raise ValueError(f"harness artifact '{name}' descriptor must be a JSON object")
+        relative_path = descriptor.get("path")
+        payload = descriptor.get("payload")
+        if not isinstance(relative_path, str) or not relative_path.startswith("artifacts/"):
+            raise ValueError(f"harness artifact '{name}' path must be under artifacts/")
+        path = workspace.write_json(relative_path, payload)
+        paths[name] = str(path.relative_to(workspace.path))
+    return paths
 
 
 def _write_report_artifacts(workspace: RunWorkspace, artifacts: dict[str, str]) -> dict[str, str]:
@@ -807,6 +1034,45 @@ def _steps_for(flow_id: str, summary: JSONDict) -> tuple[HarnessStep, ...]:
                 "Capture provider phases and policy lifecycle calls.",
                 _event_result(summary),
                 f"reset_calls={summary['policy_reset_calls']}",
+            ),
+        )
+    if flow_id == "cosmos-policy":
+        return (
+            HarnessStep(
+                "Load saved /act replay",
+                "Use a sanitized Cosmos-Policy response shape from a prepared smoke replay.",
+                "Checkout-safe replay loaded; no GPU or network call is required.",
+                f"task={summary['task_description']}",
+            ),
+            HarnessStep(
+                "Check provider boundary",
+                "Instantiate CosmosPolicyProvider with the same remote-server contract.",
+                "Provider health is configured for /act.",
+                f"model={summary['model']}",
+            ),
+            HarnessStep(
+                "Call Cosmos adapter",
+                "Route the replay through the real HTTP policy adapter and event path.",
+                f"{summary['request_count']} POST /act request handled.",
+                f"server_path={summary['server_path']}",
+            ),
+            HarnessStep(
+                "Decode action rows",
+                "Validate and decode json_numpy ALOHA action rows before translation.",
+                f"raw action shape {summary['raw_action_shape']}.",
+                "json_numpy_rows=true",
+            ),
+            HarnessStep(
+                "Translate ALOHA actions",
+                "Map raw 14D bimanual rows into executable WorldForge Action objects.",
+                f"{summary['translated_action_count']} move_to actions produced.",
+                f"value_prediction={float(summary['value_prediction']):.6f}",
+            ),
+            HarnessStep(
+                "Preserve replay artifact",
+                "Write the inspector state, provider events, and sanitized replay artifact.",
+                "artifact=artifacts/cosmos-policy-replay.json",
+                f"events={', '.join(summary['event_phases'])}",
             ),
         )
     if flow_id == "diagnostics":
@@ -973,6 +1239,31 @@ def _metrics_for(flow_id: str, summary: JSONDict) -> tuple[HarnessMetric, ...]:
                 "validation commands",
             ),
         )
+    if flow_id == "cosmos-policy":
+        return (
+            HarnessMetric("Flow", "policy", "Cosmos-Policy /act contract replay"),
+            HarnessMetric(
+                "Raw shape",
+                " x ".join(str(item) for item in summary["raw_action_shape"]),
+                "decoded json_numpy action rows",
+            ),
+            HarnessMetric(
+                "Translated",
+                str(summary["translated_action_count"]),
+                "WorldForge Action objects",
+            ),
+            HarnessMetric(
+                "Value",
+                f"{float(summary['value_prediction']):.6f}",
+                "provider value_prediction",
+            ),
+            HarnessMetric(
+                "Events",
+                str(len(summary["event_phases"])),
+                ", ".join(summary["event_phases"]),
+            ),
+            HarnessMetric("Artifact", "replay", "artifacts/cosmos-policy-replay.json"),
+        )
 
     flow_label = "score" if flow_id == "leworldmodel" else "policy+score"
     return (
@@ -1022,6 +1313,20 @@ def _transcript_for(flow_id: str, summary: JSONDict) -> tuple[str, ...]:
             f"jepa-wms_missing_stable: {', '.join(candidate_missing.get('stable', [])) or 'none'}",
             f"safe_artifacts: {summary['safe_artifact_count']}",
             f"validation_commands: {' | '.join(summary['validation_commands'])}",
+        )
+    if flow_id == "cosmos-policy":
+        return (
+            "flow: cosmos-policy",
+            f"provider: {', '.join(summary['providers'])}",
+            f"model: {summary['model']}",
+            f"server_path: {summary['server_path']}",
+            f"task: {summary['task_description']}",
+            f"health: {summary['health']['healthy']}",
+            f"raw_action_shape: {summary['raw_action_shape']}",
+            f"translated_actions: {summary['translated_action_count']}",
+            f"value_prediction: {float(summary['value_prediction']):.6f}",
+            "saved_replay_artifact: artifacts/cosmos-policy-replay.json",
+            f"events: {', '.join(summary['event_phases'])}",
         )
 
     lines = [

--- a/src/worldforge/harness/flows.py
+++ b/src/worldforge/harness/flows.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import base64
+import binascii
 import json
+import math
 import struct
 import tempfile
 from collections.abc import Callable, Sequence
@@ -106,6 +108,10 @@ _COSMOS_POLICY_MODEL = "nvidia/Cosmos-Policy-ALOHA-Predict2-2B"
 _COSMOS_POLICY_ACTION_HORIZON = 50
 _COSMOS_POLICY_ACTION_DIM = 14
 _COSMOS_POLICY_VALUE_PREDICTION = 0.190714
+_COSMOS_POLICY_REPLAY_SCHEMA_VERSION = 1
+_FLOW_ARTIFACT_RESERVED_NAMES = frozenset(
+    {"summary", "steps", "metrics", "transcript", "inspector"}
+)
 _COSMOS_POLICY_PREVIEW_ROWS = (
     (0.01227, -0.02509, -0.00844, -0.04266, 0.05760, 0.01356),
     (0.00180, -0.02080, -0.01734, -0.03035, 0.05673, 0.00983),
@@ -224,38 +230,40 @@ def _run_cosmos_policy_demo(*, state_dir: Path, emit: bool = False) -> JSONDict:
 
     events: list[ProviderEvent] = []
     request_count = 0
-    raw_rows = _cosmos_policy_action_rows()
-    encoded_rows = [_json_numpy_action_row(row) for row in raw_rows]
-    policy_info = _cosmos_policy_policy_info()
+    replay_source_path = _write_prepared_cosmos_policy_replay_artifact(state_dir)
+    saved_replay = _load_cosmos_policy_replay_artifact(replay_source_path)
+    policy_info = saved_replay["request"]["policy_info"]
+    policy_output = _cosmos_policy_response_payload(saved_replay)
 
     def handler(request: httpx.Request) -> httpx.Response:
         nonlocal request_count
         request_count += 1
-        payload = json.loads(request.content.decode("utf-8"))
-        assert request.method == "POST"
-        assert request.url.path == "/act"
-        assert payload.get("action_horizon") == _COSMOS_POLICY_ACTION_HORIZON
-        return httpx.Response(
-            200,
-            json={
-                "actions": encoded_rows,
-                "value_prediction": _COSMOS_POLICY_VALUE_PREDICTION,
-                "future_image_predictions": {
-                    "summary": "omitted from checkout-safe replay artifact",
-                    "source": "sanitized-live-shape",
-                },
-            },
-        )
+        try:
+            payload = json.loads(request.content.decode("utf-8"))
+        except json.JSONDecodeError as exc:
+            raise ValueError("Cosmos-Policy replay request body must be JSON.") from exc
+        if request.method != "POST":
+            raise ValueError(f"Cosmos-Policy replay expected POST, got {request.method}.")
+        if request.url.path != "/act":
+            raise ValueError(f"Cosmos-Policy replay expected /act, got {request.url.path}.")
+        if payload.get("action_horizon") != _COSMOS_POLICY_ACTION_HORIZON:
+            raise ValueError("Cosmos-Policy replay request action_horizon drifted.")
+        return httpx.Response(200, json=policy_output)
 
     def translator(raw_actions: object, _info: JSONDict, _provider_info: JSONDict):
-        assert isinstance(raw_actions, dict)
+        if not isinstance(raw_actions, dict):
+            raise ValueError("Cosmos-Policy replay translator expected raw action metadata.")
         matrix = raw_actions.get("actions")
-        assert isinstance(matrix, list)
-        return [
-            Action.move_to(float(row[0]), float(row[1]), float(row[2]))
-            for row in matrix
-            if isinstance(row, list)
-        ]
+        if not isinstance(matrix, list):
+            raise ValueError("Cosmos-Policy replay translator expected action rows.")
+        actions: list[Action] = []
+        for index, row in enumerate(matrix):
+            if not isinstance(row, list):
+                raise ValueError(f"Cosmos-Policy replay action row {index} must be a list.")
+            if len(row) < 3:
+                raise ValueError(f"Cosmos-Policy replay action row {index} needs x/y/z.")
+            actions.append(Action.move_to(float(row[0]), float(row[1]), float(row[2])))
+        return actions
 
     provider = CosmosPolicyProvider(
         base_url=_COSMOS_POLICY_REPLAY_BASE_URL,
@@ -275,29 +283,32 @@ def _run_cosmos_policy_demo(*, state_dir: Path, emit: bool = False) -> JSONDict:
     raw_action_shape = list(raw_action_summary.get("actions_shape", []))
     selected_action_preview = [action.to_dict() for action in result.actions[:6]]
     raw_action_preview = _preview_action_rows(raw_actions)
-    replay_artifact = {
-        "schema_version": 1,
-        "source": "sanitized Cosmos-Policy smoke shape replay",
-        "provider": result.provider,
-        "model": metadata.get("model"),
-        "server_path": metadata.get("server_path"),
-        "runtime": metadata.get("runtime"),
-        "task_description": metadata.get("task_description"),
-        "request": {
-            "observation_fields": sorted(policy_info["observation"]),
-            "proprio_dim": len(policy_info["observation"]["proprio"]),
-            "action_horizon": policy_info["action_horizon"],
-            "embodiment_tag": policy_info["embodiment_tag"],
-        },
-        "response": {
-            "json_numpy_rows": True,
-            "raw_action_shape": raw_action_shape,
-            "value_prediction": provider_info.get("value_prediction"),
-            "translated_action_count": len(result.actions),
-            "raw_action_preview": raw_action_preview,
-            "selected_action_preview": selected_action_preview,
-        },
-    }
+    replay_artifact = dict(saved_replay)
+    replay_artifact.update(
+        {
+            "manifest": {
+                "flow_id": "cosmos-policy",
+                "provider": result.provider,
+                "model": metadata.get("model"),
+                "server_path": metadata.get("server_path"),
+                "runtime": metadata.get("runtime"),
+                "task_description": metadata.get("task_description"),
+                "action_horizon": result.action_horizon,
+                "action_dim": _COSMOS_POLICY_ACTION_DIM,
+                "source_artifact": replay_source_path.name,
+            },
+            "response": {
+                "json_numpy_rows": True,
+                "raw_action_shape": raw_action_shape,
+                "value_prediction": provider_info.get("value_prediction"),
+                "translated_action_count": len(result.actions),
+                "raw_action_preview": raw_action_preview,
+                "selected_action_preview": selected_action_preview,
+            },
+            "translated_actions": [action.to_dict() for action in result.actions],
+            "provider_events": [event.to_dict() for event in events],
+        }
+    )
     summary: JSONDict = {
         "demo_kind": "cosmos_policy_saved_replay",
         "state_dir": str(state_dir),
@@ -307,6 +318,7 @@ def _run_cosmos_policy_demo(*, state_dir: Path, emit: bool = False) -> JSONDict:
         "runtime": metadata.get("runtime"),
         "server_path": metadata.get("server_path"),
         "runtime_contract": "saved /act replay through CosmosPolicyProvider",
+        "loaded_replay_artifact": replay_source_path.name,
         "health": health.to_dict(),
         "request_count": request_count,
         "raw_action_shape": raw_action_shape,
@@ -346,6 +358,145 @@ def _cosmos_policy_policy_info() -> JSONDict:
     }
 
 
+def _write_prepared_cosmos_policy_replay_artifact(state_dir: Path) -> Path:
+    state_dir.mkdir(parents=True, exist_ok=True)
+    replay_path = state_dir / "cosmos-policy-prepared-replay.json"
+    replay_path.write_text(
+        json.dumps(_cosmos_policy_saved_replay_payload(), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return replay_path
+
+
+def _cosmos_policy_saved_replay_payload() -> JSONDict:
+    policy_info = _cosmos_policy_policy_info()
+    encoded_rows = [_json_numpy_action_row(row) for row in _cosmos_policy_action_rows()]
+    return {
+        "schema_version": _COSMOS_POLICY_REPLAY_SCHEMA_VERSION,
+        "source": "sanitized Cosmos-Policy live /act response shape",
+        "manifest": {
+            "flow_id": "cosmos-policy",
+            "provider": "cosmos-policy",
+            "model": _COSMOS_POLICY_MODEL,
+            "server_path": "/act",
+            "runtime": "saved replay",
+            "task_description": policy_info["task_description"],
+            "action_horizon": _COSMOS_POLICY_ACTION_HORIZON,
+            "action_dim": _COSMOS_POLICY_ACTION_DIM,
+        },
+        "request": {
+            "policy_info": policy_info,
+            "observation_fields": sorted(policy_info["observation"]),
+            "proprio_dim": len(policy_info["observation"]["proprio"]),
+            "action_horizon": policy_info["action_horizon"],
+            "embodiment_tag": policy_info["embodiment_tag"],
+        },
+        "policy_output": {
+            "actions": encoded_rows,
+            "value_prediction": _COSMOS_POLICY_VALUE_PREDICTION,
+            "future_image_predictions": {
+                "summary": "omitted from checkout-safe replay artifact",
+                "source": "sanitized-live-shape",
+            },
+        },
+        "response": {
+            "json_numpy_rows": True,
+            "raw_action_shape": [_COSMOS_POLICY_ACTION_HORIZON, _COSMOS_POLICY_ACTION_DIM],
+            "value_prediction": _COSMOS_POLICY_VALUE_PREDICTION,
+            "translated_action_count": 0,
+            "raw_action_preview": [],
+            "selected_action_preview": [],
+        },
+        "translated_actions": [],
+        "provider_events": [],
+    }
+
+
+def _load_cosmos_policy_replay_artifact(path: Path) -> JSONDict:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Cosmos-Policy replay artifact is not valid JSON: {path}") from exc
+    if not isinstance(payload, dict):
+        raise ValueError("Cosmos-Policy replay artifact must be a JSON object.")
+    if payload.get("schema_version") != _COSMOS_POLICY_REPLAY_SCHEMA_VERSION:
+        raise ValueError("Cosmos-Policy replay artifact schema_version is unsupported.")
+
+    manifest = _require_json_object(payload.get("manifest"), "Cosmos-Policy replay manifest")
+    if manifest.get("flow_id") != "cosmos-policy":
+        raise ValueError("Cosmos-Policy replay artifact flow_id must be 'cosmos-policy'.")
+    if manifest.get("server_path") != "/act":
+        raise ValueError("Cosmos-Policy replay artifact server_path must be '/act'.")
+    if manifest.get("action_horizon") != _COSMOS_POLICY_ACTION_HORIZON:
+        raise ValueError("Cosmos-Policy replay artifact action_horizon is unsupported.")
+    if manifest.get("action_dim") != _COSMOS_POLICY_ACTION_DIM:
+        raise ValueError("Cosmos-Policy replay artifact action_dim is unsupported.")
+
+    request = _require_json_object(payload.get("request"), "Cosmos-Policy replay request")
+    policy_info = _require_json_object(
+        request.get("policy_info"),
+        "Cosmos-Policy replay request.policy_info",
+    )
+    observation = _require_json_object(
+        policy_info.get("observation"),
+        "Cosmos-Policy replay observation",
+    )
+    missing_fields = [
+        field
+        for field in ("primary_image", "left_wrist_image", "right_wrist_image", "proprio")
+        if field not in observation
+    ]
+    if missing_fields:
+        raise ValueError(
+            "Cosmos-Policy replay observation is missing fields: " + ", ".join(missing_fields)
+        )
+    proprio = observation["proprio"]
+    if not isinstance(proprio, list) or len(proprio) != _COSMOS_POLICY_ACTION_DIM:
+        raise ValueError("Cosmos-Policy replay proprio must be a 14-value list.")
+    if policy_info.get("action_horizon") != _COSMOS_POLICY_ACTION_HORIZON:
+        raise ValueError("Cosmos-Policy replay policy_info action_horizon is unsupported.")
+
+    policy_output = _require_json_object(
+        payload.get("policy_output"),
+        "Cosmos-Policy replay policy_output",
+    )
+    actions = policy_output.get("actions")
+    if not isinstance(actions, list) or len(actions) != _COSMOS_POLICY_ACTION_HORIZON:
+        raise ValueError("Cosmos-Policy replay policy_output.actions must contain 50 rows.")
+    for index, row in enumerate(actions):
+        _decode_json_numpy_action_row(row, row_index=index)
+    value_prediction = policy_output.get("value_prediction")
+    if value_prediction is not None:
+        try:
+            value_prediction_float = float(value_prediction)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                "Cosmos-Policy replay value_prediction must be numeric when present."
+            ) from exc
+        if not math.isfinite(value_prediction_float):
+            raise ValueError("Cosmos-Policy replay value_prediction must be finite when present.")
+    return payload
+
+
+def _cosmos_policy_response_payload(replay_artifact: JSONDict) -> JSONDict:
+    policy_output = _require_json_object(
+        replay_artifact.get("policy_output"),
+        "Cosmos-Policy replay policy_output",
+    )
+    response: JSONDict = {"actions": policy_output["actions"]}
+    if "value_prediction" in policy_output:
+        response["value_prediction"] = policy_output["value_prediction"]
+    if "future_image_predictions" in policy_output:
+        response["future_image_predictions"] = policy_output["future_image_predictions"]
+    return response
+
+
+def _require_json_object(value: object, name: str) -> JSONDict:
+    if not isinstance(value, dict):
+        raise ValueError(f"{name} must be a JSON object.")
+    return value
+
+
 def _cosmos_policy_action_rows() -> list[list[float]]:
     rows: list[list[float]] = []
     for index in range(_COSMOS_POLICY_ACTION_HORIZON):
@@ -378,6 +529,36 @@ def _json_numpy_action_row(row: Sequence[float]) -> JSONDict:
         "dtype": "<f4",
         "shape": [_COSMOS_POLICY_ACTION_DIM],
     }
+
+
+def _decode_json_numpy_action_row(value: object, *, row_index: int) -> list[float]:
+    if not isinstance(value, dict):
+        raise ValueError(f"Cosmos-Policy replay action row {row_index} must be JSON numpy.")
+    encoded = value.get("__numpy__")
+    if not isinstance(encoded, str) or not encoded:
+        raise ValueError(f"Cosmos-Policy replay action row {row_index} is missing __numpy__.")
+    if value.get("dtype") != "<f4":
+        raise ValueError(f"Cosmos-Policy replay action row {row_index} must use dtype <f4.")
+    if value.get("shape") != [_COSMOS_POLICY_ACTION_DIM]:
+        raise ValueError(
+            f"Cosmos-Policy replay action row {row_index} must have shape "
+            f"[{_COSMOS_POLICY_ACTION_DIM}]."
+        )
+    try:
+        raw = base64.b64decode(encoded, validate=True)
+    except (ValueError, binascii.Error) as exc:
+        raise ValueError(
+            f"Cosmos-Policy replay action row {row_index} has invalid base64."
+        ) from exc
+    expected_bytes = _COSMOS_POLICY_ACTION_DIM * 4
+    if len(raw) != expected_bytes:
+        raise ValueError(
+            f"Cosmos-Policy replay action row {row_index} must contain {expected_bytes} bytes."
+        )
+    decoded = list(struct.unpack(f"<{_COSMOS_POLICY_ACTION_DIM}f", raw))
+    if not all(math.isfinite(value) for value in decoded):
+        raise ValueError(f"Cosmos-Policy replay action row {row_index} must be finite.")
+    return decoded
 
 
 def _preview_action_rows(rows: object, *, limit: int = 6, columns: int = 6) -> list[list[float]]:
@@ -912,6 +1093,8 @@ def _write_flow_artifacts(workspace: RunWorkspace, summary: JSONDict) -> dict[st
     for name, descriptor in descriptors.items():
         if not isinstance(name, str) or not name.strip():
             raise ValueError("harness artifact names must be non-empty strings")
+        if name in _FLOW_ARTIFACT_RESERVED_NAMES:
+            raise ValueError(f"harness artifact '{name}' uses a reserved manifest key")
         if not isinstance(descriptor, dict):
             raise ValueError(f"harness artifact '{name}' descriptor must be a JSON object")
         relative_path = descriptor.get("path")
@@ -930,6 +1113,18 @@ def _write_report_artifacts(workspace: RunWorkspace, artifacts: dict[str, str]) 
         path = workspace.write_text(f"reports/report.{suffix}", content)
         paths[name] = str(path.relative_to(workspace.path))
     return paths
+
+
+def _format_optional_float(value: object) -> str:
+    if value is None:
+        return "n/a"
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return "n/a"
+    if not math.isfinite(number):
+        return "n/a"
+    return f"{number:.6f}"
 
 
 def _steps_for(flow_id: str, summary: JSONDict) -> tuple[HarnessStep, ...]:
@@ -1066,7 +1261,7 @@ def _steps_for(flow_id: str, summary: JSONDict) -> tuple[HarnessStep, ...]:
                 "Translate ALOHA actions",
                 "Map raw 14D bimanual rows into executable WorldForge Action objects.",
                 f"{summary['translated_action_count']} move_to actions produced.",
-                f"value_prediction={float(summary['value_prediction']):.6f}",
+                f"value_prediction={_format_optional_float(summary['value_prediction'])}",
             ),
             HarnessStep(
                 "Preserve replay artifact",
@@ -1254,7 +1449,7 @@ def _metrics_for(flow_id: str, summary: JSONDict) -> tuple[HarnessMetric, ...]:
             ),
             HarnessMetric(
                 "Value",
-                f"{float(summary['value_prediction']):.6f}",
+                _format_optional_float(summary["value_prediction"]),
                 "provider value_prediction",
             ),
             HarnessMetric(
@@ -1324,7 +1519,7 @@ def _transcript_for(flow_id: str, summary: JSONDict) -> tuple[str, ...]:
             f"health: {summary['health']['healthy']}",
             f"raw_action_shape: {summary['raw_action_shape']}",
             f"translated_actions: {summary['translated_action_count']}",
-            f"value_prediction: {float(summary['value_prediction']):.6f}",
+            f"value_prediction: {_format_optional_float(summary['value_prediction'])}",
             "saved_replay_artifact: artifacts/cosmos-policy-replay.json",
             f"events: {', '.join(summary['event_phases'])}",
         )

--- a/src/worldforge/harness/flows.py
+++ b/src/worldforge/harness/flows.py
@@ -110,6 +110,12 @@ _COSMOS_POLICY_ACTION_HORIZON = 50
 _COSMOS_POLICY_ACTION_DIM = 14
 _COSMOS_POLICY_VALUE_PREDICTION = 0.190714
 _COSMOS_POLICY_REPLAY_SCHEMA_VERSION = 1
+_COSMOS_POLICY_OBSERVATION_FIELDS = (
+    "left_wrist_image",
+    "primary_image",
+    "proprio",
+    "right_wrist_image",
+)
 _COSMOS_POLICY_REPLAY_REQUEST_KEYS = frozenset(
     {
         "observation_fields",
@@ -271,14 +277,18 @@ def _run_cosmos_policy_demo(*, state_dir: Path, emit: bool = False) -> JSONDict:
         for index, row in enumerate(matrix):
             if not isinstance(row, list):
                 raise ProviderError(f"Cosmos-Policy replay action row {index} must be a list.")
-            if len(row) < 3:
-                raise ProviderError(f"Cosmos-Policy replay action row {index} needs x/y/z.")
+            if len(row) != _COSMOS_POLICY_ACTION_DIM:
+                raise ProviderError(
+                    f"Cosmos-Policy replay action row {index} must be {_COSMOS_POLICY_ACTION_DIM}D."
+                )
             actions.append(Action.move_to(float(row[0]), float(row[1]), float(row[2])))
         return actions
 
     provider = CosmosPolicyProvider(
         base_url=_COSMOS_POLICY_REPLAY_BASE_URL,
         model=_COSMOS_POLICY_MODEL,
+        return_all_query_results=False,
+        allowed_hosts=("93.184.216.34",),
         transport=httpx.MockTransport(handler),
         action_translator=translator,
         event_handler=events.append,
@@ -413,9 +423,7 @@ def _write_prepared_cosmos_policy_replay_artifact(state_dir: Path) -> Path:
 def _cosmos_policy_saved_replay_payload() -> JSONDict:
     encoded_rows = [_json_numpy_action_row(row) for row in _cosmos_policy_action_rows()]
     task_description = "fold shirt"
-    observation_fields = sorted(
-        ("primary_image", "left_wrist_image", "right_wrist_image", "proprio")
-    )
+    observation_fields = list(_COSMOS_POLICY_OBSERVATION_FIELDS)
     return {
         "schema_version": _COSMOS_POLICY_REPLAY_SCHEMA_VERSION,
         "source": "sanitized Cosmos-Policy live /act response shape",
@@ -481,28 +489,15 @@ def _load_cosmos_policy_replay_artifact(path: Path) -> JSONDict:
     request = _require_json_object(payload.get("request"), "Cosmos-Policy replay request")
     if set(request) != _COSMOS_POLICY_REPLAY_REQUEST_KEYS:
         raise WorldStateError("Cosmos-Policy replay request contains unsupported fields.")
-    expected_fields = sorted(("primary_image", "left_wrist_image", "right_wrist_image", "proprio"))
+    expected_fields = list(_COSMOS_POLICY_OBSERVATION_FIELDS)
     if request.get("observation_fields") != expected_fields:
         raise WorldStateError(
             "Cosmos-Policy replay observation is missing fields or has unsupported fields."
         )
-    observation_summary = _require_json_object(
+    _validate_cosmos_policy_observation_summary(
         request.get("observation_summary"),
-        "Cosmos-Policy replay observation_summary",
+        expected_fields=expected_fields,
     )
-    if set(observation_summary) != set(expected_fields):
-        raise WorldStateError(
-            "Cosmos-Policy replay observation_summary contains unsupported fields."
-        )
-    for field in ("primary_image", "left_wrist_image", "right_wrist_image", "proprio"):
-        field_summary = _require_json_object(
-            observation_summary.get(field),
-            f"Cosmos-Policy replay observation_summary.{field}",
-        )
-        if field_summary.get("redacted") is not True:
-            raise WorldStateError(
-                f"Cosmos-Policy replay observation field {field} must be redacted."
-            )
     if request.get("proprio_dim") != _COSMOS_POLICY_ACTION_DIM:
         raise WorldStateError("Cosmos-Policy replay proprio_dim is unsupported.")
     if not isinstance(request.get("task_description"), str) or not request["task_description"]:
@@ -616,6 +611,7 @@ def _cosmos_policy_replay_failure_summary(
 def _validate_cosmos_policy_replay_request(payload: object, saved_request: JSONDict) -> None:
     if not isinstance(payload, dict):
         raise WorldStateError("Cosmos-Policy replay request payload must be a JSON object.")
+    _require_json_native_value(payload, "Cosmos-Policy replay request payload")
     expected_fields_value = saved_request.get("observation_fields")
     if not isinstance(expected_fields_value, list) or not all(
         isinstance(field, str) for field in expected_fields_value
@@ -626,6 +622,12 @@ def _validate_cosmos_policy_replay_request(payload: object, saved_request: JSOND
         raise WorldStateError("Cosmos-Policy replay saved observation fields are invalid.")
     expected_payload_keys = set(expected_fields) | {"task_description", "action_horizon"}
     payload_keys = set(payload)
+    if "return_all_query_results" in payload:
+        if not isinstance(payload["return_all_query_results"], bool):
+            raise WorldStateError(
+                "Cosmos-Policy replay request return_all_query_results must be boolean."
+            )
+        payload_keys.remove("return_all_query_results")
     if payload_keys != expected_payload_keys:
         missing = sorted(expected_payload_keys - payload_keys)
         extra = sorted(payload_keys - expected_payload_keys)
@@ -646,6 +648,15 @@ def _validate_cosmos_policy_replay_request(payload: object, saved_request: JSOND
     proprio = payload.get("proprio")
     if not isinstance(proprio, list) or len(proprio) != saved_request["proprio_dim"]:
         raise WorldStateError("Cosmos-Policy replay request proprio shape drifted.")
+    for index, value in enumerate(proprio):
+        if (
+            not isinstance(value, int | float)
+            or isinstance(value, bool)
+            or not math.isfinite(value)
+        ):
+            raise WorldStateError(
+                f"Cosmos-Policy replay request proprio[{index}] must be finite numeric."
+            )
 
 
 def _cosmos_policy_policy_info_from_replay(replay_artifact: JSONDict) -> JSONDict:
@@ -677,6 +688,64 @@ def _require_json_object(value: object, name: str) -> JSONDict:
     if not isinstance(value, dict):
         raise WorldStateError(f"{name} must be a JSON object.")
     return value
+
+
+def _require_json_native_value(value: object, name: str) -> None:
+    if value is None or isinstance(value, str | bool):
+        return
+    if isinstance(value, int | float):
+        if isinstance(value, bool) or not math.isfinite(value):
+            raise WorldStateError(f"{name} must be JSON-native and finite.")
+        return
+    if isinstance(value, list):
+        for index, item in enumerate(value):
+            _require_json_native_value(item, f"{name}[{index}]")
+        return
+    if isinstance(value, dict):
+        for key, item in value.items():
+            if not isinstance(key, str):
+                raise WorldStateError(f"{name} keys must be strings.")
+            _require_json_native_value(item, f"{name}.{key}")
+        return
+    raise WorldStateError(f"{name} must be JSON-native.")
+
+
+def _validate_cosmos_policy_observation_summary(
+    value: object,
+    *,
+    expected_fields: Sequence[str],
+) -> None:
+    observation_summary = _require_json_object(
+        value,
+        "Cosmos-Policy replay observation_summary",
+    )
+    if set(observation_summary) != set(expected_fields):
+        raise WorldStateError(
+            "Cosmos-Policy replay observation_summary contains unsupported fields."
+        )
+    expected_shapes = {
+        "primary_image": [1, 1, 1, 3],
+        "left_wrist_image": [1, 1, 1, 3],
+        "right_wrist_image": [1, 1, 1, 3],
+        "proprio": [_COSMOS_POLICY_ACTION_DIM],
+    }
+    for field in expected_fields:
+        field_summary = _require_json_object(
+            observation_summary.get(field),
+            f"Cosmos-Policy replay observation_summary.{field}",
+        )
+        if set(field_summary) != {"redacted", "shape"}:
+            raise WorldStateError(
+                f"Cosmos-Policy replay observation_summary.{field} contains unsupported fields."
+            )
+        if field_summary.get("redacted") is not True:
+            raise WorldStateError(
+                f"Cosmos-Policy replay observation field {field} must be redacted."
+            )
+        if field_summary.get("shape") != expected_shapes[field]:
+            raise WorldStateError(
+                f"Cosmos-Policy replay observation_summary.{field}.shape is unsupported."
+            )
 
 
 def _cosmos_policy_redacted_observation_summary() -> JSONDict:
@@ -734,12 +803,25 @@ def _decode_json_numpy_action_row(value: object, *, row_index: int) -> list[floa
     encoded = value.get("__numpy__")
     if not isinstance(encoded, str) or not encoded:
         raise WorldStateError(f"Cosmos-Policy replay action row {row_index} is missing __numpy__.")
-    if value.get("dtype") != "<f4":
-        raise WorldStateError(f"Cosmos-Policy replay action row {row_index} must use dtype <f4.")
+    dtype = value.get("dtype")
+    if not isinstance(dtype, str) or not dtype:
+        raise WorldStateError(
+            f"Cosmos-Policy replay action row {row_index} must include a numeric dtype."
+        )
+    endian_prefix, item_format, item_size = _json_numpy_float_format_for_replay(
+        dtype,
+        row_index=row_index,
+    )
     if value.get("shape") != [_COSMOS_POLICY_ACTION_DIM]:
         raise WorldStateError(
             f"Cosmos-Policy replay action row {row_index} must have shape "
             f"[{_COSMOS_POLICY_ACTION_DIM}]."
+        )
+    expected_bytes = _COSMOS_POLICY_ACTION_DIM * item_size
+    expected_encoded_length = 4 * math.ceil(expected_bytes / 3)
+    if len(encoded) > expected_encoded_length:
+        raise WorldStateError(
+            f"Cosmos-Policy replay action row {row_index} base64 payload is too large."
         )
     try:
         raw = base64.b64decode(encoded, validate=True)
@@ -747,15 +829,37 @@ def _decode_json_numpy_action_row(value: object, *, row_index: int) -> list[floa
         raise WorldStateError(
             f"Cosmos-Policy replay action row {row_index} has invalid base64."
         ) from exc
-    expected_bytes = _COSMOS_POLICY_ACTION_DIM * 4
     if len(raw) != expected_bytes:
         raise WorldStateError(
             f"Cosmos-Policy replay action row {row_index} must contain {expected_bytes} bytes."
         )
-    decoded = list(struct.unpack(f"<{_COSMOS_POLICY_ACTION_DIM}f", raw))
+    decoded = list(struct.unpack(f"{endian_prefix}{_COSMOS_POLICY_ACTION_DIM}{item_format}", raw))
     if not all(math.isfinite(value) for value in decoded):
         raise WorldStateError(f"Cosmos-Policy replay action row {row_index} must be finite.")
     return decoded
+
+
+def _json_numpy_float_format_for_replay(
+    dtype: str,
+    *,
+    row_index: int,
+) -> tuple[str, str, int]:
+    normalized = dtype.strip().lower()
+    if not normalized:
+        raise WorldStateError(
+            f"Cosmos-Policy replay action row {row_index} must include a numeric dtype."
+        )
+    endian_prefix = "<"
+    if normalized[0] in ("<", ">", "=", "|"):
+        endian_prefix = "=" if normalized[0] == "|" else normalized[0]
+        normalized = normalized[1:]
+    if normalized in ("f4", "float32"):
+        return endian_prefix, "f", 4
+    if normalized in ("f8", "float64"):
+        return endian_prefix, "d", 8
+    raise WorldStateError(
+        f"Cosmos-Policy replay action row {row_index} dtype must be float32 or float64."
+    )
 
 
 def _preview_action_rows(rows: object, *, limit: int = 6, columns: int = 6) -> list[list[float]]:

--- a/src/worldforge/harness/flows.py
+++ b/src/worldforge/harness/flows.py
@@ -232,7 +232,7 @@ def _run_cosmos_policy_demo(*, state_dir: Path, emit: bool = False) -> JSONDict:
     request_count = 0
     replay_source_path = _write_prepared_cosmos_policy_replay_artifact(state_dir)
     saved_replay = _load_cosmos_policy_replay_artifact(replay_source_path)
-    policy_info = saved_replay["request"]["policy_info"]
+    policy_info = _cosmos_policy_policy_info_from_replay(saved_replay)
     policy_output = _cosmos_policy_response_payload(saved_replay)
 
     def handler(request: httpx.Request) -> httpx.Response:
@@ -385,9 +385,10 @@ def _cosmos_policy_saved_replay_payload() -> JSONDict:
             "action_dim": _COSMOS_POLICY_ACTION_DIM,
         },
         "request": {
-            "policy_info": policy_info,
             "observation_fields": sorted(policy_info["observation"]),
+            "observation_summary": _cosmos_policy_observation_summary(policy_info["observation"]),
             "proprio_dim": len(policy_info["observation"]["proprio"]),
+            "task_description": policy_info["task_description"],
             "action_horizon": policy_info["action_horizon"],
             "embodiment_tag": policy_info["embodiment_tag"],
         },
@@ -433,28 +434,30 @@ def _load_cosmos_policy_replay_artifact(path: Path) -> JSONDict:
         raise ValueError("Cosmos-Policy replay artifact action_dim is unsupported.")
 
     request = _require_json_object(payload.get("request"), "Cosmos-Policy replay request")
-    policy_info = _require_json_object(
-        request.get("policy_info"),
-        "Cosmos-Policy replay request.policy_info",
-    )
-    observation = _require_json_object(
-        policy_info.get("observation"),
-        "Cosmos-Policy replay observation",
-    )
-    missing_fields = [
-        field
-        for field in ("primary_image", "left_wrist_image", "right_wrist_image", "proprio")
-        if field not in observation
-    ]
-    if missing_fields:
+    expected_fields = sorted(("primary_image", "left_wrist_image", "right_wrist_image", "proprio"))
+    if request.get("observation_fields") != expected_fields:
         raise ValueError(
-            "Cosmos-Policy replay observation is missing fields: " + ", ".join(missing_fields)
+            "Cosmos-Policy replay observation is missing fields or has unsupported fields."
         )
-    proprio = observation["proprio"]
-    if not isinstance(proprio, list) or len(proprio) != _COSMOS_POLICY_ACTION_DIM:
-        raise ValueError("Cosmos-Policy replay proprio must be a 14-value list.")
-    if policy_info.get("action_horizon") != _COSMOS_POLICY_ACTION_HORIZON:
-        raise ValueError("Cosmos-Policy replay policy_info action_horizon is unsupported.")
+    observation_summary = _require_json_object(
+        request.get("observation_summary"),
+        "Cosmos-Policy replay observation_summary",
+    )
+    for field in ("primary_image", "left_wrist_image", "right_wrist_image"):
+        field_summary = _require_json_object(
+            observation_summary.get(field),
+            f"Cosmos-Policy replay observation_summary.{field}",
+        )
+        if field_summary.get("redacted") is not True:
+            raise ValueError(f"Cosmos-Policy replay image field {field} must be redacted.")
+    if request.get("proprio_dim") != _COSMOS_POLICY_ACTION_DIM:
+        raise ValueError("Cosmos-Policy replay proprio_dim is unsupported.")
+    if not isinstance(request.get("task_description"), str) or not request["task_description"]:
+        raise ValueError("Cosmos-Policy replay task_description must be a non-empty string.")
+    if request.get("action_horizon") != _COSMOS_POLICY_ACTION_HORIZON:
+        raise ValueError("Cosmos-Policy replay request action_horizon is unsupported.")
+    if request.get("embodiment_tag") != "aloha":
+        raise ValueError("Cosmos-Policy replay embodiment_tag must be 'aloha'.")
 
     policy_output = _require_json_object(
         payload.get("policy_output"),
@@ -478,6 +481,18 @@ def _load_cosmos_policy_replay_artifact(path: Path) -> JSONDict:
     return payload
 
 
+def _cosmos_policy_policy_info_from_replay(replay_artifact: JSONDict) -> JSONDict:
+    request = _require_json_object(
+        replay_artifact.get("request"),
+        "Cosmos-Policy replay request",
+    )
+    policy_info = _cosmos_policy_policy_info()
+    policy_info["task_description"] = request["task_description"]
+    policy_info["action_horizon"] = request["action_horizon"]
+    policy_info["embodiment_tag"] = request["embodiment_tag"]
+    return policy_info
+
+
 def _cosmos_policy_response_payload(replay_artifact: JSONDict) -> JSONDict:
     policy_output = _require_json_object(
         replay_artifact.get("policy_output"),
@@ -495,6 +510,30 @@ def _require_json_object(value: object, name: str) -> JSONDict:
     if not isinstance(value, dict):
         raise ValueError(f"{name} must be a JSON object.")
     return value
+
+
+def _cosmos_policy_observation_summary(observation: JSONDict) -> JSONDict:
+    return {
+        "primary_image": {"redacted": True, "shape": _nested_shape(observation["primary_image"])},
+        "left_wrist_image": {
+            "redacted": True,
+            "shape": _nested_shape(observation["left_wrist_image"]),
+        },
+        "right_wrist_image": {
+            "redacted": True,
+            "shape": _nested_shape(observation["right_wrist_image"]),
+        },
+        "proprio": {"redacted": True, "shape": [len(observation["proprio"])]},
+    }
+
+
+def _nested_shape(value: object) -> list[int]:
+    shape: list[int] = []
+    current = value
+    while isinstance(current, list):
+        shape.append(len(current))
+        current = current[0] if current else []
+    return shape
 
 
 def _cosmos_policy_action_rows() -> list[list[float]]:
@@ -1085,11 +1124,11 @@ def _inspector_payload(run: HarnessRun) -> JSONDict:
     }
 
 
-def _write_flow_artifacts(workspace: RunWorkspace, summary: JSONDict) -> dict[str, str]:
+def _write_flow_artifacts(workspace: RunWorkspace, summary: JSONDict) -> JSONDict:
     descriptors = summary.get("harness_artifacts")
     if not isinstance(descriptors, dict):
         return {}
-    paths: dict[str, str] = {}
+    paths: JSONDict = {}
     for name, descriptor in descriptors.items():
         if not isinstance(name, str) or not name.strip():
             raise ValueError("harness artifact names must be non-empty strings")

--- a/src/worldforge/harness/flows.py
+++ b/src/worldforge/harness/flows.py
@@ -462,28 +462,28 @@ def _load_cosmos_policy_replay_artifact(path: Path) -> JSONDict:
     try:
         payload = json.loads(path.read_text(encoding="utf-8"))
     except json.JSONDecodeError as exc:
-        raise ValueError(f"Cosmos-Policy replay artifact is not valid JSON: {path}") from exc
+        raise WorldStateError(f"Cosmos-Policy replay artifact is not valid JSON: {path}") from exc
     if not isinstance(payload, dict):
-        raise ValueError("Cosmos-Policy replay artifact must be a JSON object.")
+        raise WorldStateError("Cosmos-Policy replay artifact must be a JSON object.")
     if payload.get("schema_version") != _COSMOS_POLICY_REPLAY_SCHEMA_VERSION:
-        raise ValueError("Cosmos-Policy replay artifact schema_version is unsupported.")
+        raise WorldStateError("Cosmos-Policy replay artifact schema_version is unsupported.")
 
     manifest = _require_json_object(payload.get("manifest"), "Cosmos-Policy replay manifest")
     if manifest.get("flow_id") != "cosmos-policy":
-        raise ValueError("Cosmos-Policy replay artifact flow_id must be 'cosmos-policy'.")
+        raise WorldStateError("Cosmos-Policy replay artifact flow_id must be 'cosmos-policy'.")
     if manifest.get("server_path") != "/act":
-        raise ValueError("Cosmos-Policy replay artifact server_path must be '/act'.")
+        raise WorldStateError("Cosmos-Policy replay artifact server_path must be '/act'.")
     if manifest.get("action_horizon") != _COSMOS_POLICY_ACTION_HORIZON:
-        raise ValueError("Cosmos-Policy replay artifact action_horizon is unsupported.")
+        raise WorldStateError("Cosmos-Policy replay artifact action_horizon is unsupported.")
     if manifest.get("action_dim") != _COSMOS_POLICY_ACTION_DIM:
-        raise ValueError("Cosmos-Policy replay artifact action_dim is unsupported.")
+        raise WorldStateError("Cosmos-Policy replay artifact action_dim is unsupported.")
 
     request = _require_json_object(payload.get("request"), "Cosmos-Policy replay request")
     if set(request) != _COSMOS_POLICY_REPLAY_REQUEST_KEYS:
-        raise ValueError("Cosmos-Policy replay request contains unsupported fields.")
+        raise WorldStateError("Cosmos-Policy replay request contains unsupported fields.")
     expected_fields = sorted(("primary_image", "left_wrist_image", "right_wrist_image", "proprio"))
     if request.get("observation_fields") != expected_fields:
-        raise ValueError(
+        raise WorldStateError(
             "Cosmos-Policy replay observation is missing fields or has unsupported fields."
         )
     observation_summary = _require_json_object(
@@ -491,22 +491,26 @@ def _load_cosmos_policy_replay_artifact(path: Path) -> JSONDict:
         "Cosmos-Policy replay observation_summary",
     )
     if set(observation_summary) != set(expected_fields):
-        raise ValueError("Cosmos-Policy replay observation_summary contains unsupported fields.")
+        raise WorldStateError(
+            "Cosmos-Policy replay observation_summary contains unsupported fields."
+        )
     for field in ("primary_image", "left_wrist_image", "right_wrist_image", "proprio"):
         field_summary = _require_json_object(
             observation_summary.get(field),
             f"Cosmos-Policy replay observation_summary.{field}",
         )
         if field_summary.get("redacted") is not True:
-            raise ValueError(f"Cosmos-Policy replay observation field {field} must be redacted.")
+            raise WorldStateError(
+                f"Cosmos-Policy replay observation field {field} must be redacted."
+            )
     if request.get("proprio_dim") != _COSMOS_POLICY_ACTION_DIM:
-        raise ValueError("Cosmos-Policy replay proprio_dim is unsupported.")
+        raise WorldStateError("Cosmos-Policy replay proprio_dim is unsupported.")
     if not isinstance(request.get("task_description"), str) or not request["task_description"]:
-        raise ValueError("Cosmos-Policy replay task_description must be a non-empty string.")
+        raise WorldStateError("Cosmos-Policy replay task_description must be a non-empty string.")
     if request.get("action_horizon") != _COSMOS_POLICY_ACTION_HORIZON:
-        raise ValueError("Cosmos-Policy replay request action_horizon is unsupported.")
+        raise WorldStateError("Cosmos-Policy replay request action_horizon is unsupported.")
     if request.get("embodiment_tag") != "aloha":
-        raise ValueError("Cosmos-Policy replay embodiment_tag must be 'aloha'.")
+        raise WorldStateError("Cosmos-Policy replay embodiment_tag must be 'aloha'.")
 
     policy_output = _require_json_object(
         payload.get("policy_output"),
@@ -514,7 +518,7 @@ def _load_cosmos_policy_replay_artifact(path: Path) -> JSONDict:
     )
     actions = policy_output.get("actions")
     if not isinstance(actions, list) or len(actions) != _COSMOS_POLICY_ACTION_HORIZON:
-        raise ValueError("Cosmos-Policy replay policy_output.actions must contain 50 rows.")
+        raise WorldStateError("Cosmos-Policy replay policy_output.actions must contain 50 rows.")
     for index, row in enumerate(actions):
         _decode_json_numpy_action_row(row, row_index=index)
     value_prediction = policy_output.get("value_prediction")
@@ -522,11 +526,13 @@ def _load_cosmos_policy_replay_artifact(path: Path) -> JSONDict:
         try:
             value_prediction_float = float(value_prediction)
         except (TypeError, ValueError) as exc:
-            raise ValueError(
+            raise WorldStateError(
                 "Cosmos-Policy replay value_prediction must be numeric when present."
             ) from exc
         if not math.isfinite(value_prediction_float):
-            raise ValueError("Cosmos-Policy replay value_prediction must be finite when present.")
+            raise WorldStateError(
+                "Cosmos-Policy replay value_prediction must be finite when present."
+            )
     return payload
 
 
@@ -669,7 +675,7 @@ def _cosmos_policy_response_payload(replay_artifact: JSONDict) -> JSONDict:
 
 def _require_json_object(value: object, name: str) -> JSONDict:
     if not isinstance(value, dict):
-        raise ValueError(f"{name} must be a JSON object.")
+        raise WorldStateError(f"{name} must be a JSON object.")
     return value
 
 
@@ -724,31 +730,31 @@ def _json_numpy_action_row(row: Sequence[float]) -> JSONDict:
 
 def _decode_json_numpy_action_row(value: object, *, row_index: int) -> list[float]:
     if not isinstance(value, dict):
-        raise ValueError(f"Cosmos-Policy replay action row {row_index} must be JSON numpy.")
+        raise WorldStateError(f"Cosmos-Policy replay action row {row_index} must be JSON numpy.")
     encoded = value.get("__numpy__")
     if not isinstance(encoded, str) or not encoded:
-        raise ValueError(f"Cosmos-Policy replay action row {row_index} is missing __numpy__.")
+        raise WorldStateError(f"Cosmos-Policy replay action row {row_index} is missing __numpy__.")
     if value.get("dtype") != "<f4":
-        raise ValueError(f"Cosmos-Policy replay action row {row_index} must use dtype <f4.")
+        raise WorldStateError(f"Cosmos-Policy replay action row {row_index} must use dtype <f4.")
     if value.get("shape") != [_COSMOS_POLICY_ACTION_DIM]:
-        raise ValueError(
+        raise WorldStateError(
             f"Cosmos-Policy replay action row {row_index} must have shape "
             f"[{_COSMOS_POLICY_ACTION_DIM}]."
         )
     try:
         raw = base64.b64decode(encoded, validate=True)
     except (ValueError, binascii.Error) as exc:
-        raise ValueError(
+        raise WorldStateError(
             f"Cosmos-Policy replay action row {row_index} has invalid base64."
         ) from exc
     expected_bytes = _COSMOS_POLICY_ACTION_DIM * 4
     if len(raw) != expected_bytes:
-        raise ValueError(
+        raise WorldStateError(
             f"Cosmos-Policy replay action row {row_index} must contain {expected_bytes} bytes."
         )
     decoded = list(struct.unpack(f"<{_COSMOS_POLICY_ACTION_DIM}f", raw))
     if not all(math.isfinite(value) for value in decoded):
-        raise ValueError(f"Cosmos-Policy replay action row {row_index} must be finite.")
+        raise WorldStateError(f"Cosmos-Policy replay action row {row_index} must be finite.")
     return decoded
 
 

--- a/src/worldforge/harness/flows.py
+++ b/src/worldforge/harness/flows.py
@@ -110,6 +110,16 @@ _COSMOS_POLICY_ACTION_HORIZON = 50
 _COSMOS_POLICY_ACTION_DIM = 14
 _COSMOS_POLICY_VALUE_PREDICTION = 0.190714
 _COSMOS_POLICY_REPLAY_SCHEMA_VERSION = 1
+_COSMOS_POLICY_REPLAY_REQUEST_KEYS = frozenset(
+    {
+        "observation_fields",
+        "observation_summary",
+        "proprio_dim",
+        "task_description",
+        "action_horizon",
+        "embodiment_tag",
+    }
+)
 _FLOW_ARTIFACT_RESERVED_NAMES = frozenset(
     {"summary", "steps", "metrics", "transcript", "inspector"}
 )
@@ -469,6 +479,8 @@ def _load_cosmos_policy_replay_artifact(path: Path) -> JSONDict:
         raise ValueError("Cosmos-Policy replay artifact action_dim is unsupported.")
 
     request = _require_json_object(payload.get("request"), "Cosmos-Policy replay request")
+    if set(request) != _COSMOS_POLICY_REPLAY_REQUEST_KEYS:
+        raise ValueError("Cosmos-Policy replay request contains unsupported fields.")
     expected_fields = sorted(("primary_image", "left_wrist_image", "right_wrist_image", "proprio"))
     if request.get("observation_fields") != expected_fields:
         raise ValueError(
@@ -478,13 +490,15 @@ def _load_cosmos_policy_replay_artifact(path: Path) -> JSONDict:
         request.get("observation_summary"),
         "Cosmos-Policy replay observation_summary",
     )
-    for field in ("primary_image", "left_wrist_image", "right_wrist_image"):
+    if set(observation_summary) != set(expected_fields):
+        raise ValueError("Cosmos-Policy replay observation_summary contains unsupported fields.")
+    for field in ("primary_image", "left_wrist_image", "right_wrist_image", "proprio"):
         field_summary = _require_json_object(
             observation_summary.get(field),
             f"Cosmos-Policy replay observation_summary.{field}",
         )
         if field_summary.get("redacted") is not True:
-            raise ValueError(f"Cosmos-Policy replay image field {field} must be redacted.")
+            raise ValueError(f"Cosmos-Policy replay observation field {field} must be redacted.")
     if request.get("proprio_dim") != _COSMOS_POLICY_ACTION_DIM:
         raise ValueError("Cosmos-Policy replay proprio_dim is unsupported.")
     if not isinstance(request.get("task_description"), str) or not request["task_description"]:

--- a/src/worldforge/harness/flows.py
+++ b/src/worldforge/harness/flows.py
@@ -23,8 +23,9 @@ from worldforge.harness.workspace import (
     workspace_root_for_state_dir,
     write_run_manifest,
 )
-from worldforge.models import JSONDict, ProviderEvent, WorldForgeError
+from worldforge.models import JSONDict, ProviderEvent, WorldForgeError, WorldStateError
 from worldforge.provenance import ProvenanceEnvelope
+from worldforge.providers.base import ProviderError
 
 FlowRunner = Callable[..., JSONDict]
 
@@ -232,6 +233,7 @@ def _run_cosmos_policy_demo(*, state_dir: Path, emit: bool = False) -> JSONDict:
     request_count = 0
     replay_source_path = _write_prepared_cosmos_policy_replay_artifact(state_dir)
     saved_replay = _load_cosmos_policy_replay_artifact(replay_source_path)
+    saved_request = _require_json_object(saved_replay["request"], "Cosmos-Policy replay request")
     policy_info = _cosmos_policy_policy_info_from_replay(saved_replay)
     policy_output = _cosmos_policy_response_payload(saved_replay)
 
@@ -241,27 +243,26 @@ def _run_cosmos_policy_demo(*, state_dir: Path, emit: bool = False) -> JSONDict:
         try:
             payload = json.loads(request.content.decode("utf-8"))
         except json.JSONDecodeError as exc:
-            raise ValueError("Cosmos-Policy replay request body must be JSON.") from exc
+            raise WorldStateError("Cosmos-Policy replay request body must be JSON.") from exc
         if request.method != "POST":
-            raise ValueError(f"Cosmos-Policy replay expected POST, got {request.method}.")
+            raise WorldStateError(f"Cosmos-Policy replay expected POST, got {request.method}.")
         if request.url.path != "/act":
-            raise ValueError(f"Cosmos-Policy replay expected /act, got {request.url.path}.")
-        if payload.get("action_horizon") != _COSMOS_POLICY_ACTION_HORIZON:
-            raise ValueError("Cosmos-Policy replay request action_horizon drifted.")
+            raise WorldStateError(f"Cosmos-Policy replay expected /act, got {request.url.path}.")
+        _validate_cosmos_policy_replay_request(payload, saved_request)
         return httpx.Response(200, json=policy_output)
 
     def translator(raw_actions: object, _info: JSONDict, _provider_info: JSONDict):
         if not isinstance(raw_actions, dict):
-            raise ValueError("Cosmos-Policy replay translator expected raw action metadata.")
+            raise ProviderError("Cosmos-Policy replay translator expected raw action metadata.")
         matrix = raw_actions.get("actions")
         if not isinstance(matrix, list):
-            raise ValueError("Cosmos-Policy replay translator expected action rows.")
+            raise ProviderError("Cosmos-Policy replay translator expected action rows.")
         actions: list[Action] = []
         for index, row in enumerate(matrix):
             if not isinstance(row, list):
-                raise ValueError(f"Cosmos-Policy replay action row {index} must be a list.")
+                raise ProviderError(f"Cosmos-Policy replay action row {index} must be a list.")
             if len(row) < 3:
-                raise ValueError(f"Cosmos-Policy replay action row {index} needs x/y/z.")
+                raise ProviderError(f"Cosmos-Policy replay action row {index} needs x/y/z.")
             actions.append(Action.move_to(float(row[0]), float(row[1]), float(row[2])))
         return actions
 
@@ -274,8 +275,39 @@ def _run_cosmos_policy_demo(*, state_dir: Path, emit: bool = False) -> JSONDict:
     )
     forge = WorldForge(state_dir=state_dir, auto_register_remote=False)
     forge.register_provider(provider)
-    health = provider.health()
-    result = forge.select_actions("cosmos-policy", info=policy_info)
+    health = None
+    try:
+        health = provider.health()
+        result = forge.select_actions("cosmos-policy", info=policy_info)
+    except Exception as exc:
+        failure_event = ProviderEvent(
+            provider="cosmos-policy",
+            operation="policy",
+            phase="failure",
+            message=str(exc),
+            metadata={"stage": "harness-replay"},
+        )
+        if not events or events[-1].message != failure_event.message:
+            events.append(failure_event)
+        replay_artifact = _cosmos_policy_failure_replay_artifact(
+            saved_replay,
+            replay_source_path=replay_source_path,
+            events=events,
+            error=exc,
+        )
+        summary = _cosmos_policy_replay_failure_summary(
+            state_dir=state_dir,
+            saved_replay=saved_replay,
+            replay_source_path=replay_source_path,
+            health=health.to_dict() if health is not None else None,
+            request_count=request_count,
+            events=events,
+            replay_artifact=replay_artifact,
+            error=exc,
+        )
+        if emit:
+            print("\n".join(_transcript_for("cosmos-policy", summary)))
+        return summary
     metadata = result.metadata
     provider_info = metadata.get("provider_info", {})
     raw_action_summary = metadata.get("raw_action_summary", {})
@@ -369,8 +401,11 @@ def _write_prepared_cosmos_policy_replay_artifact(state_dir: Path) -> Path:
 
 
 def _cosmos_policy_saved_replay_payload() -> JSONDict:
-    policy_info = _cosmos_policy_policy_info()
     encoded_rows = [_json_numpy_action_row(row) for row in _cosmos_policy_action_rows()]
+    task_description = "fold shirt"
+    observation_fields = sorted(
+        ("primary_image", "left_wrist_image", "right_wrist_image", "proprio")
+    )
     return {
         "schema_version": _COSMOS_POLICY_REPLAY_SCHEMA_VERSION,
         "source": "sanitized Cosmos-Policy live /act response shape",
@@ -380,17 +415,17 @@ def _cosmos_policy_saved_replay_payload() -> JSONDict:
             "model": _COSMOS_POLICY_MODEL,
             "server_path": "/act",
             "runtime": "saved replay",
-            "task_description": policy_info["task_description"],
+            "task_description": task_description,
             "action_horizon": _COSMOS_POLICY_ACTION_HORIZON,
             "action_dim": _COSMOS_POLICY_ACTION_DIM,
         },
         "request": {
-            "observation_fields": sorted(policy_info["observation"]),
-            "observation_summary": _cosmos_policy_observation_summary(policy_info["observation"]),
-            "proprio_dim": len(policy_info["observation"]["proprio"]),
-            "task_description": policy_info["task_description"],
-            "action_horizon": policy_info["action_horizon"],
-            "embodiment_tag": policy_info["embodiment_tag"],
+            "observation_fields": observation_fields,
+            "observation_summary": _cosmos_policy_redacted_observation_summary(),
+            "proprio_dim": _COSMOS_POLICY_ACTION_DIM,
+            "task_description": task_description,
+            "action_horizon": _COSMOS_POLICY_ACTION_HORIZON,
+            "embodiment_tag": "aloha",
         },
         "policy_output": {
             "actions": encoded_rows,
@@ -481,6 +516,118 @@ def _load_cosmos_policy_replay_artifact(path: Path) -> JSONDict:
     return payload
 
 
+def _cosmos_policy_failure_replay_artifact(
+    saved_replay: JSONDict,
+    *,
+    replay_source_path: Path,
+    events: Sequence[ProviderEvent],
+    error: Exception,
+) -> JSONDict:
+    replay_artifact = dict(saved_replay)
+    manifest = dict(_require_json_object(saved_replay["manifest"], "Cosmos-Policy replay manifest"))
+    manifest.update(
+        {
+            "flow_id": "cosmos-policy",
+            "status": "failed",
+            "source_artifact": replay_source_path.name,
+        }
+    )
+    response = dict(_require_json_object(saved_replay["response"], "Cosmos-Policy replay response"))
+    response.update({"translated_action_count": 0, "error": str(error)})
+    replay_artifact.update(
+        {
+            "manifest": manifest,
+            "response": response,
+            "translated_actions": [],
+            "provider_events": [event.to_dict() for event in events],
+        }
+    )
+    return replay_artifact
+
+
+def _cosmos_policy_replay_failure_summary(
+    *,
+    state_dir: Path,
+    saved_replay: JSONDict,
+    replay_source_path: Path,
+    health: JSONDict | None,
+    request_count: int,
+    events: Sequence[ProviderEvent],
+    replay_artifact: JSONDict,
+    error: Exception,
+) -> JSONDict:
+    manifest = _require_json_object(saved_replay["manifest"], "Cosmos-Policy replay manifest")
+    request = _require_json_object(saved_replay["request"], "Cosmos-Policy replay request")
+    response = _require_json_object(saved_replay["response"], "Cosmos-Policy replay response")
+    return {
+        "demo_kind": "cosmos_policy_saved_replay",
+        "status": "failed",
+        "state_dir": str(state_dir),
+        "providers": ["cosmos-policy"],
+        "model": manifest.get("model"),
+        "task_description": request.get("task_description"),
+        "runtime": manifest.get("runtime"),
+        "server_path": manifest.get("server_path"),
+        "runtime_contract": "saved /act replay through CosmosPolicyProvider",
+        "loaded_replay_artifact": replay_source_path.name,
+        "health": health or {"healthy": False, "message": "not checked"},
+        "request_count": request_count,
+        "raw_action_shape": response.get("raw_action_shape", []),
+        "translated_action_count": 0,
+        "action_horizon": request.get("action_horizon"),
+        "selected_candidate_index": None,
+        "candidate_count": 0,
+        "value_prediction": response.get("value_prediction"),
+        "selected_actions": [],
+        "selected_action_preview": [],
+        "raw_action_preview": [],
+        "event_phases": [event.phase for event in events],
+        "provider_events": [event.to_dict() for event in events],
+        "validation_errors": [str(error)],
+        "harness_artifacts": {
+            "cosmos_policy_replay": {
+                "path": "artifacts/cosmos-policy-replay.json",
+                "payload": replay_artifact,
+            },
+        },
+    }
+
+
+def _validate_cosmos_policy_replay_request(payload: object, saved_request: JSONDict) -> None:
+    if not isinstance(payload, dict):
+        raise WorldStateError("Cosmos-Policy replay request payload must be a JSON object.")
+    expected_fields_value = saved_request.get("observation_fields")
+    if not isinstance(expected_fields_value, list) or not all(
+        isinstance(field, str) for field in expected_fields_value
+    ):
+        raise WorldStateError("Cosmos-Policy replay saved observation fields are invalid.")
+    expected_fields = sorted(expected_fields_value)
+    if expected_fields != expected_fields_value:
+        raise WorldStateError("Cosmos-Policy replay saved observation fields are invalid.")
+    expected_payload_keys = set(expected_fields) | {"task_description", "action_horizon"}
+    payload_keys = set(payload)
+    if payload_keys != expected_payload_keys:
+        missing = sorted(expected_payload_keys - payload_keys)
+        extra = sorted(payload_keys - expected_payload_keys)
+        detail = []
+        if missing:
+            detail.append(f"missing={missing}")
+        if extra:
+            detail.append(f"extra={extra}")
+        raise WorldStateError(
+            "Cosmos-Policy replay request keys drifted"
+            + (f" ({'; '.join(detail)})" if detail else "")
+            + "."
+        )
+    if payload.get("task_description") != saved_request["task_description"]:
+        raise WorldStateError("Cosmos-Policy replay request task_description drifted.")
+    if payload.get("action_horizon") != saved_request["action_horizon"]:
+        raise WorldStateError("Cosmos-Policy replay request action_horizon drifted.")
+    proprio = payload.get("proprio")
+    if not isinstance(proprio, list) or len(proprio) != saved_request["proprio_dim"]:
+        raise WorldStateError("Cosmos-Policy replay request proprio shape drifted.")
+
+
 def _cosmos_policy_policy_info_from_replay(replay_artifact: JSONDict) -> JSONDict:
     request = _require_json_object(
         replay_artifact.get("request"),
@@ -512,28 +659,19 @@ def _require_json_object(value: object, name: str) -> JSONDict:
     return value
 
 
-def _cosmos_policy_observation_summary(observation: JSONDict) -> JSONDict:
+def _cosmos_policy_redacted_observation_summary() -> JSONDict:
     return {
-        "primary_image": {"redacted": True, "shape": _nested_shape(observation["primary_image"])},
+        "primary_image": {"redacted": True, "shape": [1, 1, 1, 3]},
         "left_wrist_image": {
             "redacted": True,
-            "shape": _nested_shape(observation["left_wrist_image"]),
+            "shape": [1, 1, 1, 3],
         },
         "right_wrist_image": {
             "redacted": True,
-            "shape": _nested_shape(observation["right_wrist_image"]),
+            "shape": [1, 1, 1, 3],
         },
-        "proprio": {"redacted": True, "shape": [len(observation["proprio"])]},
+        "proprio": {"redacted": True, "shape": [_COSMOS_POLICY_ACTION_DIM]},
     }
-
-
-def _nested_shape(value: object) -> list[int]:
-    shape: list[int] = []
-    current = value
-    while isinstance(current, list):
-        shape.append(len(current))
-        current = current[0] if current else []
-    return shape
 
 
 def _cosmos_policy_action_rows() -> list[list[float]]:
@@ -698,6 +836,7 @@ def run_flow(flow_id: str, *, state_dir: Path | None = None) -> HarnessRun:
         transcript=_transcript_for(flow_id, summary),
         workspace_path=workspace.path,
         provider_events=_provider_events_for(flow_id, summary),
+        validation_errors=tuple(str(error) for error in summary.get("validation_errors", [])),
     )
     _write_flow_workspace(workspace, run)
     return run

--- a/src/worldforge/harness/flows.py
+++ b/src/worldforge/harness/flows.py
@@ -23,7 +23,7 @@ from worldforge.harness.workspace import (
     workspace_root_for_state_dir,
     write_run_manifest,
 )
-from worldforge.models import JSONDict, ProviderEvent
+from worldforge.models import JSONDict, ProviderEvent, WorldForgeError
 from worldforge.provenance import ProvenanceEnvelope
 
 FlowRunner = Callable[..., JSONDict]
@@ -620,7 +620,7 @@ def run_flow(flow_id: str, *, state_dir: Path | None = None) -> HarnessRun:
     flows = flow_index()
     if flow_id not in flows:
         valid = ", ".join(sorted(flows))
-        raise ValueError(f"unknown harness flow '{flow_id}'. Valid flows: {valid}.")
+        raise WorldForgeError(f"unknown harness flow '{flow_id}'. Valid flows: {valid}.")
 
     flow = flows[flow_id]
     resolved_state_dir = state_dir or Path(

--- a/src/worldforge/harness/tui.py
+++ b/src/worldforge/harness/tui.py
@@ -1048,7 +1048,9 @@ class RunInspectorScreen(Screen):
         Binding("r", "run_selected", "Run", show=True),
         Binding("1", "select_flow('leworldmodel')", "LeWorldModel", show=True),
         Binding("2", "select_flow('lerobot')", "LeRobot", show=True),
-        Binding("3", "select_flow('diagnostics')", "Diagnostics", show=True),
+        Binding("3", "select_flow('cosmos-policy')", "Cosmos", show=True),
+        Binding("4", "select_flow('diagnostics')", "Diagnostics", show=True),
+        Binding("5", "select_flow('workbench')", "Workbench", show=True),
     ]
 
     DEFAULT_CSS = """

--- a/tests/test_harness_cli.py
+++ b/tests/test_harness_cli.py
@@ -19,6 +19,7 @@ def test_worldforge_harness_lists_flows_without_textual(monkeypatch, capsys) -> 
     assert output.startswith("# TheWorldHarness Flows")
     assert "leworldmodel" in output
     assert "lerobot" in output
+    assert "cosmos-policy" in output
     assert "diagnostics" in output
     assert "workbench" in output
 
@@ -36,6 +37,7 @@ def test_worldforge_harness_lists_json_without_textual(monkeypatch, capsys) -> N
     assert [flow["id"] for flow in payload] == [
         "leworldmodel",
         "lerobot",
+        "cosmos-policy",
         "diagnostics",
         "workbench",
     ]

--- a/tests/test_harness_flows.py
+++ b/tests/test_harness_flows.py
@@ -30,14 +30,21 @@ from worldforge.harness.workspace import create_run_workspace, write_run_manifes
 
 def test_harness_flow_metadata_is_available_without_textual() -> None:
     flows = available_flows()
-    assert [flow.id for flow in flows] == ["leworldmodel", "lerobot", "diagnostics", "workbench"]
+    assert [flow.id for flow in flows] == [
+        "leworldmodel",
+        "lerobot",
+        "cosmos-policy",
+        "diagnostics",
+        "workbench",
+    ]
     assert flow_index()["leworldmodel"].provider == "LeWorldModelProvider"
 
     payload = flow_to_dicts()
     assert payload[0]["command"] == "uv run worldforge-demo-leworldmodel"
     assert payload[1]["focus"] == "policy plus score planning"
-    assert payload[2]["command"] == "uv run worldforge harness --flow diagnostics"
-    assert payload[3]["command"] == "uv run worldforge provider workbench mock"
+    assert payload[2]["command"] == "uv run --extra harness worldforge-harness --flow cosmos-policy"
+    assert payload[3]["command"] == "uv run worldforge harness --flow diagnostics"
+    assert payload[4]["command"] == "uv run worldforge provider workbench mock"
 
 
 def test_harness_runs_leworldmodel_flow(tmp_path) -> None:
@@ -68,6 +75,146 @@ def test_harness_runs_lerobot_flow(tmp_path) -> None:
     assert run.summary["selected_candidate_index"] == 1
     assert run.summary["policy_select_calls"] == 2
     assert "policy_select_calls: 2" in run.transcript
+
+
+def test_harness_runs_cosmos_policy_flow(tmp_path) -> None:
+    run = run_flow("cosmos-policy", state_dir=tmp_path)
+
+    assert run.flow.id == "cosmos-policy"
+    assert len(run.steps) == 6
+    assert len(run.metrics) == 6
+    assert run.summary["model"] == "nvidia/Cosmos-Policy-ALOHA-Predict2-2B"
+    assert run.summary["server_path"] == "/act"
+    assert run.summary["raw_action_shape"] == [50, 14]
+    assert run.summary["translated_action_count"] == 50
+    assert run.summary["action_horizon"] == 50
+    assert run.summary["value_prediction"] == 0.190714
+    assert run.summary["selected_candidate_index"] == 0
+    assert run.summary["selected_action_preview"][0]["type"] == "move_to"
+    assert [event["phase"] for event in run.provider_events] == ["success"]
+    assert "raw_action_shape: [50, 14]" in run.transcript
+    assert "saved_replay_artifact: artifacts/cosmos-policy-replay.json" in run.transcript
+    assert run.workspace_path is not None
+    manifest = json.loads((run.workspace_path / "run_manifest.json").read_text())
+    assert manifest["artifact_paths"]["cosmos_policy_replay"] == (
+        "artifacts/cosmos-policy-replay.json"
+    )
+    replay = json.loads((run.workspace_path / "artifacts/cosmos-policy-replay.json").read_text())
+    assert replay["response"]["json_numpy_rows"] is True
+    assert replay["response"]["raw_action_shape"] == [50, 14]
+    assert replay["request"]["observation_fields"] == [
+        "left_wrist_image",
+        "primary_image",
+        "proprio",
+        "right_wrist_image",
+    ]
+
+
+def test_harness_cosmos_policy_flow_can_emit_transcript(tmp_path, capsys) -> None:
+    from worldforge.harness import flows
+
+    summary = flows._run_cosmos_policy_demo(state_dir=tmp_path, emit=True)
+
+    output = capsys.readouterr().out
+    assert summary["raw_action_shape"] == [50, 14]
+    assert "flow: cosmos-policy" in output
+    assert "translated_actions: 50" in output
+
+
+def test_harness_rejects_unknown_flow(tmp_path) -> None:
+    with pytest.raises(ValueError, match="unknown harness flow 'unknown'"):
+        run_flow("unknown", state_dir=tmp_path)
+
+
+def test_harness_flow_artifact_descriptors_are_validated(tmp_path) -> None:
+    from worldforge.harness import flows
+
+    workspace = create_run_workspace(
+        tmp_path,
+        kind="flow",
+        command="worldforge harness --flow demo",
+        provider="demo",
+        operation="demo",
+    )
+
+    assert flows._write_flow_artifacts(workspace, {"harness_artifacts": {}}) == {}
+
+    with pytest.raises(ValueError, match="artifact names"):
+        flows._write_flow_artifacts(
+            workspace,
+            {"harness_artifacts": {"": {"path": "artifacts/demo.json"}}},
+        )
+    with pytest.raises(ValueError, match="descriptor"):
+        flows._write_flow_artifacts(workspace, {"harness_artifacts": {"demo": "bad"}})
+    with pytest.raises(ValueError, match="under artifacts"):
+        flows._write_flow_artifacts(
+            workspace,
+            {"harness_artifacts": {"demo": {"path": "results/demo.json"}}},
+        )
+
+
+def test_harness_private_helpers_cover_invalid_and_emit_paths(tmp_path, capsys) -> None:
+    from worldforge.harness import flows
+
+    assert flows._preview_action_rows("not rows") == []
+    assert flows._preview_action_rows([[1, 2], "bad", [3]]) == [[1.0, 2.0], [3.0]]
+
+    with pytest.raises(ValueError, match="unknown harness flow"):
+        flows._steps_for("unknown", {})
+
+    forge = WorldForge(state_dir=tmp_path)
+    with pytest.raises(ValueError, match="must include a json entry"):
+        write_report(forge, "missing-json", {})
+
+    unsupported_path = tmp_path / "unsupported-report.json"
+    unsupported_path.write_text("{}", encoding="utf-8")
+    with pytest.raises(ValueError, match="unsupported harness report payload"):
+        report_run_from_path(unsupported_path, state_dir=tmp_path)
+
+    def broken_glob(_self: Path, _pattern: str):
+        raise OSError("cannot scan")
+
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr(Path, "glob", broken_glob)
+    try:
+        assert recent_report_paths(tmp_path) == ()
+    finally:
+        monkeypatch.undo()
+
+    assert flows._provider_events_for("diagnostics", {}) == ()
+    assert [
+        event["phase"]
+        for event in flows._provider_events_for(
+            "diagnostics",
+            {"event_phases": ["success"]},
+        )
+    ] == ["success"]
+    events = flows._provider_events_for(
+        "diagnostics",
+        {
+            "benchmark_results": [
+                "bad",
+                {"operation_metrics": "bad"},
+                {
+                    "provider": "mock",
+                    "operation": "predict",
+                    "operation_metrics": {
+                        "events": [
+                            "bad",
+                            {"request_count": 1, "retry_count": 1, "error_count": 0},
+                        ],
+                    },
+                },
+            ],
+        },
+    )
+    assert [event["phase"] for event in events] == ["retry"]
+
+    flows._run_diagnostics_demo(state_dir=tmp_path / "diagnostics", emit=True)
+    flows._run_workbench_demo(state_dir=tmp_path / "workbench", emit=True)
+    output = capsys.readouterr().out
+    assert "Benchmark Report" in output
+    assert "Provider Workbench" in output
 
 
 def test_harness_failed_flow_preserves_manifest_and_inspector(

--- a/tests/test_harness_flows.py
+++ b/tests/test_harness_flows.py
@@ -105,6 +105,10 @@ def test_harness_runs_cosmos_policy_flow(tmp_path) -> None:
     assert len(replay["policy_output"]["actions"]) == 50
     assert len(replay["translated_actions"]) == 50
     assert replay["provider_events"][0]["phase"] == "success"
+    assert "policy_info" not in replay["request"]
+    assert replay["request"]["observation_summary"]["primary_image"]["redacted"] is True
+    assert replay["request"]["observation_summary"]["left_wrist_image"]["redacted"] is True
+    assert replay["request"]["observation_summary"]["right_wrist_image"]["redacted"] is True
     assert replay["response"]["json_numpy_rows"] is True
     assert replay["response"]["raw_action_shape"] == [50, 14]
     assert replay["request"]["observation_fields"] == [
@@ -136,7 +140,9 @@ def test_harness_loads_cosmos_policy_replay_artifact(tmp_path) -> None:
     loaded = flows._load_cosmos_policy_replay_artifact(path)
 
     assert loaded["manifest"]["model"] == "nvidia/Cosmos-Policy-ALOHA-Predict2-2B"
-    assert loaded["request"]["policy_info"]["task_description"] == "fold shirt"
+    assert loaded["request"]["task_description"] == "fold shirt"
+    assert loaded["request"]["observation_summary"]["primary_image"]["redacted"] is True
+    assert "policy_info" not in loaded["request"]
     assert len(loaded["policy_output"]["actions"]) == 50
 
 
@@ -155,10 +161,17 @@ def test_harness_rejects_malformed_cosmos_policy_replay_artifacts(tmp_path) -> N
         flows._load_cosmos_policy_replay_artifact(write_payload("bad-schema.json", invalid_schema))
 
     missing_observation = json.loads(json.dumps(payload))
-    del missing_observation["request"]["policy_info"]["observation"]["proprio"]
+    missing_observation["request"]["observation_fields"] = ["primary_image"]
     with pytest.raises(ValueError, match="missing fields"):
         flows._load_cosmos_policy_replay_artifact(
             write_payload("missing-observation.json", missing_observation)
+        )
+
+    unredacted_image = json.loads(json.dumps(payload))
+    unredacted_image["request"]["observation_summary"]["primary_image"]["redacted"] = False
+    with pytest.raises(ValueError, match="must be redacted"):
+        flows._load_cosmos_policy_replay_artifact(
+            write_payload("unredacted-image.json", unredacted_image)
         )
 
     bad_action_shape = json.loads(json.dumps(payload))

--- a/tests/test_harness_flows.py
+++ b/tests/test_harness_flows.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import base64
 import importlib
 import json
+import math
+import struct
 import sys
 from pathlib import Path
 
@@ -26,6 +29,33 @@ from worldforge.harness.run_history import (
     run_history_markdown,
 )
 from worldforge.harness.workspace import create_run_workspace, write_run_manifest
+
+
+def _copy_json_payload(value: object) -> object:
+    return json.loads(json.dumps(value))
+
+
+def _write_cosmos_replay_payload(tmp_path: Path, name: str, payload: object) -> Path:
+    path = tmp_path / name
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def _cosmos_replay_request_payload(tmp_path: Path) -> tuple[dict, dict]:
+    from worldforge.harness import flows
+
+    replay_path = tmp_path / "cosmos-policy-replay.json"
+    replay_path.write_text(
+        json.dumps(flows._cosmos_policy_saved_replay_payload()),
+        encoding="utf-8",
+    )
+    replay = flows._load_cosmos_policy_replay_artifact(replay_path)
+    saved_request = replay["request"]
+    policy_info = flows._cosmos_policy_policy_info_from_replay(replay)
+    outbound_payload = dict(policy_info["observation"])
+    outbound_payload["task_description"] = saved_request["task_description"]
+    outbound_payload["action_horizon"] = saved_request["action_horizon"]
+    return outbound_payload, saved_request
 
 
 def test_harness_flow_metadata_is_available_without_textual() -> None:
@@ -131,6 +161,16 @@ def test_harness_cosmos_policy_flow_can_emit_transcript(tmp_path, capsys) -> Non
     assert "translated_actions: 50" in output
 
 
+def test_harness_cosmos_policy_flow_ignores_live_cosmos_env(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("COSMOS_POLICY_ALLOWED_HOSTS", "live-cosmos.example")
+    monkeypatch.setenv("COSMOS_POLICY_RETURN_ALL_QUERY_RESULTS", "true")
+
+    run = run_flow("cosmos-policy", state_dir=tmp_path)
+
+    assert run.summary["raw_action_shape"] == [50, 14]
+    assert run.summary["translated_action_count"] == 50
+
+
 def test_harness_loads_cosmos_policy_replay_artifact(tmp_path) -> None:
     from worldforge.harness import flows
 
@@ -148,72 +188,152 @@ def test_harness_loads_cosmos_policy_replay_artifact(tmp_path) -> None:
     assert len(loaded["policy_output"]["actions"]) == 50
 
 
-def test_harness_rejects_malformed_cosmos_policy_replay_artifacts(tmp_path) -> None:
+def test_harness_rejects_cosmos_policy_replay_schema_drift(tmp_path) -> None:
     from worldforge.harness import flows
 
-    def write_payload(name: str, payload: object) -> Path:
-        path = tmp_path / name
-        path.write_text(json.dumps(payload), encoding="utf-8")
-        return path
+    payload = flows._cosmos_policy_saved_replay_payload()
+    invalid_schema = _copy_json_payload(payload)
+    invalid_schema["schema_version"] = 99
+
+    with pytest.raises(WorldStateError, match="schema_version"):
+        flows._load_cosmos_policy_replay_artifact(
+            _write_cosmos_replay_payload(tmp_path, "bad-schema.json", invalid_schema)
+        )
+
+
+def test_harness_rejects_cosmos_policy_replay_missing_observation(tmp_path) -> None:
+    from worldforge.harness import flows
 
     payload = flows._cosmos_policy_saved_replay_payload()
-    invalid_schema = json.loads(json.dumps(payload))
-    invalid_schema["schema_version"] = 99
-    with pytest.raises(WorldStateError, match="schema_version"):
-        flows._load_cosmos_policy_replay_artifact(write_payload("bad-schema.json", invalid_schema))
-
-    missing_observation = json.loads(json.dumps(payload))
+    missing_observation = _copy_json_payload(payload)
     missing_observation["request"]["observation_fields"] = ["primary_image"]
+
     with pytest.raises(WorldStateError, match="missing fields"):
         flows._load_cosmos_policy_replay_artifact(
-            write_payload("missing-observation.json", missing_observation)
+            _write_cosmos_replay_payload(
+                tmp_path,
+                "missing-observation.json",
+                missing_observation,
+            )
         )
 
-    unredacted_image = json.loads(json.dumps(payload))
+
+def test_harness_rejects_unredacted_cosmos_policy_replay_image(tmp_path) -> None:
+    from worldforge.harness import flows
+
+    payload = flows._cosmos_policy_saved_replay_payload()
+    unredacted_image = _copy_json_payload(payload)
     unredacted_image["request"]["observation_summary"]["primary_image"]["redacted"] = False
+
     with pytest.raises(WorldStateError, match="must be redacted"):
         flows._load_cosmos_policy_replay_artifact(
-            write_payload("unredacted-image.json", unredacted_image)
+            _write_cosmos_replay_payload(tmp_path, "unredacted-image.json", unredacted_image)
         )
 
-    unredacted_proprio = json.loads(json.dumps(payload))
+
+def test_harness_rejects_unredacted_cosmos_policy_replay_proprio(tmp_path) -> None:
+    from worldforge.harness import flows
+
+    payload = flows._cosmos_policy_saved_replay_payload()
+    unredacted_proprio = _copy_json_payload(payload)
     unredacted_proprio["request"]["observation_summary"]["proprio"]["redacted"] = False
+
     with pytest.raises(WorldStateError, match="must be redacted"):
         flows._load_cosmos_policy_replay_artifact(
-            write_payload("unredacted-proprio.json", unredacted_proprio)
+            _write_cosmos_replay_payload(tmp_path, "unredacted-proprio.json", unredacted_proprio)
         )
 
-    raw_observation = json.loads(json.dumps(payload))
+
+def test_harness_rejects_raw_cosmos_policy_replay_observation(tmp_path) -> None:
+    from worldforge.harness import flows
+
+    payload = flows._cosmos_policy_saved_replay_payload()
+    raw_observation = _copy_json_payload(payload)
     raw_observation["request"]["observation"] = {"primary_image": [[[[0, 0, 0]]]]}
+
     with pytest.raises(WorldStateError, match="unsupported fields"):
         flows._load_cosmos_policy_replay_artifact(
-            write_payload("raw-observation.json", raw_observation)
+            _write_cosmos_replay_payload(tmp_path, "raw-observation.json", raw_observation)
         )
 
-    bad_action_shape = json.loads(json.dumps(payload))
+
+def test_harness_rejects_cosmos_policy_replay_observation_summary_extra_keys(
+    tmp_path,
+) -> None:
+    from worldforge.harness import flows
+
+    payload = flows._cosmos_policy_saved_replay_payload()
+    extra_summary_key = _copy_json_payload(payload)
+    extra_summary_key["request"]["observation_summary"]["primary_image"]["raw_tensor"] = [
+        0,
+        1,
+        2,
+    ]
+
+    with pytest.raises(WorldStateError, match="unsupported fields"):
+        flows._load_cosmos_policy_replay_artifact(
+            _write_cosmos_replay_payload(
+                tmp_path,
+                "extra-summary-key.json",
+                extra_summary_key,
+            )
+        )
+
+
+def test_harness_rejects_cosmos_policy_replay_bad_action_shape(tmp_path) -> None:
+    from worldforge.harness import flows
+
+    payload = flows._cosmos_policy_saved_replay_payload()
+    bad_action_shape = _copy_json_payload(payload)
     bad_action_shape["policy_output"]["actions"][0]["shape"] = [15]
+
     with pytest.raises(WorldStateError, match="shape"):
         flows._load_cosmos_policy_replay_artifact(
-            write_payload("bad-action-shape.json", bad_action_shape)
+            _write_cosmos_replay_payload(tmp_path, "bad-action-shape.json", bad_action_shape)
         )
+
+
+def test_harness_rejects_cosmos_policy_replay_large_base64_before_decode(tmp_path) -> None:
+    from worldforge.harness import flows
+
+    payload = flows._cosmos_policy_saved_replay_payload()
+    large_row = _copy_json_payload(payload)
+    large_row["policy_output"]["actions"][0]["__numpy__"] = "A" * 512
+
+    with pytest.raises(WorldStateError, match="base64 payload is too large"):
+        flows._load_cosmos_policy_replay_artifact(
+            _write_cosmos_replay_payload(tmp_path, "large-row.json", large_row)
+        )
+
+
+def test_harness_accepts_cosmos_policy_replay_float64_dtype(tmp_path) -> None:
+    from worldforge.harness import flows
+
+    payload = flows._cosmos_policy_saved_replay_payload()
+    float64_row = _copy_json_payload(payload)
+    raw = struct.pack("<14d", *[float(index) / 100.0 for index in range(14)])
+    float64_row["policy_output"]["actions"][0] = {
+        "__numpy__": base64.b64encode(raw).decode("ascii"),
+        "dtype": "float64",
+        "shape": [14],
+    }
+
+    loaded = flows._load_cosmos_policy_replay_artifact(
+        _write_cosmos_replay_payload(tmp_path, "float64-row.json", float64_row)
+    )
+
+    assert loaded["policy_output"]["actions"][0]["dtype"] == "float64"
 
 
 def test_harness_validates_cosmos_policy_replay_request_contract(tmp_path) -> None:
     from worldforge.harness import flows
 
-    replay_path = tmp_path / "cosmos-policy-replay.json"
-    replay_path.write_text(
-        json.dumps(flows._cosmos_policy_saved_replay_payload()),
-        encoding="utf-8",
-    )
-    replay = flows._load_cosmos_policy_replay_artifact(replay_path)
-    saved_request = replay["request"]
-    policy_info = flows._cosmos_policy_policy_info_from_replay(replay)
-    outbound_payload = dict(policy_info["observation"])
-    outbound_payload["task_description"] = saved_request["task_description"]
-    outbound_payload["action_horizon"] = saved_request["action_horizon"]
+    outbound_payload, saved_request = _cosmos_replay_request_payload(tmp_path)
 
     flows._validate_cosmos_policy_replay_request(outbound_payload, saved_request)
+
+    return_all_payload = {**outbound_payload, "return_all_query_results": False}
+    flows._validate_cosmos_policy_replay_request(return_all_payload, saved_request)
 
     drifted_payload = {**outbound_payload, "task_description": "pick cube"}
     with pytest.raises(WorldStateError, match="task_description drifted"):
@@ -223,6 +343,28 @@ def test_harness_validates_cosmos_policy_replay_request_contract(tmp_path) -> No
     del missing_field_payload["left_wrist_image"]
     with pytest.raises(WorldStateError, match="request keys drifted"):
         flows._validate_cosmos_policy_replay_request(missing_field_payload, saved_request)
+
+    bad_return_all_payload = {**outbound_payload, "return_all_query_results": "false"}
+    with pytest.raises(WorldStateError, match="return_all_query_results"):
+        flows._validate_cosmos_policy_replay_request(bad_return_all_payload, saved_request)
+
+
+def test_harness_rejects_cosmos_policy_replay_request_non_json_values(tmp_path) -> None:
+    from worldforge.harness import flows
+
+    outbound_payload, saved_request = _cosmos_replay_request_payload(tmp_path)
+
+    tuple_payload = {**outbound_payload, "primary_image": tuple(outbound_payload["primary_image"])}
+    with pytest.raises(WorldStateError, match="JSON-native"):
+        flows._validate_cosmos_policy_replay_request(tuple_payload, saved_request)
+
+    bytes_payload = {**outbound_payload, "left_wrist_image": b"not-json"}
+    with pytest.raises(WorldStateError, match="JSON-native"):
+        flows._validate_cosmos_policy_replay_request(bytes_payload, saved_request)
+
+    nan_payload = {**outbound_payload, "proprio": [0.0] * 13 + [math.nan]}
+    with pytest.raises(WorldStateError, match="JSON-native"):
+        flows._validate_cosmos_policy_replay_request(nan_payload, saved_request)
 
 
 def test_harness_cosmos_policy_optional_value_prediction_renders(tmp_path) -> None:

--- a/tests/test_harness_flows.py
+++ b/tests/test_harness_flows.py
@@ -100,6 +100,11 @@ def test_harness_runs_cosmos_policy_flow(tmp_path) -> None:
         "artifacts/cosmos-policy-replay.json"
     )
     replay = json.loads((run.workspace_path / "artifacts/cosmos-policy-replay.json").read_text())
+    assert replay["manifest"]["flow_id"] == "cosmos-policy"
+    assert replay["manifest"]["server_path"] == "/act"
+    assert len(replay["policy_output"]["actions"]) == 50
+    assert len(replay["translated_actions"]) == 50
+    assert replay["provider_events"][0]["phase"] == "success"
     assert replay["response"]["json_numpy_rows"] is True
     assert replay["response"]["raw_action_shape"] == [50, 14]
     assert replay["request"]["observation_fields"] == [
@@ -119,6 +124,60 @@ def test_harness_cosmos_policy_flow_can_emit_transcript(tmp_path, capsys) -> Non
     assert summary["raw_action_shape"] == [50, 14]
     assert "flow: cosmos-policy" in output
     assert "translated_actions: 50" in output
+
+
+def test_harness_loads_cosmos_policy_replay_artifact(tmp_path) -> None:
+    from worldforge.harness import flows
+
+    path = tmp_path / "cosmos-policy-replay.json"
+    payload = flows._cosmos_policy_saved_replay_payload()
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    loaded = flows._load_cosmos_policy_replay_artifact(path)
+
+    assert loaded["manifest"]["model"] == "nvidia/Cosmos-Policy-ALOHA-Predict2-2B"
+    assert loaded["request"]["policy_info"]["task_description"] == "fold shirt"
+    assert len(loaded["policy_output"]["actions"]) == 50
+
+
+def test_harness_rejects_malformed_cosmos_policy_replay_artifacts(tmp_path) -> None:
+    from worldforge.harness import flows
+
+    def write_payload(name: str, payload: object) -> Path:
+        path = tmp_path / name
+        path.write_text(json.dumps(payload), encoding="utf-8")
+        return path
+
+    payload = flows._cosmos_policy_saved_replay_payload()
+    invalid_schema = json.loads(json.dumps(payload))
+    invalid_schema["schema_version"] = 99
+    with pytest.raises(ValueError, match="schema_version"):
+        flows._load_cosmos_policy_replay_artifact(write_payload("bad-schema.json", invalid_schema))
+
+    missing_observation = json.loads(json.dumps(payload))
+    del missing_observation["request"]["policy_info"]["observation"]["proprio"]
+    with pytest.raises(ValueError, match="missing fields"):
+        flows._load_cosmos_policy_replay_artifact(
+            write_payload("missing-observation.json", missing_observation)
+        )
+
+    bad_action_shape = json.loads(json.dumps(payload))
+    bad_action_shape["policy_output"]["actions"][0]["shape"] = [15]
+    with pytest.raises(ValueError, match="shape"):
+        flows._load_cosmos_policy_replay_artifact(
+            write_payload("bad-action-shape.json", bad_action_shape)
+        )
+
+
+def test_harness_cosmos_policy_optional_value_prediction_renders(tmp_path) -> None:
+    from worldforge.harness import flows
+
+    summary = run_flow("cosmos-policy", state_dir=tmp_path).summary
+    summary = {**summary, "value_prediction": None}
+
+    assert flows._steps_for("cosmos-policy", summary)[4].artifact == "value_prediction=n/a"
+    assert flows._metrics_for("cosmos-policy", summary)[3].value == "n/a"
+    assert "value_prediction: n/a" in flows._transcript_for("cosmos-policy", summary)
 
 
 def test_harness_rejects_unknown_flow(tmp_path) -> None:
@@ -150,6 +209,11 @@ def test_harness_flow_artifact_descriptors_are_validated(tmp_path) -> None:
         flows._write_flow_artifacts(
             workspace,
             {"harness_artifacts": {"demo": {"path": "results/demo.json"}}},
+        )
+    with pytest.raises(ValueError, match="reserved"):
+        flows._write_flow_artifacts(
+            workspace,
+            {"harness_artifacts": {"summary": {"path": "artifacts/summary.json"}}},
         )
 
 

--- a/tests/test_harness_flows.py
+++ b/tests/test_harness_flows.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import pytest
 
-from worldforge import WorldForge, WorldForgeError
+from worldforge import WorldForge, WorldForgeError, WorldStateError
 from worldforge.evaluation import EvaluationSuite
 from worldforge.harness import available_flows, flow_index, run_flow
 from worldforge.harness.flows import (
@@ -182,6 +182,33 @@ def test_harness_rejects_malformed_cosmos_policy_replay_artifacts(tmp_path) -> N
         )
 
 
+def test_harness_validates_cosmos_policy_replay_request_contract(tmp_path) -> None:
+    from worldforge.harness import flows
+
+    replay_path = tmp_path / "cosmos-policy-replay.json"
+    replay_path.write_text(
+        json.dumps(flows._cosmos_policy_saved_replay_payload()),
+        encoding="utf-8",
+    )
+    replay = flows._load_cosmos_policy_replay_artifact(replay_path)
+    saved_request = replay["request"]
+    policy_info = flows._cosmos_policy_policy_info_from_replay(replay)
+    outbound_payload = dict(policy_info["observation"])
+    outbound_payload["task_description"] = saved_request["task_description"]
+    outbound_payload["action_horizon"] = saved_request["action_horizon"]
+
+    flows._validate_cosmos_policy_replay_request(outbound_payload, saved_request)
+
+    drifted_payload = {**outbound_payload, "task_description": "pick cube"}
+    with pytest.raises(WorldStateError, match="task_description drifted"):
+        flows._validate_cosmos_policy_replay_request(drifted_payload, saved_request)
+
+    missing_field_payload = dict(outbound_payload)
+    del missing_field_payload["left_wrist_image"]
+    with pytest.raises(WorldStateError, match="request keys drifted"):
+        flows._validate_cosmos_policy_replay_request(missing_field_payload, saved_request)
+
+
 def test_harness_cosmos_policy_optional_value_prediction_renders(tmp_path) -> None:
     from worldforge.harness import flows
 
@@ -191,6 +218,31 @@ def test_harness_cosmos_policy_optional_value_prediction_renders(tmp_path) -> No
     assert flows._steps_for("cosmos-policy", summary)[4].artifact == "value_prediction=n/a"
     assert flows._metrics_for("cosmos-policy", summary)[3].value == "n/a"
     assert "value_prediction: n/a" in flows._transcript_for("cosmos-policy", summary)
+
+
+def test_harness_cosmos_policy_failure_preserves_replay_artifact(tmp_path, monkeypatch) -> None:
+    from worldforge.harness import flows
+
+    original_response_payload = flows._cosmos_policy_response_payload
+
+    def malformed_response(replay_artifact):
+        response = json.loads(json.dumps(original_response_payload(replay_artifact)))
+        response["actions"][0]["shape"] = [15]
+        return response
+
+    monkeypatch.setattr(flows, "_cosmos_policy_response_payload", malformed_response)
+
+    run = run_flow("cosmos-policy", state_dir=tmp_path)
+
+    assert run.validation_errors
+    assert run.workspace_path is not None
+    manifest = json.loads((run.workspace_path / "run_manifest.json").read_text())
+    assert manifest["status"] == "failed"
+    replay_path = run.workspace_path / "artifacts" / "cosmos-policy-replay.json"
+    replay = json.loads(replay_path.read_text())
+    assert replay["manifest"]["status"] == "failed"
+    assert "failure" in [event["phase"] for event in replay["provider_events"]]
+    assert replay["translated_actions"] == []
 
 
 def test_harness_rejects_unknown_flow(tmp_path) -> None:

--- a/tests/test_harness_flows.py
+++ b/tests/test_harness_flows.py
@@ -181,7 +181,7 @@ def test_harness_cosmos_policy_optional_value_prediction_renders(tmp_path) -> No
 
 
 def test_harness_rejects_unknown_flow(tmp_path) -> None:
-    with pytest.raises(ValueError, match="unknown harness flow 'unknown'"):
+    with pytest.raises(WorldForgeError, match="unknown harness flow 'unknown'"):
         run_flow("unknown", state_dir=tmp_path)
 
 

--- a/tests/test_harness_flows.py
+++ b/tests/test_harness_flows.py
@@ -109,6 +109,7 @@ def test_harness_runs_cosmos_policy_flow(tmp_path) -> None:
     assert replay["request"]["observation_summary"]["primary_image"]["redacted"] is True
     assert replay["request"]["observation_summary"]["left_wrist_image"]["redacted"] is True
     assert replay["request"]["observation_summary"]["right_wrist_image"]["redacted"] is True
+    assert replay["request"]["observation_summary"]["proprio"]["redacted"] is True
     assert replay["response"]["json_numpy_rows"] is True
     assert replay["response"]["raw_action_shape"] == [50, 14]
     assert replay["request"]["observation_fields"] == [
@@ -142,6 +143,7 @@ def test_harness_loads_cosmos_policy_replay_artifact(tmp_path) -> None:
     assert loaded["manifest"]["model"] == "nvidia/Cosmos-Policy-ALOHA-Predict2-2B"
     assert loaded["request"]["task_description"] == "fold shirt"
     assert loaded["request"]["observation_summary"]["primary_image"]["redacted"] is True
+    assert loaded["request"]["observation_summary"]["proprio"]["redacted"] is True
     assert "policy_info" not in loaded["request"]
     assert len(loaded["policy_output"]["actions"]) == 50
 
@@ -172,6 +174,20 @@ def test_harness_rejects_malformed_cosmos_policy_replay_artifacts(tmp_path) -> N
     with pytest.raises(ValueError, match="must be redacted"):
         flows._load_cosmos_policy_replay_artifact(
             write_payload("unredacted-image.json", unredacted_image)
+        )
+
+    unredacted_proprio = json.loads(json.dumps(payload))
+    unredacted_proprio["request"]["observation_summary"]["proprio"]["redacted"] = False
+    with pytest.raises(ValueError, match="must be redacted"):
+        flows._load_cosmos_policy_replay_artifact(
+            write_payload("unredacted-proprio.json", unredacted_proprio)
+        )
+
+    raw_observation = json.loads(json.dumps(payload))
+    raw_observation["request"]["observation"] = {"primary_image": [[[[0, 0, 0]]]]}
+    with pytest.raises(ValueError, match="unsupported fields"):
+        flows._load_cosmos_policy_replay_artifact(
+            write_payload("raw-observation.json", raw_observation)
         )
 
     bad_action_shape = json.loads(json.dumps(payload))

--- a/tests/test_harness_flows.py
+++ b/tests/test_harness_flows.py
@@ -159,40 +159,40 @@ def test_harness_rejects_malformed_cosmos_policy_replay_artifacts(tmp_path) -> N
     payload = flows._cosmos_policy_saved_replay_payload()
     invalid_schema = json.loads(json.dumps(payload))
     invalid_schema["schema_version"] = 99
-    with pytest.raises(ValueError, match="schema_version"):
+    with pytest.raises(WorldStateError, match="schema_version"):
         flows._load_cosmos_policy_replay_artifact(write_payload("bad-schema.json", invalid_schema))
 
     missing_observation = json.loads(json.dumps(payload))
     missing_observation["request"]["observation_fields"] = ["primary_image"]
-    with pytest.raises(ValueError, match="missing fields"):
+    with pytest.raises(WorldStateError, match="missing fields"):
         flows._load_cosmos_policy_replay_artifact(
             write_payload("missing-observation.json", missing_observation)
         )
 
     unredacted_image = json.loads(json.dumps(payload))
     unredacted_image["request"]["observation_summary"]["primary_image"]["redacted"] = False
-    with pytest.raises(ValueError, match="must be redacted"):
+    with pytest.raises(WorldStateError, match="must be redacted"):
         flows._load_cosmos_policy_replay_artifact(
             write_payload("unredacted-image.json", unredacted_image)
         )
 
     unredacted_proprio = json.loads(json.dumps(payload))
     unredacted_proprio["request"]["observation_summary"]["proprio"]["redacted"] = False
-    with pytest.raises(ValueError, match="must be redacted"):
+    with pytest.raises(WorldStateError, match="must be redacted"):
         flows._load_cosmos_policy_replay_artifact(
             write_payload("unredacted-proprio.json", unredacted_proprio)
         )
 
     raw_observation = json.loads(json.dumps(payload))
     raw_observation["request"]["observation"] = {"primary_image": [[[[0, 0, 0]]]]}
-    with pytest.raises(ValueError, match="unsupported fields"):
+    with pytest.raises(WorldStateError, match="unsupported fields"):
         flows._load_cosmos_policy_replay_artifact(
             write_payload("raw-observation.json", raw_observation)
         )
 
     bad_action_shape = json.loads(json.dumps(payload))
     bad_action_shape["policy_output"]["actions"][0]["shape"] = [15]
-    with pytest.raises(ValueError, match="shape"):
+    with pytest.raises(WorldStateError, match="shape"):
         flows._load_cosmos_policy_replay_artifact(
             write_payload("bad-action-shape.json", bad_action_shape)
         )

--- a/tests/test_harness_snapshots.py
+++ b/tests/test_harness_snapshots.py
@@ -12,6 +12,7 @@ SCREEN_CASES = (
     ("eval", "eval", "leworldmodel"),
     ("benchmark", "benchmark", "leworldmodel"),
     ("run-inspector", "run-inspector", "leworldmodel"),
+    ("cosmos-policy", "run-inspector", "cosmos-policy"),
     ("diagnostics", "run-inspector", "diagnostics"),
 )
 

--- a/tests/test_harness_tui.py
+++ b/tests/test_harness_tui.py
@@ -340,6 +340,10 @@ def test_harness_status_pill_reflects_selected_flow_provider(tmp_path) -> None:
             assert pill.label.endswith("· policy")
             await pilot.press("3")
             await pilot.pause()
+            assert "CosmosPolicyProvider" in pill.label
+            assert pill.label.endswith("· policy")
+            await pilot.press("4")
+            await pilot.pause()
             assert pill.label.endswith("· diagnostics")
 
     asyncio.run(scenario())
@@ -408,7 +412,7 @@ def test_the_world_harness_app_switches_to_diagnostics_flow(tmp_path) -> None:
             step_delay=0.0,
         )
         async with app.run_test(size=(140, 44)) as pilot:
-            await pilot.press("3")
+            await pilot.press("4")
             await pilot.press("r")
             await pilot.pause()
             screen = app.screen
@@ -416,6 +420,32 @@ def test_the_world_harness_app_switches_to_diagnostics_flow(tmp_path) -> None:
             assert screen.last_run is not None
             assert screen.last_run.flow.id == "diagnostics"
             assert screen.last_run.summary["benchmark_operation_count"] == 5
+
+    asyncio.run(scenario())
+
+
+def test_the_world_harness_app_switches_to_cosmos_policy_flow(tmp_path) -> None:
+    pytest.importorskip("textual")
+
+    from worldforge.harness.tui import RunInspectorScreen, TheWorldHarnessApp
+
+    async def scenario() -> None:
+        app = TheWorldHarnessApp(
+            initial_flow_id="leworldmodel",
+            initial_screen="run-inspector",
+            state_dir=tmp_path,
+            step_delay=0.0,
+        )
+        async with app.run_test(size=(140, 44)) as pilot:
+            await pilot.press("3")
+            await pilot.press("r")
+            await pilot.pause()
+            screen = app.screen
+            assert isinstance(screen, RunInspectorScreen)
+            assert screen.last_run is not None
+            assert screen.last_run.flow.id == "cosmos-policy"
+            assert screen.last_run.summary["raw_action_shape"] == [50, 14]
+            assert screen.last_run.summary["translated_action_count"] == 50
 
     asyncio.run(scenario())
 


### PR DESCRIPTION
## Summary

- add a checkout-safe `cosmos-policy` flow to TheWorldHarness
- replay a sanitized Cosmos-Policy ALOHA `/act` response through the real `CosmosPolicyProvider` boundary
- validate/decode json_numpy action rows, enforce the 50 x 14 ALOHA action contract, translate the selected plan into WorldForge actions, and preserve provider events plus a replay artifact
- add TUI keyboard selection, docs, snapshots, CLI/harness coverage, and stricter replay-artifact validation

Refs #214.

## Important note

This PR does **not** commit a true live GPU artifact or any NVIDIA checkpoint/runtime output. The real Cosmos-Policy integration was validated live on a remote RTX A6000 server, but the committed harness artifact is a sanitized deterministic replay. That is intentional: it keeps the repo checkout-safe, avoids large/raw image tensors, and lets reviewers inspect the WorldForge provider/replay contract without needing a GPU.

## Why

Cosmos-Policy should stay host-owned: NVIDIA/CUDA/checkpoints/server runtime live outside WorldForge. WorldForge should own the contract around the model output: request validation, response validation, action-shape validation, action translation, provider events, saved run artifacts, and TUI inspection.

This adds that inspectable harness path without moving GPU/runtime responsibilities into the base package.

## Validation

- `uv lock --check`
- `uv run ruff check src tests examples scripts`
- `uv run ruff format --check src tests examples scripts`
- `uv run python scripts/generate_provider_docs.py --check`
- `uv run python scripts/check_docs_commands.py`
- `uv run mkdocs build --strict`
- `uv run pytest tests/test_harness_flows.py tests/test_harness_cli.py tests/test_harness_tui.py tests/test_harness_snapshots.py -q` (`126 passed`)
- `uv run pytest -q` (`1052 passed, 2 skipped`)
