### PR TITLE
docs: add capability protocol mini demo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ releases may still include breaking changes when the public API needs to tighten
 
 - Added an adoption case-study gallery, reusable case-study template, Adoption Story issue
   template, and smoke tests for future submitted adoption stories.
+- Added a runnable capability protocol mini-demo with docs and tests for in-process predictor,
+  policy, and cost registration.
 - Added a checkout-safe external provider package demo workflow. `scripts/demo_showcases.py run
   external-provider-package` generates a temp provider package, proves `worldforge.providers`
   entry-point discovery, disabled discovery, duplicate-name handling, and missing optional

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -41,6 +41,7 @@
   - [Public API Stability](./api-stability.md)
   - [Capability Fixture Corpus](./fixtures.md)
   - [Capability Negotiation](./capability-negotiation.md)
+  - [Capability Protocols Quickstart](./capability-protocols-quickstart.md)
 - Evidence And Evaluation
   - [Evaluation](./evaluation.md)
   - [Benchmarking](./benchmarking.md)

--- a/docs/src/api/python.md
+++ b/docs/src/api/python.md
@@ -83,6 +83,9 @@ implementations appear in `providers()`, `provider_profile(...)`, `doctor(...)`,
 benchmark harness. Existing calls such as `forge.generate("prompt", "mock")` keep resolving
 through the legacy provider registry.
 
+For a runnable policy-plus-score example that registers plain in-process objects, see
+[Capability Protocols Quickstart](../capability-protocols-quickstart.md).
+
 Capability protocol implementations and `BaseProvider` subclasses may also expose provider-owned
 `preflight`, `warmup`, and `teardown` hooks that return `ProviderLifecycleResult`. Diagnostics
 surface the aggregate `ProviderLifecycleStatus` through `doctor()` and

--- a/docs/src/capability-protocols-quickstart.md
+++ b/docs/src/capability-protocols-quickstart.md
@@ -1,0 +1,68 @@
+# Capability Protocols Quickstart
+
+Capability protocols are the small-registration path for host applications that already own a
+local function, model wrapper, or service client. Use this path when a single in-process object can
+score, select, predict, generate, reason, embed, or transfer without needing a full provider
+package.
+
+Use a `BaseProvider` subclass when the adapter needs catalog registration, custom health checks,
+credential handling, generated provider docs, or multiple provider-owned surfaces. Use capability
+protocols when the host application owns the runtime and only needs to plug one narrow capability
+into `WorldForge`.
+
+The runnable mini-demo lives at `examples/capability_protocols_mini.py`.
+
+```bash
+uv run python examples/capability_protocols_mini.py
+```
+
+The script registers three plain Python objects:
+
+- `LocalPredictor` implements `predict(...)` and returns `PredictionPayload`.
+- `LocalPolicy` implements `select_actions(...)` and returns `ActionPolicyResult` with candidate
+  action plans.
+- `LocalCost` implements `score_actions(...)` and returns `ActionScoreResult`.
+
+Each object declares a non-empty `name` and an optional `ProviderProfileSpec`. No subclassing is
+required:
+
+<!-- worldforge-snippet: skip-illustrative -->
+```python
+forge = WorldForge(auto_register_remote=False, discover_entry_points=False)
+forge.register_predictor(LocalPredictor())
+forge.register_policy(LocalPolicy())
+forge.register_cost(LocalCost())
+```
+
+After registration, the objects can be resolved by name just like provider-backed surfaces. The
+demo creates a world whose default prediction provider is `local-predictor`, then asks
+`World.plan(...)` to compose policy proposals with score-based ranking:
+
+<!-- worldforge-snippet: skip-illustrative -->
+```python
+plan = world.plan(
+    goal="keep the blue cube near the origin",
+    policy_provider="local-policy",
+    policy_info={"object_id": "cube-1"},
+    score_provider="local-cost",
+    score_info={"goal": "stay near origin"},
+)
+```
+
+The resulting plan is deterministic JSON. Its metadata shows the composed path:
+
+<!-- worldforge-snippet: skip-illustrative -->
+```json
+{
+  "metadata": {
+    "planning_mode": "policy+score",
+    "policy_provider": "local-policy",
+    "score_provider": "local-cost"
+  }
+}
+```
+
+Keep protocol implementations narrow. Validate caller input at the boundary, return the exact
+WorldForge result type for the capability, and keep optional runtimes, credentials, checkpoints,
+and telemetry export host-owned.
+

