### PR TITLE
Add TUI shortcut to open TensorBoard from the robotics showcase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ releases may still include breaking changes when the public API needs to tighten
 
 ### Added
 
+- Added a `t` keybinding to `RoboticsShowcaseApp` that launches the run's
+  TensorBoard log directory via
+  `uvx --from "tensorboard>=2.16,<3" tensorboard --logdir <path>` in a
+  detached subprocess, mirroring the existing `o` shortcut for Rerun. A new
+  `RoboticsTensorBoardPane` surfaces the resolved log directory, run name,
+  `events_written` status, the viewer command, and the shortcut hint. The
+  pane and binding gracefully degrade when the run summary has no
+  `"tensorboard"` block. Issue #304.
 - Added an optional TensorBoard bridge for inspecting the LeWorldModel
   checkpoint used during local inference in the robotics showcase. The new
   `worldforge.tensorboard` module exposes `TensorBoardLogConfig`,

--- a/docs/src/robotics-showcase.md
+++ b/docs/src/robotics-showcase.md
@@ -75,7 +75,7 @@ Open the Rerun artifact from the TUI with `o`, or from the shell with:
 uvx --from "rerun-sdk>=0.24,<0.32" rerun /tmp/worldforge-robotics-showcase/real-run.rrd
 ```
 
-Open the TensorBoard logs with:
+Open the TensorBoard logs from the TUI with `t`, or from the shell with:
 
 ```bash
 uvx --from "tensorboard>=2.16,<3" tensorboard --logdir .worldforge/tensorboard

--- a/docs/src/tensorboard.md
+++ b/docs/src/tensorboard.md
@@ -84,6 +84,14 @@ The summary JSON gains a ``"tensorboard"`` block listing ``log_dir``,
 ``run_name``, ``flush_secs``, and an ``events_written`` flag that mirrors what
 the wrapper would show under the ``Artifacts`` section of the visual report.
 
+The Textual showcase report (`worldforge.harness.tui.RoboticsShowcaseApp`)
+surfaces the run with a ``RoboticsTensorBoardPane`` and a ``t`` keybinding that
+launches ``uvx --from "tensorboard>=2.16,<3" tensorboard --logdir <path>`` in a
+detached subprocess. The shortcut is also visible in the footer alongside
+``o`` for Rerun. If the summary lacks a ``"tensorboard"`` block (for example
+when ``--no-tensorboard`` is passed), the pane is omitted and the keybinding
+emits a warning notification instead of launching anything.
+
 ## Programmatic surface
 
 Hosts that already drive WorldForge directly can use the bridge without going

--- a/src/worldforge/harness/tui.py
+++ b/src/worldforge/harness/tui.py
@@ -3494,6 +3494,32 @@ def _robotics_rerun_viewer_command_text(path: Path) -> str:
     return " ".join(shlex.quote(part) for part in _robotics_rerun_viewer_command(path))
 
 
