### PR TITLE
Add TensorBoard checkpoint visualization for the robotics showcase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ releases may still include breaking changes when the public API needs to tighten
 
 ### Added
 
+- Added an optional TensorBoard bridge for inspecting the LeWorldModel
+  checkpoint used during local inference in the robotics showcase. The new
+  `worldforge.tensorboard` module exposes `TensorBoardLogConfig`,
+  `TensorBoardSession`, `TensorBoardCheckpointInspector`, and a
+  `create_tensorboard_inspector` helper. It writes sanitized provenance text,
+  per-candidate cost scalars and a histogram, latency metrics, and a
+  per-provider-event text feed to a local `tfevents` directory.
+  `scripts/robotics-showcase` enables the writer by default (unless
+  `--no-tensorboard`, `--health-only`, or `--json-only` is passed) and gains
+  `--tensorboard`, `--tensorboard-logdir`, `--tensorboard-run-name`,
+  `--tensorboard-flush-secs`, and `--no-tensorboard` flags. Install with
+  `uv add "worldforge-ai[tensorboard]"`. Base WorldForge still depends only on
+  `httpx`. See `docs/src/tensorboard.md` for the tag layout and programmatic
+  API. Issue #302.
 - Added a public-API snapshot test. `tests/fixtures/public_api/exports.json`
   records the current export set for `worldforge`, `worldforge.testing`,
   `worldforge.observability`, `worldforge.providers`, and

--- a/README.md
+++ b/README.md
@@ -268,6 +268,13 @@ If you want Rerun-backed event and artifact recording:
 uv add "worldforge-ai[rerun]"
 ```
 
+If you want TensorBoard inspection of the LeWorldModel checkpoint used during
+the robotics showcase:
+
+```bash
+uv add "worldforge-ai[tensorboard]"
+```
+
 ### From source (bleeding edge)
 
 ```bash
@@ -288,6 +295,7 @@ Optional extras:
 ```bash
 uv sync --group dev --extra harness   # TheWorldHarness Textual TUI
 uv sync --group dev --extra rerun     # Rerun event and artifact recording
+uv sync --group dev --extra tensorboard  # TensorBoard LeWorldModel checkpoint inspection
 ```
 
 Python 3.13 only. Base install depends only on `httpx`. Optional runtimes are host-owned.

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -13,6 +13,7 @@
   - [Robotics Showcase Deep Dive](./robotics-showcase-deep-dive.md)
   - [TheWorldHarness](./theworldharness.md)
   - [Rerun Integration](./rerun.md)
+  - [TensorBoard Integration](./tensorboard.md)
 - System Model
   - [World Model Taxonomy](./world-model-taxonomy.md)
   - [Architecture](./architecture.md)

--- a/docs/src/robotics-showcase.md
+++ b/docs/src/robotics-showcase.md
@@ -48,7 +48,10 @@ By default, the script:
 - opens a staged Textual report with the pipeline trace, metric bars, tensor contract, candidate
   ranking, provider event log, robot-arm illustration, tabletop replay, and Rerun open shortcut;
 - writes a JSON summary to `/tmp/worldforge-robotics-showcase/real-run.json`;
-- writes a visual Rerun recording to `/tmp/worldforge-robotics-showcase/real-run.rrd`.
+- writes a visual Rerun recording to `/tmp/worldforge-robotics-showcase/real-run.rrd`;
+- writes TensorBoard ``tfevents`` logs under `.worldforge/tensorboard/` for
+  LeWorldModel checkpoint inspection (provenance, score distribution, latency,
+  provider events).
 
 Useful flags:
 
@@ -58,6 +61,8 @@ scripts/robotics-showcase --no-tui            # plain terminal report
 scripts/robotics-showcase --json-only         # machine-readable summary only
 scripts/robotics-showcase --no-rerun          # skip the default Rerun .rrd artifact
 scripts/robotics-showcase --rerun-output /tmp/pusht.rrd
+scripts/robotics-showcase --no-tensorboard    # skip the default TensorBoard tfevents
+scripts/robotics-showcase --tensorboard-logdir .worldforge/tensorboard/pusht
 scripts/robotics-showcase --tui-stage-delay 0.1
 scripts/robotics-showcase --no-tui-animation
 scripts/robotics-showcase --lewm-asset-cache-dir ~/.cache/worldforge/leworldmodel
@@ -69,6 +74,15 @@ Open the Rerun artifact from the TUI with `o`, or from the shell with:
 ```bash
 uvx --from "rerun-sdk>=0.24,<0.32" rerun /tmp/worldforge-robotics-showcase/real-run.rrd
 ```
+
+Open the TensorBoard logs with:
+
+```bash
+uvx --from "tensorboard>=2.16,<3" tensorboard --logdir .worldforge/tensorboard
+```
+
+See [TensorBoard Integration](./tensorboard.md) for the tag layout and
+programmatic API.
 
 ## CI Smoke Strategy
 

