### PR TITLE
Poll the TensorBoard port before opening the browser and capture launcher logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ releases may still include breaking changes when the public API needs to tighten
 
 ### Fixed
 
+- The `t` shortcut in `RoboticsShowcaseApp` no longer opens the browser
+  before TensorBoard has bound the port (causing a blank page on first-run
+  `uvx` resolves). The fixed `set_timer(2.5, ...)` is replaced with a
+  Textual background worker that polls `localhost:6006` every ~0.5 s for
+  up to ~60 s and only calls `webbrowser.open` once the port responds.
+  The action also stops swallowing the TensorBoard subprocess's output:
+  stdout/stderr are now captured to `tensorboard.stdout.log` and
+  `tensorboard.stderr.log` inside the run's log directory. Timeouts now
+  emit an error notification pointing at the stderr log path. Issue #308.
 - The `t` shortcut in `RoboticsShowcaseApp` now actually shows TensorBoard.
   The launched command pins `--port 6006`, and the action additionally
   schedules a `webbrowser.open("http://localhost:6006/")` via a Textual timer

--- a/docs/src/tensorboard.md
+++ b/docs/src/tensorboard.md
@@ -88,16 +88,27 @@ The Textual showcase report (`worldforge.harness.tui.RoboticsShowcaseApp`)
 surfaces the run with a ``RoboticsTensorBoardPane`` and a ``t`` keybinding that
 launches ``uvx --from "tensorboard>=2.16,<3" tensorboard --logdir <path> --port 6006``
 in a detached subprocess. The shortcut is also visible in the footer alongside
-``o`` for Rerun. Because TensorBoard is a web server (not a GUI app like
-Rerun), the binding additionally schedules a ~2.5 s delayed browser-open to
-``http://localhost:6006/`` via Python's ``webbrowser`` module so the run is
-visible without manual steps. The URL is also surfaced in the pane and in the
-notification so headless / remote users can copy-paste it (or set up an SSH
-tunnel). If ``webbrowser`` cannot find a default browser, the binding emits a
-warning telling the user to visit the URL manually. If the summary lacks a
-``"tensorboard"`` block (for example when ``--no-tensorboard`` is passed),
-the pane is omitted, no subprocess is started, no browser is opened, and the
-keybinding emits a warning notification instead.
+``o`` for Rerun.
+
+Because TensorBoard is a web server (not a GUI app like Rerun), the binding
+then runs a Textual background worker that polls ``localhost:6006`` every
+~0.5 s for up to ~60 s and only opens the browser to ``http://localhost:6006/``
+once the port responds. This survives a slow first-run ``uvx`` resolve where
+TensorBoard takes longer than a couple of seconds to bind. The URL is surfaced
+in the pane and in the notification so headless / remote users can copy-paste
+it (or set up an SSH tunnel). If ``webbrowser`` cannot find a default browser,
+the binding emits a warning telling the user to visit the URL manually.
+
+The TensorBoard subprocess's ``stdout`` and ``stderr`` are captured to
+``tensorboard.stdout.log`` and ``tensorboard.stderr.log`` next to the run's
+``events.out.tfevents.*`` files. When the server never comes up within the
+poll window, the binding emits an error notification pointing at the stderr
+log so the failure is debuggable rather than silent.
+
+If the summary lacks a ``"tensorboard"`` block (for example when
+``--no-tensorboard`` is passed), the pane is omitted, no subprocess is
+started, no browser is opened, and the keybinding emits a warning
+notification instead.
 
 ## Programmatic surface
 

--- a/src/worldforge/harness/tui.py
+++ b/src/worldforge/harness/tui.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import queue
 import shlex
+import socket
 import statistics
 import subprocess
 import time
@@ -3507,7 +3508,21 @@ def _robotics_tensorboard_log_dir(payload: dict[str, object]) -> Path | None:
 
 
 ROBOTICS_TENSORBOARD_DEFAULT_PORT = 6006
