### PR TITLE
Add robotics policy comparison harness flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ uv run --extra harness worldforge-harness
 uv run --extra harness worldforge-harness --flow lerobot
 uv run --extra harness worldforge-harness --flow cosmos-policy
 uv run --extra harness worldforge-harness --flow gr00t-replay
+uv run --extra harness worldforge-harness --flow robotics-compare
 uv run --extra harness worldforge-harness --flow diagnostics
 ```
 

--- a/README.md
+++ b/README.md
@@ -77,15 +77,17 @@ safety checks, robot-controller integration, and task-specific preprocessing sta
 
 ```bash
 scripts/robotics-showcase
+uv run python scripts/demo_showcases.py run all --workspace-dir .worldforge/demo-showcases
 ```
 
-The command launches a staged Textual report by default, writes the same run data to
+The first command launches a staged Textual report by default, writes the same run data to
 `/tmp/worldforge-robotics-showcase/real-run.json`, and writes a visual Rerun recording to
 `/tmp/worldforge-robotics-showcase/real-run.rrd`. Press `o` in the TUI to open that recording in
 Rerun. Use `--tui-stage-delay 0.1` for a faster reveal, `--no-tui-animation` to skip sleeps and
 arm motion, `--no-tui` for the plain terminal report, `--no-rerun` to skip the Rerun artifact,
 `--json-only` for automation, or `--health-only` for a non-mutating dependency/checkpoint
 preflight. Use `--lewm-revision <40-char-commit-sha>` to pin auto-built LeWorldModel assets.
+The second command runs the checkout-safe demo showcase suite without external credentials.
 
 The optional live robotics workflow, `.github/workflows/robotics-showcase.yml`, runs this same
 showcase in non-interactive JSON mode on every pull request run and on pushes to `main`. It caches

--- a/docs/src/cli.md
+++ b/docs/src/cli.md
@@ -141,6 +141,7 @@ uv run --extra harness worldforge-harness --flow leworldmodel
 uv run --extra harness worldforge-harness --flow lerobot
 uv run --extra harness worldforge-harness --flow cosmos-policy
 uv run --extra harness worldforge-harness --flow gr00t-replay
+uv run --extra harness worldforge-harness --flow robotics-compare
 uv run --extra harness worldforge-harness --flow diagnostics
 uv run --extra harness worldforge-harness --flow workbench
 uv run --extra harness worldforge-harness --flow runs
@@ -159,10 +160,13 @@ Expected success signal: the selected flow reaches a completed run workspace and
 shows its saved artifact paths. For `cosmos-policy`, the replay should report
 `raw_action_shape: [50, 14]`, `translated_actions: 50`, and
 `saved_replay_artifact: artifacts/cosmos-policy-replay.json`. For `gr00t-replay`, expect
-`translated_actions: 40` and `saved_replay_artifact: artifacts/gr00t-replay.json`. First triage
-step: open the saved run workspace and inspect `logs/provider-events.jsonl` plus the flow-specific
-artifact, either `artifacts/cosmos-policy-replay.json` or `artifacts/gr00t-replay.json`;
-for live-provider readiness checks, run `uv run worldforge harness --connectors --format json`.
+`translated_actions: 40` and `saved_replay_artifact: artifacts/gr00t-replay.json`. For
+`robotics-compare`, expect `total_translated_actions: 92` and
+`comparison_artifact: artifacts/robotics-policy-comparison.json`. First triage step: open the saved
+run workspace and inspect `logs/provider-events.jsonl` plus the flow-specific artifact, either
+`artifacts/cosmos-policy-replay.json`, `artifacts/gr00t-replay.json`, or
+`artifacts/robotics-policy-comparison.json`; for live-provider readiness checks, run
+`uv run worldforge harness --connectors --format json`.
 
 ## Packaged Demos
 

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -41,6 +41,7 @@ uv run --extra harness worldforge-harness
 uv run --extra harness worldforge-harness --flow lerobot
 uv run --extra harness worldforge-harness --flow cosmos-policy
 uv run --extra harness worldforge-harness --flow gr00t-replay
+uv run --extra harness worldforge-harness --flow robotics-compare
 uv run --extra harness worldforge-harness --flow diagnostics
 uv run --extra harness worldforge-harness --flow workbench
 uv run worldforge harness --list
@@ -57,6 +58,7 @@ Available flows:
 | `lerobot` | Visual policy-plus-score path through the LeRobot provider surface. |
 | `cosmos-policy` | Visual saved ALOHA `/act` replay through the Cosmos-Policy provider surface. |
 | `gr00t-replay` | Visual saved GR00T N1.7 PolicyClient replay through the GR00T provider surface. |
+| `robotics-compare` | Visual LeRobot, Cosmos-Policy, and GR00T policy comparison through one replay surface. |
 | `diagnostics` | Visual provider diagnostics and benchmark comparison path. |
 | `workbench` | Visual provider-authoring evidence path for adapter promotion work. |
 

--- a/docs/src/theworldharness.md
+++ b/docs/src/theworldharness.md
@@ -23,6 +23,7 @@ uv run --extra harness worldforge-harness
 uv run --extra harness worldforge-harness --flow lerobot
 uv run --extra harness worldforge-harness --flow cosmos-policy
 uv run --extra harness worldforge-harness --flow gr00t-replay
+uv run --extra harness worldforge-harness --flow robotics-compare
 uv run --extra harness worldforge-harness --flow diagnostics
 uv run --extra harness worldforge-harness --flow workbench
 uv run --extra harness worldforge-harness --flow eval
@@ -63,6 +64,7 @@ dependencies at package import time.
 | `lerobot` | `policy` plus score provider | Deterministic LeRobot-shaped policy, action translation, policy candidate ranking, execution, persistence, reload, provider events. |
 | `cosmos-policy` | `policy` | Saved Cosmos-Policy ALOHA `/act` replay through the real provider adapter, json_numpy 50 x 14 action validation, action translation, provider events, and a sanitized replay artifact. |
 | `gr00t-replay` | `policy` | Saved GR00T N1.7 PolicyClient replay through the real provider adapter, named eef/gripper/joint tensor validation, action translation, provider events, and a sanitized replay artifact. |
+| `robotics-compare` | policy comparison | LeRobot, Cosmos-Policy, and GR00T replay paths compared side by side by action shape, translated action count, provider events, and sanitized artifacts without requiring live GPU servers. |
 | `diagnostics` | provider catalog plus benchmark harness | `doctor()` provider scan, registered/unregistered provider status, mock benchmark matrix across predict/reason/generate/transfer/embed, latency/throughput comparison, provider events. |
 | `workbench` | provider authoring | Checkout-safe provider workbench evidence for stable and candidate adapters, promotion gaps, safe artifacts, and validation commands. |
 
@@ -81,6 +83,13 @@ is deterministic and checkout-safe; the live RTX A6000 validation is mentioned a
 stored as GPU logs, checkpoints, private endpoints, or raw observations. If it fails, start with
 the preserved run workspace: inspect `logs/provider-events.jsonl` for provider events/errors and
 `artifacts/gr00t-replay.json` for the saved replay request/response/translated-action artifact.
+
+For the robotics comparison, run
+`uv run --extra harness worldforge-harness --flow robotics-compare`. A good run reports
+`total_translated_actions: 92` and
+`comparison_artifact: artifacts/robotics-policy-comparison.json`. If it fails, inspect
+`logs/provider-events.jsonl` and the comparison artifact first; the replay artifacts remain
+checkout-safe and do not include raw observations or checkpoint files.
 
 ## Provider Connector Workspace
 
@@ -231,8 +240,9 @@ provider health, benchmark latency, benchmark throughput, and provider event pha
 - `2`: select LeRobot policy-plus-score planning.
 - `3`: select Cosmos-Policy ALOHA replay.
 - `4`: select GR00T DROID replay.
-- `5`: select provider diagnostics and benchmark comparison.
-- `6`: select adapter author workbench.
+- `5`: select robotics policy replay comparison.
+- `6`: select provider diagnostics and benchmark comparison.
+- `7`: select adapter author workbench.
 - `g w`: jump to Worlds.
 - `g p`: jump to Providers.
 - `g e`: jump to Eval.

--- a/src/worldforge/harness/flows.py
+++ b/src/worldforge/harness/flows.py
@@ -1716,55 +1716,74 @@ def _run_robotics_compare_demo(*, state_dir: Path, emit: bool = False) -> JSONDi
 
 
 def _robotics_compare_lerobot_row(summary: JSONDict) -> JSONDict:
-    selected_index = int(summary["selected_candidate_index"])
-    candidate_costs = list(summary["candidate_costs"])
-    selected_cost = candidate_costs[selected_index]
-    return {
-        "flow_id": "lerobot",
-        "provider": "lerobot",
-        "model": "injected deterministic LeRobot-shaped policy",
-        "source": "checkout-safe policy plus score demo",
-        "raw_shape": f"{summary['policy_candidate_count']} candidate chunks",
-        "candidate_count": int(summary["policy_candidate_count"]),
-        "selected_candidate_index": selected_index,
-        "selected_score": float(selected_cost),
-        "translated_action_count": len(summary["selected_actions"]),
-        "events": len(summary.get("event_phases", [])),
-        "artifact": "run summary only",
-    }
+    try:
+        selected_index = int(summary["selected_candidate_index"])
+        candidate_costs = list(summary["candidate_costs"])
+        selected_cost = candidate_costs[selected_index]
+        return {
+            "flow_id": "lerobot",
+            "provider": "lerobot",
+            "model": "injected deterministic LeRobot-shaped policy",
+            "source": "checkout-safe policy plus score demo",
+            "raw_shape": f"{summary['policy_candidate_count']} candidate chunks",
+            "candidate_count": int(summary["policy_candidate_count"]),
+            "selected_candidate_index": selected_index,
+            "selected_score": float(selected_cost),
+            "translated_action_count": len(summary["selected_actions"]),
+            "events": len(summary.get("event_phases", [])),
+            "artifact": "run summary only",
+        }
+    except KeyError as exc:
+        raise WorldStateError(f"lerobot comparison summary missing required key {exc!s}.") from exc
+    except (IndexError, TypeError, ValueError) as exc:
+        raise WorldStateError(f"lerobot comparison summary is malformed: {exc}") from exc
 
 
 def _robotics_compare_cosmos_row(summary: JSONDict) -> JSONDict:
-    raw_shape = " x ".join(str(item) for item in summary["raw_action_shape"])
-    return {
-        "flow_id": "cosmos-policy",
-        "provider": str(summary["providers"][0]),
-        "model": summary["model"],
-        "source": "sanitized ALOHA /act replay",
-        "raw_shape": raw_shape,
-        "candidate_count": int(summary["candidate_count"]),
-        "selected_candidate_index": int(summary["selected_candidate_index"]),
-        "value_prediction": summary["value_prediction"],
-        "translated_action_count": int(summary["translated_action_count"]),
-        "events": len(summary.get("event_phases", [])),
-        "artifact": "artifacts/cosmos-policy-replay.json",
-    }
+    try:
+        raw_shape = " x ".join(str(item) for item in summary["raw_action_shape"])
+        return {
+            "flow_id": "cosmos-policy",
+            "provider": str(summary["providers"][0]),
+            "model": summary["model"],
+            "source": "sanitized ALOHA /act replay",
+            "raw_shape": raw_shape,
+            "candidate_count": int(summary["candidate_count"]),
+            "selected_candidate_index": int(summary["selected_candidate_index"]),
+            "value_prediction": summary["value_prediction"],
+            "translated_action_count": int(summary["translated_action_count"]),
+            "events": len(summary.get("event_phases", [])),
+            "artifact": "artifacts/cosmos-policy-replay.json",
+        }
+    except KeyError as exc:
+        raise WorldStateError(
+            f"cosmos-policy comparison summary missing required key {exc!s}."
+        ) from exc
+    except (IndexError, TypeError, ValueError) as exc:
+        raise WorldStateError(f"cosmos-policy comparison summary is malformed: {exc}") from exc
 
 
 def _robotics_compare_groot_row(summary: JSONDict) -> JSONDict:
-    return {
-        "flow_id": "gr00t-replay",
-        "provider": str(summary["providers"][0]),
-        "model": summary["model"],
-        "source": "sanitized GR00T PolicyClient replay",
-        "raw_shape": _groot_shape_result(summary),
-        "raw_tensor_count": len(summary["raw_action_shapes"]),
-        "embodiment_tag": summary["embodiment_tag"],
-        "latency_ms": summary["latency_ms"],
-        "translated_action_count": int(summary["translated_action_count"]),
-        "events": len(summary.get("event_phases", [])),
-        "artifact": "artifacts/gr00t-replay.json",
-    }
+    try:
+        return {
+            "flow_id": "gr00t-replay",
+            "provider": str(summary["providers"][0]),
+            "model": summary["model"],
+            "source": "sanitized GR00T PolicyClient replay",
+            "raw_shape": _groot_shape_result(summary),
+            "raw_tensor_count": len(summary["raw_action_shapes"]),
+            "embodiment_tag": summary["embodiment_tag"],
+            "latency_ms": summary["latency_ms"],
+            "translated_action_count": int(summary["translated_action_count"]),
+            "events": len(summary.get("event_phases", [])),
+            "artifact": "artifacts/gr00t-replay.json",
+        }
+    except KeyError as exc:
+        raise WorldStateError(
+            f"gr00t-replay comparison summary missing required key {exc!s}."
+        ) from exc
+    except (IndexError, TypeError, ValueError) as exc:
+        raise WorldStateError(f"gr00t-replay comparison summary is malformed: {exc}") from exc
 
 
 def _harness_artifact_payload(summary: JSONDict, name: str) -> object:

--- a/src/worldforge/harness/flows.py
+++ b/src/worldforge/harness/flows.py
@@ -1778,7 +1778,7 @@ def _robotics_compare_exception_type_name(exc: BaseException) -> str:
         return "WorldStateError"
     if isinstance(exc, WorldForgeError):
         return "WorldForgeError"
-    return "WorldStateError"
+    return "ProviderError"
 
 
 def _robotics_compare_failure_summary(

--- a/src/worldforge/harness/flows.py
+++ b/src/worldforge/harness/flows.py
@@ -94,7 +94,7 @@ FLOWS: tuple[HarnessFlow, ...] = (
         short_title="Compare",
         focus="cross-provider policy inspection",
         provider="LeRobot + Cosmos-Policy + GR00T",
-        capability="policy comparison",
+        capability="policy",
         command="uv run --extra harness worldforge-harness --flow robotics-compare",
         accent="#ffcc66",
         summary=(
@@ -1638,38 +1638,61 @@ def _run_robotics_compare_demo(*, state_dir: Path, emit: bool = False) -> JSONDi
             emit=False,
         ),
     }
-    for flow_id, summary in subflows.items():
-        errors = summary.get("validation_errors")
-        if isinstance(errors, list) and errors:
-            raise WorldStateError(f"{flow_id} comparison input failed: {errors[0]}")
+    validation_errors = _robotics_compare_validation_errors(subflows)
+    source_validation = _robotics_compare_source_validation()
+    if validation_errors:
+        comparison_payload: JSONDict = {
+            "schema_version": 1,
+            "flow_id": "robotics-compare",
+            "status": "failed",
+            "source_validation": source_validation,
+            "validation_errors": validation_errors,
+            "artifacts": {
+                "cosmos_policy_replay": "artifacts/cosmos-policy-replay.json",
+                "gr00t_replay": "artifacts/gr00t-replay.json",
+            },
+            "notes": [
+                "At least one subflow failed before comparison rows could be normalized.",
+                "Available sanitized replay artifacts are still preserved for triage.",
+            ],
+        }
+        provider_events = _robotics_compare_provider_events(
+            subflows,
+            validation_errors=validation_errors,
+        )
+        summary: JSONDict = {
+            "demo_kind": "robotics_policy_replay_comparison",
+            "state_dir": str(state_dir),
+            "status": "failed",
+            "providers": ["lerobot", "cosmos-policy", "gr00t"],
+            "flow_ids": list(subflows),
+            "comparison_count": len(subflows),
+            "gpu_required": False,
+            "source_validation": source_validation,
+            "event_phases": [str(event.get("phase", "unknown")) for event in provider_events],
+            "provider_events": provider_events,
+            "validation_errors": validation_errors,
+            "harness_artifacts": _robotics_compare_artifacts(
+                subflows,
+                comparison_payload,
+                require_replays=False,
+            ),
+        }
+        if emit:
+            print("\n".join(_transcript_for("robotics-compare", summary)))
+        return summary
 
     rows = [
         _robotics_compare_lerobot_row(subflows["lerobot"]),
         _robotics_compare_cosmos_row(subflows["cosmos-policy"]),
         _robotics_compare_groot_row(subflows["gr00t-replay"]),
     ]
-    events = [
-        ProviderEvent(
-            provider=str(row["provider"]),
-            operation="robotics-compare",
-            phase="success",
-            message=f"{row['flow_id']} policy output compared",
-            metadata={
-                "flow_id": row["flow_id"],
-                "raw_shape": row["raw_shape"],
-                "translated_action_count": row["translated_action_count"],
-            },
-        )
-        for row in rows
-    ]
+    provider_events = _robotics_compare_provider_events(subflows, rows=rows)
     comparison_payload: JSONDict = {
         "schema_version": 1,
         "flow_id": "robotics-compare",
-        "source_validation": {
-            "lerobot": "deterministic checkout-safe provider demo",
-            "cosmos-policy": "validated live on RTX A6000; committed artifact is sanitized",
-            "gr00t-replay": "validated live on RTX A6000; committed artifact is sanitized",
-        },
+        "status": "completed",
+        "source_validation": source_validation,
         "rows": rows,
         "artifacts": {
             "cosmos_policy_replay": "artifacts/cosmos-policy-replay.json",
@@ -1690,29 +1713,117 @@ def _run_robotics_compare_demo(*, state_dir: Path, emit: bool = False) -> JSONDi
         "total_translated_actions": sum(int(row["translated_action_count"]) for row in rows),
         "gpu_required": False,
         "source_validation": comparison_payload["source_validation"],
-        "event_phases": [event.phase for event in events],
-        "provider_events": [event.to_dict() for event in events],
-        "harness_artifacts": {
-            "robotics_comparison": {
-                "path": "artifacts/robotics-policy-comparison.json",
-                "payload": comparison_payload,
-            },
-            "cosmos_policy_replay": {
-                "path": "artifacts/cosmos-policy-replay.json",
-                "payload": _harness_artifact_payload(
-                    subflows["cosmos-policy"],
-                    "cosmos_policy_replay",
-                ),
-            },
-            "gr00t_replay": {
-                "path": "artifacts/gr00t-replay.json",
-                "payload": _harness_artifact_payload(subflows["gr00t-replay"], "gr00t_replay"),
-            },
-        },
+        "event_phases": [str(event.get("phase", "unknown")) for event in provider_events],
+        "provider_events": provider_events,
+        "harness_artifacts": _robotics_compare_artifacts(
+            subflows,
+            comparison_payload,
+            require_replays=True,
+        ),
     }
     if emit:
         print("\n".join(_transcript_for("robotics-compare", summary)))
     return summary
+
+
+def _robotics_compare_source_validation() -> JSONDict:
+    return {
+        "lerobot": "deterministic checkout-safe provider demo",
+        "cosmos-policy": "validated live on RTX A6000; committed artifact is sanitized",
+        "gr00t-replay": "validated live on RTX A6000; committed artifact is sanitized",
+    }
+
+
+def _robotics_compare_validation_errors(subflows: dict[str, JSONDict]) -> list[str]:
+    errors: list[str] = []
+    for flow_id, summary in subflows.items():
+        flow_errors = summary.get("validation_errors")
+        if isinstance(flow_errors, list):
+            errors.extend(f"{flow_id}: {error}" for error in flow_errors)
+    return errors
+
+
+def _robotics_compare_provider_events(
+    subflows: dict[str, JSONDict],
+    *,
+    rows: list[JSONDict] | None = None,
+    validation_errors: list[str] | None = None,
+) -> list[JSONDict]:
+    events: list[JSONDict] = []
+    for subflow_id, summary in subflows.items():
+        events.extend(_robotics_compare_subflow_events(subflow_id, summary))
+    if rows is not None:
+        events.extend(
+            ProviderEvent(
+                provider=str(row["provider"]),
+                operation="robotics-compare",
+                phase="success",
+                message=f"{row['flow_id']} policy output compared",
+                metadata={
+                    "flow_id": row["flow_id"],
+                    "raw_shape": row["raw_shape"],
+                    "translated_action_count": row["translated_action_count"],
+                },
+            ).to_dict()
+            for row in rows
+        )
+    if validation_errors:
+        events.append(
+            ProviderEvent(
+                provider="robotics-compare",
+                operation="robotics-compare",
+                phase="failure",
+                message="; ".join(validation_errors),
+                metadata={"failed": True},
+            ).to_dict()
+        )
+    return events
+
+
+def _robotics_compare_subflow_events(subflow_id: str, summary: JSONDict) -> list[JSONDict]:
+    events = summary.get("provider_events")
+    if not isinstance(events, list):
+        return []
+    tagged: list[JSONDict] = []
+    for event in events:
+        if not isinstance(event, dict):
+            continue
+        copied = dict(event)
+        metadata = copied.get("metadata")
+        copied["metadata"] = {
+            **(metadata if isinstance(metadata, dict) else {}),
+            "comparison_flow_id": "robotics-compare",
+            "subflow_id": subflow_id,
+        }
+        tagged.append(copied)
+    return tagged
+
+
+def _robotics_compare_artifacts(
+    subflows: dict[str, JSONDict],
+    comparison_payload: JSONDict,
+    *,
+    require_replays: bool,
+) -> JSONDict:
+    artifacts: JSONDict = {
+        "robotics_comparison": {
+            "path": "artifacts/robotics-policy-comparison.json",
+            "payload": comparison_payload,
+        },
+    }
+    replay_artifacts = (
+        ("cosmos-policy", "cosmos_policy_replay", "artifacts/cosmos-policy-replay.json"),
+        ("gr00t-replay", "gr00t_replay", "artifacts/gr00t-replay.json"),
+    )
+    for flow_id, name, path in replay_artifacts:
+        try:
+            payload = _harness_artifact_payload(subflows[flow_id], name)
+        except WorldStateError:
+            if require_replays:
+                raise
+            continue
+        artifacts[name] = {"path": path, "payload": payload}
+    return artifacts
 
 
 def _robotics_compare_lerobot_row(summary: JSONDict) -> JSONDict:
@@ -1786,14 +1897,17 @@ def _robotics_compare_groot_row(summary: JSONDict) -> JSONDict:
         raise WorldStateError(f"gr00t-replay comparison summary is malformed: {exc}") from exc
 
 
-def _harness_artifact_payload(summary: JSONDict, name: str) -> object:
+def _harness_artifact_payload(summary: JSONDict, name: str) -> JSONDict:
     artifacts = summary.get("harness_artifacts")
     if not isinstance(artifacts, dict):
         raise WorldStateError(f"{name} source flow did not expose harness artifacts.")
     descriptor = artifacts.get(name)
     if not isinstance(descriptor, dict) or "payload" not in descriptor:
         raise WorldStateError(f"{name} source flow did not expose an artifact payload.")
-    return descriptor["payload"]
+    payload = descriptor["payload"]
+    if not isinstance(payload, dict):
+        raise WorldStateError(f"{name} source flow artifact payload must be a JSON object.")
+    return payload
 
 
 _RUNNERS: dict[str, FlowRunner] = {

--- a/src/worldforge/harness/flows.py
+++ b/src/worldforge/harness/flows.py
@@ -89,6 +89,21 @@ FLOWS: tuple[HarnessFlow, ...] = (
         ),
     ),
     HarnessFlow(
+        id="robotics-compare",
+        title="Robotics Policy Replay Comparison",
+        short_title="Compare",
+        focus="cross-provider policy inspection",
+        provider="LeRobot + Cosmos-Policy + GR00T",
+        capability="policy comparison",
+        command="uv run --extra harness worldforge-harness --flow robotics-compare",
+        accent="#ffcc66",
+        summary=(
+            "Run the checkout-safe LeRobot, Cosmos-Policy, and GR00T policy paths side by side, "
+            "compare action shapes and translation counts, and preserve a sanitized comparison "
+            "artifact without keeping GPU servers online."
+        ),
+    ),
+    HarnessFlow(
         id="diagnostics",
         title="Provider Diagnostics + Benchmark",
         short_title="Diagnostics",
@@ -1611,11 +1626,163 @@ def _run_lerobot_demo(**kwargs: object) -> JSONDict:
     return lerobot_e2e.run_demo(**kwargs)  # type: ignore[arg-type]
 
 
+def _run_robotics_compare_demo(*, state_dir: Path, emit: bool = False) -> JSONDict:
+    subflows = {
+        "lerobot": _run_lerobot_demo(state_dir=state_dir / "lerobot", emit=False),
+        "cosmos-policy": _run_cosmos_policy_demo(
+            state_dir=state_dir / "cosmos-policy",
+            emit=False,
+        ),
+        "gr00t-replay": _run_gr00t_replay_demo(
+            state_dir=state_dir / "gr00t-replay",
+            emit=False,
+        ),
+    }
+    for flow_id, summary in subflows.items():
+        errors = summary.get("validation_errors")
+        if isinstance(errors, list) and errors:
+            raise WorldStateError(f"{flow_id} comparison input failed: {errors[0]}")
+
+    rows = [
+        _robotics_compare_lerobot_row(subflows["lerobot"]),
+        _robotics_compare_cosmos_row(subflows["cosmos-policy"]),
+        _robotics_compare_groot_row(subflows["gr00t-replay"]),
+    ]
+    events = [
+        ProviderEvent(
+            provider=str(row["provider"]),
+            operation="robotics-compare",
+            phase="success",
+            message=f"{row['flow_id']} policy output compared",
+            metadata={
+                "flow_id": row["flow_id"],
+                "raw_shape": row["raw_shape"],
+                "translated_action_count": row["translated_action_count"],
+            },
+        )
+        for row in rows
+    ]
+    comparison_payload: JSONDict = {
+        "schema_version": 1,
+        "flow_id": "robotics-compare",
+        "source_validation": {
+            "lerobot": "deterministic checkout-safe provider demo",
+            "cosmos-policy": "validated live on RTX A6000; committed artifact is sanitized",
+            "gr00t-replay": "validated live on RTX A6000; committed artifact is sanitized",
+        },
+        "rows": rows,
+        "artifacts": {
+            "cosmos_policy_replay": "artifacts/cosmos-policy-replay.json",
+            "gr00t_replay": "artifacts/gr00t-replay.json",
+        },
+        "notes": [
+            "WorldForge owns the common policy contract, validation, events, and replay surface.",
+            "Robotics model runtimes remain host-owned and are not required for this replay.",
+        ],
+    }
+    summary: JSONDict = {
+        "demo_kind": "robotics_policy_replay_comparison",
+        "state_dir": str(state_dir),
+        "providers": [str(row["provider"]) for row in rows],
+        "flow_ids": [str(row["flow_id"]) for row in rows],
+        "comparison_count": len(rows),
+        "rows": rows,
+        "total_translated_actions": sum(int(row["translated_action_count"]) for row in rows),
+        "gpu_required": False,
+        "source_validation": comparison_payload["source_validation"],
+        "event_phases": [event.phase for event in events],
+        "provider_events": [event.to_dict() for event in events],
+        "harness_artifacts": {
+            "robotics_comparison": {
+                "path": "artifacts/robotics-policy-comparison.json",
+                "payload": comparison_payload,
+            },
+            "cosmos_policy_replay": {
+                "path": "artifacts/cosmos-policy-replay.json",
+                "payload": _harness_artifact_payload(
+                    subflows["cosmos-policy"],
+                    "cosmos_policy_replay",
+                ),
+            },
+            "gr00t_replay": {
+                "path": "artifacts/gr00t-replay.json",
+                "payload": _harness_artifact_payload(subflows["gr00t-replay"], "gr00t_replay"),
+            },
+        },
+    }
+    if emit:
+        print("\n".join(_transcript_for("robotics-compare", summary)))
+    return summary
+
+
+def _robotics_compare_lerobot_row(summary: JSONDict) -> JSONDict:
+    selected_index = int(summary["selected_candidate_index"])
+    candidate_costs = list(summary["candidate_costs"])
+    selected_cost = candidate_costs[selected_index]
+    return {
+        "flow_id": "lerobot",
+        "provider": "lerobot",
+        "model": "injected deterministic LeRobot-shaped policy",
+        "source": "checkout-safe policy plus score demo",
+        "raw_shape": f"{summary['policy_candidate_count']} candidate chunks",
+        "candidate_count": int(summary["policy_candidate_count"]),
+        "selected_candidate_index": selected_index,
+        "selected_score": float(selected_cost),
+        "translated_action_count": len(summary["selected_actions"]),
+        "events": len(summary.get("event_phases", [])),
+        "artifact": "run summary only",
+    }
+
+
+def _robotics_compare_cosmos_row(summary: JSONDict) -> JSONDict:
+    raw_shape = " x ".join(str(item) for item in summary["raw_action_shape"])
+    return {
+        "flow_id": "cosmos-policy",
+        "provider": str(summary["providers"][0]),
+        "model": summary["model"],
+        "source": "sanitized ALOHA /act replay",
+        "raw_shape": raw_shape,
+        "candidate_count": int(summary["candidate_count"]),
+        "selected_candidate_index": int(summary["selected_candidate_index"]),
+        "value_prediction": summary["value_prediction"],
+        "translated_action_count": int(summary["translated_action_count"]),
+        "events": len(summary.get("event_phases", [])),
+        "artifact": "artifacts/cosmos-policy-replay.json",
+    }
+
+
+def _robotics_compare_groot_row(summary: JSONDict) -> JSONDict:
+    return {
+        "flow_id": "gr00t-replay",
+        "provider": str(summary["providers"][0]),
+        "model": summary["model"],
+        "source": "sanitized GR00T PolicyClient replay",
+        "raw_shape": _groot_shape_result(summary),
+        "raw_tensor_count": len(summary["raw_action_shapes"]),
+        "embodiment_tag": summary["embodiment_tag"],
+        "latency_ms": summary["latency_ms"],
+        "translated_action_count": int(summary["translated_action_count"]),
+        "events": len(summary.get("event_phases", [])),
+        "artifact": "artifacts/gr00t-replay.json",
+    }
+
+
+def _harness_artifact_payload(summary: JSONDict, name: str) -> object:
+    artifacts = summary.get("harness_artifacts")
+    if not isinstance(artifacts, dict):
+        raise WorldStateError(f"{name} source flow did not expose harness artifacts.")
+    descriptor = artifacts.get(name)
+    if not isinstance(descriptor, dict) or "payload" not in descriptor:
+        raise WorldStateError(f"{name} source flow did not expose an artifact payload.")
+    return descriptor["payload"]
+
+
 _RUNNERS: dict[str, FlowRunner] = {
     "leworldmodel": _run_leworldmodel_demo,
     "lerobot": _run_lerobot_demo,
     "cosmos-policy": _run_cosmos_policy_demo,
     "gr00t-replay": _run_gr00t_replay_demo,
+    "robotics-compare": _run_robotics_compare_demo,
     "diagnostics": _run_diagnostics_demo,
     "workbench": _run_workbench_demo,
 }
@@ -2354,6 +2521,52 @@ def _steps_for(flow_id: str, summary: JSONDict) -> tuple[HarnessStep, ...]:
                 f"events={', '.join(summary['event_phases'])}",
             ),
         )
+    if flow_id == "robotics-compare":
+        rows_by_flow = {str(row["flow_id"]): row for row in summary["rows"]}
+        return (
+            HarnessStep(
+                "Run LeRobot policy path",
+                "Execute the checkout-safe LeRobot policy-plus-score flow.",
+                (
+                    f"{rows_by_flow['lerobot']['candidate_count']} candidate chunks, "
+                    f"selected #{rows_by_flow['lerobot']['selected_candidate_index']}."
+                ),
+                f"translated_actions={rows_by_flow['lerobot']['translated_action_count']}",
+            ),
+            HarnessStep(
+                "Replay Cosmos-Policy /act",
+                "Route the sanitized ALOHA replay through CosmosPolicyProvider.",
+                f"raw action shape {rows_by_flow['cosmos-policy']['raw_shape']}.",
+                f"translated_actions={rows_by_flow['cosmos-policy']['translated_action_count']}",
+            ),
+            HarnessStep(
+                "Replay GR00T PolicyClient",
+                "Route the sanitized DROID replay through GrootPolicyClientProvider.",
+                str(rows_by_flow["gr00t-replay"]["raw_shape"]),
+                f"translated_actions={rows_by_flow['gr00t-replay']['translated_action_count']}",
+            ),
+            HarnessStep(
+                "Normalize policy contracts",
+                (
+                    "Compare provider outputs by shape, selected candidate, and translated "
+                    "action count."
+                ),
+                f"{summary['comparison_count']} policy surfaces normalized.",
+                f"total_translated_actions={summary['total_translated_actions']}",
+            ),
+            HarnessStep(
+                "Inspect provider events",
+                "Record a comparable event for each policy surface.",
+                _event_result(summary),
+                f"events={len(summary['event_phases'])}",
+            ),
+            HarnessStep(
+                "Preserve comparison artifact",
+                "Write a sanitized comparison plus replay artifacts for offline inspection.",
+                "artifact=artifacts/robotics-policy-comparison.json",
+                "gpu_required=false",
+            ),
+        )
     if flow_id == "diagnostics":
         return (
             HarnessStep(
@@ -2568,6 +2781,36 @@ def _metrics_for(flow_id: str, summary: JSONDict) -> tuple[HarnessMetric, ...]:
             ),
             HarnessMetric("Artifact", "replay", "artifacts/gr00t-replay.json"),
         )
+    if flow_id == "robotics-compare":
+        rows_by_flow = {str(row["flow_id"]): row for row in summary["rows"]}
+        return (
+            HarnessMetric("Flow", "policy comparison", "three robotics policy surfaces"),
+            HarnessMetric(
+                "LeRobot",
+                f"{rows_by_flow['lerobot']['candidate_count']} candidates",
+                f"selected #{rows_by_flow['lerobot']['selected_candidate_index']}",
+            ),
+            HarnessMetric(
+                "Cosmos",
+                str(rows_by_flow["cosmos-policy"]["raw_shape"]),
+                f"value={_format_optional_float(rows_by_flow['cosmos-policy']['value_prediction'])}",
+            ),
+            HarnessMetric(
+                "GR00T",
+                str(rows_by_flow["gr00t-replay"]["raw_tensor_count"]),
+                "named action tensors",
+            ),
+            HarnessMetric(
+                "Translated",
+                str(summary["total_translated_actions"]),
+                "WorldForge Action objects",
+            ),
+            HarnessMetric(
+                "Artifacts",
+                "3",
+                "comparison plus replay artifacts",
+            ),
+        )
 
     flow_label = "score" if flow_id == "leworldmodel" else "policy+score"
     return (
@@ -2645,6 +2888,37 @@ def _transcript_for(flow_id: str, summary: JSONDict) -> tuple[str, ...]:
             f"latency_ms: {float(summary['latency_ms']):.1f}",
             f"result_digest: {summary['result_digest']}",
             "saved_replay_artifact: artifacts/gr00t-replay.json",
+            f"events: {', '.join(summary['event_phases'])}",
+        )
+    if flow_id == "robotics-compare":
+        rows_by_flow = {str(row["flow_id"]): row for row in summary["rows"]}
+        return (
+            "flow: robotics-compare",
+            f"providers: {', '.join(summary['providers'])}",
+            f"flow_ids: {', '.join(summary['flow_ids'])}",
+            "gpu_required: false",
+            (
+                "lerobot: "
+                f"candidates={rows_by_flow['lerobot']['candidate_count']} "
+                f"selected=#{rows_by_flow['lerobot']['selected_candidate_index']} "
+                f"translated_actions={rows_by_flow['lerobot']['translated_action_count']}"
+            ),
+            (
+                "cosmos-policy: "
+                f"raw_shape={rows_by_flow['cosmos-policy']['raw_shape']} "
+                f"translated_actions={rows_by_flow['cosmos-policy']['translated_action_count']} "
+                "value_prediction="
+                f"{_format_optional_float(rows_by_flow['cosmos-policy']['value_prediction'])}"
+            ),
+            (
+                "gr00t-replay: "
+                f"raw_tensors={rows_by_flow['gr00t-replay']['raw_tensor_count']} "
+                f"translated_actions={rows_by_flow['gr00t-replay']['translated_action_count']} "
+                f"latency_ms={_format_ms(rows_by_flow['gr00t-replay']['latency_ms'])}"
+            ),
+            f"total_translated_actions: {summary['total_translated_actions']}",
+            "comparison_artifact: artifacts/robotics-policy-comparison.json",
+            "replay_artifacts: artifacts/cosmos-policy-replay.json, artifacts/gr00t-replay.json",
             f"events: {', '.join(summary['event_phases'])}",
         )
 

--- a/src/worldforge/harness/flows.py
+++ b/src/worldforge/harness/flows.py
@@ -1668,10 +1668,7 @@ def _run_robotics_compare_demo(*, state_dir: Path, emit: bool = False) -> JSONDi
             "status": "completed",
             "source_validation": source_validation,
             "rows": rows,
-            "artifacts": {
-                "cosmos_policy_replay": "artifacts/cosmos-policy-replay.json",
-                "gr00t_replay": "artifacts/gr00t-replay.json",
-            },
+            "artifacts": {},
             "notes": [
                 (
                     "WorldForge owns the common policy contract, validation, events, and "
@@ -1685,6 +1682,7 @@ def _run_robotics_compare_demo(*, state_dir: Path, emit: bool = False) -> JSONDi
             comparison_payload,
             require_replays=True,
         )
+        comparison_payload["artifacts"] = _robotics_compare_replay_artifact_paths(harness_artifacts)
     except Exception as exc:
         return _robotics_compare_failure_summary(
             state_dir=state_dir,
@@ -1754,10 +1752,7 @@ def _robotics_compare_failure_summary(
         "status": "failed",
         "source_validation": source_validation,
         "validation_errors": validation_errors,
-        "artifacts": {
-            "cosmos_policy_replay": "artifacts/cosmos-policy-replay.json",
-            "gr00t_replay": "artifacts/gr00t-replay.json",
-        },
+        "artifacts": {},
         "notes": [
             "At least one subflow failed before comparison rows could be normalized.",
             "Available sanitized replay artifacts are still preserved for triage.",
@@ -1767,6 +1762,12 @@ def _robotics_compare_failure_summary(
         subflows,
         validation_errors=validation_errors,
     )
+    harness_artifacts = _robotics_compare_artifacts(
+        subflows,
+        comparison_payload,
+        require_replays=False,
+    )
+    comparison_payload["artifacts"] = _robotics_compare_replay_artifact_paths(harness_artifacts)
     summary: JSONDict = {
         "demo_kind": "robotics_policy_replay_comparison",
         "state_dir": str(state_dir),
@@ -1779,11 +1780,7 @@ def _robotics_compare_failure_summary(
         "event_phases": [str(event.get("phase", "unknown")) for event in provider_events],
         "provider_events": provider_events,
         "validation_errors": validation_errors,
-        "harness_artifacts": _robotics_compare_artifacts(
-            subflows,
-            comparison_payload,
-            require_replays=False,
-        ),
+        "harness_artifacts": harness_artifacts,
     }
     if emit:
         print("\n".join(_transcript_for("robotics-compare", summary)))
@@ -1888,6 +1885,18 @@ def _robotics_compare_artifacts(
             continue
         artifacts[name] = {"path": path, "payload": payload}
     return artifacts
+
+
+def _robotics_compare_replay_artifact_paths(harness_artifacts: JSONDict) -> JSONDict:
+    paths: JSONDict = {}
+    for name in ("cosmos_policy_replay", "gr00t_replay"):
+        descriptor = harness_artifacts.get(name)
+        if not isinstance(descriptor, dict):
+            continue
+        path = descriptor.get("path")
+        if isinstance(path, str):
+            paths[name] = path
+    return paths
 
 
 def _robotics_compare_lerobot_row(summary: JSONDict) -> JSONDict:

--- a/src/worldforge/harness/flows.py
+++ b/src/worldforge/harness/flows.py
@@ -1628,81 +1628,72 @@ def _run_lerobot_demo(**kwargs: object) -> JSONDict:
 
 def _run_robotics_compare_demo(*, state_dir: Path, emit: bool = False) -> JSONDict:
     subflows = {
-        "lerobot": _run_lerobot_demo(state_dir=state_dir / "lerobot", emit=False),
-        "cosmos-policy": _run_cosmos_policy_demo(
-            state_dir=state_dir / "cosmos-policy",
-            emit=False,
+        "lerobot": _run_robotics_compare_subflow(
+            "lerobot",
+            _run_lerobot_demo,
+            state_dir / "lerobot",
         ),
-        "gr00t-replay": _run_gr00t_replay_demo(
+        "cosmos-policy": _run_robotics_compare_subflow(
+            "cosmos-policy",
+            _run_cosmos_policy_demo,
+            state_dir=state_dir / "cosmos-policy",
+        ),
+        "gr00t-replay": _run_robotics_compare_subflow(
+            "gr00t-replay",
+            _run_gr00t_replay_demo,
             state_dir=state_dir / "gr00t-replay",
-            emit=False,
         ),
     }
     validation_errors = _robotics_compare_validation_errors(subflows)
     source_validation = _robotics_compare_source_validation()
     if validation_errors:
+        return _robotics_compare_failure_summary(
+            state_dir=state_dir,
+            subflows=subflows,
+            source_validation=source_validation,
+            validation_errors=validation_errors,
+            emit=emit,
+        )
+
+    try:
+        rows = [
+            _robotics_compare_lerobot_row(subflows["lerobot"]),
+            _robotics_compare_cosmos_row(subflows["cosmos-policy"]),
+            _robotics_compare_groot_row(subflows["gr00t-replay"]),
+        ]
+        provider_events = _robotics_compare_provider_events(subflows, rows=rows)
         comparison_payload: JSONDict = {
             "schema_version": 1,
             "flow_id": "robotics-compare",
-            "status": "failed",
+            "status": "completed",
             "source_validation": source_validation,
-            "validation_errors": validation_errors,
+            "rows": rows,
             "artifacts": {
                 "cosmos_policy_replay": "artifacts/cosmos-policy-replay.json",
                 "gr00t_replay": "artifacts/gr00t-replay.json",
             },
             "notes": [
-                "At least one subflow failed before comparison rows could be normalized.",
-                "Available sanitized replay artifacts are still preserved for triage.",
+                (
+                    "WorldForge owns the common policy contract, validation, events, and "
+                    "replay surface."
+                ),
+                "Robotics model runtimes remain host-owned and are not required for this replay.",
             ],
         }
-        provider_events = _robotics_compare_provider_events(
+        harness_artifacts = _robotics_compare_artifacts(
             subflows,
-            validation_errors=validation_errors,
+            comparison_payload,
+            require_replays=True,
         )
-        summary: JSONDict = {
-            "demo_kind": "robotics_policy_replay_comparison",
-            "state_dir": str(state_dir),
-            "status": "failed",
-            "providers": ["lerobot", "cosmos-policy", "gr00t"],
-            "flow_ids": list(subflows),
-            "comparison_count": len(subflows),
-            "gpu_required": False,
-            "source_validation": source_validation,
-            "event_phases": [str(event.get("phase", "unknown")) for event in provider_events],
-            "provider_events": provider_events,
-            "validation_errors": validation_errors,
-            "harness_artifacts": _robotics_compare_artifacts(
-                subflows,
-                comparison_payload,
-                require_replays=False,
-            ),
-        }
-        if emit:
-            print("\n".join(_transcript_for("robotics-compare", summary)))
-        return summary
+    except Exception as exc:
+        return _robotics_compare_failure_summary(
+            state_dir=state_dir,
+            subflows=subflows,
+            source_validation=source_validation,
+            validation_errors=[f"robotics-compare: {type(exc).__name__}: {exc}"],
+            emit=emit,
+        )
 
-    rows = [
-        _robotics_compare_lerobot_row(subflows["lerobot"]),
-        _robotics_compare_cosmos_row(subflows["cosmos-policy"]),
-        _robotics_compare_groot_row(subflows["gr00t-replay"]),
-    ]
-    provider_events = _robotics_compare_provider_events(subflows, rows=rows)
-    comparison_payload: JSONDict = {
-        "schema_version": 1,
-        "flow_id": "robotics-compare",
-        "status": "completed",
-        "source_validation": source_validation,
-        "rows": rows,
-        "artifacts": {
-            "cosmos_policy_replay": "artifacts/cosmos-policy-replay.json",
-            "gr00t_replay": "artifacts/gr00t-replay.json",
-        },
-        "notes": [
-            "WorldForge owns the common policy contract, validation, events, and replay surface.",
-            "Robotics model runtimes remain host-owned and are not required for this replay.",
-        ],
-    }
     summary: JSONDict = {
         "demo_kind": "robotics_policy_replay_comparison",
         "state_dir": str(state_dir),
@@ -1715,10 +1706,83 @@ def _run_robotics_compare_demo(*, state_dir: Path, emit: bool = False) -> JSONDi
         "source_validation": comparison_payload["source_validation"],
         "event_phases": [str(event.get("phase", "unknown")) for event in provider_events],
         "provider_events": provider_events,
+        "harness_artifacts": harness_artifacts,
+    }
+    if emit:
+        print("\n".join(_transcript_for("robotics-compare", summary)))
+    return summary
+
+
+def _run_robotics_compare_subflow(
+    flow_id: str,
+    runner: FlowRunner,
+    state_dir: Path,
+) -> JSONDict:
+    try:
+        return runner(state_dir=state_dir, emit=False)
+    except Exception as exc:
+        message = f"{type(exc).__name__}: {exc}"
+        event = ProviderEvent(
+            provider=flow_index()[flow_id].provider,
+            operation=flow_id,
+            phase="failure",
+            message=message,
+            metadata={"stage": "robotics-compare-subflow"},
+        )
+        return {
+            "demo_kind": "robotics_compare_subflow",
+            "state_dir": str(state_dir),
+            "status": "failed",
+            "providers": [flow_id],
+            "event_phases": [event.phase],
+            "provider_events": [event.to_dict()],
+            "validation_errors": [message],
+        }
+
+
+def _robotics_compare_failure_summary(
+    *,
+    state_dir: Path,
+    subflows: dict[str, JSONDict],
+    source_validation: JSONDict,
+    validation_errors: list[str],
+    emit: bool,
+) -> JSONDict:
+    comparison_payload: JSONDict = {
+        "schema_version": 1,
+        "flow_id": "robotics-compare",
+        "status": "failed",
+        "source_validation": source_validation,
+        "validation_errors": validation_errors,
+        "artifacts": {
+            "cosmos_policy_replay": "artifacts/cosmos-policy-replay.json",
+            "gr00t_replay": "artifacts/gr00t-replay.json",
+        },
+        "notes": [
+            "At least one subflow failed before comparison rows could be normalized.",
+            "Available sanitized replay artifacts are still preserved for triage.",
+        ],
+    }
+    provider_events = _robotics_compare_provider_events(
+        subflows,
+        validation_errors=validation_errors,
+    )
+    summary: JSONDict = {
+        "demo_kind": "robotics_policy_replay_comparison",
+        "state_dir": str(state_dir),
+        "status": "failed",
+        "providers": ["lerobot", "cosmos-policy", "gr00t"],
+        "flow_ids": list(subflows),
+        "comparison_count": len(subflows),
+        "gpu_required": False,
+        "source_validation": source_validation,
+        "event_phases": [str(event.get("phase", "unknown")) for event in provider_events],
+        "provider_events": provider_events,
+        "validation_errors": validation_errors,
         "harness_artifacts": _robotics_compare_artifacts(
             subflows,
             comparison_payload,
-            require_replays=True,
+            require_replays=False,
         ),
     }
     if emit:

--- a/src/worldforge/harness/flows.py
+++ b/src/worldforge/harness/flows.py
@@ -23,7 +23,13 @@ from worldforge.harness.workspace import (
     workspace_root_for_state_dir,
     write_run_manifest,
 )
-from worldforge.models import JSONDict, ProviderEvent, WorldForgeError, WorldStateError
+from worldforge.models import (
+    JSONDict,
+    ProviderEvent,
+    WorldForgeError,
+    WorldStateError,
+    _redact_observable_text,
+)
 from worldforge.provenance import ProvenanceEnvelope
 from worldforge.providers.base import ProviderError
 
@@ -1688,7 +1694,7 @@ def _run_robotics_compare_demo(*, state_dir: Path, emit: bool = False) -> JSONDi
             state_dir=state_dir,
             subflows=subflows,
             source_validation=source_validation,
-            validation_errors=[f"robotics-compare: {type(exc).__name__}: {exc}"],
+            validation_errors=[_robotics_compare_exception_error("robotics-compare", exc)],
             emit=emit,
         )
 
@@ -1717,25 +1723,52 @@ def _run_robotics_compare_subflow(
     state_dir: Path,
 ) -> JSONDict:
     try:
-        return runner(state_dir=state_dir, emit=False)
+        summary = runner(state_dir=state_dir, emit=False)
     except Exception as exc:
-        message = f"{type(exc).__name__}: {exc}"
-        event = ProviderEvent(
-            provider=flow_index()[flow_id].provider,
-            operation=flow_id,
-            phase="failure",
-            message=message,
-            metadata={"stage": "robotics-compare-subflow"},
+        return _robotics_compare_failed_subflow_summary(
+            flow_id,
+            state_dir,
+            _robotics_compare_exception_error("", exc),
         )
-        return {
-            "demo_kind": "robotics_compare_subflow",
-            "state_dir": str(state_dir),
-            "status": "failed",
-            "providers": [flow_id],
-            "event_phases": [event.phase],
-            "provider_events": [event.to_dict()],
-            "validation_errors": [message],
-        }
+    if not isinstance(summary, dict):
+        return _robotics_compare_failed_subflow_summary(
+            flow_id,
+            state_dir,
+            f"WorldStateError: {flow_id} subflow returned {type(summary).__name__}, "
+            "expected JSON object",
+        )
+    return summary
+
+
+def _robotics_compare_failed_subflow_summary(
+    flow_id: str,
+    state_dir: Path,
+    message: str,
+) -> JSONDict:
+    safe_message = _redact_observable_text(message).strip()
+    event = ProviderEvent(
+        provider=flow_index()[flow_id].provider,
+        operation=flow_id,
+        phase="failure",
+        message=safe_message,
+        metadata={"stage": "robotics-compare-subflow"},
+    )
+    return {
+        "demo_kind": "robotics_compare_subflow",
+        "state_dir": str(state_dir),
+        "status": "failed",
+        "providers": [flow_id],
+        "event_phases": [event.phase],
+        "provider_events": [event.to_dict()],
+        "validation_errors": [safe_message],
+    }
+
+
+def _robotics_compare_exception_error(prefix: str, exc: BaseException) -> str:
+    detail = _redact_observable_text(str(exc)).strip()
+    type_name = type(exc).__name__
+    message = f"{type_name}: {detail}" if detail else type_name
+    return f"{prefix}: {message}" if prefix else message
 
 
 def _robotics_compare_failure_summary(
@@ -1746,6 +1779,7 @@ def _robotics_compare_failure_summary(
     validation_errors: list[str],
     emit: bool,
 ) -> JSONDict:
+    validation_errors = [_redact_observable_text(error) for error in validation_errors]
     comparison_payload: JSONDict = {
         "schema_version": 1,
         "flow_id": "robotics-compare",
@@ -1800,7 +1834,7 @@ def _robotics_compare_validation_errors(subflows: dict[str, JSONDict]) -> list[s
     for flow_id, summary in subflows.items():
         flow_errors = summary.get("validation_errors")
         if isinstance(flow_errors, list):
-            errors.extend(f"{flow_id}: {error}" for error in flow_errors)
+            errors.extend(_redact_observable_text(f"{flow_id}: {error}") for error in flow_errors)
     return errors
 
 

--- a/src/worldforge/harness/flows.py
+++ b/src/worldforge/harness/flows.py
@@ -1766,9 +1766,19 @@ def _robotics_compare_failed_subflow_summary(
 
 def _robotics_compare_exception_error(prefix: str, exc: BaseException) -> str:
     detail = _redact_observable_text(str(exc)).strip()
-    type_name = type(exc).__name__
+    type_name = _robotics_compare_exception_type_name(exc)
     message = f"{type_name}: {detail}" if detail else type_name
     return f"{prefix}: {message}" if prefix else message
+
+
+def _robotics_compare_exception_type_name(exc: BaseException) -> str:
+    if isinstance(exc, ProviderError):
+        return "ProviderError"
+    if isinstance(exc, WorldStateError):
+        return "WorldStateError"
+    if isinstance(exc, WorldForgeError):
+        return "WorldForgeError"
+    return "WorldStateError"
 
 
 def _robotics_compare_failure_summary(

--- a/src/worldforge/harness/tui.py
+++ b/src/worldforge/harness/tui.py
@@ -1050,8 +1050,9 @@ class RunInspectorScreen(Screen):
         Binding("2", "select_flow('lerobot')", "LeRobot", show=True),
         Binding("3", "select_flow('cosmos-policy')", "Cosmos", show=True),
         Binding("4", "select_flow('gr00t-replay')", "GR00T", show=True),
-        Binding("5", "select_flow('diagnostics')", "Diagnostics", show=True),
-        Binding("6", "select_flow('workbench')", "Workbench", show=True),
+        Binding("5", "select_flow('robotics-compare')", "Compare", show=True),
+        Binding("6", "select_flow('diagnostics')", "Diagnostics", show=True),
+        Binding("7", "select_flow('workbench')", "Workbench", show=True),
     ]
 
     DEFAULT_CSS = """

--- a/tests/test_harness_cli.py
+++ b/tests/test_harness_cli.py
@@ -21,6 +21,7 @@ def test_worldforge_harness_lists_flows_without_textual(monkeypatch, capsys) -> 
     assert "lerobot" in output
     assert "cosmos-policy" in output
     assert "gr00t-replay" in output
+    assert "robotics-compare" in output
     assert "diagnostics" in output
     assert "workbench" in output
 
@@ -40,6 +41,7 @@ def test_worldforge_harness_lists_json_without_textual(monkeypatch, capsys) -> N
         "lerobot",
         "cosmos-policy",
         "gr00t-replay",
+        "robotics-compare",
         "diagnostics",
         "workbench",
     ]

--- a/tests/test_harness_flows.py
+++ b/tests/test_harness_flows.py
@@ -324,6 +324,10 @@ def test_harness_robotics_compare_preserves_replay_artifacts_on_subflow_failure(
     )
     assert comparison["status"] == "failed"
     assert comparison["validation_errors"] == ["cosmos-policy: simulated replay validation failure"]
+    assert comparison["artifacts"] == {
+        "cosmos_policy_replay": "artifacts/cosmos-policy-replay.json",
+        "gr00t_replay": "artifacts/gr00t-replay.json",
+    }
     assert run.provider_events[-1]["phase"] == "failure"
 
 
@@ -350,6 +354,10 @@ def test_harness_robotics_compare_preserves_other_artifacts_when_subflow_raises(
     )
     assert manifest["artifact_paths"]["gr00t_replay"] == "artifacts/gr00t-replay.json"
     assert "cosmos_policy_replay" not in manifest["artifact_paths"]
+    comparison = json.loads(
+        (run.workspace_path / "artifacts/robotics-policy-comparison.json").read_text()
+    )
+    assert comparison["artifacts"] == {"gr00t_replay": "artifacts/gr00t-replay.json"}
     assert run.provider_events[-1]["phase"] == "failure"
     assert any(
         event["metadata"].get("subflow_id") == "cosmos-policy" for event in run.provider_events

--- a/tests/test_harness_flows.py
+++ b/tests/test_harness_flows.py
@@ -358,7 +358,7 @@ def test_harness_robotics_compare_preserves_other_artifacts_when_subflow_raises(
     run = run_flow("robotics-compare", state_dir=tmp_path)
 
     assert run.validation_errors == (
-        "cosmos-policy: WorldStateError: transport exploded for https://example.test/act "
+        "cosmos-policy: ProviderError: transport exploded for https://example.test/act "
         "with api_key=[redacted]",
     )
     assert run.workspace_path is not None

--- a/tests/test_harness_flows.py
+++ b/tests/test_harness_flows.py
@@ -263,8 +263,17 @@ def test_harness_runs_robotics_compare_flow(tmp_path) -> None:
     assert rows["gr00t-replay"]["raw_tensor_count"] == 3
     assert rows["gr00t-replay"]["translated_action_count"] == 40
     assert run.summary["total_translated_actions"] == 92
-    assert len(run.provider_events) == 7
     assert {event["phase"] for event in run.provider_events} == {"success"}
+    comparison_events = [
+        event
+        for event in run.provider_events
+        if event["operation"] == "robotics-compare" and event["metadata"].get("flow_id") in rows
+    ]
+    assert {event["metadata"]["flow_id"] for event in comparison_events} == {
+        "lerobot",
+        "cosmos-policy",
+        "gr00t-replay",
+    }
     assert {
         event["metadata"]["subflow_id"]
         for event in run.provider_events
@@ -339,13 +348,19 @@ def test_harness_robotics_compare_preserves_other_artifacts_when_subflow_raises(
 
     def failed_cosmos(*, state_dir: Path, emit: bool = False) -> dict:
         _ = (state_dir, emit)
-        raise RuntimeError("transport exploded")
+        raise RuntimeError(
+            "transport exploded for https://example.test/act?token=cosmos-secret "
+            "with api_key=raw-secret"
+        )
 
     monkeypatch.setattr(flows, "_run_cosmos_policy_demo", failed_cosmos)
 
     run = run_flow("robotics-compare", state_dir=tmp_path)
 
-    assert run.validation_errors == ("cosmos-policy: RuntimeError: transport exploded",)
+    assert run.validation_errors == (
+        "cosmos-policy: RuntimeError: transport exploded for https://example.test/act "
+        "with api_key=[redacted]",
+    )
     assert run.workspace_path is not None
     manifest = json.loads((run.workspace_path / "run_manifest.json").read_text())
     assert manifest["status"] == "failed"
@@ -358,10 +373,41 @@ def test_harness_robotics_compare_preserves_other_artifacts_when_subflow_raises(
         (run.workspace_path / "artifacts/robotics-policy-comparison.json").read_text()
     )
     assert comparison["artifacts"] == {"gr00t_replay": "artifacts/gr00t-replay.json"}
+    comparison_text = json.dumps(comparison)
+    assert "cosmos-secret" not in comparison_text
+    assert "raw-secret" not in comparison_text
+    assert "token=" not in comparison_text
     assert run.provider_events[-1]["phase"] == "failure"
     assert any(
         event["metadata"].get("subflow_id") == "cosmos-policy" for event in run.provider_events
     )
+
+
+def test_harness_robotics_compare_handles_non_dict_subflow_result(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    from worldforge.harness import flows
+
+    def invalid_cosmos(*, state_dir: Path, emit: bool = False) -> None:
+        _ = (state_dir, emit)
+
+    monkeypatch.setattr(flows, "_run_cosmos_policy_demo", invalid_cosmos)
+
+    run = run_flow("robotics-compare", state_dir=tmp_path)
+
+    assert run.validation_errors == (
+        "cosmos-policy: WorldStateError: cosmos-policy subflow returned NoneType, "
+        "expected JSON object",
+    )
+    assert run.workspace_path is not None
+    manifest = json.loads((run.workspace_path / "run_manifest.json").read_text())
+    assert manifest["status"] == "failed"
+    assert manifest["artifact_paths"]["robotics_comparison"] == (
+        "artifacts/robotics-policy-comparison.json"
+    )
+    assert manifest["artifact_paths"]["gr00t_replay"] == "artifacts/gr00t-replay.json"
+    assert "cosmos_policy_replay" not in manifest["artifact_paths"]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_harness_flows.py
+++ b/tests/test_harness_flows.py
@@ -358,7 +358,7 @@ def test_harness_robotics_compare_preserves_other_artifacts_when_subflow_raises(
     run = run_flow("robotics-compare", state_dir=tmp_path)
 
     assert run.validation_errors == (
-        "cosmos-policy: RuntimeError: transport exploded for https://example.test/act "
+        "cosmos-policy: WorldStateError: transport exploded for https://example.test/act "
         "with api_key=[redacted]",
     )
     assert run.workspace_path is not None
@@ -374,6 +374,7 @@ def test_harness_robotics_compare_preserves_other_artifacts_when_subflow_raises(
     )
     assert comparison["artifacts"] == {"gr00t_replay": "artifacts/gr00t-replay.json"}
     comparison_text = json.dumps(comparison)
+    assert "RuntimeError" not in comparison_text
     assert "cosmos-secret" not in comparison_text
     assert "raw-secret" not in comparison_text
     assert "token=" not in comparison_text

--- a/tests/test_harness_flows.py
+++ b/tests/test_harness_flows.py
@@ -263,11 +263,13 @@ def test_harness_runs_robotics_compare_flow(tmp_path) -> None:
     assert rows["gr00t-replay"]["raw_tensor_count"] == 3
     assert rows["gr00t-replay"]["translated_action_count"] == 40
     assert run.summary["total_translated_actions"] == 92
-    assert [event["phase"] for event in run.provider_events] == [
-        "success",
-        "success",
-        "success",
-    ]
+    assert len(run.provider_events) == 7
+    assert {event["phase"] for event in run.provider_events} == {"success"}
+    assert {
+        event["metadata"]["subflow_id"]
+        for event in run.provider_events
+        if "subflow_id" in event.get("metadata", {})
+    } == {"lerobot", "cosmos-policy", "gr00t-replay"}
     transcript = "\n".join(run.transcript)
     assert "flow: robotics-compare" in transcript
     assert "comparison_artifact: artifacts/robotics-policy-comparison.json" in transcript
@@ -287,6 +289,42 @@ def test_harness_runs_robotics_compare_flow(tmp_path) -> None:
         "validated live on RTX A6000; committed artifact is sanitized"
     )
     assert not _contains_dict_key(comparison, "observation")
+
+
+def test_harness_robotics_compare_preserves_replay_artifacts_on_subflow_failure(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    from worldforge.harness import flows
+
+    original_cosmos = flows._run_cosmos_policy_demo
+
+    def failed_cosmos(*, state_dir: Path, emit: bool = False) -> dict:
+        summary = original_cosmos(state_dir=state_dir, emit=emit)
+        summary["validation_errors"] = ["simulated replay validation failure"]
+        return summary
+
+    monkeypatch.setattr(flows, "_run_cosmos_policy_demo", failed_cosmos)
+
+    run = run_flow("robotics-compare", state_dir=tmp_path)
+
+    assert run.validation_errors == ("cosmos-policy: simulated replay validation failure",)
+    assert run.workspace_path is not None
+    manifest = json.loads((run.workspace_path / "run_manifest.json").read_text())
+    assert manifest["status"] == "failed"
+    assert manifest["artifact_paths"]["robotics_comparison"] == (
+        "artifacts/robotics-policy-comparison.json"
+    )
+    assert manifest["artifact_paths"]["cosmos_policy_replay"] == (
+        "artifacts/cosmos-policy-replay.json"
+    )
+    assert manifest["artifact_paths"]["gr00t_replay"] == "artifacts/gr00t-replay.json"
+    comparison = json.loads(
+        (run.workspace_path / "artifacts/robotics-policy-comparison.json").read_text()
+    )
+    assert comparison["status"] == "failed"
+    assert comparison["validation_errors"] == ["cosmos-policy: simulated replay validation failure"]
+    assert run.provider_events[-1]["phase"] == "failure"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_harness_flows.py
+++ b/tests/test_harness_flows.py
@@ -37,6 +37,17 @@ def _copy_json_payload(value: object) -> object:
     return json.loads(json.dumps(value))
 
 
+def _contains_dict_key(value: object, key: str) -> bool:
+    if isinstance(value, dict):
+        return any(
+            item_key == key or _contains_dict_key(item_value, key)
+            for item_key, item_value in value.items()
+        )
+    if isinstance(value, list):
+        return any(_contains_dict_key(item, key) for item in value)
+    return False
+
+
 def _write_cosmos_replay_payload(tmp_path: Path, name: str, payload: object) -> Path:
     path = tmp_path / name
     path.write_text(json.dumps(payload), encoding="utf-8")
@@ -275,7 +286,60 @@ def test_harness_runs_robotics_compare_flow(tmp_path) -> None:
     assert comparison["source_validation"]["gr00t-replay"] == (
         "validated live on RTX A6000; committed artifact is sanitized"
     )
-    assert "observation" not in json.dumps(comparison)
+    assert not _contains_dict_key(comparison, "observation")
+
+
+@pytest.mark.parametrize(
+    ("helper_name", "flow_id", "summary", "missing_key"),
+    [
+        (
+            "_robotics_compare_lerobot_row",
+            "lerobot",
+            {"selected_candidate_index": 0, "candidate_costs": [0.0], "selected_actions": []},
+            "policy_candidate_count",
+        ),
+        (
+            "_robotics_compare_cosmos_row",
+            "cosmos-policy",
+            {
+                "providers": ["cosmos-policy"],
+                "model": "cosmos",
+                "candidate_count": 1,
+                "selected_candidate_index": 0,
+                "value_prediction": None,
+                "translated_action_count": 50,
+            },
+            "raw_action_shape",
+        ),
+        (
+            "_robotics_compare_groot_row",
+            "gr00t-replay",
+            {
+                "providers": ["gr00t"],
+                "model": "gr00t",
+                "embodiment_tag": "DROID",
+                "latency_ms": 1.0,
+                "translated_action_count": 40,
+            },
+            "raw_action_shapes",
+        ),
+    ],
+)
+def test_harness_robotics_compare_rows_report_missing_keys(
+    helper_name: str,
+    flow_id: str,
+    summary: dict,
+    missing_key: str,
+) -> None:
+    from worldforge.harness import flows
+
+    helper = getattr(flows, helper_name)
+
+    with pytest.raises(
+        WorldStateError,
+        match=rf"{flow_id} comparison summary missing required key '{missing_key}'",
+    ):
+        helper(summary)
 
 
 def test_harness_robotics_compare_flow_can_emit_transcript(tmp_path, capsys) -> None:

--- a/tests/test_harness_flows.py
+++ b/tests/test_harness_flows.py
@@ -73,6 +73,7 @@ def test_harness_flow_metadata_is_available_without_textual() -> None:
         "lerobot",
         "cosmos-policy",
         "gr00t-replay",
+        "robotics-compare",
         "diagnostics",
         "workbench",
     ]
@@ -83,8 +84,11 @@ def test_harness_flow_metadata_is_available_without_textual() -> None:
     assert payload[1]["focus"] == "policy plus score planning"
     assert payload[2]["command"] == "uv run --extra harness worldforge-harness --flow cosmos-policy"
     assert payload[3]["command"] == "uv run --extra harness worldforge-harness --flow gr00t-replay"
-    assert payload[4]["command"] == "uv run worldforge harness --flow diagnostics"
-    assert payload[5]["command"] == "uv run worldforge provider workbench mock"
+    assert payload[4]["command"] == (
+        "uv run --extra harness worldforge-harness --flow robotics-compare"
+    )
+    assert payload[5]["command"] == "uv run worldforge harness --flow diagnostics"
+    assert payload[6]["command"] == "uv run worldforge provider workbench mock"
 
 
 def test_harness_runs_leworldmodel_flow(tmp_path) -> None:
@@ -228,6 +232,61 @@ def test_harness_groot_replay_flow_can_emit_transcript(tmp_path, capsys) -> None
     assert summary["translated_action_count"] == 40
     assert "flow: gr00t-replay" in output
     assert "translated_actions: 40" in output
+
+
+def test_harness_runs_robotics_compare_flow(tmp_path) -> None:
+    run = run_flow("robotics-compare", state_dir=tmp_path)
+
+    assert run.flow.id == "robotics-compare"
+    assert len(run.steps) == 6
+    assert len(run.metrics) == 6
+    assert run.summary["comparison_count"] == 3
+    assert run.summary["gpu_required"] is False
+    rows = {row["flow_id"]: row for row in run.summary["rows"]}
+    assert rows["lerobot"]["candidate_count"] == 3
+    assert rows["lerobot"]["selected_candidate_index"] == 1
+    assert rows["lerobot"]["translated_action_count"] == 2
+    assert rows["cosmos-policy"]["raw_shape"] == "50 x 14"
+    assert rows["cosmos-policy"]["translated_action_count"] == 50
+    assert rows["cosmos-policy"]["value_prediction"] == 0.190714
+    assert rows["gr00t-replay"]["raw_tensor_count"] == 3
+    assert rows["gr00t-replay"]["translated_action_count"] == 40
+    assert run.summary["total_translated_actions"] == 92
+    assert [event["phase"] for event in run.provider_events] == [
+        "success",
+        "success",
+        "success",
+    ]
+    transcript = "\n".join(run.transcript)
+    assert "flow: robotics-compare" in transcript
+    assert "comparison_artifact: artifacts/robotics-policy-comparison.json" in transcript
+    assert run.workspace_path is not None
+    manifest = json.loads((run.workspace_path / "run_manifest.json").read_text())
+    assert manifest["artifact_paths"]["robotics_comparison"] == (
+        "artifacts/robotics-policy-comparison.json"
+    )
+    assert manifest["artifact_paths"]["cosmos_policy_replay"] == (
+        "artifacts/cosmos-policy-replay.json"
+    )
+    assert manifest["artifact_paths"]["gr00t_replay"] == "artifacts/gr00t-replay.json"
+    comparison = json.loads(
+        (run.workspace_path / "artifacts/robotics-policy-comparison.json").read_text()
+    )
+    assert comparison["source_validation"]["gr00t-replay"] == (
+        "validated live on RTX A6000; committed artifact is sanitized"
+    )
+    assert "observation" not in json.dumps(comparison)
+
+
+def test_harness_robotics_compare_flow_can_emit_transcript(tmp_path, capsys) -> None:
+    from worldforge.harness import flows
+
+    summary = flows._run_robotics_compare_demo(state_dir=tmp_path, emit=True)
+
+    output = capsys.readouterr().out
+    assert summary["comparison_count"] == 3
+    assert "flow: robotics-compare" in output
+    assert "total_translated_actions: 92" in output
 
 
 def test_harness_loads_groot_replay_artifact(tmp_path) -> None:

--- a/tests/test_harness_flows.py
+++ b/tests/test_harness_flows.py
@@ -327,6 +327,35 @@ def test_harness_robotics_compare_preserves_replay_artifacts_on_subflow_failure(
     assert run.provider_events[-1]["phase"] == "failure"
 
 
+def test_harness_robotics_compare_preserves_other_artifacts_when_subflow_raises(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    from worldforge.harness import flows
+
+    def failed_cosmos(*, state_dir: Path, emit: bool = False) -> dict:
+        _ = (state_dir, emit)
+        raise RuntimeError("transport exploded")
+
+    monkeypatch.setattr(flows, "_run_cosmos_policy_demo", failed_cosmos)
+
+    run = run_flow("robotics-compare", state_dir=tmp_path)
+
+    assert run.validation_errors == ("cosmos-policy: RuntimeError: transport exploded",)
+    assert run.workspace_path is not None
+    manifest = json.loads((run.workspace_path / "run_manifest.json").read_text())
+    assert manifest["status"] == "failed"
+    assert manifest["artifact_paths"]["robotics_comparison"] == (
+        "artifacts/robotics-policy-comparison.json"
+    )
+    assert manifest["artifact_paths"]["gr00t_replay"] == "artifacts/gr00t-replay.json"
+    assert "cosmos_policy_replay" not in manifest["artifact_paths"]
+    assert run.provider_events[-1]["phase"] == "failure"
+    assert any(
+        event["metadata"].get("subflow_id") == "cosmos-policy" for event in run.provider_events
+    )
+
+
 @pytest.mark.parametrize(
     ("helper_name", "flow_id", "summary", "missing_key"),
     [

--- a/tests/test_harness_tui.py
+++ b/tests/test_harness_tui.py
@@ -348,6 +348,10 @@ def test_harness_status_pill_reflects_selected_flow_provider(tmp_path) -> None:
             assert pill.label.endswith("· policy")
             await pilot.press("5")
             await pilot.pause()
+            assert "LeRobot + Cosmos-Policy + GR00T" in pill.label
+            assert pill.label.endswith("· policy comparison")
+            await pilot.press("6")
+            await pilot.pause()
             assert pill.label.endswith("· diagnostics")
 
     asyncio.run(scenario())
@@ -416,7 +420,7 @@ def test_the_world_harness_app_switches_to_diagnostics_flow(tmp_path) -> None:
             step_delay=0.0,
         )
         async with app.run_test(size=(140, 44)) as pilot:
-            await pilot.press("5")
+            await pilot.press("6")
             await pilot.press("r")
             await pilot.pause()
             screen = app.screen
@@ -424,6 +428,32 @@ def test_the_world_harness_app_switches_to_diagnostics_flow(tmp_path) -> None:
             assert screen.last_run is not None
             assert screen.last_run.flow.id == "diagnostics"
             assert screen.last_run.summary["benchmark_operation_count"] == 5
+
+    asyncio.run(scenario())
+
+
+def test_the_world_harness_app_switches_to_robotics_compare_flow(tmp_path) -> None:
+    pytest.importorskip("textual")
+
+    from worldforge.harness.tui import RunInspectorScreen, TheWorldHarnessApp
+
+    async def scenario() -> None:
+        app = TheWorldHarnessApp(
+            initial_flow_id="leworldmodel",
+            initial_screen="run-inspector",
+            state_dir=tmp_path,
+            step_delay=0.0,
+        )
+        async with app.run_test(size=(150, 46)) as pilot:
+            await pilot.press("5")
+            await pilot.press("r")
+            await pilot.pause()
+            screen = app.screen
+            assert isinstance(screen, RunInspectorScreen)
+            assert screen.last_run is not None
+            assert screen.last_run.flow.id == "robotics-compare"
+            assert screen.last_run.summary["comparison_count"] == 3
+            assert screen.last_run.summary["total_translated_actions"] == 92
 
     asyncio.run(scenario())
 

--- a/tests/test_harness_tui.py
+++ b/tests/test_harness_tui.py
@@ -349,7 +349,7 @@ def test_harness_status_pill_reflects_selected_flow_provider(tmp_path) -> None:
             await pilot.press("5")
             await pilot.pause()
             assert "LeRobot + Cosmos-Policy + GR00T" in pill.label
-            assert pill.label.endswith("· policy comparison")
+            assert pill.label.endswith("· policy")
             await pilot.press("6")
             await pilot.pause()
             assert pill.label.endswith("· diagnostics")


### PR DESCRIPTION
Summary
- add a `robotics-compare` TheWorldHarness flow that runs LeRobot, Cosmos-Policy, and GR00T replay paths side by side
- preserve a sanitized comparison artifact plus the existing Cosmos and GR00T replay artifacts
- expose the flow in the TUI, CLI listings, README, and harness docs
- keep failure output in domain error categories (`ProviderError` for provider/runtime failures, `WorldStateError` for malformed state)

Why
- this makes the "LangChain for robotics" idea easier to inspect: different robotics policy providers, one WorldForge replay/validation/event surface
- no GPU is required for the comparison flow; Cosmos and GR00T use sanitized deterministic replay artifacts from prior live validation
- this is intentionally a checkout-safe replay/comparison path, not a live GPU artifact or robot hardware control path

Validation
- `uv lock --check`
- `uv run ruff check src tests examples scripts`
- `uv run ruff format --check src tests examples scripts`
- `uv run python scripts/generate_provider_docs.py --check`
- `uv run mkdocs build --strict`
- `uv run pytest tests/test_harness_flows.py tests/test_harness_cli.py tests/test_harness_tui.py -q` (131 passed)
- `uv run pytest -q` (1327 passed, 2 skipped)
