### PR TITLE
Add GR00T replay flow to TheWorldHarness

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ world editing, and saved report previews through the `harness` extra.
 uv run --extra harness worldforge-harness
 uv run --extra harness worldforge-harness --flow lerobot
 uv run --extra harness worldforge-harness --flow cosmos-policy
+uv run --extra harness worldforge-harness --flow gr00t-replay
 uv run --extra harness worldforge-harness --flow diagnostics
 ```
 

--- a/docs/src/cli.md
+++ b/docs/src/cli.md
@@ -149,10 +149,10 @@ recovery actions without printing secret values.
 Expected success signal: the selected flow reaches a completed run workspace and the inspector
 shows its saved artifact paths. For `cosmos-policy`, the replay should report
 `raw_action_shape: [50, 14]`, `translated_actions: 50`, and
-`saved_replay_artifact: artifacts/cosmos-policy-replay.json`. First triage step: open the saved
-run workspace and inspect `logs/provider-events.jsonl` plus `artifacts/cosmos-policy-replay.json`;
-for `gr00t-replay`, expect `translated_actions: 40` and
-`saved_replay_artifact: artifacts/gr00t-replay.json`;
+`saved_replay_artifact: artifacts/cosmos-policy-replay.json`. For `gr00t-replay`, expect
+`translated_actions: 40` and `saved_replay_artifact: artifacts/gr00t-replay.json`. First triage
+step: open the saved run workspace and inspect `logs/provider-events.jsonl` plus the flow-specific
+artifact, either `artifacts/cosmos-policy-replay.json` or `artifacts/gr00t-replay.json`;
 for live-provider readiness checks, run `uv run worldforge harness --connectors --format json`.
 
 ## Packaged Demos

--- a/docs/src/cli.md
+++ b/docs/src/cli.md
@@ -131,6 +131,7 @@ uv run --extra harness worldforge-harness
 uv run --extra harness worldforge-harness --flow leworldmodel
 uv run --extra harness worldforge-harness --flow lerobot
 uv run --extra harness worldforge-harness --flow cosmos-policy
+uv run --extra harness worldforge-harness --flow gr00t-replay
 uv run --extra harness worldforge-harness --flow diagnostics
 uv run --extra harness worldforge-harness --flow workbench
 uv run --extra harness worldforge-harness --flow runs
@@ -150,6 +151,8 @@ shows its saved artifact paths. For `cosmos-policy`, the replay should report
 `raw_action_shape: [50, 14]`, `translated_actions: 50`, and
 `saved_replay_artifact: artifacts/cosmos-policy-replay.json`. First triage step: open the saved
 run workspace and inspect `logs/provider-events.jsonl` plus `artifacts/cosmos-policy-replay.json`;
+for `gr00t-replay`, expect `translated_actions: 40` and
+`saved_replay_artifact: artifacts/gr00t-replay.json`;
 for live-provider readiness checks, run `uv run worldforge harness --connectors --format json`.
 
 ## Packaged Demos

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -40,6 +40,7 @@ provider workflows.
 uv run --extra harness worldforge-harness
 uv run --extra harness worldforge-harness --flow lerobot
 uv run --extra harness worldforge-harness --flow cosmos-policy
+uv run --extra harness worldforge-harness --flow gr00t-replay
 uv run --extra harness worldforge-harness --flow diagnostics
 uv run --extra harness worldforge-harness --flow workbench
 uv run worldforge harness --list
@@ -55,6 +56,7 @@ Available flows:
 | `leworldmodel` | Visual score-planning path through the LeWorldModel provider surface. |
 | `lerobot` | Visual policy-plus-score path through the LeRobot provider surface. |
 | `cosmos-policy` | Visual saved ALOHA `/act` replay through the Cosmos-Policy provider surface. |
+| `gr00t-replay` | Visual saved GR00T N1.7 PolicyClient replay through the GR00T provider surface. |
 | `diagnostics` | Visual provider diagnostics and benchmark comparison path. |
 | `workbench` | Visual provider-authoring evidence path for adapter promotion work. |
 

--- a/docs/src/theworldharness.md
+++ b/docs/src/theworldharness.md
@@ -78,7 +78,9 @@ For the GR00T replay, run
 `translated_actions: 40`, raw tensor shapes for `eef_9d`, `gripper_position`, and
 `joint_position`, and `saved_replay_artifact: artifacts/gr00t-replay.json`. The committed artifact
 is deterministic and checkout-safe; the live RTX A6000 validation is mentioned as provenance, not
-stored as GPU logs, checkpoints, private endpoints, or raw observations.
+stored as GPU logs, checkpoints, private endpoints, or raw observations. If it fails, start with
+the preserved run workspace: inspect `logs/provider-events.jsonl` for provider events/errors and
+`artifacts/gr00t-replay.json` for the saved replay request/response/translated-action artifact.
 
 ## Provider Connector Workspace
 

--- a/docs/src/theworldharness.md
+++ b/docs/src/theworldharness.md
@@ -22,6 +22,7 @@ Textual is optional. The base package keeps `httpx` as its only runtime dependen
 uv run --extra harness worldforge-harness
 uv run --extra harness worldforge-harness --flow lerobot
 uv run --extra harness worldforge-harness --flow cosmos-policy
+uv run --extra harness worldforge-harness --flow gr00t-replay
 uv run --extra harness worldforge-harness --flow diagnostics
 uv run --extra harness worldforge-harness --flow workbench
 uv run --extra harness worldforge-harness --flow eval
@@ -61,6 +62,7 @@ dependencies at package import time.
 | `leworldmodel` | `score` | Deterministic LeWorldModel-shaped cost runtime, candidate scoring, score planning, execution, persistence, reload, provider events. |
 | `lerobot` | `policy` plus score provider | Deterministic LeRobot-shaped policy, action translation, policy candidate ranking, execution, persistence, reload, provider events. |
 | `cosmos-policy` | `policy` | Saved Cosmos-Policy ALOHA `/act` replay through the real provider adapter, json_numpy 50 x 14 action validation, action translation, provider events, and a sanitized replay artifact. |
+| `gr00t-replay` | `policy` | Saved GR00T N1.7 PolicyClient replay through the real provider adapter, named eef/gripper/joint tensor validation, action translation, provider events, and a sanitized replay artifact. |
 | `diagnostics` | provider catalog plus benchmark harness | `doctor()` provider scan, registered/unregistered provider status, mock benchmark matrix across predict/reason/generate/transfer/embed, latency/throughput comparison, provider events. |
 | `workbench` | provider authoring | Checkout-safe provider workbench evidence for stable and candidate adapters, promotion gaps, safe artifacts, and validation commands. |
 
@@ -70,6 +72,13 @@ For the Cosmos replay, run
 `saved_replay_artifact: artifacts/cosmos-policy-replay.json`. If it fails, start with the preserved
 run workspace: inspect `logs/provider-events.jsonl` for the provider phase and
 `artifacts/cosmos-policy-replay.json` for the saved request/response/translated-action artifact.
+
+For the GR00T replay, run
+`uv run --extra harness worldforge-harness --flow gr00t-replay`. A good run reports
+`translated_actions: 40`, raw tensor shapes for `eef_9d`, `gripper_position`, and
+`joint_position`, and `saved_replay_artifact: artifacts/gr00t-replay.json`. The committed artifact
+is deterministic and checkout-safe; the live RTX A6000 validation is mentioned as provenance, not
+stored as GPU logs, checkpoints, private endpoints, or raw observations.
 
 ## Provider Connector Workspace
 
@@ -216,8 +225,9 @@ provider health, benchmark latency, benchmark throughput, and provider event pha
 - `1`: select LeWorldModel score planning.
 - `2`: select LeRobot policy-plus-score planning.
 - `3`: select Cosmos-Policy ALOHA replay.
-- `4`: select provider diagnostics and benchmark comparison.
-- `5`: select adapter author workbench.
+- `4`: select GR00T DROID replay.
+- `5`: select provider diagnostics and benchmark comparison.
+- `6`: select adapter author workbench.
 - `g w`: jump to Worlds.
 - `g p`: jump to Providers.
 - `g e`: jump to Eval.

--- a/src/worldforge/harness/flows.py
+++ b/src/worldforge/harness/flows.py
@@ -74,6 +74,21 @@ FLOWS: tuple[HarnessFlow, ...] = (
         ),
     ),
     HarnessFlow(
+        id="gr00t-replay",
+        title="GR00T DROID Replay",
+        short_title="GR00T",
+        focus="saved GR00T PolicyClient replay",
+        provider="GrootPolicyClientProvider",
+        capability="policy",
+        command="uv run --extra harness worldforge-harness --flow gr00t-replay",
+        accent="#b6f377",
+        summary=(
+            "Replay a sanitized NVIDIA GR00T N1.7 PolicyClient response through the real provider "
+            "boundary, validate named action tensors, translate 40 steps, and preserve an "
+            "inspectable artifact without requiring a live GPU."
+        ),
+    ),
+    HarnessFlow(
         id="diagnostics",
         title="Provider Diagnostics + Benchmark",
         short_title="Diagnostics",
@@ -136,6 +151,141 @@ _COSMOS_POLICY_PREVIEW_ROWS = (
     (0.00418, -0.02012, -0.01506, -0.03610, 0.06206, 0.01546),
     (0.01023, -0.02691, -0.01081, -0.05677, 0.06027, 0.01551),
     (0.00377, -0.02269, -0.01370, -0.04925, 0.06735, 0.01213),
+)
+_GROOT_REPLAY_MODEL = "nvidia/GR00T-N1.7-3B"
+_GROOT_REPLAY_RUNTIME = "gr00t-policy-client"
+_GROOT_REPLAY_ACTION_HORIZON = 40
+_GROOT_REPLAY_SCHEMA_VERSION = 1
+_GROOT_REPLAY_EMBODIMENT_TAG = "OXE_DROID_RELATIVE_EEF_RELATIVE_JOINT"
+_GROOT_REPLAY_TASK = "fold cloth"
+_GROOT_REPLAY_LATENCY_MS = 933.7297500460409
+_GROOT_REPLAY_RESULT_DIGEST = (
+    "sha256:cccfed332ffc54e1a4ff6afdb17e1e5aae6c73cb433b74cfe3a2e7bed62ac1f5"
+)
+_GROOT_REPLAY_OBSERVATION_FIELDS = ("language", "state", "video")
+_GROOT_REPLAY_REQUEST_KEYS = frozenset(
+    {
+        "observation_fields",
+        "observation_summary",
+        "task_description",
+        "action_horizon",
+        "embodiment_tag",
+    }
+)
+_GROOT_REPLAY_RAW_ACTION_SHAPES: JSONDict = {
+    "eef_9d": [1, _GROOT_REPLAY_ACTION_HORIZON, 9],
+    "gripper_position": [1, _GROOT_REPLAY_ACTION_HORIZON, 1],
+    "joint_position": [1, _GROOT_REPLAY_ACTION_HORIZON, 7],
+}
+_GROOT_REPLAY_EEF_PREFIX_ROWS = (
+    (
+        0.45209485,
+        -0.04993579,
+        0.35151827,
+        0.99991280,
+        -0.00503587,
+        -0.01220623,
+        0.00520440,
+        0.99989104,
+        0.01381495,
+    ),
+    (
+        0.45370448,
+        -0.05460007,
+        0.35082236,
+        0.99975926,
+        -0.00603632,
+        -0.02109618,
+        0.00664691,
+        0.99955750,
+        0.02899381,
+    ),
+    (
+        0.45319659,
+        -0.04851697,
+        0.35273436,
+        0.99879819,
+        -0.01500455,
+        -0.04665894,
+        0.01667653,
+        0.99922508,
+        0.03565361,
+    ),
+    (
+        0.45103294,
+        -0.05216613,
+        0.35121581,
+        0.99818760,
+        -0.01888346,
+        -0.05713980,
+        0.02149428,
+        0.99873638,
+        0.04542767,
+    ),
+    (
+        0.45371175,
+        -0.04883665,
+        0.35304552,
+        0.99673748,
+        -0.02772977,
+        -0.07579842,
+        0.03198496,
+        0.99794549,
+        0.05551316,
+    ),
+    (
+        0.45116049,
+        -0.04859919,
+        0.35463876,
+        0.99458879,
+        -0.04060974,
+        -0.09562392,
+        0.04728588,
+        0.99652177,
+        0.06861795,
+    ),
+    (
+        0.45225149,
+        -0.04907730,
+        0.35640752,
+        0.99183750,
+        -0.05253663,
+        -0.11618217,
+        0.06253119,
+        0.99449146,
+        0.08412262,
+    ),
+    (
+        0.45332921,
+        -0.04459824,
+        0.35799032,
+        0.98470002,
+        -0.05842229,
+        -0.16417292,
+        0.07588259,
+        0.99186796,
+        0.10217515,
+    ),
+)
+_GROOT_REPLAY_GRIPPER_PREFIX_ROWS = (
+    (0.00195312,),
+    (0.0,),
+    (0.00390625,),
+    (0.0,),
+    (0.00195312,),
+    (0.0,),
+    (0.0,),
+    (0.00585938,),
+)
+_GROOT_REPLAY_JOINT_PREFIX_ROWS = (
+    (-0.19574580, -0.40341792, -0.10423726, -2.19564652, -0.21871637, 2.10479379, 0.39902940),
+    (-0.19844921, -0.40122452, -0.09466118, -2.19360781, -0.24168095, 2.11665559, 0.39399421),
+    (-0.21554480, -0.41246665, -0.09100682, -2.19702625, -0.24528827, 2.11675787, 0.38742143),
+    (-0.19939159, -0.40944505, -0.09160183, -2.19366264, -0.26949242, 2.11434579, 0.37265414),
+    (-0.19068547, -0.40942037, -0.09546585, -2.19406295, -0.27474448, 2.12093925, 0.37172550),
+    (-0.18911973, -0.41755563, -0.09746341, -2.19225788, -0.29558879, 2.12040114, 0.35820645),
+    (-0.19144866, -0.41764820, -0.09365430, -2.18930912, -0.30929935, 2.13109922, 0.33803242),
+    (-0.17990023, -0.43038398, -0.09860370, -2.18720603, -0.32697150, 2.13032913, 0.33624285),
 )
 
 
@@ -873,6 +1023,487 @@ def _preview_action_rows(rows: object, *, limit: int = 6, columns: int = 6) -> l
     return preview
 
 
+def _run_gr00t_replay_demo(*, state_dir: Path, emit: bool = False) -> JSONDict:
+    from worldforge.models import Action
+    from worldforge.providers import GrootPolicyClientProvider
+
+    events: list[ProviderEvent] = []
+    replay_source_path = _write_prepared_groot_replay_artifact(state_dir)
+    saved_replay = _load_groot_replay_artifact(replay_source_path)
+    policy_info = _groot_policy_info_from_replay(saved_replay)
+    policy_output = _require_json_object(saved_replay["policy_output"], "GR00T replay output")
+    raw_actions = _require_json_object(policy_output["raw_actions"], "GR00T replay raw actions")
+    provider_info = _require_json_object(
+        policy_output.get("provider_info", {}),
+        "GR00T replay provider_info",
+    )
+
+    class ReplayPolicyClient:
+        def __init__(self) -> None:
+            self.get_action_calls = 0
+
+        def ping(self) -> bool:
+            return True
+
+        def get_action(self, _observation: object, options: object | None = None) -> object:
+            self.get_action_calls += 1
+            if options not in (None, {}):
+                raise ProviderError("GR00T replay does not support policy options.")
+            return (
+                json.loads(json.dumps(raw_actions)),
+                json.loads(json.dumps(provider_info)),
+            )
+
+    def translator(raw: object, _info: JSONDict, _provider_info: JSONDict):
+        actions = _require_json_object(raw, "GR00T replay translator raw actions")
+        _validate_groot_raw_actions(actions)
+        eef_rows = _groot_eef_rows(actions)
+        return [Action.move_to(float(row[0]), float(row[1]), float(row[2])) for row in eef_rows]
+
+    client = ReplayPolicyClient()
+    provider = GrootPolicyClientProvider(
+        policy_client=client,
+        embodiment_tag=_GROOT_REPLAY_EMBODIMENT_TAG,
+        action_translator=translator,
+        event_handler=events.append,
+    )
+    forge = WorldForge(state_dir=state_dir, auto_register_remote=False)
+    forge.register_provider(provider)
+    health = None
+    try:
+        health = provider.health()
+        result = forge.select_actions("gr00t", info=policy_info)
+    except Exception as exc:
+        failure_event = ProviderEvent(
+            provider="gr00t",
+            operation="policy",
+            phase="failure",
+            message=str(exc),
+            metadata={"stage": "harness-replay"},
+        )
+        if not events or events[-1].message != failure_event.message:
+            events.append(failure_event)
+        replay_artifact = _groot_failure_replay_artifact(
+            saved_replay,
+            replay_source_path=replay_source_path,
+            events=events,
+            error=exc,
+        )
+        summary = _groot_replay_failure_summary(
+            state_dir=state_dir,
+            saved_replay=saved_replay,
+            replay_source_path=replay_source_path,
+            health=health.to_dict() if health is not None else None,
+            events=events,
+            replay_artifact=replay_artifact,
+            error=exc,
+        )
+        if emit:
+            print("\n".join(_transcript_for("gr00t-replay", summary)))
+        return summary
+
+    metadata = result.metadata
+    normalized_raw_actions = _require_json_object(result.raw_actions, "GR00T raw actions")
+    raw_action_shapes = _groot_raw_action_shapes(normalized_raw_actions)
+    raw_action_preview = _groot_action_preview(normalized_raw_actions)
+    selected_action_preview = [action.to_dict() for action in result.actions[:8]]
+    replay_artifact = dict(saved_replay)
+    replay_artifact.update(
+        {
+            "manifest": {
+                "flow_id": "gr00t-replay",
+                "provider": result.provider,
+                "model": _GROOT_REPLAY_MODEL,
+                "runtime": metadata.get("runtime"),
+                "task_description": _GROOT_REPLAY_TASK,
+                "action_horizon": result.action_horizon,
+                "embodiment_tag": result.embodiment_tag,
+                "source_artifact": replay_source_path.name,
+                "source_validation": "validated live on RTX A6000; committed artifact is sanitized",
+                "result_digest": _GROOT_REPLAY_RESULT_DIGEST,
+            },
+            "response": {
+                "raw_action_shapes": raw_action_shapes,
+                "translated_action_count": len(result.actions),
+                "raw_action_preview": raw_action_preview,
+                "selected_action_preview": selected_action_preview,
+                "latency_ms": _GROOT_REPLAY_LATENCY_MS,
+            },
+            "translated_actions": [action.to_dict() for action in result.actions],
+            "provider_events": [event.to_dict() for event in events],
+        }
+    )
+    summary: JSONDict = {
+        "demo_kind": "gr00t_saved_replay",
+        "state_dir": str(state_dir),
+        "providers": [result.provider],
+        "model": _GROOT_REPLAY_MODEL,
+        "task_description": _GROOT_REPLAY_TASK,
+        "runtime": metadata.get("runtime"),
+        "runtime_contract": "saved PolicyClient replay through GrootPolicyClientProvider",
+        "loaded_replay_artifact": replay_source_path.name,
+        "health": health.to_dict(),
+        "raw_action_shapes": raw_action_shapes,
+        "translated_action_count": len(result.actions),
+        "action_horizon": result.action_horizon,
+        "embodiment_tag": result.embodiment_tag,
+        "candidate_count": metadata.get("candidate_count"),
+        "policy_select_calls": client.get_action_calls,
+        "latency_ms": _GROOT_REPLAY_LATENCY_MS,
+        "result_digest": _GROOT_REPLAY_RESULT_DIGEST,
+        "selected_actions": [action.to_dict() for action in result.actions],
+        "selected_action_preview": selected_action_preview,
+        "raw_action_preview": raw_action_preview,
+        "event_phases": [event.phase for event in events],
+        "provider_events": [event.to_dict() for event in events],
+        "harness_artifacts": {
+            "gr00t_replay": {
+                "path": "artifacts/gr00t-replay.json",
+                "payload": replay_artifact,
+            },
+        },
+    }
+    if emit:
+        print("\n".join(_transcript_for("gr00t-replay", summary)))
+    return summary
+
+
+def _write_prepared_groot_replay_artifact(state_dir: Path) -> Path:
+    state_dir.mkdir(parents=True, exist_ok=True)
+    replay_path = state_dir / "gr00t-prepared-replay.json"
+    replay_path.write_text(
+        json.dumps(_groot_saved_replay_payload(), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return replay_path
+
+
+def _groot_saved_replay_payload() -> JSONDict:
+    raw_actions = _groot_raw_actions()
+    return {
+        "schema_version": _GROOT_REPLAY_SCHEMA_VERSION,
+        "source": "sanitized GR00T N1.7 live PolicyClient response shape",
+        "manifest": {
+            "flow_id": "gr00t-replay",
+            "provider": "gr00t",
+            "model": _GROOT_REPLAY_MODEL,
+            "runtime": "saved replay",
+            "task_description": _GROOT_REPLAY_TASK,
+            "action_horizon": _GROOT_REPLAY_ACTION_HORIZON,
+            "embodiment_tag": _GROOT_REPLAY_EMBODIMENT_TAG,
+            "raw_action_shapes": dict(_GROOT_REPLAY_RAW_ACTION_SHAPES),
+            "source_validation": "validated live on RTX A6000; committed artifact is sanitized",
+        },
+        "request": {
+            "observation_fields": list(_GROOT_REPLAY_OBSERVATION_FIELDS),
+            "observation_summary": _groot_redacted_observation_summary(),
+            "task_description": _GROOT_REPLAY_TASK,
+            "action_horizon": _GROOT_REPLAY_ACTION_HORIZON,
+            "embodiment_tag": _GROOT_REPLAY_EMBODIMENT_TAG,
+        },
+        "policy_output": {
+            "raw_actions": raw_actions,
+            "provider_info": {
+                "model": _GROOT_REPLAY_MODEL,
+                "latency_ms": _GROOT_REPLAY_LATENCY_MS,
+                "runtime": "remote PolicyServer replay",
+            },
+        },
+        "response": {
+            "raw_action_shapes": dict(_GROOT_REPLAY_RAW_ACTION_SHAPES),
+            "translated_action_count": 0,
+            "raw_action_preview": [],
+            "selected_action_preview": [],
+            "latency_ms": _GROOT_REPLAY_LATENCY_MS,
+        },
+        "translated_actions": [],
+        "provider_events": [],
+    }
+
+
+def _load_groot_replay_artifact(path: Path) -> JSONDict:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise WorldStateError(f"GR00T replay artifact is not valid JSON: {path}") from exc
+    if not isinstance(payload, dict):
+        raise WorldStateError("GR00T replay artifact must be a JSON object.")
+    if payload.get("schema_version") != _GROOT_REPLAY_SCHEMA_VERSION:
+        raise WorldStateError("GR00T replay artifact schema_version is unsupported.")
+
+    manifest = _require_json_object(payload.get("manifest"), "GR00T replay manifest")
+    if manifest.get("flow_id") != "gr00t-replay":
+        raise WorldStateError("GR00T replay artifact flow_id must be 'gr00t-replay'.")
+    if manifest.get("action_horizon") != _GROOT_REPLAY_ACTION_HORIZON:
+        raise WorldStateError("GR00T replay artifact action_horizon is unsupported.")
+    if manifest.get("embodiment_tag") != _GROOT_REPLAY_EMBODIMENT_TAG:
+        raise WorldStateError("GR00T replay artifact embodiment_tag is unsupported.")
+    if manifest.get("raw_action_shapes") != _GROOT_REPLAY_RAW_ACTION_SHAPES:
+        raise WorldStateError("GR00T replay artifact raw_action_shapes are unsupported.")
+
+    request = _require_json_object(payload.get("request"), "GR00T replay request")
+    if set(request) != _GROOT_REPLAY_REQUEST_KEYS:
+        raise WorldStateError("GR00T replay request contains unsupported fields.")
+    if request.get("observation_fields") != list(_GROOT_REPLAY_OBSERVATION_FIELDS):
+        raise WorldStateError("GR00T replay observation fields are unsupported.")
+    _validate_groot_observation_summary(request.get("observation_summary"))
+    if not isinstance(request.get("task_description"), str) or not request["task_description"]:
+        raise WorldStateError("GR00T replay task_description must be a non-empty string.")
+    if request.get("action_horizon") != _GROOT_REPLAY_ACTION_HORIZON:
+        raise WorldStateError("GR00T replay request action_horizon is unsupported.")
+    if request.get("embodiment_tag") != _GROOT_REPLAY_EMBODIMENT_TAG:
+        raise WorldStateError("GR00T replay request embodiment_tag is unsupported.")
+
+    policy_output = _require_json_object(payload.get("policy_output"), "GR00T replay output")
+    raw_actions = _require_json_object(policy_output.get("raw_actions"), "GR00T replay raw_actions")
+    _validate_groot_raw_actions(raw_actions)
+    _require_json_object(policy_output.get("provider_info", {}), "GR00T replay provider_info")
+    return payload
+
+
+def _groot_policy_info_from_replay(replay_artifact: JSONDict) -> JSONDict:
+    request = _require_json_object(replay_artifact.get("request"), "GR00T replay request")
+    return {
+        "observation": {
+            "video": {"exterior_image": [[[[[0, 0, 0]]]]]},
+            "state": {
+                "eef_9d": [[[0.0 for _ in range(9)]]],
+                "joint_position": [[[0.0 for _ in range(7)]]],
+            },
+            "language": {"task": [[request["task_description"]]]},
+        },
+        "action_horizon": request["action_horizon"],
+        "embodiment_tag": request["embodiment_tag"],
+    }
+
+
+def _groot_failure_replay_artifact(
+    saved_replay: JSONDict,
+    *,
+    replay_source_path: Path,
+    events: Sequence[ProviderEvent],
+    error: Exception,
+) -> JSONDict:
+    replay_artifact = dict(saved_replay)
+    manifest = dict(_require_json_object(saved_replay["manifest"], "GR00T replay manifest"))
+    manifest.update(
+        {
+            "flow_id": "gr00t-replay",
+            "status": "failed",
+            "source_artifact": replay_source_path.name,
+        }
+    )
+    response = dict(_require_json_object(saved_replay["response"], "GR00T replay response"))
+    response.update({"translated_action_count": 0, "error": str(error)})
+    replay_artifact.update(
+        {
+            "manifest": manifest,
+            "response": response,
+            "translated_actions": [],
+            "provider_events": [event.to_dict() for event in events],
+        }
+    )
+    return replay_artifact
+
+
+def _groot_replay_failure_summary(
+    *,
+    state_dir: Path,
+    saved_replay: JSONDict,
+    replay_source_path: Path,
+    health: JSONDict | None,
+    events: Sequence[ProviderEvent],
+    replay_artifact: JSONDict,
+    error: Exception,
+) -> JSONDict:
+    manifest = _require_json_object(saved_replay["manifest"], "GR00T replay manifest")
+    request = _require_json_object(saved_replay["request"], "GR00T replay request")
+    response = _require_json_object(saved_replay["response"], "GR00T replay response")
+    return {
+        "demo_kind": "gr00t_saved_replay",
+        "status": "failed",
+        "state_dir": str(state_dir),
+        "providers": ["gr00t"],
+        "model": manifest.get("model"),
+        "task_description": request.get("task_description"),
+        "runtime": manifest.get("runtime"),
+        "runtime_contract": "saved PolicyClient replay through GrootPolicyClientProvider",
+        "loaded_replay_artifact": replay_source_path.name,
+        "health": health or {"healthy": False, "message": "not checked"},
+        "raw_action_shapes": response.get("raw_action_shapes", {}),
+        "translated_action_count": 0,
+        "action_horizon": request.get("action_horizon"),
+        "embodiment_tag": request.get("embodiment_tag"),
+        "candidate_count": 0,
+        "policy_select_calls": 0,
+        "latency_ms": response.get("latency_ms"),
+        "selected_actions": [],
+        "selected_action_preview": [],
+        "raw_action_preview": [],
+        "event_phases": [event.phase for event in events],
+        "provider_events": [event.to_dict() for event in events],
+        "validation_errors": [str(error)],
+        "harness_artifacts": {
+            "gr00t_replay": {
+                "path": "artifacts/gr00t-replay.json",
+                "payload": replay_artifact,
+            },
+        },
+    }
+
+
+def _groot_raw_actions() -> JSONDict:
+    return {
+        "eef_9d": [[_groot_eef_row(index) for index in range(_GROOT_REPLAY_ACTION_HORIZON)]],
+        "gripper_position": [
+            [_groot_gripper_row(index) for index in range(_GROOT_REPLAY_ACTION_HORIZON)]
+        ],
+        "joint_position": [
+            [_groot_joint_row(index) for index in range(_GROOT_REPLAY_ACTION_HORIZON)]
+        ],
+    }
+
+
+def _groot_eef_row(index: int) -> list[float]:
+    if index < len(_GROOT_REPLAY_EEF_PREFIX_ROWS):
+        return list(_GROOT_REPLAY_EEF_PREFIX_ROWS[index])
+    return [
+        round(0.454 - index * 0.00034 + math.sin(index) * 0.0011, 8),
+        round(-0.052 + index * 0.00052 + math.cos(index) * 0.0010, 8),
+        round(0.351 + index * 0.00318 + math.sin(index / 2) * 0.0012, 8),
+        round(0.985 - index * 0.00135, 8),
+        round(-0.058 - index * 0.00195, 8),
+        round(-0.164 - index * 0.00485, 8),
+        round(0.076 + index * 0.0023, 8),
+        round(0.992 - index * 0.0012, 8),
+        round(0.102 + index * 0.0042, 8),
+    ]
+
+
+def _groot_gripper_row(index: int) -> list[float]:
+    if index < len(_GROOT_REPLAY_GRIPPER_PREFIX_ROWS):
+        return list(_GROOT_REPLAY_GRIPPER_PREFIX_ROWS[index])
+    return [round(0.00195312 * (index % 4), 8)]
+
+
+def _groot_joint_row(index: int) -> list[float]:
+    if index < len(_GROOT_REPLAY_JOINT_PREFIX_ROWS):
+        return list(_GROOT_REPLAY_JOINT_PREFIX_ROWS[index])
+    return [
+        round(-0.180 - index * 0.0023, 8),
+        round(-0.430 - index * 0.0021, 8),
+        round(-0.099 + index * 0.00035, 8),
+        round(-2.187 + index * 0.00095, 8),
+        round(-0.327 - index * 0.0052, 8),
+        round(2.130 + index * 0.0011, 8),
+        round(0.336 - index * 0.0033, 8),
+    ]
+
+
+def _validate_groot_raw_actions(raw_actions: JSONDict) -> None:
+    if set(raw_actions) != set(_GROOT_REPLAY_RAW_ACTION_SHAPES):
+        raise WorldStateError("GR00T replay raw_actions contain unsupported fields.")
+    for key, expected_shape in _GROOT_REPLAY_RAW_ACTION_SHAPES.items():
+        _validate_numeric_tensor(
+            raw_actions.get(key),
+            expected_shape=expected_shape,
+            name=f"GR00T replay raw_actions.{key}",
+        )
+
+
+def _validate_numeric_tensor(value: object, *, expected_shape: Sequence[int], name: str) -> None:
+    if not expected_shape:
+        if (
+            not isinstance(value, int | float)
+            or isinstance(value, bool)
+            or not math.isfinite(value)
+        ):
+            raise WorldStateError(f"{name} must contain finite numeric values.")
+        return
+    if not isinstance(value, list):
+        raise WorldStateError(f"{name} must have shape {list(expected_shape)}.")
+    if len(value) != expected_shape[0]:
+        raise WorldStateError(f"{name} must have shape {list(expected_shape)}.")
+    for index, item in enumerate(value):
+        _validate_numeric_tensor(
+            item,
+            expected_shape=expected_shape[1:],
+            name=f"{name}[{index}]",
+        )
+
+
+def _groot_raw_action_shapes(raw_actions: JSONDict) -> JSONDict:
+    _validate_groot_raw_actions(raw_actions)
+    return dict(_GROOT_REPLAY_RAW_ACTION_SHAPES)
+
+
+def _groot_eef_rows(raw_actions: JSONDict) -> list[list[float]]:
+    eef = raw_actions["eef_9d"]
+    if not isinstance(eef, list) or not eef or not isinstance(eef[0], list):
+        raise WorldStateError("GR00T replay eef_9d must contain one batch of action rows.")
+    rows = eef[0]
+    if not all(isinstance(row, list) for row in rows):
+        raise WorldStateError("GR00T replay eef_9d rows must be lists.")
+    return rows
+
+
+def _groot_action_preview(raw_actions: JSONDict, *, limit: int = 8) -> list[list[float]]:
+    _validate_groot_raw_actions(raw_actions)
+    eef_rows = _groot_eef_rows(raw_actions)
+    gripper_rows = raw_actions["gripper_position"][0]
+    joint_rows = raw_actions["joint_position"][0]
+    preview: list[list[float]] = []
+    for index, eef_row in enumerate(eef_rows[:limit]):
+        gripper = gripper_rows[index][0]
+        joints = joint_rows[index]
+        preview.append(
+            [
+                round(float(eef_row[0]), 5),
+                round(float(eef_row[1]), 5),
+                round(float(eef_row[2]), 5),
+                round(float(gripper), 5),
+                round(float(joints[0]), 5),
+                round(float(joints[1]), 5),
+            ]
+        )
+    return preview
+
+
+def _validate_groot_observation_summary(value: object) -> None:
+    observation_summary = _require_json_object(value, "GR00T replay observation_summary")
+    if set(observation_summary) != set(_GROOT_REPLAY_OBSERVATION_FIELDS):
+        raise WorldStateError("GR00T replay observation_summary contains unsupported fields.")
+    expected_shapes = {
+        "video": {"exterior_image": [1, 1, 1, 1, 3]},
+        "state": {"eef_9d": [1, 1, 9], "joint_position": [1, 1, 7]},
+        "language": {"task": [1, 1]},
+    }
+    for field in _GROOT_REPLAY_OBSERVATION_FIELDS:
+        field_summary = _require_json_object(
+            observation_summary.get(field),
+            f"GR00T replay observation_summary.{field}",
+        )
+        if set(field_summary) != {"redacted", "shape"}:
+            raise WorldStateError(
+                f"GR00T replay observation_summary.{field} contains unsupported fields."
+            )
+        if field_summary.get("redacted") is not True:
+            raise WorldStateError(f"GR00T replay observation field {field} must be redacted.")
+        if field_summary.get("shape") != expected_shapes[field]:
+            raise WorldStateError(f"GR00T replay observation_summary.{field}.shape is unsupported.")
+
+
+def _groot_redacted_observation_summary() -> JSONDict:
+    return {
+        "video": {"redacted": True, "shape": {"exterior_image": [1, 1, 1, 1, 3]}},
+        "state": {
+            "redacted": True,
+            "shape": {"eef_9d": [1, 1, 9], "joint_position": [1, 1, 7]},
+        },
+        "language": {"redacted": True, "shape": {"task": [1, 1]}},
+    }
+
+
 # Demo modules import the optional-runtime provider classes at module scope, so
 # keep these imports lazy: loading the harness should not pull LeRobot/LeWorldModel
 # adapters into the base cold-start path.
@@ -892,6 +1523,7 @@ _RUNNERS: dict[str, FlowRunner] = {
     "leworldmodel": _run_leworldmodel_demo,
     "lerobot": _run_lerobot_demo,
     "cosmos-policy": _run_cosmos_policy_demo,
+    "gr00t-replay": _run_gr00t_replay_demo,
     "diagnostics": _run_diagnostics_demo,
     "workbench": _run_workbench_demo,
 }
@@ -1573,6 +2205,45 @@ def _steps_for(flow_id: str, summary: JSONDict) -> tuple[HarnessStep, ...]:
                 f"events={', '.join(summary['event_phases'])}",
             ),
         )
+    if flow_id == "gr00t-replay":
+        return (
+            HarnessStep(
+                "Load saved PolicyClient replay",
+                "Use a sanitized GR00T N1.7 response shape from the live GPU smoke.",
+                "Checkout-safe replay loaded; no GPU or network call is required.",
+                f"task={summary['task_description']}",
+            ),
+            HarnessStep(
+                "Check provider boundary",
+                "Instantiate GrootPolicyClientProvider with an injected replay client.",
+                "Provider health is configured for PolicyClient.get_action.",
+                f"model={summary['model']}",
+            ),
+            HarnessStep(
+                "Call GR00T adapter",
+                "Route the replay through the same policy provider event path.",
+                f"{summary['policy_select_calls']} get_action call handled.",
+                f"embodiment={summary['embodiment_tag']}",
+            ),
+            HarnessStep(
+                "Validate raw tensors",
+                "Check named eef, gripper, and joint tensors before translation.",
+                _groot_shape_result(summary),
+                "raw=eef_9d,gripper_position,joint_position",
+            ),
+            HarnessStep(
+                "Translate actions",
+                "Map GR00T end-effector rows into executable WorldForge Action objects.",
+                f"{summary['translated_action_count']} move_to actions produced.",
+                f"latency_ms={float(summary['latency_ms']):.1f}",
+            ),
+            HarnessStep(
+                "Preserve replay artifact",
+                "Write the inspector state, provider events, and sanitized replay artifact.",
+                "artifact=artifacts/gr00t-replay.json",
+                f"events={', '.join(summary['event_phases'])}",
+            ),
+        )
     if flow_id == "diagnostics":
         return (
             HarnessStep(
@@ -1762,6 +2433,31 @@ def _metrics_for(flow_id: str, summary: JSONDict) -> tuple[HarnessMetric, ...]:
             ),
             HarnessMetric("Artifact", "replay", "artifacts/cosmos-policy-replay.json"),
         )
+    if flow_id == "gr00t-replay":
+        return (
+            HarnessMetric("Flow", "policy", "GR00T PolicyClient contract replay"),
+            HarnessMetric(
+                "Raw tensors",
+                str(len(summary["raw_action_shapes"])),
+                _groot_shape_result(summary),
+            ),
+            HarnessMetric(
+                "Translated",
+                str(summary["translated_action_count"]),
+                "WorldForge Action objects",
+            ),
+            HarnessMetric(
+                "Latency",
+                _format_ms(summary["latency_ms"]),
+                "live-smoke reference latency",
+            ),
+            HarnessMetric(
+                "Events",
+                str(len(summary["event_phases"])),
+                ", ".join(summary["event_phases"]),
+            ),
+            HarnessMetric("Artifact", "replay", "artifacts/gr00t-replay.json"),
+        )
 
     flow_label = "score" if flow_id == "leworldmodel" else "policy+score"
     return (
@@ -1826,6 +2522,21 @@ def _transcript_for(flow_id: str, summary: JSONDict) -> tuple[str, ...]:
             "saved_replay_artifact: artifacts/cosmos-policy-replay.json",
             f"events: {', '.join(summary['event_phases'])}",
         )
+    if flow_id == "gr00t-replay":
+        return (
+            "flow: gr00t-replay",
+            f"provider: {', '.join(summary['providers'])}",
+            f"model: {summary['model']}",
+            f"task: {summary['task_description']}",
+            f"embodiment_tag: {summary['embodiment_tag']}",
+            f"health: {summary['health']['healthy']}",
+            f"raw_action_shapes: {summary['raw_action_shapes']}",
+            f"translated_actions: {summary['translated_action_count']}",
+            f"latency_ms: {float(summary['latency_ms']):.1f}",
+            f"result_digest: {summary['result_digest']}",
+            "saved_replay_artifact: artifacts/gr00t-replay.json",
+            f"events: {', '.join(summary['event_phases'])}",
+        )
 
     lines = [
         f"flow: {flow_id}",
@@ -1868,6 +2579,14 @@ def _final_position_result(summary: JSONDict) -> str:
 
 def _event_result(summary: JSONDict) -> str:
     return f"Provider phases: {', '.join(summary['event_phases'])}."
+
+
+def _groot_shape_result(summary: JSONDict) -> str:
+    shapes = summary["raw_action_shapes"]
+    return ", ".join(
+        f"{name}={' x '.join(str(item) for item in shape)}"
+        for name, shape in sorted(shapes.items())
+    )
 
 
 def _provider_events_for(flow_id: str, summary: JSONDict) -> tuple[JSONDict, ...]:

--- a/src/worldforge/harness/flows.py
+++ b/src/worldforge/harness/flows.py
@@ -163,6 +163,31 @@ _GROOT_REPLAY_RESULT_DIGEST = (
     "sha256:cccfed332ffc54e1a4ff6afdb17e1e5aae6c73cb433b74cfe3a2e7bed62ac1f5"
 )
 _GROOT_REPLAY_OBSERVATION_FIELDS = ("language", "state", "video")
+_GROOT_REPLAY_TOP_LEVEL_KEYS = frozenset(
+    {
+        "schema_version",
+        "source",
+        "manifest",
+        "request",
+        "policy_output",
+        "response",
+        "translated_actions",
+        "provider_events",
+    }
+)
+_GROOT_REPLAY_MANIFEST_KEYS = frozenset(
+    {
+        "flow_id",
+        "provider",
+        "model",
+        "runtime",
+        "task_description",
+        "action_horizon",
+        "embodiment_tag",
+        "raw_action_shapes",
+        "source_validation",
+    }
+)
 _GROOT_REPLAY_REQUEST_KEYS = frozenset(
     {
         "observation_fields",
@@ -170,6 +195,17 @@ _GROOT_REPLAY_REQUEST_KEYS = frozenset(
         "task_description",
         "action_horizon",
         "embodiment_tag",
+    }
+)
+_GROOT_REPLAY_POLICY_OUTPUT_KEYS = frozenset({"raw_actions", "provider_info"})
+_GROOT_REPLAY_PROVIDER_INFO_KEYS = frozenset({"model", "latency_ms", "runtime"})
+_GROOT_REPLAY_RESPONSE_KEYS = frozenset(
+    {
+        "raw_action_shapes",
+        "translated_action_count",
+        "raw_action_preview",
+        "selected_action_preview",
+        "latency_ms",
     }
 )
 _GROOT_REPLAY_RAW_ACTION_SHAPES: JSONDict = {
@@ -1097,6 +1133,7 @@ def _run_gr00t_replay_demo(*, state_dir: Path, emit: bool = False) -> JSONDict:
             events=events,
             replay_artifact=replay_artifact,
             error=exc,
+            policy_select_calls=client.get_action_calls,
         )
         if emit:
             print("\n".join(_transcript_for("gr00t-replay", summary)))
@@ -1228,12 +1265,22 @@ def _load_groot_replay_artifact(path: Path) -> JSONDict:
         raise WorldStateError(f"GR00T replay artifact is not valid JSON: {path}") from exc
     if not isinstance(payload, dict):
         raise WorldStateError("GR00T replay artifact must be a JSON object.")
+    if set(payload) != _GROOT_REPLAY_TOP_LEVEL_KEYS:
+        raise WorldStateError("GR00T replay artifact contains unsupported top-level fields.")
     if payload.get("schema_version") != _GROOT_REPLAY_SCHEMA_VERSION:
         raise WorldStateError("GR00T replay artifact schema_version is unsupported.")
+    if not isinstance(payload.get("source"), str) or not payload["source"]:
+        raise WorldStateError("GR00T replay artifact source must be a non-empty string.")
 
     manifest = _require_json_object(payload.get("manifest"), "GR00T replay manifest")
+    if set(manifest) != _GROOT_REPLAY_MANIFEST_KEYS:
+        raise WorldStateError("GR00T replay manifest contains unsupported fields.")
     if manifest.get("flow_id") != "gr00t-replay":
         raise WorldStateError("GR00T replay artifact flow_id must be 'gr00t-replay'.")
+    if manifest.get("provider") != "gr00t":
+        raise WorldStateError("GR00T replay artifact provider is unsupported.")
+    if manifest.get("model") != _GROOT_REPLAY_MODEL:
+        raise WorldStateError("GR00T replay artifact model is unsupported.")
     if manifest.get("action_horizon") != _GROOT_REPLAY_ACTION_HORIZON:
         raise WorldStateError("GR00T replay artifact action_horizon is unsupported.")
     if manifest.get("embodiment_tag") != _GROOT_REPLAY_EMBODIMENT_TAG:
@@ -1255,9 +1302,25 @@ def _load_groot_replay_artifact(path: Path) -> JSONDict:
         raise WorldStateError("GR00T replay request embodiment_tag is unsupported.")
 
     policy_output = _require_json_object(payload.get("policy_output"), "GR00T replay output")
+    if set(policy_output) != _GROOT_REPLAY_POLICY_OUTPUT_KEYS:
+        raise WorldStateError("GR00T replay policy_output contains unsupported fields.")
     raw_actions = _require_json_object(policy_output.get("raw_actions"), "GR00T replay raw_actions")
     _validate_groot_raw_actions(raw_actions)
-    _require_json_object(policy_output.get("provider_info", {}), "GR00T replay provider_info")
+    _validate_groot_provider_info(policy_output.get("provider_info", {}))
+    response = _require_json_object(payload.get("response"), "GR00T replay response")
+    if set(response) != _GROOT_REPLAY_RESPONSE_KEYS:
+        raise WorldStateError("GR00T replay response contains unsupported fields.")
+    if response.get("raw_action_shapes") != _GROOT_REPLAY_RAW_ACTION_SHAPES:
+        raise WorldStateError("GR00T replay response raw_action_shapes are unsupported.")
+    if response.get("translated_action_count") != 0:
+        raise WorldStateError("GR00T replay seed response translated_action_count must be zero.")
+    if response.get("raw_action_preview") != [] or response.get("selected_action_preview") != []:
+        raise WorldStateError("GR00T replay seed response previews must be empty.")
+    _validate_groot_latency(response.get("latency_ms"), "GR00T replay response latency_ms")
+    if payload.get("translated_actions") != []:
+        raise WorldStateError("GR00T replay seed translated_actions must be empty.")
+    if payload.get("provider_events") != []:
+        raise WorldStateError("GR00T replay seed provider_events must be empty.")
     return payload
 
 
@@ -1315,6 +1378,7 @@ def _groot_replay_failure_summary(
     events: Sequence[ProviderEvent],
     replay_artifact: JSONDict,
     error: Exception,
+    policy_select_calls: int,
 ) -> JSONDict:
     manifest = _require_json_object(saved_replay["manifest"], "GR00T replay manifest")
     request = _require_json_object(saved_replay["request"], "GR00T replay request")
@@ -1335,7 +1399,7 @@ def _groot_replay_failure_summary(
         "action_horizon": request.get("action_horizon"),
         "embodiment_tag": request.get("embodiment_tag"),
         "candidate_count": 0,
-        "policy_select_calls": 0,
+        "policy_select_calls": policy_select_calls,
         "latency_ms": response.get("latency_ms"),
         "selected_actions": [],
         "selected_action_preview": [],
@@ -1409,6 +1473,26 @@ def _validate_groot_raw_actions(raw_actions: JSONDict) -> None:
             expected_shape=expected_shape,
             name=f"GR00T replay raw_actions.{key}",
         )
+
+
+def _validate_groot_provider_info(value: object) -> JSONDict:
+    provider_info = _require_json_object(value, "GR00T replay provider_info")
+    if set(provider_info) != _GROOT_REPLAY_PROVIDER_INFO_KEYS:
+        raise WorldStateError("GR00T replay provider_info contains unsupported fields.")
+    if provider_info.get("model") != _GROOT_REPLAY_MODEL:
+        raise WorldStateError("GR00T replay provider_info model is unsupported.")
+    _validate_groot_latency(
+        provider_info.get("latency_ms"),
+        "GR00T replay provider_info latency_ms",
+    )
+    if not isinstance(provider_info.get("runtime"), str) or not provider_info["runtime"]:
+        raise WorldStateError("GR00T replay provider_info runtime must be a non-empty string.")
+    return provider_info
+
+
+def _validate_groot_latency(value: object, name: str) -> None:
+    if not isinstance(value, int | float) or isinstance(value, bool) or not math.isfinite(value):
+        raise WorldStateError(f"{name} must be a finite number.")
 
 
 def _validate_numeric_tensor(value: object, *, expected_shape: Sequence[int], name: str) -> None:

--- a/src/worldforge/harness/flows.py
+++ b/src/worldforge/harness/flows.py
@@ -1145,27 +1145,35 @@ def _run_gr00t_replay_demo(*, state_dir: Path, emit: bool = False) -> JSONDict:
     raw_action_preview = _groot_action_preview(normalized_raw_actions)
     selected_action_preview = [action.to_dict() for action in result.actions[:8]]
     replay_artifact = dict(saved_replay)
+    manifest = dict(_require_json_object(saved_replay["manifest"], "GR00T replay manifest"))
+    manifest.update(
+        {
+            "flow_id": "gr00t-replay",
+            "provider": result.provider,
+            "model": _GROOT_REPLAY_MODEL,
+            "runtime": metadata.get("runtime"),
+            "task_description": _GROOT_REPLAY_TASK,
+            "action_horizon": result.action_horizon,
+            "embodiment_tag": result.embodiment_tag,
+            "source_artifact": replay_source_path.name,
+            "source_validation": "validated live on RTX A6000; committed artifact is sanitized",
+            "result_digest": _GROOT_REPLAY_RESULT_DIGEST,
+        }
+    )
+    response = dict(_require_json_object(saved_replay["response"], "GR00T replay response"))
+    response.update(
+        {
+            "raw_action_shapes": raw_action_shapes,
+            "translated_action_count": len(result.actions),
+            "raw_action_preview": raw_action_preview,
+            "selected_action_preview": selected_action_preview,
+            "latency_ms": _GROOT_REPLAY_LATENCY_MS,
+        }
+    )
     replay_artifact.update(
         {
-            "manifest": {
-                "flow_id": "gr00t-replay",
-                "provider": result.provider,
-                "model": _GROOT_REPLAY_MODEL,
-                "runtime": metadata.get("runtime"),
-                "task_description": _GROOT_REPLAY_TASK,
-                "action_horizon": result.action_horizon,
-                "embodiment_tag": result.embodiment_tag,
-                "source_artifact": replay_source_path.name,
-                "source_validation": "validated live on RTX A6000; committed artifact is sanitized",
-                "result_digest": _GROOT_REPLAY_RESULT_DIGEST,
-            },
-            "response": {
-                "raw_action_shapes": raw_action_shapes,
-                "translated_action_count": len(result.actions),
-                "raw_action_preview": raw_action_preview,
-                "selected_action_preview": selected_action_preview,
-                "latency_ms": _GROOT_REPLAY_LATENCY_MS,
-            },
+            "manifest": manifest,
+            "response": response,
             "translated_actions": [action.to_dict() for action in result.actions],
             "provider_events": [event.to_dict() for event in events],
         }

--- a/src/worldforge/harness/tui.py
+++ b/src/worldforge/harness/tui.py
@@ -1049,8 +1049,9 @@ class RunInspectorScreen(Screen):
         Binding("1", "select_flow('leworldmodel')", "LeWorldModel", show=True),
         Binding("2", "select_flow('lerobot')", "LeRobot", show=True),
         Binding("3", "select_flow('cosmos-policy')", "Cosmos", show=True),
-        Binding("4", "select_flow('diagnostics')", "Diagnostics", show=True),
-        Binding("5", "select_flow('workbench')", "Workbench", show=True),
+        Binding("4", "select_flow('gr00t-replay')", "GR00T", show=True),
+        Binding("5", "select_flow('diagnostics')", "Diagnostics", show=True),
+        Binding("6", "select_flow('workbench')", "Workbench", show=True),
     ]
 
     DEFAULT_CSS = """

--- a/tests/test_harness_cli.py
+++ b/tests/test_harness_cli.py
@@ -20,6 +20,7 @@ def test_worldforge_harness_lists_flows_without_textual(monkeypatch, capsys) -> 
     assert "leworldmodel" in output
     assert "lerobot" in output
     assert "cosmos-policy" in output
+    assert "gr00t-replay" in output
     assert "diagnostics" in output
     assert "workbench" in output
 
@@ -38,6 +39,7 @@ def test_worldforge_harness_lists_json_without_textual(monkeypatch, capsys) -> N
         "leworldmodel",
         "lerobot",
         "cosmos-policy",
+        "gr00t-replay",
         "diagnostics",
         "workbench",
     ]

--- a/tests/test_harness_flows.py
+++ b/tests/test_harness_flows.py
@@ -207,6 +207,7 @@ def test_harness_runs_groot_replay_flow(tmp_path) -> None:
     assert replay["manifest"]["source_validation"] == (
         "validated live on RTX A6000; committed artifact is sanitized"
     )
+    assert replay["manifest"]["raw_action_shapes"] == run.summary["raw_action_shapes"]
     assert len(replay["policy_output"]["raw_actions"]["eef_9d"][0]) == 40
     assert len(replay["translated_actions"]) == 40
     assert replay["provider_events"][0]["phase"] == "success"

--- a/tests/test_harness_flows.py
+++ b/tests/test_harness_flows.py
@@ -41,6 +41,12 @@ def _write_cosmos_replay_payload(tmp_path: Path, name: str, payload: object) -> 
     return path
 
 
+def _write_groot_replay_payload(tmp_path: Path, name: str, payload: object) -> Path:
+    path = tmp_path / name
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
 def _cosmos_replay_request_payload(tmp_path: Path) -> tuple[dict, dict]:
     from worldforge.harness import flows
 
@@ -64,6 +70,7 @@ def test_harness_flow_metadata_is_available_without_textual() -> None:
         "leworldmodel",
         "lerobot",
         "cosmos-policy",
+        "gr00t-replay",
         "diagnostics",
         "workbench",
     ]
@@ -73,8 +80,9 @@ def test_harness_flow_metadata_is_available_without_textual() -> None:
     assert payload[0]["command"] == "uv run worldforge-demo-leworldmodel"
     assert payload[1]["focus"] == "policy plus score planning"
     assert payload[2]["command"] == "uv run --extra harness worldforge-harness --flow cosmos-policy"
-    assert payload[3]["command"] == "uv run worldforge harness --flow diagnostics"
-    assert payload[4]["command"] == "uv run worldforge provider workbench mock"
+    assert payload[3]["command"] == "uv run --extra harness worldforge-harness --flow gr00t-replay"
+    assert payload[4]["command"] == "uv run worldforge harness --flow diagnostics"
+    assert payload[5]["command"] == "uv run worldforge provider workbench mock"
 
 
 def test_harness_runs_leworldmodel_flow(tmp_path) -> None:
@@ -169,6 +177,162 @@ def test_harness_cosmos_policy_flow_ignores_live_cosmos_env(tmp_path, monkeypatc
 
     assert run.summary["raw_action_shape"] == [50, 14]
     assert run.summary["translated_action_count"] == 50
+
+
+def test_harness_runs_groot_replay_flow(tmp_path) -> None:
+    run = run_flow("gr00t-replay", state_dir=tmp_path)
+
+    assert run.flow.id == "gr00t-replay"
+    assert len(run.steps) == 6
+    assert len(run.metrics) == 6
+    assert run.summary["model"] == "nvidia/GR00T-N1.7-3B"
+    assert run.summary["raw_action_shapes"] == {
+        "eef_9d": [1, 40, 9],
+        "gripper_position": [1, 40, 1],
+        "joint_position": [1, 40, 7],
+    }
+    assert run.summary["translated_action_count"] == 40
+    assert run.summary["action_horizon"] == 40
+    assert run.summary["embodiment_tag"] == "OXE_DROID_RELATIVE_EEF_RELATIVE_JOINT"
+    assert run.summary["selected_action_preview"][0]["type"] == "move_to"
+    assert [event["phase"] for event in run.provider_events] == ["success"]
+    transcript = "\n".join(run.transcript)
+    assert "raw_action_shapes:" in transcript
+    assert "saved_replay_artifact: artifacts/gr00t-replay.json" in transcript
+    assert run.workspace_path is not None
+    manifest = json.loads((run.workspace_path / "run_manifest.json").read_text())
+    assert manifest["artifact_paths"]["gr00t_replay"] == "artifacts/gr00t-replay.json"
+    replay = json.loads((run.workspace_path / "artifacts/gr00t-replay.json").read_text())
+    assert replay["manifest"]["flow_id"] == "gr00t-replay"
+    assert replay["manifest"]["source_validation"] == (
+        "validated live on RTX A6000; committed artifact is sanitized"
+    )
+    assert len(replay["policy_output"]["raw_actions"]["eef_9d"][0]) == 40
+    assert len(replay["translated_actions"]) == 40
+    assert replay["provider_events"][0]["phase"] == "success"
+    assert "observation" not in replay["request"]
+    assert replay["request"]["observation_summary"]["video"]["redacted"] is True
+    assert replay["request"]["observation_summary"]["state"]["redacted"] is True
+    assert replay["request"]["observation_summary"]["language"]["redacted"] is True
+
+
+def test_harness_groot_replay_flow_can_emit_transcript(tmp_path, capsys) -> None:
+    from worldforge.harness import flows
+
+    summary = flows._run_gr00t_replay_demo(state_dir=tmp_path, emit=True)
+
+    output = capsys.readouterr().out
+    assert summary["translated_action_count"] == 40
+    assert "flow: gr00t-replay" in output
+    assert "translated_actions: 40" in output
+
+
+def test_harness_loads_groot_replay_artifact(tmp_path) -> None:
+    from worldforge.harness import flows
+
+    path = tmp_path / "gr00t-replay.json"
+    payload = flows._groot_saved_replay_payload()
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    loaded = flows._load_groot_replay_artifact(path)
+
+    assert loaded["manifest"]["model"] == "nvidia/GR00T-N1.7-3B"
+    assert loaded["request"]["task_description"] == "fold cloth"
+    assert loaded["request"]["observation_summary"]["video"]["redacted"] is True
+    assert "observation" not in loaded["request"]
+    assert len(loaded["policy_output"]["raw_actions"]["eef_9d"][0]) == 40
+
+
+def test_harness_rejects_groot_replay_schema_drift(tmp_path) -> None:
+    from worldforge.harness import flows
+
+    payload = flows._groot_saved_replay_payload()
+    invalid_schema = _copy_json_payload(payload)
+    invalid_schema["schema_version"] = 99
+
+    with pytest.raises(WorldStateError, match="schema_version"):
+        flows._load_groot_replay_artifact(
+            _write_groot_replay_payload(tmp_path, "bad-schema.json", invalid_schema)
+        )
+
+
+def test_harness_rejects_unredacted_groot_replay_observation(tmp_path) -> None:
+    from worldforge.harness import flows
+
+    payload = flows._groot_saved_replay_payload()
+    unredacted = _copy_json_payload(payload)
+    unredacted["request"]["observation_summary"]["video"]["redacted"] = False
+
+    with pytest.raises(WorldStateError, match="must be redacted"):
+        flows._load_groot_replay_artifact(
+            _write_groot_replay_payload(tmp_path, "unredacted-video.json", unredacted)
+        )
+
+
+def test_harness_rejects_raw_groot_replay_observation(tmp_path) -> None:
+    from worldforge.harness import flows
+
+    payload = flows._groot_saved_replay_payload()
+    raw_observation = _copy_json_payload(payload)
+    raw_observation["request"]["observation"] = {"video": {"exterior_image": [[[[[0, 0, 0]]]]]}}
+
+    with pytest.raises(WorldStateError, match="unsupported fields"):
+        flows._load_groot_replay_artifact(
+            _write_groot_replay_payload(tmp_path, "raw-observation.json", raw_observation)
+        )
+
+
+def test_harness_rejects_groot_replay_bad_raw_tensor_shape(tmp_path) -> None:
+    from worldforge.harness import flows
+
+    payload = flows._groot_saved_replay_payload()
+    bad_shape = _copy_json_payload(payload)
+    bad_shape["policy_output"]["raw_actions"]["eef_9d"][0][0] = [0.0] * 8
+
+    with pytest.raises(WorldStateError, match="shape"):
+        flows._load_groot_replay_artifact(
+            _write_groot_replay_payload(tmp_path, "bad-shape.json", bad_shape)
+        )
+
+
+def test_harness_rejects_groot_replay_non_finite_raw_value(tmp_path) -> None:
+    from worldforge.harness import flows
+
+    payload = flows._groot_saved_replay_payload()
+    non_finite = _copy_json_payload(payload)
+    non_finite["policy_output"]["raw_actions"]["joint_position"][0][0][0] = math.nan
+
+    with pytest.raises(WorldStateError, match="finite numeric"):
+        flows._load_groot_replay_artifact(
+            _write_groot_replay_payload(tmp_path, "non-finite.json", non_finite)
+        )
+
+
+def test_harness_groot_replay_failure_preserves_replay_artifact(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from worldforge.harness import flows
+
+    def broken_rows(_raw_actions):
+        raise WorldStateError("GR00T replay tensor decode failed")
+
+    monkeypatch.setattr(flows, "_groot_eef_rows", broken_rows)
+
+    run = run_flow("gr00t-replay", state_dir=tmp_path)
+
+    assert run.validation_errors == (
+        "GR00T action translation failed: GR00T replay tensor decode failed",
+    )
+    assert run.workspace_path is not None
+    manifest = json.loads((run.workspace_path / "run_manifest.json").read_text())
+    assert manifest["status"] == "failed"
+    replay_path = run.workspace_path / "artifacts" / "gr00t-replay.json"
+    replay = json.loads(replay_path.read_text())
+    assert replay["manifest"]["status"] == "failed"
+    assert replay["response"]["translated_action_count"] == 0
+    assert replay["translated_actions"] == []
+    assert "failure" in [event["phase"] for event in replay["provider_events"]]
 
 
 def test_harness_loads_cosmos_policy_replay_artifact(tmp_path) -> None:

--- a/tests/test_harness_flows.py
+++ b/tests/test_harness_flows.py
@@ -282,6 +282,91 @@ def test_harness_rejects_raw_groot_replay_observation(tmp_path) -> None:
         )
 
 
+def test_harness_rejects_extra_groot_replay_artifact_fields(tmp_path) -> None:
+    from worldforge.harness import flows
+
+    payload = flows._groot_saved_replay_payload()
+    extra_field = _copy_json_payload(payload)
+    extra_field["raw_observation"] = {"token": "secret"}
+
+    with pytest.raises(WorldStateError, match="unsupported top-level fields"):
+        flows._load_groot_replay_artifact(
+            _write_groot_replay_payload(tmp_path, "extra-field.json", extra_field)
+        )
+
+
+def test_harness_rejects_secret_groot_replay_provider_info(tmp_path) -> None:
+    from worldforge.harness import flows
+
+    payload = flows._groot_saved_replay_payload()
+    secret_info = _copy_json_payload(payload)
+    secret_info["policy_output"]["provider_info"]["api_key"] = "secret"
+
+    with pytest.raises(WorldStateError, match="provider_info contains unsupported fields"):
+        flows._load_groot_replay_artifact(
+            _write_groot_replay_payload(tmp_path, "secret-info.json", secret_info)
+        )
+
+
+@pytest.mark.parametrize(
+    ("mutator", "match"),
+    [
+        (
+            lambda payload: payload["manifest"].__setitem__("secret", "value"),
+            "manifest contains unsupported fields",
+        ),
+        (
+            lambda payload: payload["policy_output"].__setitem__("secret", "value"),
+            "policy_output contains unsupported fields",
+        ),
+        (
+            lambda payload: payload["response"].__setitem__("secret", "value"),
+            "response contains unsupported fields",
+        ),
+        (
+            lambda payload: payload["response"].__setitem__("translated_action_count", 1),
+            "translated_action_count must be zero",
+        ),
+        (
+            lambda payload: payload.__setitem__(
+                "translated_actions",
+                [{"type": "move_to"}],
+            ),
+            "translated_actions must be empty",
+        ),
+        (
+            lambda payload: payload["policy_output"]["provider_info"].__setitem__(
+                "runtime",
+                "",
+            ),
+            "runtime must be a non-empty string",
+        ),
+        (
+            lambda payload: payload["policy_output"]["provider_info"].__setitem__(
+                "latency_ms",
+                math.nan,
+            ),
+            "latency_ms must be a finite number",
+        ),
+    ],
+)
+def test_harness_rejects_groot_replay_retained_field_drift(
+    tmp_path,
+    mutator,
+    match: str,
+) -> None:
+    from worldforge.harness import flows
+
+    payload = flows._groot_saved_replay_payload()
+    drifted = _copy_json_payload(payload)
+    mutator(drifted)
+
+    with pytest.raises(WorldStateError, match=match):
+        flows._load_groot_replay_artifact(
+            _write_groot_replay_payload(tmp_path, "retained-field-drift.json", drifted)
+        )
+
+
 def test_harness_rejects_groot_replay_bad_raw_tensor_shape(tmp_path) -> None:
     from worldforge.harness import flows
 
@@ -324,6 +409,7 @@ def test_harness_groot_replay_failure_preserves_replay_artifact(
     assert run.validation_errors == (
         "GR00T action translation failed: GR00T replay tensor decode failed",
     )
+    assert run.summary["policy_select_calls"] == 1
     assert run.workspace_path is not None
     manifest = json.loads((run.workspace_path / "run_manifest.json").read_text())
     assert manifest["status"] == "failed"

--- a/tests/test_harness_flows.py
+++ b/tests/test_harness_flows.py
@@ -282,6 +282,21 @@ def test_harness_rejects_raw_groot_replay_observation(tmp_path) -> None:
         )
 
 
+def test_harness_rejects_groot_replay_observation_summary_extra_keys(tmp_path) -> None:
+    from worldforge.harness import flows
+
+    payload = flows._groot_saved_replay_payload()
+    extra_summary_key = _copy_json_payload(payload)
+    extra_summary_key["request"]["observation_summary"]["video"]["raw_tensor"] = {
+        "some_raw": [[[[[0]]]]],
+    }
+
+    with pytest.raises(WorldStateError, match="unsupported fields"):
+        flows._load_groot_replay_artifact(
+            _write_groot_replay_payload(tmp_path, "extra-summary-key.json", extra_summary_key)
+        )
+
+
 def test_harness_rejects_extra_groot_replay_artifact_fields(tmp_path) -> None:
     from worldforge.harness import flows
 

--- a/tests/test_harness_tui.py
+++ b/tests/test_harness_tui.py
@@ -344,6 +344,10 @@ def test_harness_status_pill_reflects_selected_flow_provider(tmp_path) -> None:
             assert pill.label.endswith("· policy")
             await pilot.press("4")
             await pilot.pause()
+            assert "GrootPolicyClientProvider" in pill.label
+            assert pill.label.endswith("· policy")
+            await pilot.press("5")
+            await pilot.pause()
             assert pill.label.endswith("· diagnostics")
 
     asyncio.run(scenario())
@@ -412,7 +416,7 @@ def test_the_world_harness_app_switches_to_diagnostics_flow(tmp_path) -> None:
             step_delay=0.0,
         )
         async with app.run_test(size=(140, 44)) as pilot:
-            await pilot.press("4")
+            await pilot.press("5")
             await pilot.press("r")
             await pilot.pause()
             screen = app.screen
@@ -420,6 +424,32 @@ def test_the_world_harness_app_switches_to_diagnostics_flow(tmp_path) -> None:
             assert screen.last_run is not None
             assert screen.last_run.flow.id == "diagnostics"
             assert screen.last_run.summary["benchmark_operation_count"] == 5
+
+    asyncio.run(scenario())
+
+
+def test_the_world_harness_app_switches_to_gr00t_replay_flow(tmp_path) -> None:
+    pytest.importorskip("textual")
+
+    from worldforge.harness.tui import RunInspectorScreen, TheWorldHarnessApp
+
+    async def scenario() -> None:
+        app = TheWorldHarnessApp(
+            initial_flow_id="leworldmodel",
+            initial_screen="run-inspector",
+            state_dir=tmp_path,
+            step_delay=0.0,
+        )
+        async with app.run_test(size=(140, 44)) as pilot:
+            await pilot.press("4")
+            await pilot.press("r")
+            await pilot.pause()
+            screen = app.screen
+            assert isinstance(screen, RunInspectorScreen)
+            assert screen.last_run is not None
+            assert screen.last_run.flow.id == "gr00t-replay"
+            assert screen.last_run.summary["translated_action_count"] == 40
+            assert screen.last_run.summary["raw_action_shapes"]["eef_9d"] == [1, 40, 9]
 
     asyncio.run(scenario())
 


### PR DESCRIPTION
## Summary

Adds a checkout-safe `gr00t-replay` flow to TheWorldHarness.

This builds on #225. The live RTX A6000 run validated the GR00T PolicyClient response shape, but this PR commits only a sanitized deterministic replay. It lets operators inspect the GR00T policy output in the TUI without keeping a GPU server online.

Closes #226.

## What changed

- add `gr00t-replay` harness flow metadata and runner
- replay a sanitized GR00T N1.7 PolicyClient response through `GrootPolicyClientProvider`
- validate named GR00T tensors before translation:
  - `eef_9d`
  - `gripper_position`
  - `joint_position`
- translate end-effector rows into WorldForge `Action.move_to(...)` objects
- persist `artifacts/gr00t-replay.json` with redacted observation summaries
- allowlist retained replay artifact fields so raw observations or secret-bearing metadata cannot silently enter saved workspaces
- report the real `PolicyClient.get_action()` call count in failure summaries
- add TUI keybinding `4` for GR00T and shift Diagnostics/Workbench to `5`/`6`
- document the new command, expected success signals, and first triage steps

## Safety boundary

The committed artifact is intentionally checkout-safe:

- no raw observations
- no private endpoints
- no GPU logs
- no checkpoint files
- no model weights

The live GPU run proved the response contract shape; this PR makes that shape replayable and inspectable inside WorldForge.

## Validation

- `uv lock --check`
- `uv run ruff check src tests examples scripts`
- `uv run ruff format --check src tests examples scripts`
- `uv run python scripts/generate_provider_docs.py --check`
- `uv run python scripts/check_docs_commands.py`
- `uv run python scripts/check_wrapper_portability.py`
- `uv run python scripts/check_core_performance.py`
- `uv run mkdocs build --strict`
- `uv run pytest tests/test_harness_flows.py tests/test_harness_cli.py tests/test_harness_tui.py tests/test_docs_site.py -q` (`103 passed, 58 skipped`)
- `uv run pytest -q` (`1180 passed, 2 skipped`)
- `uv run --extra harness pytest --cov=src/worldforge --cov-report=term-missing --cov-fail-under=90` (`1180 passed, 2 skipped`, coverage `90.07%`)
- `bash scripts/test_package.sh` (`1097 passed, 85 skipped`)
- `uv build --out-dir dist --clear --no-build-logs`