--- a/docs/src/provider-authoring-guide.md
+++ b/docs/src/provider-authoring-guide.md
@@ -410,6 +410,9 @@ forge = WorldForge(auto_register_remote=False)
 forge.register_cost(ExampleCost())
 ```
 
+For a runnable policy-plus-score example using plain in-process protocol objects, see
+[Capability Protocols Quickstart](./capability-protocols-quickstart.md).
+
 ## Step 6: Boundary Validation Checklist
 
 Validate at the narrowest boundary. Do not let malformed upstream or caller data leak into public

--- a/examples/capability_protocols_mini.py
+++ b/examples/capability_protocols_mini.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import json
+from tempfile import TemporaryDirectory
+
+import worldforge as wf
+from worldforge.providers.base import PredictionPayload
+
+
+class LocalPredictor:
+    name = "local-predictor"
+    profile = None
+
+    def predict(self, world_state, action, steps) -> PredictionPayload:
+        state = {
+            **world_state,
+            "step": int(world_state.get("step", 0)) + steps,
+            "metadata": {"last_action": action.to_dict()},
+        }
+        return PredictionPayload(state, 0.92, 0.87, [], {"source": "demo"}, 0.1)
+
+
+class LocalPolicy:
+    name = "local-policy"
+    profile = None
+
+    def select_actions(self, *, info):
+        object_id = str(info.get("object_id", "cube-1"))
+        cautious = wf.Action.move_to(0.2, 0.8, 0.0, object_id=object_id)
+        aggressive = wf.Action.move_to(1.2, 0.8, 0.0, object_id=object_id)
+        return wf.ActionPolicyResult(
+            self.name,
+            [cautious],
+            action_candidates=[[cautious], [aggressive]],
+        )
+
+
+class LocalCost:
+    name = "local-cost"
+    profile = None
+
+    def score_actions(self, *, info, action_candidates):
+        candidates = action_candidates if isinstance(action_candidates, list) else []
+        scores = [0.1 + index for index, _candidate in enumerate(candidates)]
+        return wf.ActionScoreResult(self.name, scores or [0.1], 0, metadata={"goal": info["goal"]})
+
+
+def build_plan_json() -> str:
+    with TemporaryDirectory() as tmpdir:
+        forge = wf.WorldForge(state_dir=tmpdir, auto_register_remote=False)
+        forge.register_predictor(LocalPredictor())
+        forge.register_policy(LocalPolicy())
+        forge.register_cost(LocalCost())
+
+        world = forge.create_world("protocol-demo", provider="local-predictor")
+        plan = world.plan(
+            goal="keep the blue cube near the origin",
+            policy_provider="local-policy",
+            policy_info={"object_id": "cube-1"},
+            score_provider="local-cost",
+            score_info={"goal": "stay near origin"},
+        )
+        return json.dumps(plan.to_dict(), indent=2, sort_keys=True)
+
+
+def main() -> None:
+    print(build_plan_json())
+
+
+if __name__ == "__main__":
+    main()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -81,6 +81,7 @@ nav:
       - Public API Stability: api-stability.md
       - Capability Fixture Corpus: fixtures.md
       - Capability Negotiation: capability-negotiation.md
+      - Capability Protocols Quickstart: capability-protocols-quickstart.md
   - Evidence And Evaluation:
       - Evaluation: evaluation.md
       - Benchmarking: benchmarking.md

--- a/tests/test_capability_protocols_mini_example.py
+++ b/tests/test_capability_protocols_mini_example.py
@@ -27,4 +27,3 @@ def test_capability_protocols_mini_example_outputs_plan_json() -> None:
     assert plan["metadata"]["policy_provider"] == "local-policy"
     assert plan["metadata"]["score_provider"] == "local-cost"
     assert plan["metadata"]["candidate_count"] == 2
-

--- a/tests/test_capability_protocols_mini_example.py
+++ b/tests/test_capability_protocols_mini_example.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_capability_protocols_mini_example_outputs_plan_json() -> None:
+    result = subprocess.run(
+        [sys.executable, str(ROOT / "examples/capability_protocols_mini.py")],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    plan = json.loads(result.stdout)
+
+    assert plan["provider"] == "local-cost"
+    assert plan["goal"] == "keep the blue cube near the origin"
+    assert plan["action_count"] == 1
+    assert plan["actions"][0]["type"] == "move_to"
+    assert plan["actions"][0]["parameters"]["object_id"] == "cube-1"
+    assert plan["metadata"]["planning_mode"] == "policy+score"
+    assert plan["metadata"]["policy_provider"] == "local-policy"
+    assert plan["metadata"]["score_provider"] == "local-cost"
+    assert plan["metadata"]["candidate_count"] == 2
+


### PR DESCRIPTION
Fixes #275

## Summary
- Added a 71-line runnable capability protocol mini-demo that registers in-process predictor, policy, and cost objects.
- Added a focused quickstart page contrasting protocol registration with the `BaseProvider` path.
- Added a subprocess test that runs the example and asserts the emitted plan JSON.
- Linked the new page from the Python API docs, provider authoring guide, SUMMARY, mkdocs nav, and CHANGELOG.

## Tests
- `uv run python examples/capability_protocols_mini.py`
- `uv run pytest tests/test_capability_protocols_mini_example.py tests/test_capability_protocols.py -q`
- `uv run pytest tests/test_docs_site.py -q`
- `uv run ruff check examples/capability_protocols_mini.py tests/test_capability_protocols_mini_example.py`
- `uv run python scripts/check_docs_snippets.py`
- `uv run mkdocs build --strict`
- `git diff --check`

## Notes
- `uv run python scripts/check_docs_commands.py` still fails on existing stale script references across AGENTS/README/docs; I did not change that surface in this PR.