-ROBOTICS_TENSORBOARD_BROWSER_DELAY_S = 2.5
+ROBOTICS_TENSORBOARD_READY_TIMEOUT_S = 60.0
+ROBOTICS_TENSORBOARD_POLL_INTERVAL_S = 0.5
+ROBOTICS_TENSORBOARD_STDOUT_LOG = "tensorboard.stdout.log"
+ROBOTICS_TENSORBOARD_STDERR_LOG = "tensorboard.stderr.log"
+
+
+def _tensorboard_port_open(host: str, port: int, *, timeout: float = 1.0) -> bool:
+    """Return True when a TCP connect to ``host:port`` succeeds within ``timeout``."""
+
+    try:
+        sock = socket.create_connection((host, port), timeout=timeout)
+    except OSError:
+        return False
+    sock.close()
+    return True
 
 
 def _robotics_tensorboard_viewer_command(path: Path) -> list[str]:
@@ -4406,31 +4421,63 @@ class RoboticsShowcaseApp(App[None]):
                 title="TensorBoard",
             )
             return
+        stdout_log = path / ROBOTICS_TENSORBOARD_STDOUT_LOG
+        stderr_log = path / ROBOTICS_TENSORBOARD_STDERR_LOG
         command = _robotics_tensorboard_viewer_command(path)
         try:
-            subprocess.Popen(
-                command,
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
-                start_new_session=True,
-            )
+            stdout_handle = stdout_log.open("wb")
+            try:
+                stderr_handle = stderr_log.open("wb")
+                try:
+                    subprocess.Popen(
+                        command,
+                        stdout=stdout_handle,
+                        stderr=stderr_handle,
+                        start_new_session=True,
+                    )
+                finally:
+                    stderr_handle.close()
+            finally:
+                stdout_handle.close()
         except OSError as exc:
             self.notify(str(exc), severity="error", title="TensorBoard")
             return
         url = _robotics_tensorboard_url()
-        self.set_timer(
-            ROBOTICS_TENSORBOARD_BROWSER_DELAY_S,
-            lambda: self._open_tensorboard_browser(url),
-        )
         self.notify(
-            f"{_robotics_tensorboard_viewer_command_text(path)}\n{url}",
+            f"Waiting for TensorBoard to start at {url}\nlogs: {stderr_log}",
             severity="information",
-            title="Opening TensorBoard",
+            title="TensorBoard",
+        )
+        self.run_worker(
+            self._open_tensorboard_browser_when_ready(url, stderr_log),
+            name="tensorboard.open",
+            group="tensorboard",
+            exclusive=True,
         )
 
-    def _open_tensorboard_browser(self, url: str) -> None:
+    async def _open_tensorboard_browser_when_ready(self, url: str, stderr_log: Path) -> None:
+        deadline = time.monotonic() + ROBOTICS_TENSORBOARD_READY_TIMEOUT_S
+        ready = False
+        while time.monotonic() < deadline:
+            if await asyncio.to_thread(
+                _tensorboard_port_open,
+                "localhost",
+                ROBOTICS_TENSORBOARD_DEFAULT_PORT,
+            ):
+                ready = True
+                break
+            await asyncio.sleep(ROBOTICS_TENSORBOARD_POLL_INTERVAL_S)
+        if not ready:
+            self.notify(
+                f"TensorBoard did not come up at {url} within "
+                f"{ROBOTICS_TENSORBOARD_READY_TIMEOUT_S:.0f}s. "
+                f"See {stderr_log} for the launcher output.",
+                severity="error",
+                title="TensorBoard",
+            )
+            return
         try:
-            opened = webbrowser.open(url)
+            opened = await asyncio.to_thread(webbrowser.open, url)
         except webbrowser.Error as exc:
             self.notify(str(exc), severity="warning", title="TensorBoard")
             return
@@ -4440,6 +4487,12 @@ class RoboticsShowcaseApp(App[None]):
                 severity="warning",
                 title="TensorBoard",
             )
