### PR TITLE
Pin setuptools<81 in TensorBoard launch and add worldforge-open-tensorboard CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,29 @@ releases may still include breaking changes when the public API needs to tighten
 
 ## Unreleased
 
+### Added
+
+- Added a non-interactive TensorBoard launcher CLI:
+  `worldforge-open-tensorboard --logdir <path> [--probe] [--no-browser]
+  [--keep-running] [--ready-timeout 60] [--poll-interval 0.5]`. Wraps the
+  same launch / poll / probe flow the TUI uses behind a single shell
+  command; `--probe` fetches the index page and asserts it contains the
+  `TensorBoard` marker so wiring changes can be validated end-to-end from
+  a script. Exit codes are `0` on success, `1` on ready timeout / probe
+  failure, `2` on bad input. The new `worldforge.harness.tensorboard_launcher`
+  module owns the shared helpers (`viewer_command`, `port_open`,
+  `wait_until_ready`, `probe_html`, `launch`); the TUI now imports them so
+  both surfaces stay in sync. Issue #310.
+
 ### Fixed
 
+- The `t` shortcut in `RoboticsShowcaseApp` no longer fails silently because
+  TensorBoard cannot import `pkg_resources`. The launched `uvx` command now
+  pins `--with "setuptools<81"` so `pkg_resources` is available (setuptools
+  81+ removed it; TensorBoard still imports it at startup). Captured
+  `tensorboard.stderr.log` files for previous-version runs showed the
+  `ModuleNotFoundError`; the new command resolves a working environment.
+  Issue #310.
 - The `t` shortcut in `RoboticsShowcaseApp` no longer opens the browser
   before TensorBoard has bound the port (causing a blank page on first-run
   `uvx` resolves). The fixed `set_timer(2.5, ...)` is replaced with a

--- a/docs/src/cli.md
+++ b/docs/src/cli.md
@@ -204,6 +204,16 @@ scripts/robotics-showcase
 uvx --from "rerun-sdk>=0.24,<0.32" rerun /tmp/worldforge-robotics-showcase/real-run.rrd
 ```
 
+Open the run's TensorBoard logs without launching the Textual report - useful
+for non-interactive verification or for opening TensorBoard from a shell:
+
+```bash
+uv run worldforge-open-tensorboard --logdir .worldforge/tensorboard/<run>
+uv run worldforge-open-tensorboard --logdir .worldforge/tensorboard/<run> --probe --no-browser
+```
+
+See [TensorBoard Integration](./tensorboard.md) for the full flag reference.
+
 Live GR00T and LeRobot policy smoke helpers:
 
 ```bash

--- a/docs/src/tensorboard.md
+++ b/docs/src/tensorboard.md
@@ -86,9 +86,12 @@ the wrapper would show under the ``Artifacts`` section of the visual report.
 
 The Textual showcase report (`worldforge.harness.tui.RoboticsShowcaseApp`)
 surfaces the run with a ``RoboticsTensorBoardPane`` and a ``t`` keybinding that
-launches ``uvx --from "tensorboard>=2.16,<3" tensorboard --logdir <path> --port 6006``
-in a detached subprocess. The shortcut is also visible in the footer alongside
-``o`` for Rerun.
+launches
+``uvx --from "tensorboard>=2.16,<3" --with "setuptools<81" tensorboard --logdir <path> --port 6006``
+in a detached subprocess. The ``setuptools<81`` constraint keeps
+``pkg_resources`` available for TensorBoard's import path (TensorBoard still
+calls ``import pkg_resources`` at startup but ``setuptools>=81`` removed that
+package). The shortcut is also visible in the footer alongside ``o`` for Rerun.
 
 Because TensorBoard is a web server (not a GUI app like Rerun), the binding
 then runs a Textual background worker that polls ``localhost:6006`` every
@@ -109,6 +112,43 @@ If the summary lacks a ``"tensorboard"`` block (for example when
 ``--no-tensorboard`` is passed), the pane is omitted, no subprocess is
 started, no browser is opened, and the keybinding emits a warning
 notification instead.
