### PR TITLE
Open the browser when the TUI 't' shortcut launches TensorBoard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ releases may still include breaking changes when the public API needs to tighten
 
 ## Unreleased
 
+### Fixed
+
+- The `t` shortcut in `RoboticsShowcaseApp` now actually shows TensorBoard.
+  The launched command pins `--port 6006`, and the action additionally
+  schedules a `webbrowser.open("http://localhost:6006/")` via a Textual timer
+  (~2.5 s after launch) so the run becomes visible without manual browser
+  navigation - parity with the desktop Rerun viewer. The URL is also
+  surfaced in `RoboticsTensorBoardPane` and in the action notification so
+  headless / remote users can copy-paste it; a fallback warning is emitted
+  when `webbrowser.open` returns false. Issue #306.
+
 ### Added
 
 - Added a `t` keybinding to `RoboticsShowcaseApp` that launches the run's

--- a/docs/src/tensorboard.md
+++ b/docs/src/tensorboard.md
@@ -86,11 +86,18 @@ the wrapper would show under the ``Artifacts`` section of the visual report.
 
 The Textual showcase report (`worldforge.harness.tui.RoboticsShowcaseApp`)
 surfaces the run with a ``RoboticsTensorBoardPane`` and a ``t`` keybinding that
-launches ``uvx --from "tensorboard>=2.16,<3" tensorboard --logdir <path>`` in a
-detached subprocess. The shortcut is also visible in the footer alongside
-``o`` for Rerun. If the summary lacks a ``"tensorboard"`` block (for example
-when ``--no-tensorboard`` is passed), the pane is omitted and the keybinding
-emits a warning notification instead of launching anything.
+launches ``uvx --from "tensorboard>=2.16,<3" tensorboard --logdir <path> --port 6006``
+in a detached subprocess. The shortcut is also visible in the footer alongside
+``o`` for Rerun. Because TensorBoard is a web server (not a GUI app like
+Rerun), the binding additionally schedules a ~2.5 s delayed browser-open to
+``http://localhost:6006/`` via Python's ``webbrowser`` module so the run is
+visible without manual steps. The URL is also surfaced in the pane and in the
+notification so headless / remote users can copy-paste it (or set up an SSH
+tunnel). If ``webbrowser`` cannot find a default browser, the binding emits a
+warning telling the user to visit the URL manually. If the summary lacks a
+``"tensorboard"`` block (for example when ``--no-tensorboard`` is passed),
+the pane is omitted, no subprocess is started, no browser is opened, and the
+keybinding emits a warning notification instead.
 
 ## Programmatic surface
 

--- a/src/worldforge/harness/tui.py
+++ b/src/worldforge/harness/tui.py
@@ -8,6 +8,7 @@ import shlex
 import statistics
 import subprocess
 import time
+import webbrowser
 from collections.abc import Iterable
 from contextlib import suppress
 from pathlib import Path
@@ -3505,6 +3506,10 @@ def _robotics_tensorboard_log_dir(payload: dict[str, object]) -> Path | None:
     return path if path.is_absolute() else path.resolve()
 
 
+ROBOTICS_TENSORBOARD_DEFAULT_PORT = 6006
+ROBOTICS_TENSORBOARD_BROWSER_DELAY_S = 2.5
+
+
 def _robotics_tensorboard_viewer_command(path: Path) -> list[str]:
     return [
         "uvx",
@@ -3513,11 +3518,17 @@ def _robotics_tensorboard_viewer_command(path: Path) -> list[str]:
         "tensorboard",
         "--logdir",
         str(path),
+        "--port",
+        str(ROBOTICS_TENSORBOARD_DEFAULT_PORT),
     ]
 
 
 def _robotics_tensorboard_viewer_command_text(path: Path) -> str:
     return " ".join(shlex.quote(part) for part in _robotics_tensorboard_viewer_command(path))
+
+
+def _robotics_tensorboard_url() -> str:
+    return f"http://localhost:{ROBOTICS_TENSORBOARD_DEFAULT_PORT}/"
 
 
 def _robotics_color(token: str) -> str:
@@ -3755,6 +3766,7 @@ class RoboticsTensorBoardPane(Static, _ThemedRenderer):
             run_name = tensorboard.get("run_name")
         status = "events written" if events_written else "configured"
         command = _robotics_tensorboard_viewer_command_text(path)
+        url = _robotics_tensorboard_url()
         table = Table.grid(expand=True)
         table.add_column(no_wrap=True)
         table.add_column(ratio=1)