+            return
+        self.notify(
+            f"Opening {url}",
+            severity="information",
+            title="TensorBoard",
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_harness_tui.py
+++ b/tests/test_harness_tui.py
@@ -188,6 +188,22 @@ def test_robotics_showcase_app_exposes_rerun_open_shortcut(
     assert kwargs["start_new_session"] is True
 
 
+def _capture_notifications(
+    monkeypatch: pytest.MonkeyPatch,
+    tui_module: object,
+) -> list[tuple[str, str | None]]:
+    notifications: list[tuple[str, str | None]] = []
+    original_notify = tui_module.RoboticsShowcaseApp.notify  # type: ignore[attr-defined]
+
+    def capturing_notify(self, message: str, **kwargs: object) -> None:
+        severity = kwargs.get("severity") if isinstance(kwargs.get("severity"), str) else None
+        notifications.append((message, severity))  # type: ignore[arg-type]
+        original_notify(self, message, **kwargs)
+
+    monkeypatch.setattr(tui_module.RoboticsShowcaseApp, "notify", capturing_notify)  # type: ignore[attr-defined]
+    return notifications
+
+
 def test_robotics_showcase_app_exposes_tensorboard_open_shortcut(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -210,27 +226,22 @@ def test_robotics_showcase_app_exposes_tensorboard_open_shortcut(
 
     def fake_popen(command: list[str], **kwargs: object) -> object:
         launched["command"] = command
-        launched["kwargs"] = kwargs
+        launched["kwargs"] = dict(kwargs)
+        for handle in (kwargs.get("stdout"), kwargs.get("stderr")):
+            if hasattr(handle, "write"):
+                handle.write(b"")
         return object()
 
     monkeypatch.setattr(tui.subprocess, "Popen", fake_popen)
-    monkeypatch.setattr(tui, "ROBOTICS_TENSORBOARD_BROWSER_DELAY_S", 0.01)
+    monkeypatch.setattr(tui, "_tensorboard_port_open", lambda *args, **kwargs: True)
+    monkeypatch.setattr(tui, "ROBOTICS_TENSORBOARD_POLL_INTERVAL_S", 0.01)
     browser_opens: list[str] = []
     monkeypatch.setattr(
         tui.webbrowser,
         "open",
         lambda url, *args, **kwargs: browser_opens.append(url) or True,
     )
-
-    notifications: list[tuple[str, str | None]] = []
-    original_notify = tui.RoboticsShowcaseApp.notify
-
-    def capturing_notify(self: tui.RoboticsShowcaseApp, message: str, **kwargs: object) -> None:
-        severity = kwargs.get("severity") if isinstance(kwargs.get("severity"), str) else None
-        notifications.append((message, severity))  # type: ignore[arg-type]
-        original_notify(self, message, **kwargs)
-
-    monkeypatch.setattr(tui.RoboticsShowcaseApp, "notify", capturing_notify)
+    notifications = _capture_notifications(monkeypatch, tui)
 
     async def scenario() -> None:
         app = tui.RoboticsShowcaseApp(
@@ -243,7 +254,7 @@ def test_robotics_showcase_app_exposes_tensorboard_open_shortcut(
             await pilot.pause()
             assert app.query_one(tui.RoboticsTensorBoardPane) is not None
             await pilot.press("t")
-            await pilot.pause(delay=0.1)
+            await pilot.pause(delay=0.2)
 
     asyncio.run(scenario())
 
@@ -259,12 +270,22 @@ def test_robotics_showcase_app_exposes_tensorboard_open_shortcut(
     ]
     kwargs = launched["kwargs"]
     assert isinstance(kwargs, dict)
-    assert kwargs["stdout"] is tui.subprocess.DEVNULL
-    assert kwargs["stderr"] is tui.subprocess.DEVNULL
+    stdout_path = tensorboard_dir / tui.ROBOTICS_TENSORBOARD_STDOUT_LOG
+    stderr_path = tensorboard_dir / tui.ROBOTICS_TENSORBOARD_STDERR_LOG
+    assert kwargs["stdout"] is not tui.subprocess.DEVNULL
+    assert kwargs["stderr"] is not tui.subprocess.DEVNULL
+    assert getattr(kwargs["stdout"], "name", "") == str(stdout_path)
+    assert getattr(kwargs["stderr"], "name", "") == str(stderr_path)
     assert kwargs["start_new_session"] is True
+    assert stdout_path.exists()
+    assert stderr_path.exists()
     assert browser_opens == ["http://localhost:6006/"]
     assert any(
-        severity == "information" and "http://localhost:6006/" in message
+        severity == "information" and "Waiting for TensorBoard" in message
+        for message, severity in notifications
+    )
+    assert any(
+        severity == "information" and message == "Opening http://localhost:6006/"
         for message, severity in notifications
     )
 
@@ -286,18 +307,14 @@ def test_robotics_showcase_app_tensorboard_shortcut_warns_when_disabled(
     def fake_open(url: str, *args: object, **kwargs: object) -> bool:
         raise AssertionError("webbrowser.open should not be called when TensorBoard is disabled.")
 
+    def fake_port_open(*args: object, **kwargs: object) -> bool:
+        raise AssertionError("port poller should not run when TensorBoard is disabled.")
+
     monkeypatch.setattr(tui.subprocess, "Popen", fake_popen)
     monkeypatch.setattr(tui.webbrowser, "open", fake_open)
+    monkeypatch.setattr(tui, "_tensorboard_port_open", fake_port_open)
 
-    notifications: list[tuple[str, str | None]] = []
-    original_notify = tui.RoboticsShowcaseApp.notify
-
-    def capturing_notify(self: tui.RoboticsShowcaseApp, message: str, **kwargs: object) -> None:
-        severity = kwargs.get("severity") if isinstance(kwargs.get("severity"), str) else None
-        notifications.append((message, severity))  # type: ignore[arg-type]
-        original_notify(self, message, **kwargs)
-
-    monkeypatch.setattr(tui.RoboticsShowcaseApp, "notify", capturing_notify)
+    notifications = _capture_notifications(monkeypatch, tui)
 
     async def scenario() -> None:
         app = tui.RoboticsShowcaseApp(
@@ -346,18 +363,10 @@ def test_robotics_showcase_app_tensorboard_shortcut_notifies_when_browser_missin
         "Popen",
         lambda *args, **kwargs: object(),
     )
-    monkeypatch.setattr(tui, "ROBOTICS_TENSORBOARD_BROWSER_DELAY_S", 0.01)
+    monkeypatch.setattr(tui, "_tensorboard_port_open", lambda *args, **kwargs: True)
+    monkeypatch.setattr(tui, "ROBOTICS_TENSORBOARD_POLL_INTERVAL_S", 0.01)
     monkeypatch.setattr(tui.webbrowser, "open", lambda *args, **kwargs: False)
-
-    notifications: list[tuple[str, str | None]] = []
-    original_notify = tui.RoboticsShowcaseApp.notify
-
-    def capturing_notify(self: tui.RoboticsShowcaseApp, message: str, **kwargs: object) -> None:
-        severity = kwargs.get("severity") if isinstance(kwargs.get("severity"), str) else None
-        notifications.append((message, severity))  # type: ignore[arg-type]
-        original_notify(self, message, **kwargs)
-
-    monkeypatch.setattr(tui.RoboticsShowcaseApp, "notify", capturing_notify)
+    notifications = _capture_notifications(monkeypatch, tui)
 
     async def scenario() -> None:
         app = tui.RoboticsShowcaseApp(
@@ -369,12 +378,66 @@ def test_robotics_showcase_app_tensorboard_shortcut_notifies_when_browser_missin
         async with app.run_test(size=(150, 60)) as pilot:
             await pilot.pause()
             await pilot.press("t")
-            await pilot.pause(delay=0.1)
+            await pilot.pause(delay=0.2)
 
     asyncio.run(scenario())
 
     assert any(
         severity == "warning" and "Visit http://localhost:6006/" in message
+        for message, severity in notifications
+    )
+
+
+def test_robotics_showcase_app_tensorboard_shortcut_reports_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    pytest.importorskip("textual")
+
+    import worldforge.harness.tui as tui
+
+    summary = _robotics_summary()
+    tensorboard_dir = tmp_path / "tb" / "unit-run"
+    tensorboard_dir.mkdir(parents=True)
+    summary["tensorboard"] = {
+        "log_dir": str(tensorboard_dir),
+        "run_name": "unit-run",
+        "flush_secs": 30,
+        "events_written": True,
+    }
+
+    monkeypatch.setattr(
+        tui.subprocess,
+        "Popen",
+        lambda *args, **kwargs: object(),
+    )
+    monkeypatch.setattr(tui, "_tensorboard_port_open", lambda *args, **kwargs: False)
+    monkeypatch.setattr(tui, "ROBOTICS_TENSORBOARD_READY_TIMEOUT_S", 0.05)
+    monkeypatch.setattr(tui, "ROBOTICS_TENSORBOARD_POLL_INTERVAL_S", 0.01)
+
+    def fake_open(*args: object, **kwargs: object) -> bool:
+        raise AssertionError("webbrowser.open should not run when TensorBoard never starts.")
+
+    monkeypatch.setattr(tui.webbrowser, "open", fake_open)
+    notifications = _capture_notifications(monkeypatch, tui)
+
+    async def scenario() -> None:
+        app = tui.RoboticsShowcaseApp(
+            summary=summary,
+            summary_path=tmp_path / "summary.json",
+            stage_delay=0.0,
+            animate_arm=False,
+        )
+        async with app.run_test(size=(150, 60)) as pilot:
+            await pilot.pause()
+            await pilot.press("t")
+            await pilot.pause(delay=0.25)
+
+    asyncio.run(scenario())
+
+    stderr_path = tensorboard_dir / tui.ROBOTICS_TENSORBOARD_STDERR_LOG
+    assert any(
+        severity == "error" and "did not come up" in message and str(stderr_path) in message
         for message, severity in notifications
     )
 


### PR DESCRIPTION
## Summary

Closes #308. Follow-up to #306 / #307.

The `t` shortcut still opened the browser after a fixed 2.5 s timer. On a cold `uvx` cache, TensorBoard hasn't bound port 6006 by then — the browser hits a connection-refused page and the user is left looking at a blank tab that never updates. The TensorBoard subprocess's stdout/stderr were also routed to `DEVNULL`, so when the server died for any reason the user got no signal at all.

This PR fixes both:

- Replace `set_timer(2.5, ...)` with a Textual background worker that calls `socket.create_connection(("localhost", 6006), timeout=1.0)` every ~0.5 s for up to ~60 s via `asyncio.to_thread`, and only calls `webbrowser.open` once the port responds. The worker is registered with `group="tensorboard"` and `exclusive=True` so re-pressing `t` cancels any previous poll.
- Capture the subprocess's stdout/stderr to `tensorboard.stdout.log` and `tensorboard.stderr.log` inside the run's log directory. The initial "Waiting for TensorBoard to start" notification surfaces the stderr log path so users can tail it.
- On poll timeout, emit an `error` notification that includes the stderr log path. No more silent failure.

## Tests

- Happy path patches the new `_tensorboard_port_open` helper to return `True`, asserts argv contains `--port 6006`, that Popen's `stdout`/`stderr` are file handles pointing at the log paths (not `DEVNULL`), that both files exist on disk, that `webbrowser.open` is called with `http://localhost:6006/`, and that both "Waiting…" and "Opening…" notifications fire.
- Disabled path additionally pins a fake `_tensorboard_port_open` that asserts it is never called.
- Browser-missing path now routes through the polling worker (`port_open=True`, `webbrowser.open=False` → warning).
- New timeout test pins `_tensorboard_port_open` to `False`, drops the ready timeout and poll interval to `< 100 ms`, and asserts the error notification mentions the stderr log path.

## Test plan

- [x] `uv lock --check`
- [x] `uv run ruff check src tests examples scripts`
- [x] `uv run ruff format --check src tests examples scripts`
- [x] `uv run python scripts/generate_provider_docs.py --check`
- [x] `uv run --extra harness pytest --cov=src/worldforge --cov-fail-under=90 -q` (1421 passed, 90.09% coverage)
- [x] `bash scripts/test_package.sh` (1331 passed, 90 skipped)