### PR TITLE
Harden evidence bundle artifact safety

### DIFF
--- a/src/worldforge/evidence_bundle.py
+++ b/src/worldforge/evidence_bundle.py
@@ -11,7 +11,7 @@ from datetime import UTC, datetime
 from importlib import resources
 from pathlib import Path
 
-from worldforge.harness.workspace import runs_dir
+from worldforge.harness.workspace import runs_dir, validate_run_id
 from worldforge.html_report import render_evidence_bundle_html, render_issue_bundle_html
 from worldforge.models import JSONDict, WorldForgeError, dump_json
 from worldforge.report_renderers import (
@@ -422,10 +422,17 @@ class _BundleContext:
 def _select_run_paths(workspace_dir: Path, run_ids: tuple[str, ...]) -> list[Path]:
     root = runs_dir(workspace_dir)
     if run_ids:
-        return [root / run_id for run_id in sorted(run_ids)]
+        return [root / _validated_run_id(run_id) for run_id in sorted(run_ids)]
     if not root.exists():
         return []
     return sorted(path.parent for path in root.glob("*/run_manifest.json"))
+
+
+def _validated_run_id(run_id: str) -> str:
+    try:
+        return validate_run_id(run_id)
+    except ValueError as exc:
+        raise WorldForgeError(f"Evidence bundle run_id is invalid: {exc}") from exc
 
 
 def _load_run_manifest(run_path: Path) -> JSONDict:

--- a/src/worldforge/evidence_bundle.py
+++ b/src/worldforge/evidence_bundle.py
@@ -776,7 +776,7 @@ def _contains_unsafe_url(value: object) -> bool:
         return False
     return bool(
         re.search(
-            r"https?://[^\\s\"']+[?&](token|signature|sig|key|api_key)=",
+            r"https?://[^\s\"']+[?&](token|signature|sig|key|api_key)=",
             value,
             re.I,
         )

--- a/src/worldforge/evidence_bundle.py
+++ b/src/worldforge/evidence_bundle.py
@@ -585,6 +585,16 @@ def _record_manifest_artifact_references(
                 kind="artifact-reference",
                 local_only=True,
             )
+            continue
+        if not resolved.is_file():
+            _record_excluded(
+                context,
+                destination=Path("runs") / run_id / f"artifacts/{label}",
+                source=raw_path,
+                reason="artifact reference does not exist",
+                kind="artifact-reference",
+                local_only=True,
+            )
 
 
 def _resolve_report_reference(value: object) -> Path | None:

--- a/src/worldforge/evidence_bundle.py
+++ b/src/worldforge/evidence_bundle.py
@@ -448,16 +448,28 @@ def _copy_run_workspace(
     run_id: str,
     copied_refs: set[Path],
 ) -> None:
+    run_root = run_path.resolve()
     for source in sorted(path for path in run_path.rglob("*") if path.is_file()):
         resolved = source.resolve()
+        relative = source.relative_to(run_path)
+        destination = Path("runs") / run_id / relative
+        if not _is_relative_to(resolved, run_root):
+            _record_excluded(
+                context,
+                destination=destination,
+                source=str(source),
+                reason="run artifact resolves outside the run workspace",
+                kind="run-artifact",
+                local_only=True,
+            )
+            continue
         if resolved in copied_refs:
             continue
         copied_refs.add(resolved)
-        relative = source.relative_to(run_path)
         _copy_safe_file(
             context,
             source=source,
-            destination=Path("runs") / run_id / relative,
+            destination=destination,
             kind="run-artifact",
         )
 

--- a/src/worldforge/workflow_trace.py
+++ b/src/worldforge/workflow_trace.py
@@ -259,12 +259,17 @@ class WorkflowTrace:
             status: sum(1 for step in self.steps if step.status == status)
             for status in WORKFLOW_TRACE_STEP_STATUSES
         }
+        safe_to_attach = all(
+            artifact.safe_to_attach
+            for step in self.steps
+            for artifact in (*step.input_artifacts, *step.output_artifacts)
+        )
         return {
             "schema_version": self.schema_version,
             "workflow_id": self.workflow_id,
             "name": self.name,
             "status": self.status,
-            "safe_to_attach": True,
+            "safe_to_attach": safe_to_attach,
             "step_count": len(self.steps),
             "status_counts": status_counts,
             "metadata": dict(self.metadata),

--- a/tests/test_evidence_bundle.py
+++ b/tests/test_evidence_bundle.py
@@ -275,6 +275,44 @@ def test_evidence_bundle_excludes_run_workspace_symlink_escape(tmp_path: Path) -
     ).exists()
 
 
+def test_evidence_bundle_detects_signed_url_sig_query(tmp_path: Path) -> None:
+    workspace = create_run_workspace(
+        tmp_path,
+        kind="eval",
+        command="worldforge eval --suite planning --provider mock",
+        provider="mock",
+        operation="planning",
+        run_id="20260101T000000Z-00000001",
+        input_summary={"suite_id": "planning", "providers": ["mock"]},
+    )
+    workspace.write_json(
+        "reports/report.json",
+        {"artifact": "https://assets.example.test/output.json?sig=credential"},
+    )
+    write_run_manifest(
+        workspace,
+        kind="eval",
+        command="worldforge eval --suite planning --provider mock",
+        provider="mock",
+        operation="planning",
+        status="failed",
+        input_summary={"suite_id": "planning", "providers": ["mock"]},
+        result_summary={"failed_count": 1},
+        artifact_paths={"json": "reports/report.json"},
+    )
+
+    result = generate_evidence_bundle(
+        workspace_dir=tmp_path,
+        output_dir=tmp_path / "bundle",
+    )
+
+    manifest = result.manifest
+    excluded = {item["path"]: item for item in manifest["files"] if not item["included"]}
+    report = excluded["runs/20260101T000000Z-00000001/reports/report.json"]
+    assert report["reason"] == "signed or credentialed URL detected"
+    assert manifest["safe_to_attach"] is False
+
+
 def test_release_evidence_can_link_generated_bundle(tmp_path: Path) -> None:
     manifest_path = tmp_path / "bundle" / "evidence_manifest.json"
     manifest_path.parent.mkdir()

--- a/tests/test_evidence_bundle.py
+++ b/tests/test_evidence_bundle.py
@@ -233,6 +233,48 @@ def test_evidence_bundle_reports_missing_manifest_artifact_reference(tmp_path: P
     assert manifest["safe_to_attach"] is False
 
 
+def test_evidence_bundle_excludes_run_workspace_symlink_escape(tmp_path: Path) -> None:
+    workspace = create_run_workspace(
+        tmp_path,
+        kind="eval",
+        command="worldforge eval --suite planning --provider mock",
+        provider="mock",
+        operation="planning",
+        run_id="20260101T000000Z-00000001",
+        input_summary={"suite_id": "planning", "providers": ["mock"]},
+    )
+    external = tmp_path / "outside.json"
+    external.write_text('{"safe": true}\n', encoding="utf-8")
+    symlink_path = workspace.path / "reports" / "external.json"
+    symlink_path.symlink_to(external)
+    write_run_manifest(
+        workspace,
+        kind="eval",
+        command="worldforge eval --suite planning --provider mock",
+        provider="mock",
+        operation="planning",
+        status="failed",
+        input_summary={"suite_id": "planning", "providers": ["mock"]},
+        result_summary={"failed_count": 1},
+        artifact_paths={"json": "reports/external.json"},
+    )
+
+    result = generate_evidence_bundle(
+        workspace_dir=tmp_path,
+        output_dir=tmp_path / "bundle",
+    )
+
+    manifest = result.manifest
+    excluded = {item["path"]: item for item in manifest["files"] if not item["included"]}
+    escaped = excluded["runs/20260101T000000Z-00000001/reports/external.json"]
+    assert escaped["reason"] == "run artifact resolves outside the run workspace"
+    assert escaped["local_only"] is True
+    assert manifest["safe_to_attach"] is False
+    assert not (
+        result.output_dir / "runs" / "20260101T000000Z-00000001" / "reports" / "external.json"
+    ).exists()
+
+
 def test_release_evidence_can_link_generated_bundle(tmp_path: Path) -> None:
     manifest_path = tmp_path / "bundle" / "evidence_manifest.json"
     manifest_path.parent.mkdir()

--- a/tests/test_evidence_bundle.py
+++ b/tests/test_evidence_bundle.py
@@ -5,7 +5,10 @@ import json
 import sys
 from pathlib import Path
 
+import pytest
+
 import worldforge.evidence_bundle as evidence_bundle
+from worldforge import WorldForgeError
 from worldforge.cli import main
 from worldforge.evidence_bundle import (
     evidence_bundle_artifact,
@@ -231,6 +234,33 @@ def test_evidence_bundle_reports_missing_manifest_artifact_reference(tmp_path: P
     assert missing["reason"] == "artifact reference does not exist"
     assert missing["local_only"] is True
     assert manifest["safe_to_attach"] is False
+
+
+def test_evidence_bundle_rejects_traversal_run_id(tmp_path: Path) -> None:
+    (tmp_path / "runs").mkdir()
+    escaped = tmp_path / "escape"
+    escaped.mkdir()
+    (escaped / "run_manifest.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "run_id": "20260101T000000Z-00000001",
+                "kind": "eval",
+                "command": "worldforge eval",
+                "status": "passed",
+                "artifact_paths": {},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(WorldForgeError, match="run_id"):
+        generate_evidence_bundle(
+            workspace_dir=tmp_path,
+            output_dir=tmp_path / "bundle",
+            run_ids=("../escape",),
+        )
 
 
 def test_evidence_bundle_excludes_run_workspace_symlink_escape(tmp_path: Path) -> None:

--- a/tests/test_evidence_bundle.py
+++ b/tests/test_evidence_bundle.py
@@ -198,6 +198,41 @@ def test_evidence_bundle_marks_unsafe_and_local_only_artifacts(tmp_path: Path) -
     assert manifest["runs"][0]["skip_reason"] == "fixture drill"
 
 
+def test_evidence_bundle_reports_missing_manifest_artifact_reference(tmp_path: Path) -> None:
+    workspace = create_run_workspace(
+        tmp_path,
+        kind="eval",
+        command="worldforge eval --suite planning --provider mock",
+        provider="mock",
+        operation="planning",
+        run_id="20260101T000000Z-00000001",
+        input_summary={"suite_id": "planning", "providers": ["mock"]},
+    )
+    write_run_manifest(
+        workspace,
+        kind="eval",
+        command="worldforge eval --suite planning --provider mock",
+        provider="mock",
+        operation="planning",
+        status="failed",
+        input_summary={"suite_id": "planning", "providers": ["mock"]},
+        result_summary={"failed_count": 1},
+        artifact_paths={"missing": "artifacts/missing.json"},
+    )
+
+    result = generate_evidence_bundle(
+        workspace_dir=tmp_path,
+        output_dir=tmp_path / "bundle",
+    )
+
+    manifest = result.manifest
+    excluded = {item["path"]: item for item in manifest["files"] if not item["included"]}
+    missing = excluded["runs/20260101T000000Z-00000001/artifacts/missing"]
+    assert missing["reason"] == "artifact reference does not exist"
+    assert missing["local_only"] is True
+    assert manifest["safe_to_attach"] is False
+
+
 def test_release_evidence_can_link_generated_bundle(tmp_path: Path) -> None:
     manifest_path = tmp_path / "bundle" / "evidence_manifest.json"
     manifest_path.parent.mkdir()

--- a/tests/test_provider_events.py
+++ b/tests/test_provider_events.py
@@ -167,3 +167,29 @@ def test_workflow_trace_validates_skipped_failed_and_nested_steps() -> None:
     assert payload["status"] == "failed"
     assert payload["status_counts"]["skipped"] == 1
     assert payload["steps"][3]["parent_id"] == "provider"
+
+
+def test_workflow_trace_marks_local_only_artifacts_not_safe_to_attach() -> None:
+    trace = WorkflowTrace(
+        workflow_id="local-artifact-trace",
+        name="Local artifact trace",
+        steps=[
+            WorkflowTraceStep(
+                step_id="checkpoint",
+                operation="prepared-host checkpoint",
+                status="success",
+                output_artifacts=(
+                    WorkflowArtifactRef(
+                        label="checkpoint",
+                        path="/Users/example/.cache/model.ckpt",
+                        safe_to_attach=False,
+                    ),
+                ),
+            )
+        ],
+    )
+
+    payload = trace.to_dict()
+
+    assert payload["safe_to_attach"] is False
+    assert payload["steps"][0]["output_artifacts"][0]["safe_to_attach"] is False


### PR DESCRIPTION
## Problem

### HIGH: Evidence bundle run selection accepted traversal-shaped run IDs

`src/worldforge/evidence_bundle.py:422-435` joined requested `run_ids` directly under the workspace runs directory. A caller could pass a value like `../escape` and make bundle generation load a sibling `run_manifest.json` when the local workspace contained that path.

### HIGH: Run artifact copying followed symlinks outside the run workspace

`src/worldforge/evidence_bundle.py:451-481` iterated `run_path.rglob("*")` and copied file symlinks after `path.is_file()` followed them. A small safe-looking JSON file outside the run workspace could be included in an attachable evidence bundle through an internal symlink.

### HIGH: Workflow traces always reported top-level attachment safety as true

`src/worldforge/workflow_trace.py:257-276` hard-coded `safe_to_attach: True` even when a step referenced `WorkflowArtifactRef(..., safe_to_attach=False)`. That made composed trace metadata contradict the artifact-level safety contract.

### MEDIUM: Missing manifest artifact references were omitted instead of reported

`src/worldforge/evidence_bundle.py:565-617` validated absolute paths and workspace escapes, but a relative artifact path that resolved inside the run workspace and did not exist was silently ignored. The generated bundle could look complete while the run manifest referenced missing evidence.

### MEDIUM: Signed URL detection missed common `sig=` query parameters

`src/worldforge/evidence_bundle.py:777-790` used a raw-string regex character class that did not actually exclude whitespace as intended, so JSON artifact content containing a URL such as `https://assets.example.test/output.json?sig=credential` was not flagged as credentialed/signed material.

## Solution

- `9b0de70` records missing manifest artifact references as excluded local-only entries and marks the bundle unsafe to attach.
- `bc86c6a` resolves run workspace files before copying and excludes any artifact whose real path leaves the run directory.
- `145be77` fixes signed URL detection for `token`, `signature`, `sig`, `key`, and `api_key` query parameters.
- `b985be4` derives workflow trace top-level `safe_to_attach` from all input and output artifact references.
- `a1a0064` validates explicit evidence-bundle run IDs through the existing harness run-id contract and raises `WorldForgeError` for invalid IDs.

Each fix has a regression test that fails against the previous implementation.

## Validation

- `uv run pytest tests/test_evidence_bundle.py tests/test_provider_events.py -q` -> 16 passed.
- `uv lock --check` -> passed.
- `uv run ruff check src tests examples scripts` -> passed.
- `uv run ruff format --check src tests examples scripts` -> passed.
- `uv run python scripts/generate_provider_docs.py --check` -> passed.
- `uv run python scripts/check_docs_commands.py` -> passed; 519 documented commands scanned.
- `uv run python scripts/check_docs_snippets.py` -> passed; 19 snippets checked, 9 executed, 10 skipped by explicit markers.
- `uv run python scripts/manage_fixture_snapshots.py --format markdown` -> passed; 62 entries, 0 missing, 0 changed, 0 unsafe.
- `uv run python scripts/check_wrapper_portability.py` -> passed.
- `uv run python scripts/check_optional_import_boundaries.py` -> passed.
- `uv run python scripts/check_core_performance.py` -> passed.
- `uv run mkdocs build --strict` -> passed.
- `uv run pytest` -> 1316 passed.
- `uv run --extra harness pytest --cov=src/worldforge --cov-report=term-missing --cov-fail-under=90` -> 1316 passed, total coverage 90.07%.
- `bash scripts/test_package.sh` -> built and installed the wheel in a temporary venv; 1231 passed, 85 skipped.
- `uv build --out-dir dist --clear --no-build-logs` -> built sdist and wheel.
- `uv run python scripts/generate_dependency_audit_evidence.py` -> passed.
- `uv run python scripts/generate_quality_dashboard.py` -> passed.
- `uv run python scripts/generate_release_evidence.py --run-gates` -> passed; 15 validation gates passed, 0 failed, 0 skipped.
- `uv run python scripts/generate_release_notes.py --release-evidence .worldforge/release-evidence/release-evidence.json` -> passed.

## Caveats / Unverified

No live provider or robotics optional-runtime smoke was run. Those checks are host-owned and this PR only changes checkout-safe evidence bundle generation plus workflow trace serialization.

## Residual Risk

- Existing evidence bundles generated before this change are not rewritten.
- Workflows that intentionally used symlinks to attach files outside a run workspace must copy safe artifacts into the run workspace instead.

## Rubric Coverage Summary

| Dimension | Result |
| --- | --- |
| Correctness | Fixed missing artifact reporting and workflow trace attachment-safety aggregation. |
| API & contracts | Fixed explicit run-id validation and made evidence bundle output match manifest/artifact contracts. No public signatures changed. |
| Architecture | Local changes only; no provider, catalog, optional-runtime, or dependency-boundary changes. |
| ML-specific | No findings in tensor, checkpoint, evaluation metric, split, or device/dtype logic in the reviewed surface. |
| Performance | No findings; added path resolution remains linear in the existing artifact-copy traversal. |
| Security & safety | Fixed traversal-shaped run IDs, symlink escapes, signed URL detection, and unsafe trace attachability metadata. |
| Error handling | Invalid run IDs now raise `WorldForgeError`; missing artifact references are explicit excluded records. |
| Testing | Added five focused regression tests plus full checkout, coverage, package, build, and release-evidence gates. |
| Maintainability | Kept changes small and aligned with existing helper patterns. |
| Documentation | No docs update required because the fixes enforce existing safety contracts; docs generation, snippets, and command drift gates passed. |
| Project hygiene | Lockfile, lint, format, package contract, build, dependency audit, and release-evidence gates passed. |