### PR TITLE
docs: add adoption case study template

### DIFF
--- a/.github/ISSUE_TEMPLATE/adoption_story.yml
+++ b/.github/ISSUE_TEMPLATE/adoption_story.yml
@@ -1,0 +1,69 @@
+name: Adoption Story
+description: Share a public or anonymized WorldForge adoption story.
+title: "[Adoption Story]: "
+labels: ["documentation", "examples"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for public or anonymized adoption stories that can become entries in
+        https://abdelstark.github.io/worldforge/adoption-case-studies/
+        Do not include secrets, signed URLs, private prompts, proprietary datasets, checkpoint
+        bytes, host-local paths, or private robot/controller details.
+  - type: input
+    id: adopter
+    attributes:
+      label: Adopter name or project
+      description: Use an organization, project, team, or anonymized label that is safe to publish.
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: What host project, workflow, or environment uses WorldForge?
+    validations:
+      required: true
+  - type: textarea
+    id: worldforge_surface
+    attributes:
+      label: WorldForge surface used
+      description: Name the capabilities, providers, CLI commands, Python APIs, artifacts, or reports involved.
+    validations:
+      required: true
+  - type: textarea
+    id: custom_vs_out_of_box
+    attributes:
+      label: Custom versus out of the box
+      description: What did you build locally, and what came directly from WorldForge?
+    validations:
+      required: true
+  - type: textarea
+    id: worked
+    attributes:
+      label: What worked
+      description: What was useful, easy to validate, or easy to explain?
+    validations:
+      required: true
+  - type: textarea
+    id: awkward
+    attributes:
+      label: What was awkward
+      description: What was confusing, missing, brittle, or harder than expected?
+    validations:
+      required: true
+  - type: textarea
+    id: links
+    attributes:
+      label: Links
+      description: Public repositories, demos, papers, talks, screenshots, release notes, or related issues.
+    validations:
+      required: false
+  - type: checkboxes
+    id: safe_to_publish
+    attributes:
+      label: Safe-to-publish confirmation
+      options:
+        - label: This story does not include secrets, signed URLs, private prompts, proprietary datasets, checkpoint bytes, host-local paths, or private robot/controller details.
+          required: true
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ releases may still include breaking changes when the public API needs to tighten
 
 ### Added
 
+- Added an adoption case-study gallery, reusable case-study template, Adoption Story issue
+  template, and smoke tests for future submitted adoption stories.
 - Added a checkout-safe external provider package demo workflow. `scripts/demo_showcases.py run
   external-provider-package` generates a temp provider package, proves `worldforge.providers`
   entry-point discovery, disabled discovery, duplicate-name handling, and missing optional

--- a/README.md
+++ b/README.md
@@ -565,7 +565,9 @@ Issues, discussions, and pull requests are welcome. Please read
 [CONTRIBUTING.md](./CONTRIBUTING.md) and open an issue for non-trivial changes before sending a
 patch. For provider work, start with the
 [provider authoring guide](https://abdelstark.github.io/worldforge/provider-authoring-guide/) and
-the [playbooks](https://abdelstark.github.io/worldforge/playbooks/).
+the [playbooks](https://abdelstark.github.io/worldforge/playbooks/). External adopters can share
+integration stories through the
+[adoption case-study template](./docs/src/adoption-case-studies/README.md).
 
 ## License
 

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -33,6 +33,8 @@
 - Authoring And API
   - [Provider Authoring Guide](./provider-authoring-guide.md)
   - [External Provider Packages](./external-providers.md)
+  - [Adoption Case Studies](./adoption-case-studies/README.md)
+  - [Adoption Case Study Template](./adoption-case-studies/_template.md)
   - [Scenario Definition Format](./scenarios.md)
   - [Provider Routing And Fallback](./provider-routing.md)
   - [Python API](./api/python.md)

--- a/docs/src/adoption-case-studies/README.md
+++ b/docs/src/adoption-case-studies/README.md
@@ -1,0 +1,24 @@
+# Adoption Case Studies
+
+This section collects public WorldForge adoption stories from teams using WorldForge in an
+integration, evaluation suite, provider package, robotics workflow, or host application.
+
+No case studies have been submitted yet. To contribute one, copy
+[`_template.md`](./_template.md) into this directory with a descriptive file name, or open an
+Adoption Story issue so maintainers can help shape the final entry.
+
+Useful case studies should explain:
+
+- who adopted WorldForge, or whether the adopter must remain anonymized;
+- the host application or workflow where WorldForge is used;
+- the WorldForge capabilities, providers, artifacts, or CLI commands involved;
+- what was custom versus out of the box;
+- what worked well;
+- what was awkward, missing, or hard to explain;
+- public links, screenshots, talks, papers, repositories, or release notes when they are safe to
+  share.
+
+Do not include secrets, private prompts, credentials, signed URLs, proprietary datasets,
+checkpoint bytes, host-local paths, or private robot/controller details. If an adoption story needs
+anonymization, state what is safe to publish and keep the private details out of the pull request.
+

--- a/docs/src/adoption-case-studies/_template.md
+++ b/docs/src/adoption-case-studies/_template.md
@@ -1,0 +1,53 @@
+# Adoption Case Study: <Adopter Or Project Name>
+
+## Adopter
+
+- Name or organization:
+- Public contact or link:
+- Anonymized: yes/no
+
+## Context
+
+Describe the host project, workflow, or environment where WorldForge is used. Include the problem
+WorldForge helps with and the kind of user or team that relies on the workflow.
+
+## WorldForge Surface Used
+
+- Capabilities:
+- Providers or provider packages:
+- CLI commands or Python APIs:
+- Artifacts or reports:
+
+## Custom Versus Out Of The Box
+
+### Custom
+
+Describe code, providers, prompts, runtimes, fixtures, adapters, dashboards, or deployment pieces
+owned by the adopter.
+
+### Out Of The Box
+
+Describe WorldForge behavior used without project-specific changes, such as built-in providers,
+contract helpers, demos, diagnostics, persistence, evaluation suites, benchmarks, or docs.
+
+## What Worked
+
+List the WorldForge surfaces that were useful, easy to validate, or easy to explain to users or
+reviewers.
+
+## What Was Awkward
+
+List confusing docs, missing examples, rough setup steps, brittle assumptions, or integration
+surfaces that needed extra local work.
+
+## Links
+
+- Repository:
+- Demo, paper, talk, release note, or screenshot:
+- Related WorldForge issue or pull request:
+
+## Safe-To-Publish Notes
+
+Confirm that this story does not include secrets, signed URLs, private prompts, proprietary
+datasets, checkpoint bytes, host-local paths, or private controller details.
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -73,6 +73,8 @@ nav:
   - Authoring And API:
       - Provider Authoring Guide: provider-authoring-guide.md
       - External Provider Packages: external-providers.md
+      - Adoption Case Studies: adoption-case-studies/README.md
+      - Adoption Case Study Template: adoption-case-studies/_template.md
       - Scenario Definition Format: scenarios.md
       - Provider Routing And Fallback: provider-routing.md
       - Python API: api/python.md

--- a/tests/test_adoption_case_studies.py
+++ b/tests/test_adoption_case_studies.py
@@ -1,0 +1,66 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+CASE_STUDIES = ROOT / "docs/src/adoption-case-studies"
+TEMPLATE = CASE_STUDIES / "_template.md"
+ISSUE_TEMPLATE = ROOT / ".github/ISSUE_TEMPLATE/adoption_story.yml"
+
+REQUIRED_TEMPLATE_SECTIONS = (
+    "## Adopter",
+    "## Context",
+    "## WorldForge Surface Used",
+    "## Custom Versus Out Of The Box",
+    "## What Worked",
+    "## What Was Awkward",
+    "## Links",
+    "## Safe-To-Publish Notes",
+)
+
+
+def _case_study_files() -> list[Path]:
+    return sorted(
+        path
+        for path in CASE_STUDIES.glob("*.md")
+        if path.name not in {"README.md", "_template.md"}
+    )
+
+
+def test_adoption_case_study_template_is_well_formed() -> None:
+    template = TEMPLATE.read_text(encoding="utf-8")
+
+    for section in REQUIRED_TEMPLATE_SECTIONS:
+        assert section in template
+
+    for safety_signal in (
+        "Anonymized: yes/no",
+        "Custom",
+        "Out Of The Box",
+        "secrets",
+        "host-local paths",
+    ):
+        assert safety_signal in template
+
+
+def test_committed_adoption_case_studies_follow_template_sections() -> None:
+    for path in _case_study_files():
+        text = path.read_text(encoding="utf-8")
+        missing = [section for section in REQUIRED_TEMPLATE_SECTIONS if section not in text]
+        assert not missing, f"{path.relative_to(ROOT)} missing sections: {missing}"
+
+
+def test_adoption_story_issue_template_captures_case_study_fields() -> None:
+    issue_template = ISSUE_TEMPLATE.read_text(encoding="utf-8")
+
+    for field in (
+        "Adopter name or project",
+        "Context",
+        "WorldForge surface used",
+        "Custom versus out of the box",
+        "What worked",
+        "What was awkward",
+        "Safe-to-publish confirmation",
+    ):
+        assert field in issue_template
+
+    assert "https://abdelstark.github.io/worldforge/adoption-case-studies/" in issue_template
+

--- a/tests/test_adoption_case_studies.py
+++ b/tests/test_adoption_case_studies.py
@@ -19,9 +19,7 @@ REQUIRED_TEMPLATE_SECTIONS = (
 
 def _case_study_files() -> list[Path]:
     return sorted(
-        path
-        for path in CASE_STUDIES.glob("*.md")
-        if path.name not in {"README.md", "_template.md"}
+        path for path in CASE_STUDIES.glob("*.md") if path.name not in {"README.md", "_template.md"}
     )
 
 
@@ -63,4 +61,3 @@ def test_adoption_story_issue_template_captures_case_study_fields() -> None:
         assert field in issue_template
 
     assert "https://abdelstark.github.io/worldforge/adoption-case-studies/" in issue_template
-


### PR DESCRIPTION
Fixes #279

## Summary
- Added an adoption case-study gallery page and reusable case-study template.
- Added an Adoption Story issue template for public or anonymized adopter submissions.
- Added smoke tests that validate the template, issue template, and future committed case studies.
- Linked the new docs from README, SUMMARY, mkdocs navigation, and CHANGELOG.

## Tests
- `uv run pytest tests/test_adoption_case_studies.py -q`
- `uv run ruff check tests/test_adoption_case_studies.py`
- `uv run pytest tests/test_docs_site.py -q`
- `uv run mkdocs build --strict`
- `git diff --check`

## Notes
- Kept this scoped to the adoption case-study docs, intake template, and validation coverage.