+
+## Non-interactive launcher (`worldforge-open-tensorboard`)
+
+The same launch / poll / probe flow is available as a CLI for non-interactive
+use - validating the wiring in CI, opening TensorBoard from a shell without
+running the Textual report, or testing changes to the launch command:
+
+```bash
+uv run worldforge-open-tensorboard --logdir .worldforge/tensorboard/<run>
+```
+
+Common flags:
+
+| Flag | Default | Purpose |
+| --- | --- | --- |
+| ``--logdir <path>`` | required | Run directory with ``events.out.tfevents.*`` files. |
+| ``--port <int>`` | ``6006`` | TCP port to bind. |
+| ``--host <host>`` | ``localhost`` | Host to poll and probe. |
+| ``--ready-timeout <sec>`` | ``60`` | How long to wait for the port to bind. |
+| ``--poll-interval <sec>`` | ``0.5`` | Seconds between TCP probes during the ready wait. |
+| ``--probe`` | off | After ready, fetch ``http://host:port/`` and assert the body contains the ``TensorBoard`` marker. Tears the subprocess down on success or failure. Useful for "did it actually work" smoke checks. |
+| ``--no-browser`` | off | Skip ``webbrowser.open`` after the server is ready. |
+| ``--keep-running`` | off (implied without ``--probe``) | Block until the subprocess exits or SIGINT is received. |
+| ``--shutdown-timeout <sec>`` | ``5`` | Seconds to wait for graceful subprocess teardown. |
+
+Exit codes: ``0`` on success, ``1`` on ready timeout or probe failure, ``2``
+on bad input (missing ``--logdir``, non-positive timing, launch ``OSError``).
+
+Example smoke check:
+
+```bash
+mkdir -p /tmp/tb-smoke
+uv run worldforge-open-tensorboard \
+  --logdir /tmp/tb-smoke \
+  --probe --no-browser \
+  --ready-timeout 120
+```
 
 ## Programmatic surface
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ Changelog = "https://github.com/AbdelStark/worldforge/blob/main/CHANGELOG.md"
 [project.scripts]
 worldforge = "worldforge.cli:main"
 worldforge-harness = "worldforge.harness.cli:main"
+worldforge-open-tensorboard = "worldforge.harness.tensorboard_launcher:main"
 worldforge-demo-leworldmodel = "worldforge.demos.leworldmodel_e2e:main"
 worldforge-demo-lerobot = "worldforge.demos.lerobot_e2e:main"
 worldforge-demo-rerun = "worldforge.demos.rerun_showcase:main"