+def _robotics_tensorboard_log_dir(payload: dict[str, object]) -> Path | None:
+    tensorboard = payload.get("tensorboard")
+    if not isinstance(tensorboard, dict):
+        return None
+    log_dir = tensorboard.get("log_dir")
+    if not isinstance(log_dir, str) or not log_dir.strip():
+        return None
+    path = Path(log_dir).expanduser()
+    return path if path.is_absolute() else path.resolve()
+
+
+def _robotics_tensorboard_viewer_command(path: Path) -> list[str]:
+    return [
+        "uvx",
+        "--from",
+        "tensorboard>=2.16,<3",
+        "tensorboard",
+        "--logdir",
+        str(path),
+    ]
+
+
+def _robotics_tensorboard_viewer_command_text(path: Path) -> str:
+    return " ".join(shlex.quote(part) for part in _robotics_tensorboard_viewer_command(path))
+
+
 def _robotics_color(token: str) -> str:
     return {
         "accent": "cyan",
@@ -3698,6 +3724,47 @@ class RoboticsRerunPane(Static, _ThemedRenderer):
         table.add_row(Text("open", style="dim"), Text(command, style=_robotics_color("accent")))
         table.add_row(Text("shortcut", style="dim"), Text("press o", style="bold"))
         self.update(Panel(table, title="Rerun Recording", border_style=_robotics_color("success")))
+
+
+class RoboticsTensorBoardPane(Static, _ThemedRenderer):
+    """TensorBoard log directory and viewer command."""
+
+    def __init__(self, summary: dict[str, object]) -> None:
+        super().__init__()
+        self.summary = summary
+
+    def on_mount(self) -> None:
+        path = _robotics_tensorboard_log_dir(self.summary)
+        if path is None:
+            self.update(
+                Panel(
+                    Text(
+                        "TensorBoard recording was not enabled for this run.",
+                        style="dim",
+                    ),
+                    title="TensorBoard Logs",
+                    border_style=_robotics_color("panel"),
+                )
+            )
+            return
+        tensorboard = self.summary.get("tensorboard")
+        events_written = None
+        run_name = None
+        if isinstance(tensorboard, dict):
+            events_written = tensorboard.get("events_written")
+            run_name = tensorboard.get("run_name")
+        status = "events written" if events_written else "configured"
+        command = _robotics_tensorboard_viewer_command_text(path)
+        table = Table.grid(expand=True)
+        table.add_column(no_wrap=True)
+        table.add_column(ratio=1)
+        table.add_row(Text("path", style="dim"), Text(str(path), style="bold"))
+        if isinstance(run_name, str) and run_name.strip():
+            table.add_row(Text("run", style="dim"), Text(run_name, style="bold"))
+        table.add_row(Text("status", style="dim"), Text(status, style="bold"))
+        table.add_row(Text("open", style="dim"), Text(command, style=_robotics_color("accent")))
+        table.add_row(Text("shortcut", style="dim"), Text("press t", style="bold"))
+        self.update(Panel(table, title="TensorBoard Logs", border_style=_robotics_color("success")))
 
 
 class RoboticsMetricsPane(Static, _ThemedRenderer):
@@ -4083,6 +4150,7 @@ class RoboticsShowcaseApp(App[None]):
     BINDINGS: ClassVar[list[Binding]] = [
         Binding("?", "show_tabletop_help", "Help", show=True),
         Binding("o", "open_rerun", "Open Rerun", show=True),
+        Binding("t", "open_tensorboard", "Open TensorBoard", show=True),
         Binding("q", "quit", "Quit", show=True),
         Binding("ctrl+t", "toggle_theme", "Theme", show=True),
     ]
@@ -4128,6 +4196,11 @@ class RoboticsShowcaseApp(App[None]):
         margin-bottom: 1;
     }
 