@@ -3762,6 +3774,7 @@ class RoboticsTensorBoardPane(Static, _ThemedRenderer):
         if isinstance(run_name, str) and run_name.strip():
             table.add_row(Text("run", style="dim"), Text(run_name, style="bold"))
         table.add_row(Text("status", style="dim"), Text(status, style="bold"))
+        table.add_row(Text("url", style="dim"), Text(url, style=_robotics_color("accent")))
         table.add_row(Text("open", style="dim"), Text(command, style=_robotics_color("accent")))
         table.add_row(Text("shortcut", style="dim"), Text("press t", style="bold"))
         self.update(Panel(table, title="TensorBoard Logs", border_style=_robotics_color("success")))
@@ -4197,7 +4210,7 @@ class RoboticsShowcaseApp(App[None]):
     }
 
     RoboticsTensorBoardPane {
-        height: 10;
+        height: 11;
         margin-bottom: 1;
     }
 
@@ -4404,11 +4417,29 @@ class RoboticsShowcaseApp(App[None]):
         except OSError as exc:
             self.notify(str(exc), severity="error", title="TensorBoard")
             return
+        url = _robotics_tensorboard_url()
+        self.set_timer(
+            ROBOTICS_TENSORBOARD_BROWSER_DELAY_S,
+            lambda: self._open_tensorboard_browser(url),
+        )
         self.notify(
-            _robotics_tensorboard_viewer_command_text(path),
+            f"{_robotics_tensorboard_viewer_command_text(path)}\n{url}",
             severity="information",
             title="Opening TensorBoard",
         )