--- a/src/worldforge/harness/tensorboard_launcher.py
+++ b/src/worldforge/harness/tensorboard_launcher.py
@@ -1,0 +1,368 @@
+"""Launch, poll, and probe a TensorBoard server for the robotics showcase.
+
+This module owns the host-side launch logic the TUI uses for its ``t``
+keybinding, and exposes the same logic as a non-interactive CLI
+(``worldforge-open-tensorboard``) so the flow can be validated end-to-end
+from a shell - launch a TensorBoard subprocess, poll its TCP port, fetch the
+index page, and assert it contains a TensorBoard marker - without opening the
+Textual report.
+
+The launched command pins ``setuptools<81`` because TensorBoard still does
+``import pkg_resources`` at startup and ``setuptools>=81`` removed that
+package. The constraint lives only inside the ``uvx``-launched environment;
+WorldForge's own dependency set is unaffected.
+"""
+
+from __future__ import annotations
+
+import argparse
+import http.client
+import shlex
+import socket
+import subprocess
+import sys
+import time
+import webbrowser
+from collections.abc import Sequence
+from pathlib import Path
+
+DEFAULT_PORT = 6006
+DEFAULT_HOST = "localhost"
+DEFAULT_READY_TIMEOUT_S = 60.0
+DEFAULT_POLL_INTERVAL_S = 0.5
+DEFAULT_PROBE_TIMEOUT_S = 5.0
+DEFAULT_SHUTDOWN_TIMEOUT_S = 5.0
+STDOUT_LOG = "tensorboard.stdout.log"
+STDERR_LOG = "tensorboard.stderr.log"
+HEALTH_MARKER = "TensorBoard"
+TENSORBOARD_PIN = "tensorboard>=2.16,<3"
+SETUPTOOLS_PIN = "setuptools<81"
+
+
+def viewer_command(log_dir: Path, *, port: int = DEFAULT_PORT) -> list[str]:
+    """Return the argv that launches a TensorBoard server via uvx.
+
+    The pinned ``setuptools<81`` constraint keeps ``pkg_resources`` available
+    so TensorBoard can finish importing.
+    """
+
+    return [
+        "uvx",
+        "--from",
+        TENSORBOARD_PIN,
+        "--with",
+        SETUPTOOLS_PIN,
+        "tensorboard",
+        "--logdir",
+        str(log_dir),
+        "--port",
+        str(port),
+    ]
+
+
+def viewer_command_text(log_dir: Path, *, port: int = DEFAULT_PORT) -> str:
+    """Return :func:`viewer_command` as a shell-safe single line."""
+
+    return " ".join(shlex.quote(part) for part in viewer_command(log_dir, port=port))
+
+
+def viewer_url(*, host: str = DEFAULT_HOST, port: int = DEFAULT_PORT) -> str:
+    """Return the user-facing URL for a launched TensorBoard server."""
+
+    return f"http://{host}:{port}/"
+
+
+def port_open(host: str, port: int, *, timeout: float = 1.0) -> bool:
+    """Return ``True`` when a TCP connect to ``host:port`` succeeds in ``timeout``."""
+
+    try:
+        sock = socket.create_connection((host, port), timeout=timeout)
+    except OSError:
+        return False
+    sock.close()
+    return True
+
+
+def wait_until_ready(
+    host: str,
+    port: int,
+    *,
+    timeout: float,
+    interval: float,
+    sleep: object = time.sleep,
+    monotonic: object = time.monotonic,
+) -> bool:
+    """Block until ``host:port`` opens or ``timeout`` seconds elapse.
+
+    The ``sleep`` and ``monotonic`` hooks exist so tests can drive the loop
+    without actually waiting.
+    """
+
+    if timeout <= 0 or interval <= 0:
+        raise ValueError("timeout and interval must be positive numbers.")
+    deadline = monotonic() + timeout  # type: ignore[operator]
+    probe_timeout = min(1.0, max(0.05, interval * 4))
+    while monotonic() < deadline:  # type: ignore[operator]
+        if port_open(host, port, timeout=probe_timeout):
+            return True
+        sleep(interval)  # type: ignore[operator]
+    return False
+
+
+def probe_html(
+    host: str,
+    port: int,
+    *,
+    path: str = "/",
+    timeout: float = DEFAULT_PROBE_TIMEOUT_S,
+) -> tuple[int, str]:
+    """Fetch ``http://host:port/path`` and return ``(status, body)``."""
+
+    conn = http.client.HTTPConnection(host, port, timeout=timeout)
+    try:
+        conn.request("GET", path)
+        response = conn.getresponse()
+        body_bytes = response.read()
+        body = body_bytes.decode("utf-8", errors="replace")
+        return response.status, body
+    finally:
+        conn.close()
+
+
+def launch(
+    log_dir: Path,
+    *,
+    port: int = DEFAULT_PORT,
+    stdout_log: Path | None = None,
+    stderr_log: Path | None = None,
+) -> subprocess.Popen[bytes]:
+    """Spawn the TensorBoard subprocess in a detached session.
+
+    Stdout/stderr are routed to the log files inside ``log_dir`` so launch
+    failures are captured for debugging instead of being silently discarded.
+    """
+
+    resolved = Path(log_dir).expanduser()
+    if not resolved.is_dir():
+        raise FileNotFoundError(f"TensorBoard log directory not found: {resolved}")
+    stdout_target = stdout_log or (resolved / STDOUT_LOG)
+    stderr_target = stderr_log or (resolved / STDERR_LOG)
+    command = viewer_command(resolved, port=port)
+    stdout_handle = stdout_target.open("wb")
+    try:
+        stderr_handle = stderr_target.open("wb")
+        try:
+            return subprocess.Popen(
+                command,
+                stdout=stdout_handle,
+                stderr=stderr_handle,
+                start_new_session=True,
+            )
+        finally:
+            stderr_handle.close()
+    finally:
+        stdout_handle.close()
+
+
+def _terminate(process: subprocess.Popen[bytes], *, timeout: float) -> None:
+    if process.poll() is not None:
+        return
+    process.terminate()
+    try:
+        process.wait(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        process.wait()
+
+
+def _open_browser(url: str, *, no_browser: bool) -> bool:
+    if no_browser:
+        return False
+    try:
+        return bool(webbrowser.open(url))
+    except webbrowser.Error:
+        return False
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Launch a TensorBoard server for a robotics showcase run, wait for it to "
+            "come up, and optionally probe its HTML index page. Use --probe to validate "
+            "the launch flow end-to-end from a shell."
+        ),
+    )
+    parser.add_argument(
+        "--logdir",
+        type=Path,
+        required=True,
+        help="Directory containing ``events.out.tfevents.*`` files to serve.",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=DEFAULT_PORT,
+        help=f"TCP port to bind (default {DEFAULT_PORT}).",
+    )
+    parser.add_argument(
+        "--host",
+        default=DEFAULT_HOST,
+        help=f"Host to poll and probe (default {DEFAULT_HOST}).",
+    )
+    parser.add_argument(
+        "--ready-timeout",
+        type=float,
+        default=DEFAULT_READY_TIMEOUT_S,
+        help="Seconds to wait for TensorBoard to bind the port (default 60).",
+    )
+    parser.add_argument(
+        "--poll-interval",
+        type=float,
+        default=DEFAULT_POLL_INTERVAL_S,
+        help="Seconds between port probes during the ready wait (default 0.5).",
+    )
+    parser.add_argument(
+        "--probe",
+        action="store_true",
+        help=(
+            "After the server binds, fetch ``http://host:port/`` and assert the body "
+            "contains the ``TensorBoard`` marker. Exits 1 on probe failure and tears "
+            "down the subprocess."
+        ),
+    )
+    parser.add_argument(
+        "--no-browser",
+        action="store_true",
+        help="Skip the post-ready ``webbrowser.open`` call.",
+    )
+    parser.add_argument(
+        "--keep-running",
+        action="store_true",
+        help=(
+            "After a successful launch (and probe), block until the subprocess exits "
+            "or until SIGINT is received. Implied when --probe is not set."
+        ),
+    )
+    parser.add_argument(
+        "--shutdown-timeout",
+        type=float,
+        default=DEFAULT_SHUTDOWN_TIMEOUT_S,
+        help="Seconds to give TensorBoard to exit on teardown (default 5).",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """CLI entry point for ``worldforge-open-tensorboard``."""
+
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    log_dir = Path(args.logdir).expanduser()
+    if not log_dir.is_dir():
+        print(
+            f"error: --logdir is not a directory: {log_dir}",
+            file=sys.stderr,
+        )
+        return 2
+
+    if args.ready_timeout <= 0 or args.poll_interval <= 0:
+        print(
+            "error: --ready-timeout and --poll-interval must be positive numbers.",
+            file=sys.stderr,
+        )
+        return 2
+
+    try:
+        process = launch(log_dir, port=args.port)
+    except OSError as exc:
+        print(f"error: failed to launch tensorboard: {exc}", file=sys.stderr)
+        return 2
+
+    url = viewer_url(host=args.host, port=args.port)
+    stderr_log = log_dir / STDERR_LOG
+    print(
+        f"launching: {viewer_command_text(log_dir, port=args.port)}",
+        flush=True,
+    )
+    print(
+        f"waiting for {url} (timeout {args.ready_timeout:.0f}s, logs in {log_dir})",
+        flush=True,
+    )
+
+    ready = wait_until_ready(
+        args.host,
+        args.port,
+        timeout=args.ready_timeout,
+        interval=args.poll_interval,
+    )
+    if not ready:
+        print(
+            f"error: TensorBoard did not bind {url} within "
+            f"{args.ready_timeout:.0f}s; see {stderr_log}",
+            file=sys.stderr,
+        )
+        _terminate(process, timeout=args.shutdown_timeout)
+        return 1
+
+    print(f"tensorboard ready at {url}", flush=True)
+
+    if args.probe:
+        try:
+            status, body = probe_html(args.host, args.port)
+        except OSError as exc:
+            print(f"error: probe failed: {exc}", file=sys.stderr)
+            _terminate(process, timeout=args.shutdown_timeout)
+            return 1
+        print(f"probe: HTTP {status}, body {len(body)} bytes", flush=True)
+        if status != 200 or HEALTH_MARKER not in body:
+            print(
+                f"error: probe failed: HTTP {status}, missing '{HEALTH_MARKER}' marker",
+                file=sys.stderr,
+            )
+            _terminate(process, timeout=args.shutdown_timeout)
+            return 1
+        print(f"probe ok: index contains '{HEALTH_MARKER}' marker", flush=True)
+
+    opened = _open_browser(url, no_browser=args.no_browser)
+    if not args.no_browser and not opened:
+        print(
+            f"warning: could not auto-open a browser, visit {url} manually",
+            flush=True,
+        )
+
+    keep_running = args.keep_running or not args.probe
+    if not keep_running:
+        _terminate(process, timeout=args.shutdown_timeout)
+        return 0
+
+    print("press Ctrl+C to stop tensorboard", flush=True)
+    try:
+        process.wait()
+    except KeyboardInterrupt:
+        _terminate(process, timeout=args.shutdown_timeout)
+        return 0
+    return process.returncode or 0
+
+
+__all__ = [
+    "DEFAULT_HOST",
+    "DEFAULT_POLL_INTERVAL_S",
+    "DEFAULT_PORT",
+    "DEFAULT_PROBE_TIMEOUT_S",
+    "DEFAULT_READY_TIMEOUT_S",
+    "DEFAULT_SHUTDOWN_TIMEOUT_S",
+    "HEALTH_MARKER",
+    "SETUPTOOLS_PIN",
+    "STDERR_LOG",
+    "STDOUT_LOG",
+    "TENSORBOARD_PIN",
+    "launch",
+    "main",
+    "port_open",
+    "probe_html",
+    "viewer_command",
+    "viewer_command_text",
+    "viewer_url",
+    "wait_until_ready",
+]

--- a/src/worldforge/harness/tui.py
+++ b/src/worldforge/harness/tui.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import asyncio
 import queue
 import shlex
-import socket
 import statistics
 import subprocess
 import time
@@ -59,6 +58,7 @@ from worldforge import (
     list_eval_suites,
 )
 from worldforge.benchmark import BENCHMARKABLE_OPERATIONS
+from worldforge.harness import tensorboard_launcher
 from worldforge.harness.connectors import (
     ProviderConnectorSummary,
     provider_connector_summaries,
@@ -3507,43 +3507,35 @@ def _robotics_tensorboard_log_dir(payload: dict[str, object]) -> Path | None:
     return path if path.is_absolute() else path.resolve()
 
 
-ROBOTICS_TENSORBOARD_DEFAULT_PORT = 6006
-ROBOTICS_TENSORBOARD_READY_TIMEOUT_S = 60.0
-ROBOTICS_TENSORBOARD_POLL_INTERVAL_S = 0.5
-ROBOTICS_TENSORBOARD_STDOUT_LOG = "tensorboard.stdout.log"
-ROBOTICS_TENSORBOARD_STDERR_LOG = "tensorboard.stderr.log"
+ROBOTICS_TENSORBOARD_DEFAULT_PORT = tensorboard_launcher.DEFAULT_PORT
+ROBOTICS_TENSORBOARD_READY_TIMEOUT_S = tensorboard_launcher.DEFAULT_READY_TIMEOUT_S
+ROBOTICS_TENSORBOARD_POLL_INTERVAL_S = tensorboard_launcher.DEFAULT_POLL_INTERVAL_S
+ROBOTICS_TENSORBOARD_STDOUT_LOG = tensorboard_launcher.STDOUT_LOG
+ROBOTICS_TENSORBOARD_STDERR_LOG = tensorboard_launcher.STDERR_LOG
 
 
 def _tensorboard_port_open(host: str, port: int, *, timeout: float = 1.0) -> bool:
     """Return True when a TCP connect to ``host:port`` succeeds within ``timeout``."""
 
-    try:
-        sock = socket.create_connection((host, port), timeout=timeout)
-    except OSError:
-        return False
-    sock.close()
-    return True
+    return tensorboard_launcher.port_open(host, port, timeout=timeout)
 
 
 def _robotics_tensorboard_viewer_command(path: Path) -> list[str]:
-    return [
-        "uvx",
-        "--from",
-        "tensorboard>=2.16,<3",
-        "tensorboard",
-        "--logdir",
-        str(path),
-        "--port",
-        str(ROBOTICS_TENSORBOARD_DEFAULT_PORT),
-    ]
+    return tensorboard_launcher.viewer_command(
+        path,
+        port=ROBOTICS_TENSORBOARD_DEFAULT_PORT,
+    )
 
 
 def _robotics_tensorboard_viewer_command_text(path: Path) -> str:
-    return " ".join(shlex.quote(part) for part in _robotics_tensorboard_viewer_command(path))
+    return tensorboard_launcher.viewer_command_text(
+        path,
+        port=ROBOTICS_TENSORBOARD_DEFAULT_PORT,
+    )
 
 
 def _robotics_tensorboard_url() -> str:
-    return f"http://localhost:{ROBOTICS_TENSORBOARD_DEFAULT_PORT}/"
+    return tensorboard_launcher.viewer_url(port=ROBOTICS_TENSORBOARD_DEFAULT_PORT)
 
 
 def _robotics_color(token: str) -> str:

--- a/tests/test_harness_tui.py
+++ b/tests/test_harness_tui.py
@@ -262,6 +262,8 @@ def test_robotics_showcase_app_exposes_tensorboard_open_shortcut(
         "uvx",
         "--from",
         "tensorboard>=2.16,<3",
+        "--with",
+        "setuptools<81",
         "tensorboard",
         "--logdir",
         str(tensorboard_dir),

--- a/tests/test_tensorboard_launcher.py
+++ b/tests/test_tensorboard_launcher.py
@@ -1,0 +1,514 @@
+from __future__ import annotations
+
+import socket
+import subprocess
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from worldforge.harness import tensorboard_launcher
+
+
+class _StubHandler(BaseHTTPRequestHandler):
+    """Minimal request handler used by the probe and main-CLI tests."""
+
+    body = b"<!doctype html><title>TensorBoard</title>fake body"
+    status = 200
+
+    def do_GET(self) -> None:
+        self.send_response(self.__class__.status)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.send_header("Content-Length", str(len(self.__class__.body)))
+        self.end_headers()
+        self.wfile.write(self.__class__.body)
+
+    def log_message(self, format: str, *args: object) -> None:
+        # Silence default stderr noise in tests.
+        return
+
+
+def _spawn_local_http_server() -> tuple[HTTPServer, int]:
+    server = HTTPServer(("127.0.0.1", 0), _StubHandler)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server, port
+
+
+def test_viewer_command_pins_setuptools_and_tensorboard(tmp_path: Path) -> None:
+    command = tensorboard_launcher.viewer_command(tmp_path, port=6007)
+    assert command == [
+        "uvx",
+        "--from",
+        "tensorboard>=2.16,<3",
+        "--with",
+        "setuptools<81",
+        "tensorboard",
+        "--logdir",
+        str(tmp_path),
+        "--port",
+        "6007",
+    ]
+
+
+def test_viewer_command_text_quotes_path(tmp_path: Path) -> None:
+    path = tmp_path / "with spaces"
+    path.mkdir()
+    text = tensorboard_launcher.viewer_command_text(path)
+    assert "'" in text or '"' in text or " " not in str(path)
+    assert "tensorboard>=2.16,<3" in text
+    assert "setuptools<81" in text
+
+
+def test_viewer_url_defaults_to_localhost_6006() -> None:
+    assert tensorboard_launcher.viewer_url() == "http://localhost:6006/"
+    assert tensorboard_launcher.viewer_url(host="127.0.0.1", port=6010) == "http://127.0.0.1:6010/"
+
+
+def test_port_open_returns_false_for_closed_port() -> None:
+    # 0 is reserved and never bound; create_connection should fail fast.
+    assert tensorboard_launcher.port_open("127.0.0.1", 1, timeout=0.2) is False
+
+
+def test_port_open_returns_true_for_a_bound_socket() -> None:
+    listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    listener.bind(("127.0.0.1", 0))
+    listener.listen(1)
+    try:
+        host, port = listener.getsockname()
+        assert tensorboard_launcher.port_open(host, port, timeout=0.5) is True
+    finally:
+        listener.close()
+
+
+def test_wait_until_ready_rejects_non_positive_timeouts() -> None:
+    with pytest.raises(ValueError):
+        tensorboard_launcher.wait_until_ready(
+            "127.0.0.1",
+            1,
+            timeout=0,
+            interval=0.1,
+        )
+    with pytest.raises(ValueError):
+        tensorboard_launcher.wait_until_ready(
+            "127.0.0.1",
+            1,
+            timeout=0.1,
+            interval=0,
+        )
+
+
+def test_wait_until_ready_returns_true_when_port_opens_during_polling(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = {"count": 0}
+
+    def fake_port_open(host: str, port: int, *, timeout: float = 1.0) -> bool:
+        calls["count"] += 1
+        return calls["count"] >= 3
+
+    monkeypatch.setattr(tensorboard_launcher, "port_open", fake_port_open)
+    sleeps: list[float] = []
+    times = iter([0.0, 0.1, 0.2, 0.3, 0.4, 0.5])
+
+    assert (
+        tensorboard_launcher.wait_until_ready(
+            "127.0.0.1",
+            6006,
+            timeout=1.0,
+            interval=0.05,
+            sleep=lambda value: sleeps.append(value),
+            monotonic=lambda: next(times),
+        )
+        is True
+    )
+    assert calls["count"] == 3
+    assert sleeps == [0.05, 0.05]
+
+
+def test_wait_until_ready_returns_false_on_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        tensorboard_launcher,
+        "port_open",
+        lambda *args, **kwargs: False,
+    )
+    times = iter([0.0, 0.5, 0.9, 1.0, 1.5])
+    sleeps: list[float] = []
+    assert (
+        tensorboard_launcher.wait_until_ready(
+            "127.0.0.1",
+            6006,
+            timeout=1.0,
+            interval=0.5,
+            sleep=lambda value: sleeps.append(value),
+            monotonic=lambda: next(times),
+        )
+        is False
+    )
+    assert sleeps == [0.5, 0.5]
+
+
+def test_probe_html_returns_status_and_body() -> None:
+    server, port = _spawn_local_http_server()
+    try:
+        status, body = tensorboard_launcher.probe_html("127.0.0.1", port, timeout=2.0)
+    finally:
+        server.shutdown()
+        server.server_close()
+    assert status == 200
+    assert "TensorBoard" in body
+
+
+def test_launch_rejects_missing_logdir(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError):
+        tensorboard_launcher.launch(tmp_path / "does-not-exist")
+
+
+def test_launch_writes_log_files_and_forwards_argv(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_popen(command: list[str], **kwargs: object) -> object:
+        captured["command"] = command
+        captured["kwargs"] = dict(kwargs)
+        for handle in (kwargs.get("stdout"), kwargs.get("stderr")):
+            if hasattr(handle, "write"):
+                handle.write(b"hello\n")
+        return object()
+
+    monkeypatch.setattr(tensorboard_launcher.subprocess, "Popen", fake_popen)
+
+    tensorboard_launcher.launch(tmp_path, port=6007)
+
+    assert captured["command"][:5] == [
+        "uvx",
+        "--from",
+        "tensorboard>=2.16,<3",
+        "--with",
+        "setuptools<81",
+    ]
+    stdout_log = tmp_path / tensorboard_launcher.STDOUT_LOG
+    stderr_log = tmp_path / tensorboard_launcher.STDERR_LOG
+    assert stdout_log.exists()
+    assert stderr_log.exists()
+    assert stdout_log.read_bytes() == b"hello\n"
+    assert stderr_log.read_bytes() == b"hello\n"
+
+
+def _stub_popen(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    state: dict[str, Any] = {"terminated": False, "killed": False, "waited": False}
+
+    class _StubProcess:
+        returncode = 0
+
+        def poll(self) -> int | None:
+            return None if not state["terminated"] else 0
+
+        def terminate(self) -> None:
+            state["terminated"] = True
+
+        def kill(self) -> None:
+            state["killed"] = True
+
+        def wait(self, timeout: float | None = None) -> int:
+            state["waited"] = True
+            return 0
+
+    def fake_launch(log_dir: Path, **kwargs: object) -> _StubProcess:
+        state["launched_with"] = (log_dir, kwargs)
+        return _StubProcess()
+
+    monkeypatch.setattr(tensorboard_launcher, "launch", fake_launch)
+    return state
+
+
+def test_main_rejects_missing_logdir(
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    exit_code = tensorboard_launcher.main(
+        ["--logdir", str(tmp_path / "missing"), "--probe", "--no-browser"]
+    )
+    err = capsys.readouterr().err
+    assert exit_code == 2
+    assert "not a directory" in err
+
+
+def test_main_returns_one_on_ready_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    state = _stub_popen(monkeypatch)
+    monkeypatch.setattr(
+        tensorboard_launcher,
+        "wait_until_ready",
+        lambda *args, **kwargs: False,
+    )
+
+    exit_code = tensorboard_launcher.main(
+        [
+            "--logdir",
+            str(tmp_path),
+            "--probe",
+            "--no-browser",
+            "--ready-timeout",
+            "1",
+            "--poll-interval",
+            "0.1",
+        ]
+    )
+
+    assert exit_code == 1
+    err = capsys.readouterr().err
+    assert "did not bind" in err
+    assert tensorboard_launcher.STDERR_LOG in err
+    assert state["terminated"] is True
+
+
+def test_main_probe_success(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    state = _stub_popen(monkeypatch)
+    monkeypatch.setattr(
+        tensorboard_launcher,
+        "wait_until_ready",
+        lambda *args, **kwargs: True,
+    )
+    monkeypatch.setattr(
+        tensorboard_launcher,
+        "probe_html",
+        lambda *args, **kwargs: (200, "<title>TensorBoard</title>"),
+    )
+
+    exit_code = tensorboard_launcher.main(
+        [
+            "--logdir",
+            str(tmp_path),
+            "--probe",
+            "--no-browser",
+        ]
+    )
+
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert "tensorboard ready" in out
+    assert "probe ok" in out
+    # --probe without --keep-running tears the subprocess down.
+    assert state["terminated"] is True
+
+
+def test_main_probe_html_marker_missing_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    state = _stub_popen(monkeypatch)
+    monkeypatch.setattr(
+        tensorboard_launcher,
+        "wait_until_ready",
+        lambda *args, **kwargs: True,
+    )
+    monkeypatch.setattr(
+        tensorboard_launcher,
+        "probe_html",
+        lambda *args, **kwargs: (200, "this body does not mention the tool"),
+    )
+
+    exit_code = tensorboard_launcher.main(
+        [
+            "--logdir",
+            str(tmp_path),
+            "--probe",
+            "--no-browser",
+        ]
+    )
+
+    assert exit_code == 1
+    err = capsys.readouterr().err
+    assert "missing 'TensorBoard' marker" in err
+    assert state["terminated"] is True
+
+
+def test_main_probe_html_connection_error(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    state = _stub_popen(monkeypatch)
+    monkeypatch.setattr(
+        tensorboard_launcher,
+        "wait_until_ready",
+        lambda *args, **kwargs: True,
+    )
+
+    def boom(*args: object, **kwargs: object) -> tuple[int, str]:
+        raise ConnectionResetError("nope")
+
+    monkeypatch.setattr(tensorboard_launcher, "probe_html", boom)
+
+    exit_code = tensorboard_launcher.main(
+        [
+            "--logdir",
+            str(tmp_path),
+            "--probe",
+            "--no-browser",
+        ]
+    )
+
+    assert exit_code == 1
+    err = capsys.readouterr().err
+    assert "probe failed" in err
+    assert state["terminated"] is True
+
+
+def test_main_launch_oserror_returns_two(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    def fake_launch(log_dir: Path, **kwargs: object) -> object:
+        raise OSError("permission denied")
+
+    monkeypatch.setattr(tensorboard_launcher, "launch", fake_launch)
+    exit_code = tensorboard_launcher.main(
+        [
+            "--logdir",
+            str(tmp_path),
+            "--probe",
+            "--no-browser",
+        ]
+    )
+    err = capsys.readouterr().err
+    assert exit_code == 2
+    assert "failed to launch" in err
+
+
+def test_main_rejects_non_positive_timing_arguments(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    exit_code = tensorboard_launcher.main(
+        [
+            "--logdir",
+            str(tmp_path),
+            "--ready-timeout",
+            "0",
+        ]
+    )
+    err = capsys.readouterr().err
+    assert exit_code == 2
+    assert "must be positive" in err
+
+
+def test_main_keep_running_skips_teardown_until_subprocess_exits(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    state = _stub_popen(monkeypatch)
+    monkeypatch.setattr(
+        tensorboard_launcher,
+        "wait_until_ready",
+        lambda *args, **kwargs: True,
+    )
+
+    # Stub process.wait that returns immediately (no subprocess timeout argument).
+    class _Quick:
+        returncode = 0
+
+        def poll(self) -> int | None:
+            return None
+
+        def terminate(self) -> None:
+            state["terminated"] = True
+
+        def kill(self) -> None:
+            state["killed"] = True
+
+        def wait(self, timeout: float | None = None) -> int:
+            state["waited"] = True
+            return 0
+
+    monkeypatch.setattr(tensorboard_launcher, "launch", lambda *args, **kwargs: _Quick())
+
+    exit_code = tensorboard_launcher.main(
+        [
+            "--logdir",
+            str(tmp_path),
+            "--no-browser",
+            "--keep-running",
+        ]
+    )
+    assert exit_code == 0
+    assert state["waited"] is True
+    # --keep-running lets the subprocess complete on its own.
+    assert state["terminated"] is False
+
+
+def test_main_browser_open_called_when_browser_allowed(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    state = _stub_popen(monkeypatch)
+    monkeypatch.setattr(
+        tensorboard_launcher,
+        "wait_until_ready",
+        lambda *args, **kwargs: True,
+    )
+    monkeypatch.setattr(
+        tensorboard_launcher,
+        "probe_html",
+        lambda *args, **kwargs: (200, "<title>TensorBoard</title>"),
+    )
+    opened_urls: list[str] = []
+    monkeypatch.setattr(
+        tensorboard_launcher.webbrowser,
+        "open",
+        lambda url, *args, **kwargs: opened_urls.append(url) or True,
+    )
+
+    exit_code = tensorboard_launcher.main(
+        [
+            "--logdir",
+            str(tmp_path),
+            "--probe",
+        ]
+    )
+
+    assert exit_code == 0
+    assert opened_urls == ["http://localhost:6006/"]
+    assert state["terminated"] is True
+
+
+def test_terminate_kills_when_wait_times_out(monkeypatch: pytest.MonkeyPatch) -> None:
+    state = {"terminated": False, "killed": False, "wait_calls": 0}
+
+    class _Stub:
+        def poll(self) -> int | None:
+            return None
+
+        def terminate(self) -> None:
+            state["terminated"] = True
+
+        def kill(self) -> None:
+            state["killed"] = True
+
+        def wait(self, timeout: float | None = None) -> int:
+            state["wait_calls"] += 1
+            if state["wait_calls"] == 1:
+                raise subprocess.TimeoutExpired(cmd="x", timeout=timeout or 0.0)
+            return 0
+
+    tensorboard_launcher._terminate(_Stub(), timeout=0.01)  # type: ignore[arg-type]
+    assert state["terminated"] is True
+    assert state["killed"] is True


### PR DESCRIPTION
## Summary

Closes #310. Follow-up to #306 / #307 / #308 / #309.

After #309 the `t` shortcut polls the port and times out cleanly when TensorBoard never binds, but the underlying TensorBoard subprocess was still dying on every run with a clear error captured in the new `tensorboard.stderr.log`:

```
ModuleNotFoundError: No module named 'pkg_resources'
```

setuptools 82 removed `pkg_resources`; `tensorboard.default` still imports it at startup; `uvx --from "tensorboard>=2.16,<3"` resolves the latest setuptools by default. The combination is silently broken.

Two changes belong together here:

1. **Pin `--with "setuptools<81"`** in the uvx invocation so `pkg_resources` is available. The constraint only affects the uvx-launched environment; WorldForge's own dependency set is unchanged.
2. **Add a non-interactive CLI launcher**, `worldforge-open-tensorboard`, so the launch flow is debuggable from a shell. `--probe` mode launches TensorBoard, polls the port, fetches the index page, and asserts the body contains the `TensorBoard` marker, then tears the subprocess down. Exit codes: `0` on success, `1` on ready timeout / probe failure, `2` on bad input.

The new `worldforge.harness.tensorboard_launcher` module owns the shared helpers (`viewer_command`, `port_open`, `wait_until_ready`, `probe_html`, `launch`). The TUI's `t` shortcut imports the same helpers so both surfaces stay in sync.

## E2E verification on this branch

```
$ mkdir -p /tmp/tb-final-310
$ uv run worldforge-open-tensorboard \
    --logdir /tmp/tb-final-310 --port 6013 \
    --probe --no-browser --ready-timeout 90

launching: uvx --from 'tensorboard>=2.16,<3' --with 'setuptools<81' tensorboard --logdir /tmp/tb-final-310 --port 6013
waiting for http://localhost:6013/ (timeout 90s, logs in /tmp/tb-final-310)
tensorboard ready at http://localhost:6013/
probe: HTTP 200, body 533890 bytes
probe ok: index contains 'TensorBoard' marker

# exit=0
```

## Tests

- `tests/test_tensorboard_launcher.py` — 21 new cases covering:
  - `viewer_command` (asserts `--with setuptools<81`), `viewer_command_text`, `viewer_url`.
  - `port_open` against a real loopback listener and a known-closed port.
  - `wait_until_ready` happy / timeout paths with injected `sleep` / `monotonic`, plus non-positive timing rejection.
  - `probe_html` against a stdlib `http.server.HTTPServer`.
  - `launch` log-file capture + missing-dir rejection.
  - `main` happy probe path, ready-timeout, marker missing, HTTP connection error, launch `OSError`, non-positive timing args, `--keep-running`, browser open behavior.
  - `_terminate` falling back to `kill` after wait timeout.
- `tests/test_harness_tui.py` — happy-path argv now expects `--with setuptools<81`. Other TB TUI tests unchanged.

## Test plan

- [x] `uv lock --check`
- [x] `uv run ruff check src tests examples scripts`
- [x] `uv run ruff format --check src tests examples scripts`
- [x] `uv run python scripts/generate_provider_docs.py --check`
- [x] `uv run pytest tests/test_docs_command_drift.py` (new entry point documented in `docs/src/cli.md`)
- [x] `uv run --extra harness pytest --cov=src/worldforge --cov-fail-under=90 -q` (1442 passed, 90.14 % coverage; launcher module at 95 %)
- [x] `bash scripts/test_package.sh` (1352 passed, 90 skipped)
- [x] Manual E2E above