--- a/docs/src/tensorboard.md
+++ b/docs/src/tensorboard.md
@@ -1,0 +1,143 @@
+# TensorBoard Integration
+
+WorldForge ships an optional TensorBoard bridge for inspecting the LeWorldModel
+checkpoint used during local inference in the robotics showcase. It writes
+sanitized provenance text, latency and cost scalars, a histogram of candidate
+costs, and a per-event text feed to a local ``tfevents`` log directory.
+
+The integration is host-owned and local-only:
+
+- TensorBoard is **not** a provider capability and the catalog never advertises
+  it.
+- The base WorldForge install does **not** depend on ``tensorboard`` or
+  ``torch``. The bridge module imports the SDK lazily so the integration is a
+  no-op when the optional extra is absent.
+- ``tfevents`` files stay under the host-chosen log directory. WorldForge never
+  uploads them to a hosted service.
+
+## What you see in TensorBoard
+
+| Tag prefix | Plugin | What it shows |
+| --- | --- | --- |
+| ``worldforge/leworldmodel/checkpoint/*`` | Text, Scalars | LeWorldModel checkpoint path, policy, repo, revision, provenance JSON, and a `created` indicator. |
+| ``worldforge/leworldmodel/robotics_showcase/*`` | Text | Task description, checkpoint display path, state directory, sanitized JSON of the full run summary, inputs, and health snapshot. |
+| ``worldforge/leworldmodel/scores/*`` | Scalars, Histogram | Per-candidate costs, min/max/mean, best index, best score, and a histogram of the cost distribution. |
+| ``worldforge/leworldmodel/metrics/*`` | Scalars | Score stats and end-to-end latency metrics from the summary. |
+| ``worldforge/leworldmodel/events/<provider>/<operation>/*`` | Scalars, Text | Per-event attempt count, duration, status code, failure/retry flags, and the sanitized event message. |
+| ``worldforge/leworldmodel/weights/*`` | Histogram | Optional per-parameter weight distributions when a host passes a state dict to ``log_state_dict_histograms``. |
+
+The bridge sanitizes secret-like ``key=value`` fragments and signed-URL query
+parameters before writing text panels, so ``tfevents`` files are safe to share
+in adoption stories or evidence bundles.
+
+## Install
+
+```bash
+uv add "worldforge-ai[tensorboard]"
+```
+
+For repository development:
+
+```bash
+uv sync --group dev --extra tensorboard
+```
+
+The extra installs ``tensorboard>=2.16,<3``. Base WorldForge still depends only
+on ``httpx``. If the host already provides ``torch.utils.tensorboard`` (for
+example, through an existing PyTorch install) the bridge uses that;
+``tensorboardX`` is accepted as a fallback when both ``torch`` and
+``tensorboard`` are absent.
+
+## Robotics showcase flags
+
+``scripts/robotics-showcase`` enables the bridge by default when an interactive
+showcase is requested:
+
+| Flag | Default | Purpose |
+| --- | --- | --- |
+| ``--tensorboard`` | implied (unless ``--no-tensorboard`` / ``--health-only`` / ``--json-only``) | Enable the writer with a default log dir under ``.worldforge/tensorboard/``. |
+| ``--tensorboard-logdir <path>`` | ``.worldforge/tensorboard`` | Override the destination directory. Relative paths resolve against the repo root. |
+| ``--tensorboard-run-name <name>`` | timestamped name | Subdirectory under ``--tensorboard-logdir`` for this run. Pick a stable name to make repeated runs comparable in the same TensorBoard view. |
+| ``--tensorboard-flush-secs <int>`` | ``30`` | Flush interval (seconds) for the ``SummaryWriter``. |
+| ``--no-tensorboard`` | off | Disable the wrapper's default TensorBoard recording. |
+
+A typical inspection workflow:
+
+```bash
+# Record a real LeRobot + LeWorldModel run (TensorBoard enabled by default).
+scripts/robotics-showcase --json-only --no-tui --no-rerun
+
+# Open the run alongside the published checkpoint.
+uvx --from "tensorboard>=2.16,<3" tensorboard --logdir .worldforge/tensorboard
+```
+
+For an explicit destination:
+
+```bash
+scripts/robotics-showcase \
+  --tensorboard-logdir .worldforge/tensorboard/pusht \
+  --tensorboard-run-name baseline \
+  --no-tui --no-rerun --json-only
+```
+
+The summary JSON gains a ``"tensorboard"`` block listing ``log_dir``,
+``run_name``, ``flush_secs``, and an ``events_written`` flag that mirrors what
+the wrapper would show under the ``Artifacts`` section of the visual report.
+
+## Programmatic surface
+
+Hosts that already drive WorldForge directly can use the bridge without going
+through the showcase script. The public surface mirrors
+``worldforge.rerun`` and lives in ``worldforge.tensorboard``:
+
+```python
+from worldforge.tensorboard import (
+    TensorBoardCheckpointInspector,
+    TensorBoardLogConfig,
+    TensorBoardSession,
+    create_tensorboard_inspector,
+)
+
+inspector = create_tensorboard_inspector(
+    log_dir=".worldforge/tensorboard/checkpoint-inspection",
+    run_name="baseline",
+)
+inspector.log_checkpoint_summary(
+    {
+        "output": "/path/to/pusht/lewm_object.ckpt",
+        "policy": "pusht/lewm",
+        "repo_id": "galilai/lewm-pusht",
+        "revision": "<commit-sha>",
+    }
+)
+inspector.log_score_distribution(scores, best_index=1, best_score=scores[1])
+inspector.log_metrics({"plan_latency_ms": 25.0, "total_latency_ms": 30.0})
+
+# Optional: surface per-parameter weight histograms when host has the live
+# checkpoint loaded. Tensor-like values (``detach``/``cpu``/``numpy``) are
+# flattened automatically.
+inspector.log_state_dict_histograms(model.state_dict())
+
+inspector.flush()
+inspector.close()
+```
+
+The session is initialized lazily, so constructing an inspector is free of side
+effects until the first ``log_*`` call. ``close()`` is idempotent.
+
+## Boundaries
+
+- The bridge never advertises ``predict``, ``generate``, ``reason``, ``embed``,
+  ``plan``, ``transfer``, ``score``, or ``policy`` capabilities. It is purely
+  observability.
+- The bridge never imports torch on its own. Weight histograms require the host
+  to pass tensor-like objects through ``log_state_dict_histograms`` -
+  appropriate when the LeWorldModel runtime is already loaded host-side.
+- The bridge never reads ``.env`` or any other secret file. Provider event
+  messages are sanitized in :mod:`worldforge.models` before they reach the
+  bridge; the bridge then applies a second pass that strips ``api_key=``,
+  ``token=``, ``secret=``, ``signature=``, and signed-URL ``?signature=`` /
+  ``?token=`` query fragments before writing text panels.
+- ``tfevents`` files stay local. If you want to share a TensorBoard run as
+  release evidence, archive the log directory the same way you archive any
+  other showcase artifact.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,9 @@ harness = [
 rerun = [
     "rerun-sdk>=0.24,<0.32",
 ]
+tensorboard = [
+    "tensorboard>=2.16,<3",
+]
 
 [dependency-groups]
 dev = [

--- a/scripts/check_optional_import_boundaries.py
+++ b/scripts/check_optional_import_boundaries.py
@@ -73,6 +73,7 @@ DEFAULT_BOUNDARIES = (
             "src/worldforge/providers/jepa_wms.py",
             "src/worldforge/providers/lerobot.py",
             "src/worldforge/smoke/jepa_wms.py",
+            "src/worldforge/tensorboard.py",
         ),
         triage_step="Keep torch imports in prepared-host providers or optional smoke modules.",
     ),

--- a/scripts/robotics-showcase
+++ b/scripts/robotics-showcase
@@ -62,6 +62,28 @@ should_enable_rerun() {
   return 0
 }
 
+has_tensorboard_arg() {
+  for arg in "$@"; do
+    case "$arg" in
+      --tensorboard|--tensorboard-logdir|--tensorboard-run-name|--tensorboard-flush-secs)
+        return 0
+        ;;
+    esac
+  done
+  return 1
+}
+
+should_enable_tensorboard() {
+  for arg in "$@"; do
+    case "$arg" in
+      --help|-h|--health-only|--no-tensorboard)
+        return 1
+        ;;
+    esac
+  done
+  return 0
+}
+
 is_help_request() {
   for arg in "$@"; do
     case "$arg" in
@@ -84,6 +106,9 @@ showcase_args=("$@")
 if should_enable_rerun "$@" && ! has_rerun_sink_arg "$@"; then
   showcase_args=(--rerun "$@")
 fi
+if should_enable_tensorboard "$@" && ! has_tensorboard_arg "$@"; then
+  showcase_args=(--tensorboard "${showcase_args[@]}")
+fi
 runtime_args=(
   --with "stable-worldmodel @ git+https://github.com/galilai-group/stable-worldmodel.git"
   --with "datasets>=2.21"
@@ -99,6 +124,7 @@ runtime_args=(
   --with "pymunk"
   --with "gymnasium"
   --with "shapely"
+  --with "tensorboard>=2.16,<3"
 )
 
 if should_launch_tui "$@"; then

--- a/src/worldforge/smoke/lerobot_leworldmodel.py
+++ b/src/worldforge/smoke/lerobot_leworldmodel.py
@@ -12,6 +12,7 @@ action tensor bridge must all describe the same robotics task.
 from __future__ import annotations
 
 import argparse
+import contextlib
 import importlib
 import importlib.util
 import json
@@ -513,6 +514,73 @@ def _rerun_payload(args: argparse.Namespace, session: object | None) -> dict[str
     }
 
 
+def _create_tensorboard_inspector(args: argparse.Namespace) -> object | None:
+    if getattr(args, "tensorboard_logdir", None) is None:
+        return None
+    from worldforge.tensorboard import (
+        TensorBoardCheckpointInspector,
+        TensorBoardLogConfig,
+        TensorBoardSession,
+        default_run_name,
+    )
+
+    run_name = args.tensorboard_run_name or default_run_name("robotics-showcase")
+    config = TensorBoardLogConfig(
+        log_dir=args.tensorboard_logdir,
+        run_name=run_name,
+        flush_secs=args.tensorboard_flush_secs,
+    )
+    session = TensorBoardSession(config=config)
+    return TensorBoardCheckpointInspector(session=session)
+
+
+def _tensorboard_payload(
+    args: argparse.Namespace,
+    inspector: object | None,
+) -> dict[str, Any] | None:
+    if getattr(args, "tensorboard_logdir", None) is None or inspector is None:
+        return None
+    log_dir = getattr(inspector, "log_dir", None)
+    return {
+        "log_dir": str(log_dir) if log_dir is not None else str(args.tensorboard_logdir),
+        "run_name": args.tensorboard_run_name,
+        "flush_secs": args.tensorboard_flush_secs,
+        "events_written": None,
+    }
+
+
+def _finish_tensorboard_recording(
+    payload: dict[str, Any],
+    inspector: object | None,
+) -> None:
+    if inspector is None:
+        return
+    log_dir = getattr(inspector, "log_dir", None)
+    try:
+        inspector.flush()  # type: ignore[attr-defined]
+        inspector.close()  # type: ignore[attr-defined]
+    except Exception:
+        return
+    tb_payload = payload.get("tensorboard")
+    if not isinstance(tb_payload, dict):
+        return
+    if log_dir is None:
+        return
+    log_path = Path(str(log_dir))
+    events_written = False
+    if log_path.exists():
+        for entry in log_path.rglob("events.out.tfevents.*"):
+            if entry.is_file() and entry.stat().st_size > 0:
+                events_written = True
+                break
+    tb_payload.update(
+        {
+            "log_dir": str(log_path),
+            "events_written": events_written,
+        }
+    )
+
+
 def _finish_rerun_recording(
     payload: dict[str, Any],
     args: argparse.Namespace,
@@ -992,6 +1060,30 @@ def _parser() -> argparse.ArgumentParser:
         default=None,
         help="Serve the Rerun policy+score recording over an in-process gRPC endpoint.",
     )
+    parser.add_argument(
+        "--tensorboard-logdir",
+        type=Path,
+        default=None,
+        help=(
+            "Write per-run TensorBoard ``tfevents`` logs to this directory so the "
+            "LeWorldModel checkpoint's provenance, score distribution, latencies, and "
+            "provider events can be inspected with `tensorboard --logdir <path>`."
+        ),
+    )
+    parser.add_argument(
+        "--tensorboard-run-name",
+        default=None,
+        help=(
+            "Optional subdirectory name under --tensorboard-logdir for this run. Defaults "
+            "to a timestamped name when --tensorboard-logdir is provided without a run name."
+        ),
+    )
+    parser.add_argument(
+        "--tensorboard-flush-secs",
+        type=int,
+        default=30,
+        help="Flush interval (seconds) for the TensorBoard SummaryWriter. Defaults to 30.",
+    )
     parser.add_argument("--json-only", action="store_true")
     parser.add_argument(
         "--color",
@@ -1089,6 +1181,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     rerun_logging = _create_rerun_loggers(args)
     if rerun_logging is not None:
         rerun_session, rerun_events, rerun_artifacts = rerun_logging
+    tensorboard_inspector = _create_tensorboard_inspector(args)
 
     object_path, lewm_cache_dir = _resolve_checkpoint(
         policy=args.lewm_policy,
@@ -1136,6 +1229,9 @@ def main(argv: Sequence[str] | None = None) -> int:
         provider_events.append(event)
         if rerun_events is not None:
             rerun_events(event)  # type: ignore[operator]
+        if tensorboard_inspector is not None:
+            with contextlib.suppress(Exception):
+                tensorboard_inspector.log_provider_event(event)  # type: ignore[attr-defined]
 
     translator = _load_callable(args.translator, name="translator")
     candidate_builder = (
@@ -1227,6 +1323,15 @@ def main(argv: Sequence[str] | None = None) -> int:
             rerun_artifacts.log_json("robotics_showcase/preflight", payload)  # type: ignore[attr-defined]
         if rerun_session is not None:
             _finish_rerun_recording(payload, args, rerun_session)
+        tensorboard_payload = _tensorboard_payload(args, tensorboard_inspector)
+        if tensorboard_payload is not None:
+            payload["tensorboard"] = tensorboard_payload
+        if tensorboard_inspector is not None:
+            with contextlib.suppress(Exception):
+                tensorboard_inspector.log_json(  # type: ignore[attr-defined]
+                    "robotics_showcase/preflight", payload
+                )
+            _finish_tensorboard_recording(payload, tensorboard_inspector)
         if args.json_output is not None:
             _write_json_output(args.json_output, payload)
         if args.run_manifest is not None:
@@ -1473,6 +1578,21 @@ def main(argv: Sequence[str] | None = None) -> int:
         rerun_artifacts.log_robotics_showcase_summary(payload)  # type: ignore[attr-defined]
     if rerun_session is not None:
         _finish_rerun_recording(payload, args, rerun_session)
+    tensorboard_payload = _tensorboard_payload(args, tensorboard_inspector)
+    if tensorboard_payload is not None:
+        payload["tensorboard"] = tensorboard_payload
+    if tensorboard_inspector is not None:
+        with contextlib.suppress(Exception):
+            tensorboard_inspector.log_checkpoint_summary(  # type: ignore[attr-defined]
+                {
+                    "checkpoint": str(object_path),
+                    "output": str(object_path),
+                    "policy": args.lewm_policy,
+                    "created": checkpoint_exists,
+                }
+            )
+            tensorboard_inspector.log_robotics_showcase_summary(payload)  # type: ignore[attr-defined]
+        _finish_tensorboard_recording(payload, tensorboard_inspector)
     json_output_path = _write_json_output(args.json_output, payload) if args.json_output else None
     run_manifest_path = None
     if args.run_manifest is not None:
@@ -1562,10 +1682,12 @@ def main(argv: Sequence[str] | None = None) -> int:
         print(f"  mock final block       {execution_summary['final_block_position']}")
     _print_provider_events(event_payload)
     rerun_artifact = payload.get("rerun")
+    tensorboard_artifact = payload.get("tensorboard")
     if (
         json_output_path is not None
         or run_manifest_path is not None
         or isinstance(rerun_artifact, dict)
+        or isinstance(tensorboard_artifact, dict)
     ):
         print("\nArtifacts")
         print("---------")
@@ -1585,6 +1707,11 @@ def main(argv: Sequence[str] | None = None) -> int:
                 print(f"  rerun stream           {server_uri}")
             else:
                 print("  rerun recording        viewer")
+        if isinstance(tensorboard_artifact, dict):
+            log_dir = tensorboard_artifact.get("log_dir")
+            if log_dir:
+                suffix = " (events written)" if tensorboard_artifact.get("events_written") else ""
+                print(f"  tensorboard logdir     {_display_path(Path(str(log_dir)))}{suffix}")
     print("\nCompleted real LeRobot + LeWorldModel policy+score inference.")
     print("Use --json-only for the machine-readable summary.")
     return 0

--- a/src/worldforge/smoke/robotics_showcase.py
+++ b/src/worldforge/smoke/robotics_showcase.py
@@ -27,6 +27,7 @@ from .leworldmodel_bridges import get_bridge
 
 DEFAULT_JSON_OUTPUT = Path("/tmp/worldforge-robotics-showcase/real-run.json")
 DEFAULT_RERUN_OUTPUT = Path("/tmp/worldforge-robotics-showcase/real-run.rrd")
+DEFAULT_TENSORBOARD_OUTPUT = Path(".worldforge/tensorboard")
 DEFAULT_BRIDGE = "pusht"
 
 
@@ -159,6 +160,41 @@ def _parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Disable the wrapper's default Rerun recording.",
     )
+    parser.add_argument(
+        "--tensorboard",
+        action="store_true",
+        help=(
+            "Write TensorBoard ``tfevents`` logs for the LeWorldModel checkpoint run "
+            "under .worldforge/tensorboard/ so the checkpoint provenance, scores, "
+            "latencies, and provider events can be inspected with "
+            "`tensorboard --logdir <path>`."
+        ),
+    )
+    parser.add_argument(
+        "--tensorboard-logdir",
+        type=Path,
+        default=None,
+        help="Override the default TensorBoard log directory for this run.",
+    )
+    parser.add_argument(
+        "--tensorboard-run-name",
+        default=None,
+        help=(
+            "Optional subdirectory name under --tensorboard-logdir for this run. "
+            "Defaults to a timestamped run name when omitted."
+        ),
+    )
+    parser.add_argument(
+        "--tensorboard-flush-secs",
+        type=int,
+        default=30,
+        help="Flush interval (seconds) for the TensorBoard SummaryWriter. Defaults to 30.",
+    )
+    parser.add_argument(
+        "--no-tensorboard",
+        action="store_true",
+        help="Disable the wrapper's default TensorBoard recording.",
+    )
     parser.add_argument("--json-only", action="store_true")
     parser.add_argument(
         "--tui",
@@ -279,6 +315,15 @@ def _forward_args(args: argparse.Namespace) -> list[str]:
             forwarded.extend(["--rerun-output", str(args.rerun_output)])
         elif args.rerun:
             forwarded.extend(["--rerun-output", str(DEFAULT_RERUN_OUTPUT)])
+    if not args.no_tensorboard and not args.health_only:
+        logdir = args.tensorboard_logdir
+        if logdir is None and args.tensorboard:
+            logdir = DEFAULT_TENSORBOARD_OUTPUT
+        if logdir is not None:
+            forwarded.extend(["--tensorboard-logdir", str(logdir)])
+            if args.tensorboard_run_name is not None:
+                forwarded.extend(["--tensorboard-run-name", args.tensorboard_run_name])
+            forwarded.extend(["--tensorboard-flush-secs", str(args.tensorboard_flush_secs)])
     if args.json_only:
         forwarded.append("--json-only")
     if args.health_only:

--- a/src/worldforge/tensorboard.py
+++ b/src/worldforge/tensorboard.py
@@ -1,0 +1,649 @@
+"""Optional TensorBoard bridge for LeWorldModel checkpoint inspection.
+
+This module mirrors the optional-runtime shape of :mod:`worldforge.rerun`: the
+TensorBoard SDK is imported lazily so the base WorldForge install never pulls in
+``tensorboard`` or ``torch``. Hosts that want to inspect a LeWorldModel checkpoint
+during the robotics showcase install the optional extra and pass a configured
+:class:`TensorBoardSession` (or let the showcase wire one for them).
+
+The bridge is intentionally narrow: it logs provenance text, latency and cost
+scalars, a histogram of candidate-action costs, and a per-event text feed. It
+does not own any torch tensors or model graphs by itself — when the host
+already has live tensors (e.g. a loaded ``stable_worldmodel`` checkpoint), it
+can pass them through :meth:`TensorBoardCheckpointInspector.log_state_dict_histograms`
+to surface per-parameter weight distributions. The bridge is a no-op when the
+optional ``tensorboard`` extra is missing.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from importlib import import_module
+from pathlib import Path
+from threading import Lock
+from typing import Any
+
+from worldforge.models import JSONDict, ProviderEvent, WorldForgeError, require_json_dict
+
+_DEFAULT_NAMESPACE = "worldforge/leworldmodel"
+_TAG_SEGMENT_PATTERN = re.compile(r"[^A-Za-z0-9_.\-/]+")
+_SECRET_HINT_PATTERN = re.compile(
+    r"(api[_-]?key|token|secret|signature|password|authorization)=[^\s&]+",
+    re.IGNORECASE,
+)
+_SIGNED_URL_QUERY_PATTERN = re.compile(r"([?&](?:sig|signature|token|auth)=)[^&]+", re.IGNORECASE)
+
+
+def _require_text(value: object, *, name: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise WorldForgeError(f"{name} must be a non-empty string.")
+    return value.strip()
+
+
+def _require_optional_text(value: object, *, name: str) -> str | None:
+    if value is None:
+        return None
+    return _require_text(value, name=name)
+
+
+def _require_non_negative_int(value: object, *, name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise WorldForgeError(f"{name} must be a non-negative integer.")
+    return value
+
+
+def _require_positive_int(value: object, *, name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise WorldForgeError(f"{name} must be a positive integer.")
+    return value
+
+
+def _tag_segment(value: object, *, fallback: str = "item") -> str:
+    text = str(value).strip().strip("/")
+    if not text:
+        return fallback
+    segment = _TAG_SEGMENT_PATTERN.sub("_", text).strip("._-")
+    if not segment or segment.startswith("__"):
+        return fallback
+    return segment
+
+
+def _join_tag(namespace: str, *segments: object) -> str:
+    cleaned = [_tag_segment(namespace, fallback="worldforge")]
+    for segment in segments:
+        raw = str(segment).strip("/")
+        if not raw:
+            cleaned.append(_tag_segment(segment))
+            continue
+        cleaned.extend(_tag_segment(part) for part in raw.split("/") if part)
+    return "/".join(cleaned)
+
+
+def _validate_namespace(value: object, *, name: str) -> str:
+    text = _require_text(value, name=name).strip("/")
+    if not text:
+        raise WorldForgeError(f"{name} must contain at least one tag segment.")
+    parts = text.split("/")
+    if any(part.strip().startswith("__") for part in parts):
+        raise WorldForgeError(f"{name} must not contain reserved tag segments.")
+    cleaned = [_tag_segment(part) for part in parts]
+    return "/".join(cleaned)
+
+
+def _finite_float(value: object) -> float | None:
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        return None
+    number = float(value)
+    if number != number or number in (float("inf"), float("-inf")):
+        return None
+    return number
+
+
+def _sanitize_text(value: str) -> str:
+    def _redact_kv(match: re.Match[str]) -> str:
+        key = match.group(0).split("=", 1)[0]
+        return f"{key}=[REDACTED]"
+
+    redacted = _SECRET_HINT_PATTERN.sub(_redact_kv, value)
+    return _SIGNED_URL_QUERY_PATTERN.sub(r"\1[REDACTED]", redacted)
+
+
+def _pretty_json(payload: JSONDict) -> str:
+    try:
+        return json.dumps(payload, sort_keys=True, indent=2, allow_nan=False)
+    except (TypeError, ValueError) as exc:
+        raise WorldForgeError(
+            "TensorBoard text payloads must be JSON-serializable and contain only finite numbers."
+        ) from exc
+
+
+def _markdown_text(text: str) -> str:
+    sanitized = _sanitize_text(text)
+    return f"```\n{sanitized}\n```"
+
+
+def _load_summary_writer_class(sdk: object | None) -> Any:
+    """Return a callable that constructs a SummaryWriter-like object.
+
+    ``sdk`` may be either a class/callable returning a writer (used in tests)
+    or ``None`` (the production path that imports torch.utils.tensorboard).
+    """
+
+    if sdk is not None:
+        return sdk
+    try:
+        module = import_module("torch.utils.tensorboard")
+    except ModuleNotFoundError:
+        try:
+            module = import_module("tensorboardX")
+        except ModuleNotFoundError as exc:
+            raise WorldForgeError(
+                "TensorBoard integration requires the optional 'tensorboard' extra. Install with "
+                "`pip install 'worldforge-ai[tensorboard]'` or install `tensorboard` (and "
+                "`torch.utils.tensorboard` or `tensorboardX`) in the host environment."
+            ) from exc
+    writer_cls = getattr(module, "SummaryWriter", None)
+    if writer_cls is None:
+        raise WorldForgeError(
+            "TensorBoard module is missing the SummaryWriter class; install a supported "
+            "tensorboard or tensorboardX release."
+        )
+    return writer_cls
+
+
+def _try_load_numpy() -> Any | None:
+    try:
+        return import_module("numpy")
+    except ModuleNotFoundError:
+        return None
+
+
+def _call_if_present(target: object, name: str, *args: object, **kwargs: object) -> object | None:
+    method = getattr(target, name, None)
+    if method is None:
+        return None
+    return method(*args, **kwargs)
+
+
+def _is_tensor_like(value: object) -> bool:
+    return all(
+        callable(getattr(value, attr, None)) for attr in ("detach", "cpu", "numpy")
+    ) and not isinstance(value, dict | list | tuple | str | bytes)
+
+
+@dataclass(slots=True)
+class TensorBoardLogConfig:
+    """Configuration for a TensorBoard recording.
+
+    The recording is local-only: ``log_dir`` (combined with the optional
+    ``run_name`` subdirectory) is the destination for ``tfevents`` files. The
+    integration never uploads logs to a hosted service.
+    """
+
+    log_dir: str | Path
+    run_name: str | None = None
+    flush_secs: int = 30
+    max_queue: int = 10
+    filename_suffix: str = ""
+    purge_step: int | None = None
+    write_to_disk: bool = True
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.log_dir, str | Path):
+            raise WorldForgeError("log_dir must be a string or Path.")
+        path = Path(self.log_dir).expanduser()
+        if not str(path):
+            raise WorldForgeError("log_dir must not be empty.")
+        self.log_dir = path
+        self.run_name = _require_optional_text(self.run_name, name="run_name")
+        self.flush_secs = _require_positive_int(self.flush_secs, name="flush_secs")
+        self.max_queue = _require_positive_int(self.max_queue, name="max_queue")
+        if not isinstance(self.filename_suffix, str):
+            raise WorldForgeError("filename_suffix must be a string.")
+        if self.purge_step is not None:
+            self.purge_step = _require_non_negative_int(self.purge_step, name="purge_step")
+        if not isinstance(self.write_to_disk, bool):
+            raise WorldForgeError("write_to_disk must be a boolean.")
+
+    @property
+    def resolved_log_dir(self) -> Path:
+        """Return the final on-disk directory (``log_dir/run_name`` if set)."""
+
+        base = Path(self.log_dir).expanduser()
+        if self.run_name:
+            return base / self.run_name
+        return base
+
+
+@dataclass(slots=True)
+class TensorBoardSession:
+    """Lazy TensorBoard ``SummaryWriter`` session.
+
+    The optional SDK is loaded on the first call to :meth:`start`; constructing
+    a :class:`TensorBoardSession` is free of side effects, which keeps the
+    base import path light and matches the Rerun bridge contract.
+    """
+
+    config: TensorBoardLogConfig
+    sdk: object | None = None
+    _writer: object | None = field(default=None, init=False, repr=False)
+    _started: bool = field(default=False, init=False, repr=False)
+    _lock: Lock = field(default_factory=Lock, init=False, repr=False)
+
+    @property
+    def log_dir(self) -> Path:
+        return self.config.resolved_log_dir
+
+    def start(self) -> TensorBoardSession:
+        """Initialize the SummaryWriter and create the log directory."""
+
+        with self._lock:
+            if self._started:
+                return self
+            writer_cls = _load_summary_writer_class(self.sdk)
+            target = self.config.resolved_log_dir
+            if self.config.write_to_disk:
+                target.mkdir(parents=True, exist_ok=True)
+            writer = writer_cls(
+                log_dir=str(target),
+                flush_secs=self.config.flush_secs,
+                max_queue=self.config.max_queue,
+                filename_suffix=self.config.filename_suffix,
+                purge_step=self.config.purge_step,
+            )
+            self._writer = writer
+            self._started = True
+        return self
+
+    @property
+    def writer(self) -> Any:
+        """Return the initialized ``SummaryWriter``-like instance."""
+
+        return self.start()._writer
+
+    def flush(self) -> None:
+        with self._lock:
+            if self._writer is None:
+                return
+            _call_if_present(self._writer, "flush")
+
+    def close(self) -> None:
+        with self._lock:
+            if not self._started or self._writer is None:
+                return
+            _call_if_present(self._writer, "flush")
+            _call_if_present(self._writer, "close")
+            self._writer = None
+            self._started = False
+
+
+@dataclass(slots=True)
+class TensorBoardCheckpointInspector:
+    """Log LeWorldModel checkpoint provenance and per-run inference signals."""
+
+    session: TensorBoardSession
+    namespace: str = _DEFAULT_NAMESPACE
+    default_step: int = 0
+    _event_counter: int = field(default=0, init=False, repr=False)
+    _numpy: Any | None = field(default=None, init=False, repr=False)
+    _numpy_loaded: bool = field(default=False, init=False, repr=False)
+    _lock: Lock = field(default_factory=Lock, init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        self.namespace = _validate_namespace(self.namespace, name="namespace")
+        self.default_step = _require_non_negative_int(self.default_step, name="default_step")
+
+    @property
+    def log_dir(self) -> Path:
+        return self.session.log_dir
+
+    def close(self) -> None:
+        self.session.close()
+
+    def flush(self) -> None:
+        self.session.flush()
+
+    def _numpy_module(self) -> Any | None:
+        if not self._numpy_loaded:
+            self._numpy = _try_load_numpy()
+            self._numpy_loaded = True
+        return self._numpy
+
+    def _writer(self) -> Any:
+        return self.session.writer
+
+    def _next_event_step(self) -> int:
+        with self._lock:
+            step = self._event_counter
+            self._event_counter += 1
+        return step
+
+    def log_text(self, tag: str, text: str, *, step: int | None = None) -> None:
+        """Log a sanitized text panel under ``namespace/tag``."""
+
+        clean_tag = _join_tag(self.namespace, _require_text(tag, name="tag"))
+        if not isinstance(text, str):
+            raise WorldForgeError("text must be a string.")
+        writer = self._writer()
+        add_text = getattr(writer, "add_text", None)
+        if add_text is None:
+            return
+        add_text(clean_tag, _markdown_text(text), step or self.default_step)
+
+    def log_json(self, tag: str, payload: object, *, step: int | None = None) -> None:
+        """Log a JSON dict as a sanitized text panel."""
+
+        dict_payload = require_json_dict(payload, name="payload")
+        rendered = _pretty_json(dict_payload)
+        self.log_text(tag, rendered, step=step)
+
+    def log_scalar(self, tag: str, value: object, *, step: int | None = None) -> None:
+        """Log a finite float scalar under ``namespace/tag``."""
+
+        number = _finite_float(value)
+        if number is None:
+            return
+        clean_tag = _join_tag(self.namespace, _require_text(tag, name="tag"))
+        writer = self._writer()
+        add_scalar = getattr(writer, "add_scalar", None)
+        if add_scalar is None:
+            return
+        add_scalar(clean_tag, number, step or self.default_step)
+
+    def log_histogram(
+        self,
+        tag: str,
+        values: object,
+        *,
+        step: int | None = None,
+        bins: str | int = "auto",
+    ) -> None:
+        """Log a histogram of finite floats under ``namespace/tag``.
+
+        Falls back to no-op when numpy and torch are both unavailable.
+        """
+
+        cleaned = self._numeric_array(values)
+        if cleaned is None or len(cleaned) == 0:
+            return
+        clean_tag = _join_tag(self.namespace, _require_text(tag, name="tag"))
+        writer = self._writer()
+        add_histogram = getattr(writer, "add_histogram", None)
+        if add_histogram is None:
+            return
+        add_histogram(clean_tag, cleaned, step or self.default_step, bins=bins)
+
+    def log_checkpoint_summary(self, payload: object) -> None:
+        """Log LeWorldModel checkpoint provenance fields as text and scalars."""
+
+        data = require_json_dict(payload, name="checkpoint_summary")
+        self.log_json("checkpoint/provenance", data)
+        path = data.get("output") or data.get("checkpoint")
+        if isinstance(path, str) and path.strip():
+            self.log_text("checkpoint/path", path)
+        revision = data.get("revision")
+        if isinstance(revision, str) and revision.strip():
+            self.log_text("checkpoint/revision", revision)
+        repo_id = data.get("repo_id")
+        if isinstance(repo_id, str) and repo_id.strip():
+            self.log_text("checkpoint/repo", repo_id)
+        policy = data.get("policy")
+        if isinstance(policy, str) and policy.strip():
+            self.log_text("checkpoint/policy", policy)
+        for key in ("created",):
+            value = data.get(key)
+            if isinstance(value, bool):
+                self.log_scalar(f"checkpoint/{key}", 1.0 if value else 0.0)
+
+    def log_score_distribution(
+        self,
+        scores: Iterable[object],
+        *,
+        step: int | None = None,
+        best_index: int | None = None,
+        best_score: object = None,
+    ) -> None:
+        """Log per-candidate cost scalars and a histogram of the distribution."""
+
+        finite_scores: list[float] = []
+        for index, raw in enumerate(scores):
+            number = _finite_float(raw)
+            if number is None:
+                continue
+            finite_scores.append(number)
+            self.log_scalar(f"scores/candidate_{index:03d}", number, step=step)
+        if not finite_scores:
+            return
+        self.log_histogram("scores/cost_distribution", finite_scores, step=step)
+        self.log_scalar("scores/min", min(finite_scores), step=step)
+        self.log_scalar("scores/max", max(finite_scores), step=step)
+        self.log_scalar(
+            "scores/mean",
+            sum(finite_scores) / len(finite_scores),
+            step=step,
+        )
+        if isinstance(best_index, int) and not isinstance(best_index, bool):
+            self.log_scalar("scores/best_index", float(best_index), step=step)
+        best_number = _finite_float(best_score)
+        if best_number is not None:
+            self.log_scalar("scores/best_score", best_number, step=step)
+
+    def log_metrics(self, metrics: Mapping[str, object], *, step: int | None = None) -> None:
+        """Log a mapping of metric names to finite scalars."""
+
+        if not isinstance(metrics, Mapping):
+            raise WorldForgeError("metrics must be a mapping.")
+        for key, value in metrics.items():
+            number = _finite_float(value)
+            if number is None:
+                continue
+            self.log_scalar(f"metrics/{_tag_segment(key)}", number, step=step)
+
+    def log_provider_event(self, event: ProviderEvent) -> None:
+        """Append a sanitized provider event entry to the text feed."""
+
+        if not isinstance(event, ProviderEvent):
+            raise WorldForgeError(
+                "TensorBoardCheckpointInspector.log_provider_event accepts ProviderEvent only.",
+            )
+        step = self._next_event_step()
+        tag_suffix = f"events/{_tag_segment(event.provider)}/{_tag_segment(event.operation)}"
+        message = event.message or f"{event.provider}.{event.operation} {event.phase}"
+        self.log_text(f"{tag_suffix}/log", message, step=step)
+        self.log_scalar(f"{tag_suffix}/attempt", float(event.attempt), step=step)
+        self.log_scalar(
+            f"{tag_suffix}/max_attempts",
+            float(event.max_attempts),
+            step=step,
+        )
+        if event.duration_ms is not None:
+            self.log_scalar(f"{tag_suffix}/duration_ms", event.duration_ms, step=step)
+        if event.status_code is not None:
+            self.log_scalar(f"{tag_suffix}/status_code", float(event.status_code), step=step)
+        self.log_scalar(
+            f"{tag_suffix}/failure",
+            1.0 if event.phase == "failure" else 0.0,
+            step=step,
+        )
+        self.log_scalar(
+            f"{tag_suffix}/retry",
+            1.0 if event.phase == "retry" else 0.0,
+            step=step,
+        )
+
+    def log_robotics_showcase_summary(self, summary: object) -> None:
+        """Log the robotics showcase summary as text, scalars, and a histogram."""
+
+        payload = require_json_dict(summary, name="robotics_showcase_summary")
+        self.log_text(
+            "robotics_showcase/summary",
+            _pretty_json(payload),
+        )
+        for key in ("task", "checkpoint_display", "checkpoint", "state_dir"):
+            value = payload.get(key)
+            if isinstance(value, str) and value.strip():
+                self.log_text(f"robotics_showcase/{key}", value)
+        inputs = payload.get("inputs")
+        if isinstance(inputs, dict):
+            self.log_json("robotics_showcase/inputs", inputs)
+        health = payload.get("health")
+        if isinstance(health, dict):
+            self.log_json("robotics_showcase/health", health)
+        score_result = payload.get("score_result")
+        if isinstance(score_result, dict):
+            self.log_score_distribution(
+                score_result.get("scores", []),
+                best_index=score_result.get("best_index"),
+                best_score=score_result.get("best_score"),
+            )
+        score_stats = payload.get("score_stats")
+        if isinstance(score_stats, dict):
+            mapped = {
+                "score_min": score_stats.get("score_min"),
+                "score_max": score_stats.get("score_max"),
+                "score_mean": score_stats.get("score_mean"),
+                "score_median": score_stats.get("score_median"),
+                "score_range": score_stats.get("score_range"),
+                "gap_to_runner_up": score_stats.get("gap_to_runner_up"),
+            }
+            self.log_metrics(mapped)
+        metrics = payload.get("metrics")
+        if isinstance(metrics, dict):
+            self.log_metrics(metrics)
+        events = payload.get("provider_events")
+        if isinstance(events, list):
+            for entry in events:
+                provider_event = self._coerce_provider_event(entry)
+                if provider_event is not None:
+                    self.log_provider_event(provider_event)
+
+    def log_state_dict_histograms(
+        self,
+        state_dict: Mapping[str, object],
+        *,
+        step: int | None = None,
+    ) -> int:
+        """Log per-parameter weight histograms from a state-dict mapping.
+
+        Tensor-like values (objects exposing ``detach``/``cpu``/``numpy``) are
+        flattened and logged as histograms. Other values are ignored. Returns
+        the number of parameters that produced a histogram.
+        """
+
+        if not isinstance(state_dict, Mapping):
+            raise WorldForgeError("state_dict must be a mapping.")
+        logged = 0
+        for name, tensor in state_dict.items():
+            if not _is_tensor_like(tensor):
+                continue
+            try:
+                array = tensor.detach().cpu().numpy()  # type: ignore[union-attr]
+            except Exception:
+                continue
+            self.log_histogram(f"weights/{_tag_segment(name)}", array, step=step)
+            logged += 1
+        return logged
+
+    def _coerce_provider_event(self, candidate: object) -> ProviderEvent | None:
+        if isinstance(candidate, ProviderEvent):
+            return candidate
+        if not isinstance(candidate, dict):
+            return None
+        provider = candidate.get("provider")
+        operation = candidate.get("operation")
+        phase = candidate.get("phase")
+        if (
+            not isinstance(provider, str)
+            or not isinstance(operation, str)
+            or not isinstance(
+                phase,
+                str,
+            )
+        ):
+            return None
+        kwargs: dict[str, object] = {
+            "provider": provider,
+            "operation": operation,
+            "phase": phase,
+        }
+        for field_name in (
+            "attempt",
+            "max_attempts",
+            "method",
+            "target",
+            "status_code",
+            "duration_ms",
+            "message",
+            "metadata",
+            "run_id",
+            "request_id",
+            "trace_id",
+            "span_id",
+            "artifact_id",
+            "input_digest",
+        ):
+            if field_name in candidate:
+                kwargs[field_name] = candidate[field_name]
+        try:
+            return ProviderEvent(**kwargs)  # type: ignore[arg-type]
+        except (WorldForgeError, TypeError, ValueError):
+            return None
+
+    def _numeric_array(self, values: object) -> Any:
+        if _is_tensor_like(values):
+            try:
+                return values.detach().cpu().numpy()  # type: ignore[union-attr]
+            except Exception:
+                return None
+        if not isinstance(values, Iterable) or isinstance(values, str | bytes):
+            return None
+        finite_values: list[float] = []
+        for raw in values:
+            number = _finite_float(raw)
+            if number is not None:
+                finite_values.append(number)
+        if not finite_values:
+            return []
+        numpy = self._numpy_module()
+        if numpy is not None:
+            return numpy.asarray(finite_values, dtype="float64")
+        return finite_values
+
+
+def default_run_name(prefix: str = "run") -> str:
+    """Return a timestamped run name suitable for ``run_name``."""
+
+    safe_prefix = _tag_segment(prefix, fallback="run")
+    return f"{safe_prefix}-{datetime.now(UTC).strftime('%Y%m%dT%H%M%SZ')}"
+
+
+def create_tensorboard_inspector(
+    *,
+    log_dir: str | Path,
+    run_name: str | None = None,
+    namespace: str = _DEFAULT_NAMESPACE,
+    flush_secs: int = 30,
+    sdk: object | None = None,
+) -> TensorBoardCheckpointInspector:
+    """Create a configured :class:`TensorBoardCheckpointInspector`."""
+
+    config = TensorBoardLogConfig(
+        log_dir=log_dir,
+        run_name=run_name,
+        flush_secs=flush_secs,
+    )
+    session = TensorBoardSession(config=config, sdk=sdk)
+    return TensorBoardCheckpointInspector(session=session, namespace=namespace)
+
+
+__all__ = [
+    "TensorBoardCheckpointInspector",
+    "TensorBoardLogConfig",
+    "TensorBoardSession",
+    "create_tensorboard_inspector",
+    "default_run_name",
+]

--- a/tests/test_lerobot_leworldmodel_smoke_script.py
+++ b/tests/test_lerobot_leworldmodel_smoke_script.py
@@ -742,3 +742,94 @@ def test_main_health_only_reports_missing_checkpoint_without_loading_inputs(
     assert payload["checkpoint_exists"] is False
     assert payload["health"]["leworldmodel"]["healthy"] is False
     assert "object checkpoint not found" in payload["health"]["leworldmodel"]["details"]
+
+
+class _FakeSummaryWriter:
+    def __init__(self, **kwargs: object) -> None:
+        self.log_dir = kwargs.get("log_dir")
+        self.scalars: list[tuple[str, float, int]] = []
+        self.texts: list[tuple[str, str, int]] = []
+        self.histograms: list[tuple[str, object, int]] = []
+        self.closed = False
+
+    def add_scalar(self, tag: str, value: float, step: int) -> None:
+        self.scalars.append((tag, float(value), int(step)))
+
+    def add_text(self, tag: str, text: str, step: int) -> None:
+        self.texts.append((tag, text, int(step)))
+
+    def add_histogram(self, tag: str, values: object, step: int, *, bins: object = "auto") -> None:
+        self.histograms.append((tag, values, int(step)))
+
+    def flush(self) -> None:
+        return None
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def test_main_json_flow_writes_tensorboard_logs(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import worldforge.tensorboard as tensorboard_module
+
+    captured_writers: list[_FakeSummaryWriter] = []
+
+    def fake_loader(sdk: object | None) -> object:
+        def _build(**kwargs: object) -> _FakeSummaryWriter:
+            writer = _FakeSummaryWriter(**kwargs)
+            captured_writers.append(writer)
+            return writer
+
+        return _build
+
+    monkeypatch.setattr(tensorboard_module, "_load_summary_writer_class", fake_loader)
+
+    checkpoint, observation_path, score_info_path = _write_common_inputs(tmp_path)
+    bridge_path = _write_candidate_builder(tmp_path)
+    tensorboard_dir = tmp_path / "tb"
+    _patch_fake_providers(monkeypatch)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "lewm-lerobot-real",
+            "--policy-path",
+            "lerobot/diffusion_pusht",
+            "--checkpoint",
+            str(checkpoint),
+            "--observation-json",
+            str(observation_path),
+            "--score-info-json",
+            str(score_info_path),
+            "--candidate-builder",
+            f"{bridge_path}:build",
+            "--expected-action-dim",
+            "2",
+            "--expected-horizon",
+            "2",
+            "--tensorboard-logdir",
+            str(tensorboard_dir),
+            "--tensorboard-run-name",
+            "unit-run",
+            "--tensorboard-flush-secs",
+            "10",
+            "--json-only",
+        ],
+    )
+
+    assert lerobot_leworldmodel.main() == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["tensorboard"]["log_dir"].endswith("unit-run")
+    assert payload["tensorboard"]["run_name"] == "unit-run"
+    assert payload["tensorboard"]["flush_secs"] == 10
+    assert len(captured_writers) == 1
+    writer = captured_writers[0]
+    assert writer.closed is True
+    scalar_tags = {tag for tag, *_ in writer.scalars}
+    assert "worldforge/leworldmodel/scores/best_index" in scalar_tags
+    text_tags = {tag for tag, *_ in writer.texts}
+    assert "worldforge/leworldmodel/checkpoint/provenance" in text_tags

--- a/tests/test_robotics_showcase.py
+++ b/tests/test_robotics_showcase.py
@@ -640,3 +640,117 @@ def test_robotics_showcase_tui_mode_captures_json_and_launches_report(
     assert captured["summary_path"] == json_path
     assert captured["stage_delay"] == 0.2
     assert captured["animate_arm"] is True
+
+
+def test_robotics_showcase_forwards_tensorboard_when_requested(monkeypatch) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_low_level_main(argv: list[str]) -> int:
+        captured["argv"] = argv
+        return 0
+
+    monkeypatch.setattr(robotics_showcase.lerobot_leworldmodel, "main", fake_low_level_main)
+
+    assert (
+        robotics_showcase.main(
+            [
+                "--checkpoint",
+                "/tmp/pusht/lewm_object.ckpt",
+                "--tensorboard",
+                "--no-json-output",
+            ]
+        )
+        == 0
+    )
+
+    forwarded = captured["argv"]
+    assert forwarded[forwarded.index("--tensorboard-logdir") + 1] == str(
+        robotics_showcase.DEFAULT_TENSORBOARD_OUTPUT
+    )
+    assert forwarded[forwarded.index("--tensorboard-flush-secs") + 1] == "30"
+    assert "--tensorboard-run-name" not in forwarded
+
+
+def test_robotics_showcase_forwards_tensorboard_with_explicit_logdir_and_run_name(
+    monkeypatch, tmp_path: Path
+) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_low_level_main(argv: list[str]) -> int:
+        captured["argv"] = argv
+        return 0
+
+    monkeypatch.setattr(robotics_showcase.lerobot_leworldmodel, "main", fake_low_level_main)
+
+    log_dir = tmp_path / "tb"
+    assert (
+        robotics_showcase.main(
+            [
+                "--checkpoint",
+                "/tmp/pusht/lewm_object.ckpt",
+                "--tensorboard-logdir",
+                str(log_dir),
+                "--tensorboard-run-name",
+                "run-42",
+                "--tensorboard-flush-secs",
+                "5",
+                "--no-json-output",
+            ]
+        )
+        == 0
+    )
+
+    forwarded = captured["argv"]
+    assert forwarded[forwarded.index("--tensorboard-logdir") + 1] == str(log_dir)
+    assert forwarded[forwarded.index("--tensorboard-run-name") + 1] == "run-42"
+    assert forwarded[forwarded.index("--tensorboard-flush-secs") + 1] == "5"
+
+
+def test_robotics_showcase_no_tensorboard_disables_default(monkeypatch) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_low_level_main(argv: list[str]) -> int:
+        captured["argv"] = argv
+        return 0
+
+    monkeypatch.setattr(robotics_showcase.lerobot_leworldmodel, "main", fake_low_level_main)
+
+    assert (
+        robotics_showcase.main(
+            [
+                "--checkpoint",
+                "/tmp/pusht/lewm_object.ckpt",
+                "--tensorboard",
+                "--no-tensorboard",
+                "--no-json-output",
+            ]
+        )
+        == 0
+    )
+
+    assert "--tensorboard-logdir" not in captured["argv"]
+
+
+def test_robotics_showcase_does_not_forward_tensorboard_for_health_only(monkeypatch) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_low_level_main(argv: list[str]) -> int:
+        captured["argv"] = argv
+        return 0
+
+    monkeypatch.setattr(robotics_showcase.lerobot_leworldmodel, "main", fake_low_level_main)
+
+    assert (
+        robotics_showcase.main(
+            [
+                "--checkpoint",
+                "/tmp/pusht/lewm_object.ckpt",
+                "--tensorboard",
+                "--health-only",
+                "--no-json-output",
+            ]
+        )
+        == 0
+    )
+
+    assert "--tensorboard-logdir" not in captured["argv"]

--- a/tests/test_tensorboard_integration.py
+++ b/tests/test_tensorboard_integration.py
@@ -1,0 +1,495 @@
+from __future__ import annotations
+
+import math
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import worldforge.tensorboard as tensorboard_module
+from worldforge.models import ProviderEvent, WorldForgeError
+from worldforge.tensorboard import (
+    TensorBoardCheckpointInspector,
+    TensorBoardLogConfig,
+    TensorBoardSession,
+    create_tensorboard_inspector,
+    default_run_name,
+)
+
+
+class _FakeSummaryWriter:
+    """In-memory stand-in for ``torch.utils.tensorboard.SummaryWriter``."""
+
+    def __init__(
+        self,
+        *,
+        log_dir: str,
+        flush_secs: int = 30,
+        max_queue: int = 10,
+        filename_suffix: str = "",
+        purge_step: int | None = None,
+    ) -> None:
+        self.log_dir = log_dir
+        self.flush_secs = flush_secs
+        self.max_queue = max_queue
+        self.filename_suffix = filename_suffix
+        self.purge_step = purge_step
+        self.scalars: list[tuple[str, float, int]] = []
+        self.texts: list[tuple[str, str, int]] = []
+        self.histograms: list[tuple[str, Any, int, str | int]] = []
+        self.closed = False
+        self.flushes = 0
+
+    def add_scalar(self, tag: str, value: float, step: int) -> None:
+        self.scalars.append((tag, float(value), int(step)))
+
+    def add_text(self, tag: str, text: str, step: int) -> None:
+        self.texts.append((tag, text, int(step)))
+
+    def add_histogram(self, tag: str, values: Any, step: int, *, bins: str | int = "auto") -> None:
+        self.histograms.append((tag, values, int(step), bins))
+
+    def flush(self) -> None:
+        self.flushes += 1
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def _factory(captured: list[_FakeSummaryWriter]) -> Any:
+    def _build(**kwargs: Any) -> _FakeSummaryWriter:
+        writer = _FakeSummaryWriter(**kwargs)
+        captured.append(writer)
+        return writer
+
+    return _build
+
+
+def _inspector(
+    tmp_path: Path, captured: list[_FakeSummaryWriter] | None = None
+) -> tuple[TensorBoardCheckpointInspector, list[_FakeSummaryWriter]]:
+    captured = captured if captured is not None else []
+    config = TensorBoardLogConfig(log_dir=tmp_path, run_name="unit")
+    session = TensorBoardSession(config=config, sdk=_factory(captured))
+    inspector = TensorBoardCheckpointInspector(session=session)
+    return inspector, captured
+
+
+def test_log_config_validates_inputs(tmp_path: Path) -> None:
+    with pytest.raises(WorldForgeError, match="log_dir must be a string or Path"):
+        TensorBoardLogConfig(log_dir=42)  # type: ignore[arg-type]
+
+    with pytest.raises(WorldForgeError, match="run_name must be a non-empty string"):
+        TensorBoardLogConfig(log_dir=tmp_path, run_name="   ")
+
+    with pytest.raises(WorldForgeError, match="flush_secs must be a positive integer"):
+        TensorBoardLogConfig(log_dir=tmp_path, flush_secs=0)
+
+    with pytest.raises(WorldForgeError, match="max_queue must be a positive integer"):
+        TensorBoardLogConfig(log_dir=tmp_path, max_queue=0)
+
+    with pytest.raises(WorldForgeError, match="filename_suffix must be a string"):
+        TensorBoardLogConfig(log_dir=tmp_path, filename_suffix=12)  # type: ignore[arg-type]
+
+    with pytest.raises(WorldForgeError, match="purge_step must be a non-negative integer"):
+        TensorBoardLogConfig(log_dir=tmp_path, purge_step=-1)
+
+    with pytest.raises(WorldForgeError, match="write_to_disk must be a boolean"):
+        TensorBoardLogConfig(log_dir=tmp_path, write_to_disk="yes")  # type: ignore[arg-type]
+
+
+def test_log_config_resolved_log_dir_includes_run_name(tmp_path: Path) -> None:
+    base = TensorBoardLogConfig(log_dir=tmp_path)
+    assert base.resolved_log_dir == tmp_path
+
+    nested = TensorBoardLogConfig(log_dir=tmp_path, run_name="run-001")
+    assert nested.resolved_log_dir == tmp_path / "run-001"
+
+
+def test_session_initializes_writer_lazily_and_creates_directory(tmp_path: Path) -> None:
+    captured: list[_FakeSummaryWriter] = []
+    config = TensorBoardLogConfig(log_dir=tmp_path, run_name="run-x", flush_secs=15)
+    session = TensorBoardSession(config=config, sdk=_factory(captured))
+
+    assert captured == []
+    assert not (tmp_path / "run-x").exists()
+
+    session.start()
+    session.start()  # idempotent
+    session.close()
+    session.close()
+
+    assert len(captured) == 1
+    writer = captured[0]
+    assert writer.log_dir == str(tmp_path / "run-x")
+    assert writer.flush_secs == 15
+    assert (tmp_path / "run-x").is_dir()
+    assert writer.closed is True
+    assert writer.flushes >= 1
+
+
+def test_session_skips_directory_creation_when_disabled(tmp_path: Path) -> None:
+    captured: list[_FakeSummaryWriter] = []
+    config = TensorBoardLogConfig(
+        log_dir=tmp_path / "nope",
+        run_name="run-y",
+        write_to_disk=False,
+    )
+    session = TensorBoardSession(config=config, sdk=_factory(captured))
+
+    session.start()
+    assert not (tmp_path / "nope" / "run-y").exists()
+
+
+def test_session_reports_missing_optional_extra(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    def missing_import(name: str) -> object:
+        raise ModuleNotFoundError(name)
+
+    monkeypatch.setattr(tensorboard_module, "import_module", missing_import)
+    session = TensorBoardSession(config=TensorBoardLogConfig(log_dir=tmp_path))
+
+    with pytest.raises(WorldForgeError, match="optional 'tensorboard' extra"):
+        session.start()
+
+
+def test_session_uses_tensorboardx_fallback(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    captured: list[_FakeSummaryWriter] = []
+    fake_module = type("FakeTBX", (), {"SummaryWriter": _factory(captured)})
+
+    def import_first_match(name: str) -> object:
+        if name == "torch.utils.tensorboard":
+            raise ModuleNotFoundError(name)
+        if name == "tensorboardX":
+            return fake_module
+        raise ModuleNotFoundError(name)
+
+    monkeypatch.setattr(tensorboard_module, "import_module", import_first_match)
+
+    session = TensorBoardSession(config=TensorBoardLogConfig(log_dir=tmp_path, run_name="tbx"))
+    session.start()
+    assert len(captured) == 1
+
+
+def test_session_rejects_missing_summary_writer_class(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    fake_module = type("EmptyTB", (), {})
+
+    def import_returns_empty(name: str) -> object:
+        if name == "torch.utils.tensorboard":
+            return fake_module
+        raise ModuleNotFoundError(name)
+
+    monkeypatch.setattr(tensorboard_module, "import_module", import_returns_empty)
+    session = TensorBoardSession(config=TensorBoardLogConfig(log_dir=tmp_path))
+
+    with pytest.raises(WorldForgeError, match="missing the SummaryWriter class"):
+        session.start()
+
+
+def test_inspector_validates_namespace(tmp_path: Path) -> None:
+    config = TensorBoardLogConfig(log_dir=tmp_path)
+    session = TensorBoardSession(config=config, sdk=_factory([]))
+
+    with pytest.raises(WorldForgeError, match="namespace must be a non-empty string"):
+        TensorBoardCheckpointInspector(session=session, namespace="")
+
+    with pytest.raises(WorldForgeError, match="namespace must contain at least one"):
+        TensorBoardCheckpointInspector(session=session, namespace="///")
+
+    with pytest.raises(WorldForgeError, match="namespace must not contain reserved"):
+        TensorBoardCheckpointInspector(session=session, namespace="__reserved")
+
+    with pytest.raises(WorldForgeError, match="default_step must be a non-negative integer"):
+        TensorBoardCheckpointInspector(session=session, default_step=-1)
+
+
+def test_inspector_log_methods_sanitize_and_dispatch(tmp_path: Path) -> None:
+    inspector, captured = _inspector(tmp_path)
+
+    inspector.log_text("greeting", "hello world api_key=supersecret")
+    inspector.log_text(
+        "links",
+        "open https://example.com/path?signature=abc&other=keep",
+    )
+    inspector.log_json("payload", {"alpha": 1, "beta": [1, 2, 3]})
+    inspector.log_scalar("metrics/latency_ms", 12.5)
+    inspector.log_scalar("metrics/latency_ms", float("nan"))  # silently dropped
+    inspector.log_histogram("scores/values", [0.1, 0.2, 0.3, float("nan")])
+    inspector.log_histogram("scores/empty", [float("nan")])  # silently dropped
+    inspector.log_metrics({"plan_latency_ms": 25.0, "skip_me": "not numeric"})
+
+    writer = captured[0]
+    texts = {tag: body for tag, body, _ in writer.texts}
+    assert "worldforge/leworldmodel/greeting" in texts
+    assert "api_key=[REDACTED]" in texts["worldforge/leworldmodel/greeting"]
+    assert "supersecret" not in texts["worldforge/leworldmodel/greeting"]
+    assert "signature=[REDACTED]" in texts["worldforge/leworldmodel/links"]
+    assert "alpha" in texts["worldforge/leworldmodel/payload"]
+    assert any(
+        tag == "worldforge/leworldmodel/metrics/latency_ms" and math.isclose(value, 12.5)
+        for tag, value, _ in writer.scalars
+    )
+    assert all(value == value for _tag, value, _ in writer.scalars)  # no NaN survives
+    assert any(tag == "worldforge/leworldmodel/scores/values" for tag, *_ in writer.histograms)
+    assert not any(tag == "worldforge/leworldmodel/scores/empty" for tag, *_ in writer.histograms)
+    assert any(
+        tag == "worldforge/leworldmodel/metrics/plan_latency_ms"
+        for tag, _value, _step in writer.scalars
+    )
+
+
+def test_inspector_text_requires_string_and_metrics_mapping(tmp_path: Path) -> None:
+    inspector, _ = _inspector(tmp_path)
+
+    with pytest.raises(WorldForgeError, match="text must be a string"):
+        inspector.log_text("tag", 42)  # type: ignore[arg-type]
+
+    with pytest.raises(WorldForgeError, match="metrics must be a mapping"):
+        inspector.log_metrics([("a", 1)])  # type: ignore[arg-type]
+
+
+def test_inspector_log_checkpoint_summary(tmp_path: Path) -> None:
+    inspector, captured = _inspector(tmp_path)
+
+    inspector.log_checkpoint_summary(
+        {
+            "created": True,
+            "output": "/tmp/lewm/pusht/lewm_object.ckpt",
+            "policy": "pusht/lewm",
+            "repo_id": "galilai/lewm-pusht",
+            "revision": "abc123",
+        }
+    )
+    writer = captured[0]
+    tags = {tag for tag, *_ in writer.texts}
+    assert "worldforge/leworldmodel/checkpoint/provenance" in tags
+    assert "worldforge/leworldmodel/checkpoint/path" in tags
+    assert "worldforge/leworldmodel/checkpoint/revision" in tags
+    assert "worldforge/leworldmodel/checkpoint/repo" in tags
+    assert "worldforge/leworldmodel/checkpoint/policy" in tags
+    scalar_tags = {tag for tag, *_ in writer.scalars}
+    assert "worldforge/leworldmodel/checkpoint/created" in scalar_tags
+
+
+def test_inspector_log_provider_event_emits_scalars_and_text(tmp_path: Path) -> None:
+    inspector, captured = _inspector(tmp_path)
+
+    inspector.log_provider_event(
+        ProviderEvent(
+            provider="leworldmodel",
+            operation="score",
+            phase="success",
+            duration_ms=12.3,
+            status_code=200,
+            attempt=2,
+            max_attempts=3,
+            message="ok",
+        )
+    )
+    inspector.log_provider_event(
+        ProviderEvent(
+            provider="leworldmodel",
+            operation="score",
+            phase="failure",
+        )
+    )
+
+    writer = captured[0]
+    tags = {tag for tag, *_ in writer.scalars}
+    assert "worldforge/leworldmodel/events/leworldmodel/score/duration_ms" in tags
+    assert "worldforge/leworldmodel/events/leworldmodel/score/failure" in tags
+    failure_values = [
+        value
+        for tag, value, _ in writer.scalars
+        if tag == "worldforge/leworldmodel/events/leworldmodel/score/failure"
+    ]
+    assert failure_values[-1] == 1.0
+
+    with pytest.raises(WorldForgeError, match="log_provider_event accepts ProviderEvent only"):
+        inspector.log_provider_event("oops")  # type: ignore[arg-type]
+
+
+def test_inspector_log_score_distribution_emits_histogram_and_stats(tmp_path: Path) -> None:
+    inspector, captured = _inspector(tmp_path)
+
+    inspector.log_score_distribution(
+        [0.4, 0.1, 0.6, float("inf"), 0.2],
+        best_index=1,
+        best_score=0.1,
+    )
+
+    writer = captured[0]
+    candidate_tags = sorted(tag for tag, *_ in writer.scalars if "/scores/candidate_" in tag)
+    assert len(candidate_tags) == 4
+    summary_tags = {tag for tag, *_ in writer.scalars}
+    assert "worldforge/leworldmodel/scores/min" in summary_tags
+    assert "worldforge/leworldmodel/scores/max" in summary_tags
+    assert "worldforge/leworldmodel/scores/mean" in summary_tags
+    assert "worldforge/leworldmodel/scores/best_index" in summary_tags
+    assert "worldforge/leworldmodel/scores/best_score" in summary_tags
+    histogram_tags = {tag for tag, *_ in writer.histograms}
+    assert "worldforge/leworldmodel/scores/cost_distribution" in histogram_tags
+
+
+def test_inspector_log_robotics_showcase_summary_dispatches_all_panels(
+    tmp_path: Path,
+) -> None:
+    inspector, captured = _inspector(tmp_path)
+    summary = {
+        "task": "PushT policy+world-model planning",
+        "checkpoint_display": "~/lewm/pusht/lewm_object.ckpt",
+        "checkpoint": "/tmp/lewm/pusht/lewm_object.ckpt",
+        "state_dir": "/tmp/state",
+        "inputs": {"score_action_candidates_shape": [3, 8, 2]},
+        "health": {"lerobot": {"healthy": True}},
+        "score_result": {
+            "scores": [0.5, 0.4, 0.6],
+            "best_index": 1,
+            "best_score": 0.4,
+        },
+        "score_stats": {
+            "score_min": 0.4,
+            "score_max": 0.6,
+            "score_mean": 0.5,
+            "score_median": 0.5,
+            "score_range": 0.2,
+            "gap_to_runner_up": 0.1,
+        },
+        "metrics": {"plan_latency_ms": 25.0, "total_latency_ms": 30.0},
+        "provider_events": [
+            {
+                "provider": "lerobot",
+                "operation": "policy",
+                "phase": "success",
+                "attempt": 1,
+                "max_attempts": 1,
+                "duration_ms": 11.0,
+            },
+            "not an event",  # tolerated silently
+            {"provider": "missing fields"},  # invalid, tolerated silently
+        ],
+    }
+    inspector.log_robotics_showcase_summary(summary)
+
+    writer = captured[0]
+    text_tags = {tag for tag, *_ in writer.texts}
+    assert "worldforge/leworldmodel/robotics_showcase/summary" in text_tags
+    assert "worldforge/leworldmodel/robotics_showcase/task" in text_tags
+    assert "worldforge/leworldmodel/robotics_showcase/inputs" in text_tags
+    assert "worldforge/leworldmodel/robotics_showcase/health" in text_tags
+    scalar_tags = {tag for tag, *_ in writer.scalars}
+    assert "worldforge/leworldmodel/scores/best_index" in scalar_tags
+    assert "worldforge/leworldmodel/metrics/score_mean" in scalar_tags
+    assert "worldforge/leworldmodel/metrics/plan_latency_ms" in scalar_tags
+    assert "worldforge/leworldmodel/events/lerobot/policy/duration_ms" in scalar_tags
+
+
+def test_inspector_state_dict_histograms(tmp_path: Path) -> None:
+    class _TensorStub:
+        def __init__(self, values: list[float]) -> None:
+            self._values = values
+
+        def detach(self) -> _TensorStub:
+            return self
+
+        def cpu(self) -> _TensorStub:
+            return self
+
+        def numpy(self) -> list[float]:
+            return self._values
+
+    inspector, captured = _inspector(tmp_path)
+    logged = inspector.log_state_dict_histograms(
+        {
+            "encoder.layer.0.weight": _TensorStub([0.1, -0.2, 0.05]),
+            "encoder.layer.0.bias": _TensorStub([0.0, 0.1]),
+            "metadata.note": "non-tensor entry",
+        }
+    )
+    assert logged == 2
+    writer = captured[0]
+    histogram_tags = {tag for tag, *_ in writer.histograms}
+    assert "worldforge/leworldmodel/weights/encoder.layer.0.weight" in histogram_tags
+    assert "worldforge/leworldmodel/weights/encoder.layer.0.bias" in histogram_tags
+
+    with pytest.raises(WorldForgeError, match="state_dict must be a mapping"):
+        inspector.log_state_dict_histograms([("encoder", _TensorStub([0.0]))])  # type: ignore[arg-type]
+
+
+def test_inspector_state_dict_histograms_tolerates_broken_tensor(tmp_path: Path) -> None:
+    class _BadTensor:
+        def detach(self) -> _BadTensor:
+            return self
+
+        def cpu(self) -> _BadTensor:
+            return self
+
+        def numpy(self) -> list[float]:
+            raise RuntimeError("backend missing")
+
+    inspector, captured = _inspector(tmp_path)
+    logged = inspector.log_state_dict_histograms({"weights.bad": _BadTensor()})
+    assert logged == 0
+    # Broken tensor short-circuits before the writer is initialized.
+    assert captured == [] or captured[0].histograms == []
+
+
+def test_create_inspector_helper_and_default_run_name(tmp_path: Path) -> None:
+    captured: list[_FakeSummaryWriter] = []
+    inspector = create_tensorboard_inspector(
+        log_dir=tmp_path,
+        run_name=default_run_name(prefix="unit-test"),
+        flush_secs=5,
+        sdk=_factory(captured),
+    )
+    inspector.log_scalar("metrics/test", 1.0)
+    inspector.flush()
+    inspector.close()
+    assert captured[0].flush_secs == 5
+    assert captured[0].closed is True
+
+
+def test_inspector_handles_unfinite_scalars_and_nonnumeric_metrics(tmp_path: Path) -> None:
+    inspector, captured = _inspector(tmp_path)
+    inspector.log_scalar("metrics/inf", float("inf"))
+    inspector.log_scalar("metrics/string", "not a number")  # type: ignore[arg-type]
+    # Non-finite scalars are silently dropped before initializing the writer.
+    assert captured == [] or captured[0].scalars == []
+
+
+def test_log_histogram_with_tensor_like_values(tmp_path: Path) -> None:
+    class _Tensor:
+        def __init__(self, values: list[float]) -> None:
+            self._values = values
+
+        def detach(self) -> _Tensor:
+            return self
+
+        def cpu(self) -> _Tensor:
+            return self
+
+        def numpy(self) -> list[float]:
+            return self._values
+
+    inspector, captured = _inspector(tmp_path)
+    inspector.log_histogram("scores/tensor", _Tensor([1.0, 2.0, 3.0]))
+    assert len(captured[0].histograms) == 1
+    assert captured[0].histograms[0][0] == "worldforge/leworldmodel/scores/tensor"
+
+
+def test_log_histogram_skips_non_iterable_values(tmp_path: Path) -> None:
+    inspector, captured = _inspector(tmp_path)
+    inspector.log_histogram("scores/scalar", 42)  # type: ignore[arg-type]
+    inspector.log_histogram("scores/string", "not iterable")
+    assert captured == [] or captured[0].histograms == []
+
+
+def test_log_json_rejects_unserializable_payload(tmp_path: Path) -> None:
+    inspector, _ = _inspector(tmp_path)
+    with pytest.raises(WorldForgeError):
+        inspector.log_json("bad", {"value": float("inf")})

--- a/uv.lock
+++ b/uv.lock
@@ -280,11 +280,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.16"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1a/88/bcf9709822fe69d02c2a6a77956c98ce6ea8ca8767a9aadcedc7eb6a2390/idna-3.16.tar.gz", hash = "sha256:d7a6da03db833450fca25d2358ac9ff06cd624577a4aea3a596d5c0f77b8e03d", size = 203770, upload-time = "2026-05-22T00:16:18.781Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+    { url = "https://files.pythonhosted.org/packages/94/16/70255075a9859a0e3adb789b68ceb0e210dec03934245fd98d248226572f/idna-3.16-py3-none-any.whl", hash = "sha256:cc246e3a3f89580c3a951b5ad298ca4638078b2cdd4f115654332b5c26daded5", size = 74165, upload-time = "2026-05-22T00:16:16.698Z" },
 ]
 
 [[package]]
@@ -735,15 +735,15 @@ wheels = [
 
 [[package]]
 name = "pymdown-extensions"
-version = "10.21.2"
+version = "10.21.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/df/08/f1c908c581fd11913da4711ea7ba32c0eee40b0190000996bb863b0c9349/pymdown_extensions-10.21.2.tar.gz", hash = "sha256:c3f55a5b8a1d0edf6699e35dcbea71d978d34ff3fa79f3d807b8a5b3fa90fbdc", size = 853922, upload-time = "2026-03-29T15:01:55.233Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9e/26/d1015444da4d952a1ca487a236b522eb979766f0295a0bd0c5fc089989a9/pymdown_extensions-10.21.3.tar.gz", hash = "sha256:72cfcf55f07aea0d4af2c4f11dd4e52466ddfb1bb819673146398e0bd3a77354", size = 854140, upload-time = "2026-05-13T12:57:32.267Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f7/27/a2fc51a4a122dfd1015e921ae9d22fee3d20b0b8080d9a704578bf9deece/pymdown_extensions-10.21.2-py3-none-any.whl", hash = "sha256:5c0fd2a2bea14eb39af8ff284f1066d898ab2187d81b889b75d46d4348c01638", size = 268901, upload-time = "2026-03-29T15:01:53.244Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/85/545a951eecc270fcd688288c600017e2050a1aacb56c711d208586d3e470/pymdown_extensions-10.21.3-py3-none-any.whl", hash = "sha256:d7a5d08014fc571e80ca21dd6f854e31f94c489800350564d55d15b3c41e76b6", size = 269002, upload-time = "2026-05-13T12:57:30.296Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -3,6 +3,15 @@ revision = 3
 requires-python = "==3.13.*"
 
 [[package]]
+name = "absl-py"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/64/c7/8de93764ad66968d19329a7e0c147a2bb3c7054c554d4a119111b8f9440f/absl_py-2.4.0.tar.gz", hash = "sha256:8c6af82722b35cf71e0f4d1d47dcaebfff286e27110a99fc359349b247dfb5d4", size = 116543, upload-time = "2026-01-28T10:17:05.322Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/a6/907a406bb7d359e6a63f99c313846d9eec4f7e6f7437809e03aa00fa3074/absl_py-2.4.0-py3-none-any.whl", hash = "sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d", size = 135750, upload-time = "2026-01-28T10:17:04.19Z" },
+]
+
+[[package]]
 name = "anyio"
 version = "4.13.0"
 source = { registry = "https://pypi.org/simple" }
@@ -209,6 +218,27 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d9/29/d40217cbe2f6b1359e00c6c307bb3fc876ba74068cbab3dde77f03ca0dc4/ghp-import-2.1.0.tar.gz", hash = "sha256:9c535c4c61193c2df8871222567d7fd7e5014d835f97dc7b7439069e2413d343", size = 10943, upload-time = "2022-05-02T15:47:16.11Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f7/ec/67fbef5d497f86283db54c22eec6f6140243aae73265799baaaa19cd17fb/ghp_import-2.1.0-py3-none-any.whl", hash = "sha256:8337dd7b50877f163d4c0289bc1f1c7f127550241988d568c1db512c4324a619", size = 11034, upload-time = "2022-05-02T15:47:14.552Z" },
+]
+
+[[package]]
+name = "grpcio"
+version = "1.80.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b7/48/af6173dbca4454f4637a4678b67f52ca7e0c1ed7d5894d89d434fecede05/grpcio-1.80.0.tar.gz", hash = "sha256:29aca15edd0688c22ba01d7cc01cb000d72b2033f4a3c72a81a19b56fd143257", size = 12978905, upload-time = "2026-03-30T08:49:10.502Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2f/3a/7c3c25789e3f069e581dc342e03613c5b1cb012c4e8c7d9d5cf960a75856/grpcio-1.80.0-cp313-cp313-linux_armv7l.whl", hash = "sha256:e9e408fc016dffd20661f0126c53d8a31c2821b5c13c5d67a0f5ed5de93319ad", size = 6017243, upload-time = "2026-03-30T08:47:40.075Z" },
+    { url = "https://files.pythonhosted.org/packages/04/19/21a9806eb8240e174fd1ab0cd5b9aa948bb0e05c2f2f55f9d5d7405e6d08/grpcio-1.80.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:92d787312e613754d4d8b9ca6d3297e69994a7912a32fa38c4c4e01c272974b0", size = 12010840, upload-time = "2026-03-30T08:47:43.11Z" },
+    { url = "https://files.pythonhosted.org/packages/18/3a/23347d35f76f639e807fb7a36fad3068aed100996849a33809591f26eca6/grpcio-1.80.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8ac393b58aa16991a2f1144ec578084d544038c12242da3a215966b512904d0f", size = 6567644, upload-time = "2026-03-30T08:47:46.806Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/40/96e07ecb604a6a67ae6ab151e3e35b132875d98bc68ec65f3e5ab3e781d7/grpcio-1.80.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:68e5851ac4b9afe07e7f84483803ad167852570d65326b34d54ca560bfa53fb6", size = 7277830, upload-time = "2026-03-30T08:47:49.643Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/e2/da1506ecea1f34a5e365964644b35edef53803052b763ca214ba3870c856/grpcio-1.80.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:873ff5d17d68992ef6605330127425d2fc4e77e612fa3c3e0ed4e668685e3140", size = 6783216, upload-time = "2026-03-30T08:47:52.817Z" },
+    { url = "https://files.pythonhosted.org/packages/44/83/3b20ff58d0c3b7f6caaa3af9a4174d4023701df40a3f39f7f1c8e7c48f9d/grpcio-1.80.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:2bea16af2750fd0a899bf1abd9022244418b55d1f37da2202249ba4ba673838d", size = 7385866, upload-time = "2026-03-30T08:47:55.687Z" },
+    { url = "https://files.pythonhosted.org/packages/47/45/55c507599c5520416de5eefecc927d6a0d7af55e91cfffb2e410607e5744/grpcio-1.80.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ba0db34f7e1d803a878284cd70e4c63cb6ae2510ba51937bf8f45ba997cefcf7", size = 8391602, upload-time = "2026-03-30T08:47:58.303Z" },
+    { url = "https://files.pythonhosted.org/packages/10/bb/dd06f4c24c01db9cf11341b547d0a016b2c90ed7dbbb086a5710df7dd1d7/grpcio-1.80.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8eb613f02d34721f1acf3626dfdb3545bd3c8505b0e52bf8b5710a28d02e8aa7", size = 7826752, upload-time = "2026-03-30T08:48:01.311Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/1e/9d67992ba23371fd63d4527096eb8c6b76d74d52b500df992a3343fd7251/grpcio-1.80.0-cp313-cp313-win32.whl", hash = "sha256:93b6f823810720912fd131f561f91f5fed0fda372b6b7028a2681b8194d5d294", size = 4142310, upload-time = "2026-03-30T08:48:04.594Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/e6/283326a27da9e2c3038bc93eeea36fb118ce0b2d03922a9cda6688f53c5b/grpcio-1.80.0-cp313-cp313-win_amd64.whl", hash = "sha256:e172cf795a3ba5246d3529e4d34c53db70e888fa582a8ffebd2e6e48bc0cba50", size = 4882833, upload-time = "2026-03-30T08:48:07.363Z" },
 ]
 
 [[package]]
@@ -646,6 +676,21 @@ wheels = [
 ]
 
 [[package]]
+name = "protobuf"
+version = "7.35.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/60/fd/5b1491d9e4b586d621c54f4c36b888714164b6875f8d6afa3f9072906a51/protobuf-7.35.0.tar.gz", hash = "sha256:a2efd84605f41e559f1881b0912b44099d0a2ac9bf46b3474823f10fb393b0e6", size = 458677, upload-time = "2026-05-19T23:02:29.197Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/ee/93d06e358a4aa32280b00e722d3ea0a1f25fc3cc5778d80581c9cca2c10e/protobuf-7.35.0-cp310-abi3-macosx_10_9_universal2.whl", hash = "sha256:66be6c513931c794fa92c080ffee41671390da3d79da219cf9c0c0907f035dda", size = 433225, upload-time = "2026-05-19T23:02:19.884Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/39/1c76c2da93f3c507e958e0aecee2391cc44d4625de6c728bbc555195b5a8/protobuf-7.35.0-cp310-abi3-manylinux2014_aarch64.whl", hash = "sha256:fcbe42a4ac09d3ec9c987ddfcd956afd0b15f1ff613bd8371bde9405ffd5c8e5", size = 328847, upload-time = "2026-05-19T23:02:22.3Z" },
+    { url = "https://files.pythonhosted.org/packages/91/1a/39f7ce90a238c1a987a4d81ec26379e02ca0aff367de68e4a1fa474215b9/protobuf-7.35.0-cp310-abi3-manylinux2014_s390x.whl", hash = "sha256:4cbf5cc286130e06a6c9bbefac442431173906dfcc979712183d4adcc01b37ee", size = 344030, upload-time = "2026-05-19T23:02:23.591Z" },
+    { url = "https://files.pythonhosted.org/packages/70/5b/6baf9008817964454055ff3fe65f1de0b5f1e26c80c82f7fb108b7cd4ea3/protobuf-7.35.0-cp310-abi3-manylinux2014_x86_64.whl", hash = "sha256:6c0f98f10c8a05ea30f8993dfef2de093d27b490fdae78bb60c8343795d55011", size = 327130, upload-time = "2026-05-19T23:02:24.637Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/e5/e46adb0badc388bfb84877a5f9f026aff63f60e611016cf64dbe77e05446/protobuf-7.35.0-cp310-abi3-win32.whl", hash = "sha256:4c4617b83ade0e279d1d2bfe04025a1adb87f9ed657de038620dc0ff959357f6", size = 428946, upload-time = "2026-05-19T23:02:25.741Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/ab/547fbd9e16d879dd13c167478f8ae0a83a428008ca07a5e06acdc23ad473/protobuf-7.35.0-cp310-abi3-win_amd64.whl", hash = "sha256:f05bcadf9a2a6b8dda047007075135fb7d08c73d9177aabc067e1be46881a201", size = 439996, upload-time = "2026-05-19T23:02:26.808Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/ef/50433d346c56657a70d27f156c7b349ac59a068b01de4eb796e747eecc43/protobuf-7.35.0-py3-none-any.whl", hash = "sha256:c13f325cf242bad135c350629eeb5d54b24228eb472fb3e2e9ebbd4c5dc20ca0", size = 171659, upload-time = "2026-05-19T23:02:27.842Z" },
+]
+
+[[package]]
 name = "py-serializable"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -854,6 +899,15 @@ wheels = [
 ]
 
 [[package]]
+name = "setuptools"
+version = "82.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4f/db/cfac1baf10650ab4d1c111714410d2fbb77ac5a616db26775db562c8fab2/setuptools-82.0.1.tar.gz", hash = "sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9", size = 1152316, upload-time = "2026-03-09T12:47:17.221Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl", hash = "sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb", size = 1006223, upload-time = "2026-03-09T12:47:15.026Z" },
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -869,6 +923,36 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
+]
+
+[[package]]
+name = "tensorboard"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "absl-py" },
+    { name = "grpcio" },
+    { name = "markdown" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pillow" },
+    { name = "protobuf" },
+    { name = "setuptools" },
+    { name = "tensorboard-data-server" },
+    { name = "werkzeug" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/d9/a5db55f88f258ac669a92858b70a714bbbd5acd993820b41ec4a96a4d77f/tensorboard-2.20.0-py3-none-any.whl", hash = "sha256:9dc9f978cb84c0723acf9a345d96c184f0293d18f166bb8d59ee098e6cfaaba6", size = 5525680, upload-time = "2025-07-17T19:20:49.638Z" },
+]
+
+[[package]]
+name = "tensorboard-data-server"
+version = "0.7.2"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/13/e503968fefabd4c6b2650af21e110aa8466fe21432cd7c43a84577a89438/tensorboard_data_server-0.7.2-py3-none-any.whl", hash = "sha256:7e0610d205889588983836ec05dc098e80f97b7e7bbff7e994ebb78f578d0ddb", size = 2356, upload-time = "2023-10-23T21:23:32.16Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/85/dabeaf902892922777492e1d253bb7e1264cadce3cea932f7ff599e53fea/tensorboard_data_server-0.7.2-py3-none-macosx_10_9_x86_64.whl", hash = "sha256:9fe5d24221b29625dbc7328b0436ca7fc1c23de4acf4d272f1180856e32f9f60", size = 4823598, upload-time = "2023-10-23T21:23:33.714Z" },
+    { url = "https://files.pythonhosted.org/packages/73/c6/825dab04195756cf8ff2e12698f22513b3db2f64925bdd41671bfb33aaa5/tensorboard_data_server-0.7.2-py3-none-manylinux_2_31_x86_64.whl", hash = "sha256:ef687163c24185ae9754ed5650eb5bc4d84ff257aabdc33f0cc6f74d8ba54530", size = 6590363, upload-time = "2023-10-23T21:23:35.583Z" },
 ]
 
 [[package]]
@@ -964,6 +1048,18 @@ wheels = [
 ]
 
 [[package]]
+name = "werkzeug"
+version = "3.1.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dd/b2/381be8cfdee792dd117872481b6e378f85c957dd7c5bca38897b08f765fd/werkzeug-3.1.8.tar.gz", hash = "sha256:9bad61a4268dac112f1c5cd4630a56ede601b6ed420300677a869083d70a4c44", size = 875852, upload-time = "2026-04-02T18:49:14.268Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/8c/2e650f2afeb7ee576912636c23ddb621c91ac6a98e66dc8d29c3c69446e1/werkzeug-3.1.8-py3-none-any.whl", hash = "sha256:63a77fb8892bf28ebc3178683445222aa500e48ebad5ec77b0ad80f8726b1f50", size = 226459, upload-time = "2026-04-02T18:49:12.72Z" },
+]
+
+[[package]]
 name = "worldforge-ai"
 version = "0.5.0"
 source = { editable = "." }
@@ -977,6 +1073,9 @@ harness = [
 ]
 rerun = [
     { name = "rerun-sdk" },
+]
+tensorboard = [
+    { name = "tensorboard" },
 ]
 
 [package.dev-dependencies]
@@ -992,9 +1091,10 @@ dev = [
 requires-dist = [
     { name = "httpx", specifier = ">=0.27,<1.0" },
     { name = "rerun-sdk", marker = "extra == 'rerun'", specifier = ">=0.24,<0.32" },
+    { name = "tensorboard", marker = "extra == 'tensorboard'", specifier = ">=2.16,<3" },
     { name = "textual", marker = "extra == 'harness'", specifier = ">=8.2,<9" },
 ]
-provides-extras = ["harness", "rerun"]
+provides-extras = ["harness", "rerun", "tensorboard"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary

Closes #302.

Adds an optional TensorBoard bridge for inspecting the LeWorldModel checkpoint used during local inference in the robotics showcase. The integration follows the same optional-runtime shape as the existing Rerun bridge: the SDK is imported lazily, the base WorldForge install still depends only on `httpx`, and TensorBoard is never advertised as a provider capability.

- New `worldforge.tensorboard` module with `TensorBoardLogConfig`, `TensorBoardSession`, `TensorBoardCheckpointInspector`, and `create_tensorboard_inspector`. Logs sanitized provenance text, per-candidate cost scalars and a histogram, score-distribution stats, end-to-end latency metrics, and a per-provider-event text feed. Includes an opt-in `log_state_dict_histograms` for hosts that already hold a live torch state dict.
- `scripts/robotics-showcase` enables the writer by default (suppressed by `--no-tensorboard`, `--health-only`, or `--json-only`) and gains `--tensorboard`, `--tensorboard-logdir`, `--tensorboard-run-name`, `--tensorboard-flush-secs`, and `--no-tensorboard` flags. Defaults to `.worldforge/tensorboard/<timestamped-run>/`.
- `src/worldforge/smoke/lerobot_leworldmodel.py` plumbs the inspector through the run path. The run summary JSON gains a `tensorboard` block with the resolved `log_dir`, `run_name`, `flush_secs`, and an `events_written` flag.
- New optional dependency `tensorboard>=2.16,<3` exposed through `worldforge-ai[tensorboard]`. Base WorldForge still depends only on `httpx`. The optional-runtime Torch boundary allowlist now includes the new module, since the bridge lazily imports `torch.utils.tensorboard` (with a `tensorboardX` fallback).
- Docs: new `docs/src/tensorboard.md`, SUMMARY/robotics-showcase wiring, README install hint, and a CHANGELOG entry under Unreleased.

## Test plan

- [x] `uv lock --check`
- [x] `uv run ruff check src tests examples scripts`
- [x] `uv run ruff format --check src tests examples scripts`
- [x] `uv run python scripts/generate_provider_docs.py --check`
- [x] `uv run pytest` (1417 passed)
- [x] `uv run --extra harness pytest --cov=src/worldforge --cov-report=term-missing --cov-fail-under=90` (90.12% total; `src/worldforge/tensorboard.py` at 95%)
- [x] `bash scripts/test_package.sh` (1331 passed, 86 skipped in an isolated venv installed from the built wheel)
- [x] CLI: `uv run worldforge-robotics-showcase --help` lists the new flags
- [x] Unit tests for the bridge: validation, lazy SDK init, `tensorboardX` fallback, missing-extra error, secret/signed-URL sanitization, scalar/text/histogram dispatch, score-distribution stats, provider-event coercion, state-dict histograms, and broken-tensor tolerance
- [x] CLI tests: outer wrapper forwards `--tensorboard*` flags, `--no-tensorboard` disables forwarding, `--health-only` suppresses the writer, inner smoke writes tfevents through a fake `SummaryWriter`