+
+    def _open_tensorboard_browser(self, url: str) -> None:
+        try:
+            opened = webbrowser.open(url)
+        except webbrowser.Error as exc:
+            self.notify(str(exc), severity="warning", title="TensorBoard")
+            return
+        if not opened:
+            self.notify(
+                f"Could not auto-open a browser. Visit {url} manually.",
+                severity="warning",
+                title="TensorBoard",
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_harness_tui.py
+++ b/tests/test_harness_tui.py
@@ -214,6 +214,23 @@ def test_robotics_showcase_app_exposes_tensorboard_open_shortcut(
         return object()
 
     monkeypatch.setattr(tui.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(tui, "ROBOTICS_TENSORBOARD_BROWSER_DELAY_S", 0.01)
+    browser_opens: list[str] = []
+    monkeypatch.setattr(
+        tui.webbrowser,
+        "open",
+        lambda url, *args, **kwargs: browser_opens.append(url) or True,
+    )
+
+    notifications: list[tuple[str, str | None]] = []
+    original_notify = tui.RoboticsShowcaseApp.notify
+
+    def capturing_notify(self: tui.RoboticsShowcaseApp, message: str, **kwargs: object) -> None:
+        severity = kwargs.get("severity") if isinstance(kwargs.get("severity"), str) else None
+        notifications.append((message, severity))  # type: ignore[arg-type]
+        original_notify(self, message, **kwargs)
+
+    monkeypatch.setattr(tui.RoboticsShowcaseApp, "notify", capturing_notify)
 
     async def scenario() -> None:
         app = tui.RoboticsShowcaseApp(
@@ -226,7 +243,7 @@ def test_robotics_showcase_app_exposes_tensorboard_open_shortcut(
             await pilot.pause()
             assert app.query_one(tui.RoboticsTensorBoardPane) is not None
             await pilot.press("t")
-            await pilot.pause()
+            await pilot.pause(delay=0.1)
 
     asyncio.run(scenario())
 
@@ -237,12 +254,19 @@ def test_robotics_showcase_app_exposes_tensorboard_open_shortcut(
         "tensorboard",
         "--logdir",
         str(tensorboard_dir),
+        "--port",
+        "6006",
     ]
     kwargs = launched["kwargs"]
     assert isinstance(kwargs, dict)
     assert kwargs["stdout"] is tui.subprocess.DEVNULL
     assert kwargs["stderr"] is tui.subprocess.DEVNULL
     assert kwargs["start_new_session"] is True
+    assert browser_opens == ["http://localhost:6006/"]
+    assert any(
+        severity == "information" and "http://localhost:6006/" in message
+        for message, severity in notifications
+    )
 
 
 def test_robotics_showcase_app_tensorboard_shortcut_warns_when_disabled(
@@ -259,7 +283,11 @@ def test_robotics_showcase_app_tensorboard_shortcut_warns_when_disabled(
     def fake_popen(command: list[str], **kwargs: object) -> object:
         raise AssertionError("subprocess should not be launched when TensorBoard is disabled.")
 
+    def fake_open(url: str, *args: object, **kwargs: object) -> bool:
+        raise AssertionError("webbrowser.open should not be called when TensorBoard is disabled.")
+
     monkeypatch.setattr(tui.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(tui.webbrowser, "open", fake_open)
 
     notifications: list[tuple[str, str | None]] = []
     original_notify = tui.RoboticsShowcaseApp.notify
@@ -291,6 +319,62 @@ def test_robotics_showcase_app_tensorboard_shortcut_warns_when_disabled(
 
     assert any(
         severity == "warning" and "TensorBoard log directory" in message
+        for message, severity in notifications
+    )
+
+
+def test_robotics_showcase_app_tensorboard_shortcut_notifies_when_browser_missing(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    pytest.importorskip("textual")
+
+    import worldforge.harness.tui as tui
+
+    summary = _robotics_summary()
+    tensorboard_dir = tmp_path / "tb" / "unit-run"
+    tensorboard_dir.mkdir(parents=True)
+    summary["tensorboard"] = {
+        "log_dir": str(tensorboard_dir),
+        "run_name": "unit-run",
+        "flush_secs": 30,
+        "events_written": True,
+    }
+
+    monkeypatch.setattr(
+        tui.subprocess,
+        "Popen",
+        lambda *args, **kwargs: object(),
+    )
+    monkeypatch.setattr(tui, "ROBOTICS_TENSORBOARD_BROWSER_DELAY_S", 0.01)
+    monkeypatch.setattr(tui.webbrowser, "open", lambda *args, **kwargs: False)
+
+    notifications: list[tuple[str, str | None]] = []
+    original_notify = tui.RoboticsShowcaseApp.notify
+
+    def capturing_notify(self: tui.RoboticsShowcaseApp, message: str, **kwargs: object) -> None:
+        severity = kwargs.get("severity") if isinstance(kwargs.get("severity"), str) else None
+        notifications.append((message, severity))  # type: ignore[arg-type]
+        original_notify(self, message, **kwargs)
+
+    monkeypatch.setattr(tui.RoboticsShowcaseApp, "notify", capturing_notify)
+
+    async def scenario() -> None:
+        app = tui.RoboticsShowcaseApp(
+            summary=summary,
+            summary_path=tmp_path / "summary.json",
+            stage_delay=0.0,
+            animate_arm=False,
+        )
+        async with app.run_test(size=(150, 60)) as pilot:
+            await pilot.pause()
+            await pilot.press("t")
+            await pilot.pause(delay=0.1)
+
+    asyncio.run(scenario())
+
+    assert any(
+        severity == "warning" and "Visit http://localhost:6006/" in message
         for message, severity in notifications
     )
 


### PR DESCRIPTION
## Summary

Closes #306. Follow-up to #304 / #305.

The TensorBoard shortcut from #305 mirrored the Rerun shortcut, but Rerun is a desktop GUI app while TensorBoard is a headless web server. The result: pressing `t` showed an "Opening TensorBoard" notification, started the server in a detached subprocess, and then nothing visible happened — exactly the failure the user reported.

This PR makes the `t` shortcut actually show TensorBoard:

- Pin `--port 6006` in the launched command so the URL is predictable.
- After a successful `Popen`, schedule a Textual timer (~2.5 s) that calls `webbrowser.open("http://localhost:6006/")` so a browser tab opens once TensorBoard has had time to bind.
- Surface the URL in `RoboticsTensorBoardPane` and include it in the action notification, so headless / remote users can copy-paste it or set up an SSH tunnel.
- When `webbrowser.open` returns `False` (no default browser available, common on headless boxes), emit a warning telling the user to visit the URL manually rather than silently doing nothing.

## Tests

- Happy path: argv now includes `--port 6006`; the patched `webbrowser.open` is called with `http://localhost:6006/` once the timer fires; the notification contains the URL.
- Disabled path: also pins a fake `webbrowser.open` that asserts it is never called.
- New no-browser-available test: `webbrowser.open` returns `False`, the fallback warning fires.

## Test plan

- [x] `uv lock --check`
- [x] `uv run ruff check src tests examples scripts`
- [x] `uv run ruff format --check src tests examples scripts`
- [x] `uv run python scripts/generate_provider_docs.py --check`
- [x] `uv run --extra harness pytest --cov=src/worldforge --cov-fail-under=90 -q` (1420 passed, 90.10% coverage)
- [x] `bash scripts/test_package.sh` (1331 passed, 89 skipped)