+    RoboticsTensorBoardPane {
+        height: 10;
+        margin-bottom: 1;
+    }
+
     RoboticsMetricsPane {
         height: 12;
         margin-bottom: 1;
@@ -4168,6 +4241,7 @@ class RoboticsShowcaseApp(App[None]):
         self.stage_delay = max(0.0, stage_delay)
         self.animate_arm = animate_arm
         self.rerun_recording_path = _robotics_rerun_recording_path(summary)
+        self.tensorboard_log_dir = _robotics_tensorboard_log_dir(summary)
         self.register_theme(_build_theme(THEME_NAME_DARK, WORLDFORGE_DARK_PALETTE, dark=True))
         self.register_theme(_build_theme(THEME_NAME_LIGHT, WORLDFORGE_LIGHT_PALETTE, dark=False))
         self.register_theme(
@@ -4188,6 +4262,8 @@ class RoboticsShowcaseApp(App[None]):
                 yield RoboticsReportGuidePane()
                 if self.rerun_recording_path is not None:
                     yield RoboticsRerunPane(self.summary)
+                if self.tensorboard_log_dir is not None:
+                    yield RoboticsTensorBoardPane(self.summary)
                 yield RoboticsMetricsPane(self.summary)
                 yield RoboticsArmPane(self.summary, animate=self.animate_arm)
                 yield RoboticsCandidatePane(self.summary)
@@ -4220,6 +4296,13 @@ class RoboticsShowcaseApp(App[None]):
                 (
                     "Attaching Rerun artifact location and viewer command.",
                     RoboticsRerunPane(self.summary),
+                )
+            )
+        if self.tensorboard_log_dir is not None:
+            stages.append(
+                (
+                    "Attaching TensorBoard log directory and viewer command.",
+                    RoboticsTensorBoardPane(self.summary),
                 )
             )
         stages.extend(
@@ -4292,6 +4375,39 @@ class RoboticsShowcaseApp(App[None]):
             _robotics_rerun_viewer_command_text(path),
             severity="information",
             title="Opening Rerun",
+        )
+
+    def action_open_tensorboard(self) -> None:
+        path = self.tensorboard_log_dir
+        if path is None:
+            self.notify(
+                "This run does not include a TensorBoard log directory.",
+                severity="warning",
+                title="TensorBoard",
+            )
+            return
+        if not path.is_dir():
+            self.notify(
+                f"TensorBoard log directory not found: {path}",
+                severity="error",
+                title="TensorBoard",
+            )
+            return
+        command = _robotics_tensorboard_viewer_command(path)
+        try:
+            subprocess.Popen(
+                command,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                start_new_session=True,
+            )
+        except OSError as exc:
+            self.notify(str(exc), severity="error", title="TensorBoard")
+            return
+        self.notify(
+            _robotics_tensorboard_viewer_command_text(path),
+            severity="information",
+            title="Opening TensorBoard",
         )
 
 

--- a/tests/test_harness_tui.py
+++ b/tests/test_harness_tui.py
@@ -188,6 +188,113 @@ def test_robotics_showcase_app_exposes_rerun_open_shortcut(
     assert kwargs["start_new_session"] is True
 
 
+def test_robotics_showcase_app_exposes_tensorboard_open_shortcut(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    pytest.importorskip("textual")
+
+    import worldforge.harness.tui as tui
+
+    summary = _robotics_summary()
+    tensorboard_dir = tmp_path / "tb" / "unit-run"
+    tensorboard_dir.mkdir(parents=True)
+    (tensorboard_dir / "events.out.tfevents.placeholder").write_bytes(b"events")
+    summary["tensorboard"] = {
+        "log_dir": str(tensorboard_dir),
+        "run_name": "unit-run",
+        "flush_secs": 30,
+        "events_written": True,
+    }
+    launched: dict[str, object] = {}
+
+    def fake_popen(command: list[str], **kwargs: object) -> object:
+        launched["command"] = command
+        launched["kwargs"] = kwargs
+        return object()
+
+    monkeypatch.setattr(tui.subprocess, "Popen", fake_popen)
+
+    async def scenario() -> None:
+        app = tui.RoboticsShowcaseApp(
+            summary=summary,
+            summary_path=tmp_path / "summary.json",
+            stage_delay=0.0,
+            animate_arm=False,
+        )
+        async with app.run_test(size=(150, 60)) as pilot:
+            await pilot.pause()
+            assert app.query_one(tui.RoboticsTensorBoardPane) is not None
+            await pilot.press("t")
+            await pilot.pause()
+
+    asyncio.run(scenario())
+
+    assert launched["command"] == [
+        "uvx",
+        "--from",
+        "tensorboard>=2.16,<3",
+        "tensorboard",
+        "--logdir",
+        str(tensorboard_dir),
+    ]
+    kwargs = launched["kwargs"]
+    assert isinstance(kwargs, dict)
+    assert kwargs["stdout"] is tui.subprocess.DEVNULL
+    assert kwargs["stderr"] is tui.subprocess.DEVNULL
+    assert kwargs["start_new_session"] is True
+
+
+def test_robotics_showcase_app_tensorboard_shortcut_warns_when_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    pytest.importorskip("textual")
+
+    import worldforge.harness.tui as tui
+
+    summary = _robotics_summary()
+    summary.pop("tensorboard", None)
+
+    def fake_popen(command: list[str], **kwargs: object) -> object:
+        raise AssertionError("subprocess should not be launched when TensorBoard is disabled.")
+
+    monkeypatch.setattr(tui.subprocess, "Popen", fake_popen)
+
+    notifications: list[tuple[str, str | None]] = []
+    original_notify = tui.RoboticsShowcaseApp.notify
+
+    def capturing_notify(self: tui.RoboticsShowcaseApp, message: str, **kwargs: object) -> None:
+        severity = kwargs.get("severity") if isinstance(kwargs.get("severity"), str) else None
+        notifications.append((message, severity))  # type: ignore[arg-type]
+        original_notify(self, message, **kwargs)
+
+    monkeypatch.setattr(tui.RoboticsShowcaseApp, "notify", capturing_notify)
+
+    async def scenario() -> None:
+        app = tui.RoboticsShowcaseApp(
+            summary=summary,
+            summary_path=tmp_path / "summary.json",
+            stage_delay=0.0,
+            animate_arm=False,
+        )
+        async with app.run_test(size=(150, 52)) as pilot:
+            await pilot.pause()
+            from textual.css.query import NoMatches
+
+            with pytest.raises(NoMatches):
+                app.query_one(tui.RoboticsTensorBoardPane)
+            await pilot.press("t")
+            await pilot.pause()
+
+    asyncio.run(scenario())
+
+    assert any(
+        severity == "warning" and "TensorBoard log directory" in message
+        for message, severity in notifications
+    )
+
+
 def test_robotics_showcase_help_overlay_explains_tabletop_replay(tmp_path) -> None:
     pytest.importorskip("textual")
 


### PR DESCRIPTION
## Summary

Closes #304. Follow-up to #302 / #303.

Adds a Textual keybinding (`t`) and a `RoboticsTensorBoardPane` to `worldforge.harness.tui.RoboticsShowcaseApp`, mirroring the existing `o` shortcut for Rerun. Pressing `t` launches `uvx --from "tensorboard>=2.16,<3" tensorboard --logdir <path>` in a detached subprocess for the run's TensorBoard log directory.

The new pane is composed only when the run summary contains a `"tensorboard"` block (so `--no-tensorboard` runs cleanly). The binding itself stays registered: it notifies a warning when the block is absent and an error when the directory is missing on disk, never spawning a subprocess in those cases.

## Changes

- `src/worldforge/harness/tui.py`:
  - New helpers: `_robotics_tensorboard_log_dir`, `_robotics_tensorboard_viewer_command`, `_robotics_tensorboard_viewer_command_text`.
  - New `RoboticsTensorBoardPane` (path / run / status / open / shortcut rows).
  - `RoboticsShowcaseApp` gains `tensorboard_log_dir`, `Binding("t", "open_tensorboard", "Open TensorBoard", show=True)`, `action_open_tensorboard()`, CSS height for the new pane, and conditional composition in both immediate-render and staged-reveal paths.
- `tests/test_harness_tui.py`: two new tests
  - happy path: fake `subprocess.Popen`, asserts the launched argv shape, `DEVNULL` routing, and `start_new_session=True`;
  - disabled path: missing `"tensorboard"` block — the binding fires a warning, the pane is not composed, no subprocess is spawned.
- Docs: `docs/src/robotics-showcase.md` mentions the `t` shortcut; `docs/src/tensorboard.md` documents the binding + graceful-degradation behavior.
- `CHANGELOG.md`: Unreleased entry citing #304.

## Test plan

- [x] `uv lock --check`
- [x] `uv run ruff check src tests examples scripts`
- [x] `uv run ruff format --check src tests examples scripts`
- [x] `uv run python scripts/generate_provider_docs.py --check`
- [x] `uv run --extra harness pytest --cov=src/worldforge --cov-report=term --cov-fail-under=90` (1419 passed, 90.11% coverage)
- [x] `bash scripts/test_package.sh` (1331 passed, 88 skipped)