### PR TITLE
Add roboto-showcase spec triad for LeWorldModel-planned Atom01 control

### DIFF
--- a/specs/roboto-showcase/plan.md
+++ b/specs/roboto-showcase/plan.md
@@ -1,0 +1,121 @@
+# Plan — Roboto (Atom01) showcase
+
+## Status
+Draft · 2026-05-25
+
+## Strategy summary
+Research-gated, sim-first, phased. **P0 is a hard gate**: no data collection, training, or integration work starts until the observation-modality / planning-mode / licensing / Python-bridge questions in [spec.md](./spec.md) § "Open questions" are resolved with evidence. P0 deliberately front-loads the risk that makes this a spike rather than a copy of the PushT showcase.
+
+After P0, the lifecycle runs left-to-right (data → dataset → train → checkpoint → integrate → showcase), with each phase leaving a usable artifact that the next consumes. Real-hardware bring-up (P7) is **gated** and explicitly out of this spec's delivery scope — it is listed so the architecture does not paint itself into a sim-only corner, not as committed work.
+
+Every phase keeps heavy runtimes host-owned (invoked via `uv run --with`); the only `src/worldforge/` changes are the `roboto` provider, an Atom01-aware extension of the checkpoint builder, a `smoke/` entry point, and tests/docs. Base `pyproject.toml` / `uv.lock` do not change.
+
+## Dependencies on other work
+- **Capability-protocols refactor** ([specs/capability-protocols/](../capability-protocols/spec.md)) is in flight and rewrites the provider/registration surface. The `roboto` provider should target whichever surface is current when P4 lands: legacy `BaseProvider` + `assert_provider_contract` if before that refactor merges, or a `Policy` capability class + `assert_capability_contract` after. P4 must check the tree state first.
+- Upstream package availability: `atom01_train` (BSD-3), `le-wm`, `stable-worldmodel`, `stable-pretraining`. No version bumps to WorldForge's own toolchain.
+- GPU host for P1–P3 and P5 live runs. CI never trains.
+
+## Phases
+
+### P0 — Feasibility and decision record (HARD GATE)
+Resolve every open question in [spec.md](./spec.md) with evidence, by reading upstream **code** (not just READMEs) and running minimal probes off-repo.
+
+**Investigate:** exact `stable-worldmodel` HDF5 dataset schema and goal convention; whether LeWM's encoder is swappable for vectors (Option B feasibility) or rendering is required (Option A); whether a pretrained LeWM checkpoint exists that is plausibly warm-startable for 3D control; the candidate tensor rank `get_cost` expects; `atom01_train`'s exported policy interface (obs/action shapes from `play.py` / `sim2sim_atom01.py`); IsaacSim CI installability; LeWM/stable-worldmodel/stable-pretraining licenses; GPL-3 isolation strategy; rough compute/storage budget.
+
+**Deliverables:**
+- A decision record (new `specs/roboto-showcase/decisions.md` or an update to this triad) fixing: observation modality, action space, planning mode, goal conditioning, Python-version bridge, CI sim backend, checkpoint-allow-list strategy, dataset schema, licensing, and compute budget.
+- A minimal off-repo proof that the chosen action-candidate shape flows through `World.plan(...)` against the mock/score path.
+
+**Acceptance:** Every spec open question marked resolved with a cited source (upstream file path or measured probe). Go/no-go recorded. If no-go, the spec is closed with the finding and the showcase is not built.
+
+### P1 — Sim rollout data-collection harness (host/GPU)
+Build a host-owned collector that rolls out the trained Atom01 policy (and perturbed/exploratory variants) in IsaacLab/IsaacSim and MuJoCo Sim2Sim, capturing the P0-chosen observation modality, actions, terminals, and goal/cost signal.
+
+**Deliverables:**
+- A collection script run via `uv run --with` (host owns IsaacSim/IsaacLab/RSL_RL). Lives in a host-owned location or `scripts/`-adjacent tooling — **no** IsaacSim import inside `src/worldforge/`.
+- Configurable expert/exploratory mix, command/terrain randomization, seed capture.
+- Raw rollout dump (pre-HDF5) with a manifest of counts, seeds, and source policy revision.
+
+**Acceptance:** Reproducible rollout dump for a small pilot (enough to smoke the full pipeline) with recorded provenance. No repo-tree pollution; outputs land off-repo.
+
+### P2 — Dataset engineering → stable-worldmodel HDF5 (host/GPU)
+Convert rollouts into the upstream HDF5 layout under `$STABLEWM_HOME`, with normalization, splits, and a versioned dataset card.
+
+**Deliverables:**
+- A packing step producing `<name>_train.h5` / `<name>_val.h5` (+ test) in the exact upstream schema confirmed in P0.
+- Action normalization stats, goal-conditioning fields, episode-level train/val/test split with held-out commands/terrains.
+- Dataset card (modality, action space, mix ratio, counts, seeds, source policy revision) + content hash; published off-repo (HF dataset or object store) and pinned by revision. Never committed.
+
+**Acceptance:** `stable-worldmodel` loads the dataset without error; a tiny LeWM training step consumes a batch. Dataset card review confirms reproducibility from pinned inputs.
+
+### P3 — World-model training / fine-tuning + MLOps (host/GPU)
+Train the Atom01 LeWM via the upstream Hydra/WandB flow. Two arms: from-scratch (baseline) and warm-start (ablation, if a compatible checkpoint exists).
+
+**Deliverables:**
+- Host-owned Hydra config (`data=atom01`, encoder/predictor/action-encoder shapes from P0) and a documented `uv run --with` training command.
+- WandB-tracked runs with captured config, seed, dataset revision, code SHA, and upstream package versions.
+- `<name>_object.ckpt` + `<name>_weight.ckpt`; `config.json` + `weights.pt` published to a **pinned 40-char HF revision**.
+- A short training-debrief note (loss curves, collapse checks, chosen arm).
+
+**Acceptance:** A checkpoint that loads via `stable_worldmodel.policy.AutoCostModel` and produces finite, non-degenerate costs over held-out candidates. (Collapse / degenerate-cost diagnostics borrowed from LeWM training-debugging practice.)
+
+### P4 — Checkpoint packaging + provider wiring (WorldForge `src/`)
+Make WorldForge load the Atom01 checkpoint and feed it candidates.
+
+**Deliverables:**
+- Extend [src/worldforge/smoke/leworldmodel_checkpoint.py](../../src/worldforge/smoke/leworldmodel_checkpoint.py): widen `LEWORLDMODEL_HF_ALLOWED_CONFIG_TARGETS` and the encoder-config validator to accept the audited Atom01 config, keeping the allow-list exact and narrow; support an `atom01/<name>` policy path. Pinned-SHA validation unchanged.
+- New `src/worldforge/providers/roboto.py` implementing the `policy` capability (or the capability-protocol successor — check tree state per "Dependencies"). Client/server ZMQ bridge to a host-owned policy server if P0 confirms a Python-version split; host-supplied `action_translator`. Env-gated registration (e.g. `ROBOTO_POLICY_HOST` / `ROBOTO_POLICY_PATH`), lazy runtime imports only.
+- Catalog entry + `<provider_contracts>` row (`roboto` → `policy`, truthful).
+- Unit + contract tests with fixtures; no live runtime required for the unit path.
+
+**Acceptance:** `worldforge doctor` reports `roboto` and `leworldmodel` configured under the Atom01 env vars; contract tests pass; checkpoint builder unit tests cover the widened allow-list (positive + negative). Full gate green.
+
+### P5 — Planning loop + showcase wrapper + evidence (WorldForge `src/`)
+Close the loop and produce evidence.
+
+**Deliverables:**
+- `src/worldforge/smoke/roboto_showcase.py` composing `roboto` (policy) + `leworldmodel` (score) via `World.plan(... planning_mode=...)` (mode per P0), mirroring [robotics_showcase.py](../../src/worldforge/smoke/robotics_showcase.py).
+- `scripts/roboto-showcase` wrapper supplying runtime deps via `uv run --with`, with `--json-only` / `--no-tui` / `--no-rerun` / `--no-tensorboard` parity.
+- JSON + run-manifest output with a truthful `mode` string, both providers' health, candidate/score shapes, `best_index`, provider events, and a `capability` field.
+- Optional Rerun / TensorBoard visuals via existing bridges.
+- Evaluation artifacts: world-model fidelity + downstream planning lift vs policy-only + cost calibration.
+
+**Acceptance:** `scripts/roboto-showcase --json-only --no-tui` runs end-to-end on the host and emits a valid manifest; evaluation shows non-trivial, calibrated cost. The showcase claims real capability only if this gate is met; otherwise it ships labeled as a scaffold with the finding documented.
+
+### P6 — Optional sim-only CI + docs (gated, approval required)
+**Deliverables:**
+- A new optional workflow modeled on [.github/workflows/robotics-showcase.yml](../../.github/workflows/robotics-showcase.yml) that runs `scripts/roboto-showcase --json-only --no-tui --no-rerun` against the P0-chosen CI backend (recorded-rollout replay or MuJoCo; **not** IsaacSim on stock runners). `actions/cache` for HF + checkpoint; upload JSON/manifest evidence only; **never** train; **never** upload checkpoint/dataset artifacts.
+- Docs: `docs/src/providers/roboto.md`, a playbook section for the data/training/eval pipeline, README/AGENTS/CLAUDE `<provider_contracts>` updates, CHANGELOG entry. Provider docs regenerated (`generate_provider_docs.py --check` clean).
+
+**Acceptance:** Workflow green on a PR; docs-drift check clean; manual docs review. Workflow addition explicitly approved (CI is a gated path).
+
+### P7 — Real-hardware bring-up (GATED · DEFERRED · out of this spec's delivery)
+Listed only to keep the architecture honest. Would require: a separate safety review, host-owned ROS2/USB2CAN controller invoked as a distinct process (GPL-3 isolation preserved), explicit operator opt-in, hardware kill switch, non-mutating defaults, and its own spec triad + approval. **Not built here.**
+
+## Test strategy
+- **P0–P3** are host/GPU research phases validated by their own acceptance artifacts (decision record, dataset load, checkpoint load + finite costs), not by the repo test suite.
+- **P4–P6** ride the standard gate after every phase: `uv run ruff check src tests examples scripts`, `ruff format --check`, `generate_provider_docs.py --check`, `pytest`, `--extra harness pytest --cov-fail-under=90`, and `bash scripts/test_package.sh` before merge.
+- **Provider tests** mirror the existing leworldmodel/lerobot/gr00t suites: fixture-driven, no live runtime on the unit path; lazy-import boundaries asserted by `scripts/check_optional_import_boundaries.py`.
+- **Showcase contract test** mirrors the PushT showcase assertions (mode string, provider health, shapes, `best_index`, events) against a recorded or mock-backed run so it stays deterministic.
+- **Coverage** stays ≥90% on all `src/worldforge/` changes.
+
+## Risks and rollback
+
+### Risks
+1. **LeWM may not transfer to a 3D legged embodiment.** The PushT checkpoint is a 2D manipulation visual domain; warm-start lift is unknown and could be negative. *Mitigation:* P0 go/no-go; from-scratch baseline; Option B fallback. Honest scaffold-labeling if planning lift is not demonstrable.
+2. **Observation-modality dead-end.** If rendering is too costly and Option B is too invasive, the world-model angle may not be worth it. *Mitigation:* P0 decides before any data is collected; this is the whole point of the hard gate.
+3. **IsaacSim is not CI-installable.** *Mitigation:* P0 picks a CI backend (recorded replay / MuJoCo / self-hosted); CI never trains or runs IsaacSim on stock runners.
+4. **Python-version friction.** 3.10/3.11 sim vs 3.13 WorldForge. *Mitigation:* ZMQ client/server bridge (gr00t precedent) confirmed in P0.
+5. **Allow-list erosion.** Widening the checkpoint-builder Hydra allow-list could weaken the "exact and narrow" safety property. *Mitigation:* P4 adds the Atom01 config as explicit, audited entries with positive+negative tests; no wildcards.
+6. **Licensing.** GPL-3 contamination or non-redistributable upstream checkpoints. *Mitigation:* P0 license verification; GPL code runs only as a separate host process, never imported.
+7. **Compute/storage blow-up.** Rendered 3D rollouts are large. *Mitigation:* P0 budget estimate; pilot-scale dataset first (P1/P2) before any full training run.
+8. **Scope creep into real hardware.** *Mitigation:* P7 is explicitly gated and deferred; safety stays host-owned.
+
+### Rollback
+P0–P3 are off-repo and leave no tree changes to roll back (only host artifacts and an off-repo dataset/checkpoint). P4–P6 are independent PRs; revert the PR to roll back. The `roboto` provider and the checkpoint-builder extension are additive and env-gated, so reverting them cannot affect the existing PushT showcase or default `worldforge doctor` behavior.
+
+## Open questions / decisions needed
+All ten are tracked in [spec.md](./spec.md) § "Open questions" and are the deliverable of **P0**. None are resolved yet — this triad is authored pre-research by design.
+
+## Dependencies on other milestones
+- Soft coupling to the capability-protocols refactor (provider surface). See "Dependencies on other work." Otherwise self-contained within providers / smoke / docs / CI.

--- a/specs/roboto-showcase/spec.md
+++ b/specs/roboto-showcase/spec.md
@@ -1,0 +1,137 @@
+# Roboto (Atom01) showcase — LeWorldModel-planned humanoid control
+
+## Status
+Draft · 2026-05-25 · originating spike [#321](https://github.com/AbdelStark/worldforge/issues/321)
+
+## Outcome (one sentence)
+Stand up a host-owned, sim-first WorldForge showcase that drives RoboParty's open-source Atom01 humanoid (`Roboparty/roboto_origin`, `Roboparty/atom01_train`) by composing a `roboto` **policy** that proposes action candidates with a **fine-tuned LeWorldModel** `Cost` that ranks them through `World.plan(... planning_mode="policy+score")` — backed by an end-to-end dataset → training → checkpoint → evaluation pipeline whose heavy runtimes (torch, IsaacLab/IsaacSim, ROS2, RSL_RL, `stable-worldmodel`, checkpoints, datasets) stay entirely out of base dependencies and `src/worldforge/` imports.
+
+## Why this work
+WorldForge already ships one end-to-end `policy+score` robotics showcase (PushT: LeRobot diffusion policy proposes candidates, LeWorldModel scores them — see [scripts/robotics-showcase](../../scripts/robotics-showcase), [src/worldforge/smoke/lerobot_leworldmodel.py](../../src/worldforge/smoke/lerobot_leworldmodel.py)). That showcase is tabletop 2D manipulation with a vendor-trained world model checkpoint (`quentinll/lewm-pusht`). It demonstrates the *integration shape* but not the *full lifecycle*: nobody in this repo has collected data, engineered a dataset, trained or fine-tuned a world model, and closed the loop on a new embodiment.
+
+Atom01 is a fully open-source DIY humanoid (ROS2 Humble deploy, IsaacLab/IsaacSim + RSL_RL training, MuJoCo Sim2Sim, USB2CAN motors + IMU). It is a credible, permissively-trainable (BSD-3 `atom01_train`) target for exercising the **entire** world-model lifecycle on a legged embodiment, and a compelling public demo. The spike ([#321](https://github.com/AbdelStark/worldforge/issues/321)) established feasibility questions; this triad turns them into a phased, research-gated implementation plan.
+
+## Background (grounded)
+- **Existing planning composition.** `World.plan(...)` in [src/worldforge/framework.py](../../src/worldforge/framework.py) supports `planning_mode ∈ {policy+score, policy, score, predict}`. In `policy+score`, a `policy` returns `ActionPolicyResult.action_candidates`; a `score` (`Cost`) returns `ActionScoreResult` (lower cost = better, `best_index = argmin`); the planner picks `candidate_action_plans[best_index]`.
+- **LeWorldModel provider.** [src/worldforge/providers/leworldmodel.py](../../src/worldforge/providers/leworldmodel.py) implements `score` via `stable_worldmodel.policy.AutoCostModel.get_cost`. Registration is env-gated on `LEWORLDMODEL_POLICY` / `LEWM_POLICY`; runtime (`torch`, `stable_worldmodel`) is lazily imported only at call/health time.
+- **Checkpoint builder.** [src/worldforge/smoke/leworldmodel_checkpoint.py](../../src/worldforge/smoke/leworldmodel_checkpoint.py) downloads `config.json` + `weights.pt` from a **pinned 40-char HF revision**, validates every Hydra `_target_` against `LEWORLDMODEL_HF_ALLOWED_CONFIG_TARGETS` (currently the PushT ViT-tiny shape: `size="tiny"`, `patch_size=14`, `image_size=224`), instantiates `stable_worldmodel.wm.lewm.LeWM`, loads weights `strict=False`, and saves the object checkpoint to `$STABLEWM_HOME/<policy>_object.ckpt`. An Atom01 world model must either fit this allow-list or extend it.
+- **Policy providers.** `lerobot` ([providers/lerobot.py](../../src/worldforge/providers/lerobot.py)) and `gr00t` ([providers/gr00t.py](../../src/worldforge/providers/gr00t.py)) both implement `policy`; both require a host-supplied `action_translator`. `gr00t` is the precedent for a **client/server ZMQ bridge** across a Python-version boundary (the upstream package is pinned to an older Python; WorldForge runs 3.13).
+- **LeWM internals (per upstream README + arXiv 2603.19312, to be re-verified in P0).** JEPA from **raw pixels**: ViT encoder → AR predictor → action encoder, ~15M params, two-loss objective (next-embedding prediction + Gaussian latent regularizer), single-GPU training in hours. Built on `stable-worldmodel` (Gymnasium envs, planners CEM/MPPI/Gradient-Descent/Random, MIT) and `stable-pretraining`. Hydra configs (`config/train/`), `python train.py data=<name>`, WandB tracking, HDF5 datasets under `$STABLEWM_HOME` (default `~/.stable-wm/`).
+- **Upstream Atom01 (per repo READMEs).** `atom01_train` (BSD-3): IsaacSim 5.1.0 / IsaacLab 2.3.2 / RSL_RL 3.3.0, Python 3.11, `train.py` / `play.py` / `sim2sim_atom01.py` / `dataset_retarget.py`, supports standard RL + AMP + BeyondMimic. `roboto_origin` (GPL-3.0): ROS2 Humble deploy, USB2CAN, IMU, OrangePi, Python 3.10.
+
+## The central technical problem (must be resolved in P0)
+LeWM as published consumes **pixels** (a ViT-224 encoder). Atom01's RL control loop is **proprioceptive** (joint positions/velocities, IMU, base velocity, gait/command vector). There is no free lunch:
+
+- **Option A — render to pixels.** Render RGB camera frames during sim rollouts and train/fine-tune LeWM on those, keeping the published architecture and the existing checkpoint-builder allow-list (mostly) intact. Most faithful to "fine-tuned LeWorldModel"; cost is a rendering pipeline + a large visual+embodiment domain gap from PushT.
+- **Option B — vector-observation world model.** Adapt the LeWM recipe (same two-loss JEPA objective) to a proprioceptive encoder (MLP/transformer over state vectors). Truer to how Atom01 is actually controlled and cheaper to roll out, but it is an **architecture change**, not a fine-tune, and breaks the current checkpoint-builder allow-list (needs new `_target_`s and validation).
+
+This spec is written **Option-A-first** (preserve the LeWM pixel architecture; warm-start where a compatible pretrained 3D-control checkpoint exists) with Option B as a documented fallback, because Option A maximizes reuse of the existing `leworldmodel` provider and checkpoint builder. P0 must pick one with evidence before P1 data collection begins.
+
+## In scope
+- A **sim-first** showcase: `scripts/roboto-showcase` wrapper + a `src/worldforge/smoke/` entry point that runs the planning loop against IsaacLab/IsaacSim or MuJoCo Sim2Sim and emits JSON + a run-manifest, mirroring [src/worldforge/smoke/robotics_showcase.py](../../src/worldforge/smoke/robotics_showcase.py).
+- A **`roboto` policy adapter** (`policy` capability only) that yields action candidates from the trained Atom01 RL policy, bridged over a client/server boundary if the Python version forces it (gr00t precedent). Host-supplied `action_translator` maps raw policy tensors → WorldForge `Action`s.
+- An **end-to-end world-model pipeline**, all host/GPU-owned and invoked via `uv run --with`:
+  1. **Data collection** — roll out the trained (and perturbed) Atom01 policy in sim, capturing observations + actions + goal/cost signal.
+  2. **Dataset engineering** — pack rollouts into the `stable-worldmodel` HDF5 format under `$STABLEWM_HOME`, with train/val/test splits, action normalization, and a versioned dataset card pinned by content hash (stored off-repo, never committed).
+  3. **Training / fine-tuning** — train the LeWM world model (warm-start from a compatible checkpoint where available) via the upstream Hydra/WandB flow; produce `<name>_object.ckpt` + `<name>_weight.ckpt`.
+  4. **Checkpoint packaging** — publish to a pinned HF revision and build the object checkpoint through an Atom01-aware extension of [leworldmodel_checkpoint.py](../../src/worldforge/smoke/leworldmodel_checkpoint.py) (allow-list / ViT-config widened, audited).
+  5. **Evaluation** — world-model fidelity (latent prediction error, probes) **and** downstream planning lift (does `policy+score` MPC beat policy-only on a task metric?), with cost calibration.
+- Provider wiring so `leworldmodel` (extended) loads the Atom01 checkpoint and `roboto` feeds candidates into `World.plan(... planning_mode="policy+score")` (or a `score`/MPC mode if P0 finds that fits locomotion better).
+- Optional **Rerun / TensorBoard** visuals reusing existing bridges, kept out of base deps.
+- An **optional CI workflow** for sim inference only (training never runs in CI), modeled on [.github/workflows/robotics-showcase.yml](../../.github/workflows/robotics-showcase.yml), with a recorded-rollout or MuJoCo fallback since IsaacSim is not installable on stock CI runners.
+- Docs: a provider page for `roboto`, a playbook section for the data/training/eval pipeline, `<provider_contracts>` and CHANGELOG updates.
+
+## Out of scope (explicit)
+- **Real hardware control.** Driving USB2CAN motors / ROS2 deploy on a physical Atom01 is deferred to a **gated** phase (P7) and is not built by this spec. No robot safety layer is added to WorldForge (CLAUDE.md priority rule 4).
+- Adding torch, IsaacLab, IsaacSim, ROS2, RSL_RL, `lewm`/`stable-worldmodel`/`stable-pretraining`, robot controllers, checkpoints, or datasets to base dependencies, `src/worldforge/` imports, or the repository tree.
+- Training in CI, or uploading checkpoint/dataset artifacts from default CI (`actions/cache` is the reuse mechanism, per the existing robotics workflow).
+- Re-implementing LeWM or RSL_RL inside WorldForge. Upstream code stays upstream; WorldForge integrates it.
+- New capability *surfaces*. `roboto` advertises only `policy`; the world model uses the existing `score` capability. No new protocol is added.
+- Changing the meaning of `World.plan`, `ActionScoreResult`, `ActionPolicyResult`, or persistence.
+
+## Target architecture
+
+```text
+  ┌─ host / GPU (never base deps, never CI training) ───────────────────────────┐
+  │                                                                             │
+  │  atom01_train (BSD-3)            data collection            dataset (HDF5)   │
+  │  IsaacLab/IsaacSim + RSL_RL  ─►  roll out policy (+noise) ─► $STABLEWM_HOME  │
+  │  MuJoCo Sim2Sim                  render obs / log actions     train/val/test │
+  │                                                                  │           │
+  │                                                                  ▼           │
+  │  LeWM (stable-worldmodel + stable-pretraining)            train / fine-tune  │
+  │  Hydra config · WandB · single-GPU                       <name>_object.ckpt  │
+  │                                                                  │           │
+  │  publish to pinned HF revision  ◄────────────────────────────────┘           │
+  └─────────────────────────────────────────────────────────────────│──────────┘
+                                                                      ▼
+  ┌─ WorldForge (Python 3.13, pure base; runtimes via `uv run --with`) ─────────┐
+  │  leworldmodel_checkpoint.py (Atom01-aware) ─► AutoCostModel object ckpt      │
+  │  providers/leworldmodel.py  (score)  ◄──┐                                    │
+  │  providers/roboto.py        (policy) ───┤   World.plan(policy+score)         │
+  │      └─ ZMQ client ─► host policy server │   → ranks candidates by cost      │
+  │  smoke/roboto_showcase.py  + scripts/roboto-showcase  ─► JSON + run-manifest │
+  │      └─ optional Rerun / TensorBoard                                         │
+  └─────────────────────────────────────────────────────────────────────────────┘
+```
+
+### Dataset engineering (detail)
+- **Sources.** On-policy rollouts of the trained Atom01 RL policy plus **action-perturbed / exploratory** rollouts (Gaussian action noise, command randomization, terrain/dynamics randomization). A world model needs action diversity to learn dynamics — pure expert-only data under-covers the transition space and risks a degenerate cost surface.
+- **Observation modality.** Per P0 decision: Option A renders RGB to the LeWM input resolution (e.g. 224×224, ego- and/or third-person camera), control-rate aligned; Option B logs normalized proprioceptive state vectors.
+- **Action representation.** Decide between full actuated-joint targets (high-DoF, harder to score) and a reduced locomotion command space (e.g. `vx, vy, ωz`, gait). Reduced command space is preferred for tractable MPC candidate scoring; record the `action_translator` contract that maps it to/from policy tensors. Verify the candidate tensor rank the planner expects (PushT used `[batch, candidates, horizon, action_dim]`).
+- **Goal / cost signal.** LeWM cost is goal-relative in latent space. Define goal conditioning for locomotion (target velocity / target pose, rendered as goal image for Option A or goal vector for Option B) and store it per episode.
+- **Packaging.** `stable-worldmodel` HDF5 under `$STABLEWM_HOME`: per-episode groups, observation dataset (`uint8` NHWC for pixels / `float32` for vectors), action dataset (`float32`), terminals, and goal/metadata; `<name>_train.h5` / `<name>_val.h5` (P0 to confirm exact upstream schema keys).
+- **Splits & balance.** Episode-level train/val/test with held-out commands/terrains for generalization; documented expert/exploratory mix ratio.
+- **Versioning.** Dataset card + content hash; stored off-repo (HF dataset or object store), pinned by revision like the checkpoint SHA. Never committed.
+
+### MLOps / training pipeline (detail)
+- **Environment.** Reproducible via `uv run --with` (torch, `stable-worldmodel`, `stable-pretraining`, hydra-core, omegaconf, transformers, datasets, h5py, wandb; IsaacSim/IsaacLab/ROS2 host-installed, never pip/uv-resolvable in base). IsaacSim is multi-GB and GPU-bound — host-owned only.
+- **Training.** Upstream Hydra flow (`train.py data=atom01`) with WandB tracking. Warm-start from a compatible pretrained LeWM checkpoint as an ablation arm; from-scratch (LeWM recipe) as the baseline. Capture config, seed, dataset revision, and code SHA in the run record.
+- **Checkpoint packaging.** Publish `config.json` + `weights.pt` to a pinned HF revision; extend the audited allow-list in [leworldmodel_checkpoint.py](../../src/worldforge/smoke/leworldmodel_checkpoint.py) (and the ViT/encoder config validator) to accept the Atom01 config without weakening the "exact, narrow" `_target_` guarantee. Output object ckpt at `$STABLEWM_HOME/atom01/<name>_object.ckpt`.
+- **Evaluation.** Two layers: (1) world-model fidelity — latent next-step prediction error, linear probes for known state variables; (2) downstream planning lift — task success / tracking error for `policy+score` MPC vs policy-only, plus **cost calibration** (does lower predicted cost correlate with better realized outcome?). Surface as a deterministic evaluation/benchmark report where possible.
+- **Promotion gate.** The `roboto`+`leworldmodel` showcase advertises real capability only when the checkpoint loads, the planning loop runs end-to-end in sim, and evaluation shows non-trivial, calibrated cost — otherwise it stays a documented scaffold.
+
+## Acceptance criteria
+- [ ] P0 decision record committed under `specs/roboto-showcase/` (or `docs/`) resolving: observation modality (Option A vs B), action representation, planning mode, goal conditioning, Python-version bridge, CI sim backend, and licensing — each with evidence.
+- [ ] A reproducible data-collection entry point produces sim rollouts (expert + perturbed) with the chosen observation/action/goal schema.
+- [ ] A dataset-engineering step packs rollouts into the `stable-worldmodel` HDF5 layout under `$STABLEWM_HOME`, with documented train/val/test splits and a versioned, off-repo dataset card.
+- [ ] A training/fine-tuning run produces an Atom01 LeWM checkpoint (`_object.ckpt` + `_weight.ckpt`) via the upstream Hydra/WandB flow, with a captured run record (config, seed, dataset revision, code SHA).
+- [ ] An Atom01-aware extension of [leworldmodel_checkpoint.py](../../src/worldforge/smoke/leworldmodel_checkpoint.py) builds the object checkpoint from a pinned HF revision with an audited (still narrow) Hydra allow-list. `worldforge doctor` reports `leworldmodel` configured when the Atom01 env vars are present.
+- [ ] A `roboto` policy adapter exists, advertises **only** `policy`, passes `worldforge.testing.assert_provider_contract()` (or the capability-protocol successor), and feeds candidates into `World.plan(...)`.
+- [ ] `scripts/roboto-showcase` runs end-to-end in sim and emits JSON + a run-manifest with a truthful `mode` string, both providers' health, candidate/score shapes, `best_index`, and provider events — analogous to the PushT showcase contract.
+- [ ] Evaluation artifacts show world-model fidelity and downstream planning lift with cost calibration; the showcase claims real capability only if the gate is met, else is labeled a scaffold.
+- [ ] No torch / IsaacSim / IsaacLab / ROS2 / RSL_RL / `lewm` / `stable-worldmodel` / checkpoint / dataset import enters base deps or `src/worldforge/` module top level; `scripts/check_optional_import_boundaries.py` stays clean.
+- [ ] Full local gate green (`uv run ruff check ...`, `ruff format --check`, `generate_provider_docs.py --check`, `pytest`, coverage ≥90%, `bash scripts/test_package.sh`).
+- [ ] Optional sim-only CI workflow (recorded-rollout or MuJoCo fallback) added behind approval; it never trains and never uploads checkpoint/dataset artifacts.
+- [ ] Docs updated: `roboto` provider page, data/training/eval playbook, `<provider_contracts>` (truthful `roboto` = `policy`), README/AGENTS/CLAUDE/CHANGELOG where public behavior changes.
+
+## Non-functional requirements
+- **Optional-runtime boundary held.** All heavy runtimes are host-owned, lazily imported only inside `src/worldforge/smoke/` entry points and provider methods, and supplied via `uv run --with`. Base `pyproject.toml`/`uv.lock` unchanged (any change is gated and approved separately).
+- **Safety, sim-first.** No real-hardware actuation in this spec. Real hardware (P7) is opt-in, host-owned controller and kill switch, non-mutating defaults, gated approval. WorldForge owns planning, not safety.
+- **Capability truthfulness.** `roboto` advertises only callable, tested, typed surfaces; the world model is exposed via the existing `score` capability. No physical-fidelity claims from deterministic/mock paths.
+- **Licensing hygiene.** GPL-3.0 `roboto_origin` deploy code is invoked only as a separate host-owned process, never imported into `src/worldforge/`. BSD-3 `atom01_train` is unrestricted for our use. LeWM / `stable-worldmodel` / `stable-pretraining` licenses re-verified in P0 before any redistribution of derived checkpoints.
+- **Reproducibility.** Dataset revision, checkpoint HF SHA, training config/seed, and upstream package versions are all pinned and recorded; checkpoint building validates a pinned 40-char SHA as today.
+- **Determinism in CI.** The sim-only CI path is deterministic (recorded rollouts or seeded MuJoCo); no network model training; no flakiness from live GPU inference unless on an approved self-hosted runner.
+
+## Open questions (to resolve in P0 — this is a research-gated spec)
+1. **Observation modality** — Option A (render to pixels, keep LeWM architecture) vs Option B (vector-obs world model, architecture change). Evidence: rendering cost, domain-gap severity, checkpoint-builder impact.
+2. **Does LeWM transfer at all to a 3D legged embodiment?** Warm-start benefit from a pretrained checkpoint is unknown given the PushT visual/embodiment gap; may need from-scratch.
+3. **Planning mode for locomotion** — `policy+score` (rank policy candidates) vs `score`/MPC (sample candidates, optimize via CEM/MPPI in `stable-worldmodel`). Which improves a real task metric?
+4. **Action space** — full joint targets vs reduced locomotion command space; the candidate tensor rank the planner and cost model expect.
+5. **Python-version bridge** — `atom01_train` is 3.11, deploy is 3.10, WorldForge is 3.13. In-process vs ZMQ client/server (gr00t precedent). Likely client/server.
+6. **CI sim backend** — IsaacSim is not installable on stock GitHub runners. Recorded-rollout replay, MuJoCo-only, or an approved self-hosted GPU runner?
+7. **Checkpoint-builder allow-list** — how to widen `LEWORLDMODEL_HF_ALLOWED_CONFIG_TARGETS` / ViT-config validation for an Atom01 config while keeping it "exact and narrow."
+8. **Dataset schema** — confirm the exact `stable-worldmodel` HDF5 keys/layout and goal-conditioning convention from upstream code (not just README).
+9. **Licensing** — confirm LeWM / `stable-worldmodel` / `stable-pretraining` licenses permit redistributing an Atom01-derived checkpoint; confirm GPL-3 isolation strategy.
+10. **Compute budget** — single-GPU "few hours" is the PushT claim; rendered 3D locomotion data is larger. Estimate data volume, training time, and storage.
+
+## References
+- Originating spike: [#321](https://github.com/AbdelStark/worldforge/issues/321)
+- Existing showcase: [scripts/robotics-showcase](../../scripts/robotics-showcase), [src/worldforge/smoke/robotics_showcase.py](../../src/worldforge/smoke/robotics_showcase.py), [src/worldforge/smoke/lerobot_leworldmodel.py](../../src/worldforge/smoke/lerobot_leworldmodel.py)
+- Checkpoint builder: [src/worldforge/smoke/leworldmodel_checkpoint.py](../../src/worldforge/smoke/leworldmodel_checkpoint.py)
+- Providers: [src/worldforge/providers/leworldmodel.py](../../src/worldforge/providers/leworldmodel.py) (`score`), [src/worldforge/providers/lerobot.py](../../src/worldforge/providers/lerobot.py) (`policy`), [src/worldforge/providers/gr00t.py](../../src/worldforge/providers/gr00t.py) (`policy`, ZMQ bridge precedent)
+- Planning: `World.plan(...)` in [src/worldforge/framework.py](../../src/worldforge/framework.py)
+- CI precedent: [.github/workflows/robotics-showcase.yml](../../.github/workflows/robotics-showcase.yml)
+- Boundary rules: [CLAUDE.md](../../CLAUDE.md) (`<priority_rules>`, `<boundaries>`)
+- Upstream: https://github.com/Roboparty/roboto_origin (GPL-3.0), https://github.com/Roboparty/atom01_train (BSD-3-Clause), https://roboparty.com
+- LeWM: https://github.com/lucas-maes/le-wm , https://github.com/lucas-maes/stable-worldmodel , https://le-wm.github.io/ , arXiv 2603.19312

--- a/specs/roboto-showcase/tasks.md
+++ b/specs/roboto-showcase/tasks.md
@@ -1,0 +1,88 @@
+# Tasks — Roboto (Atom01) showcase
+
+## Status
+Draft · 2026-05-25
+
+Checkable task list matching the phases in [plan.md](./plan.md). P0 is a hard gate; P1–P3 are host/GPU research; P4–P6 are WorldForge `src/` PRs; P7 is gated/deferred. Nothing in P1+ starts until P0 is signed off.
+
+## P0 — Feasibility and decision record (HARD GATE)
+- [ ] Read upstream `stable-worldmodel` code and confirm the exact HDF5 dataset schema (keys, dtypes, episode layout) and goal-conditioning convention.
+- [ ] Read `le-wm` code; determine whether the encoder is swappable for vector observations (Option B) or pixels are required (Option A).
+- [ ] Determine the action-candidate tensor rank/shape that `AutoCostModel.get_cost` expects; confirm against the PushT `[batch, candidates, horizon, action_dim]` precedent.
+- [ ] Inspect `atom01_train` `play.py` / `sim2sim_atom01.py` for the exported policy's observation and action shapes and control rate.
+- [ ] Check whether a pretrained LeWM checkpoint exists that is plausibly warm-startable for 3D control.
+- [ ] Decide observation modality: Option A (render to pixels) vs Option B (vector-obs world model). Record evidence.
+- [ ] Decide action space: full joint targets vs reduced locomotion command space.
+- [ ] Decide planning mode: `policy+score` vs `score`/MPC (CEM/MPPI) — pick the one expected to lift a real task metric.
+- [ ] Decide goal-conditioning representation for locomotion.
+- [ ] Decide Python-version bridge: in-process vs ZMQ client/server (gr00t precedent).
+- [ ] Decide CI sim backend: recorded-rollout replay vs MuJoCo vs approved self-hosted GPU runner (IsaacSim not on stock runners).
+- [ ] Verify licenses: `le-wm`, `stable-worldmodel`, `stable-pretraining` (checkpoint redistribution); confirm GPL-3 `roboto_origin` isolation strategy.
+- [ ] Estimate compute/storage budget (data volume, training time, checkpoint/dataset sizes).
+- [ ] Off-repo proof: chosen action-candidate shape flows through `World.plan(...)` against the mock/score path.
+- [ ] Write the decision record (`specs/roboto-showcase/decisions.md` or triad update); record go/no-go. Every spec open question cited with a source.
+
+## P1 — Sim rollout data-collection harness (host/GPU)
+- [ ] Stand up `atom01_train` (BSD-3) on a GPU host; reproduce `play.py` and `sim2sim_atom01.py`.
+- [ ] Build a host-owned collector (run via `uv run --with`) that rolls out the trained policy in IsaacLab/IsaacSim and MuJoCo Sim2Sim.
+- [ ] Capture the P0-chosen observation modality, actions, terminals, and goal/cost signal per step.
+- [ ] Add configurable expert/exploratory mix, command/terrain/dynamics randomization, and seed capture.
+- [ ] Emit a raw rollout dump + manifest (counts, seeds, source policy revision) to an off-repo location.
+- [ ] Confirm no IsaacSim/IsaacLab/RSL_RL import touches `src/worldforge/`.
+
+## P2 — Dataset engineering → HDF5 (host/GPU)
+- [ ] Implement a packing step that converts rollouts into the upstream `stable-worldmodel` HDF5 layout under `$STABLEWM_HOME`.
+- [ ] Compute and store action normalization stats and goal-conditioning fields.
+- [ ] Produce episode-level train/val/test splits with held-out commands/terrains.
+- [ ] Write a dataset card (modality, action space, mix ratio, counts, seeds, source revision) + content hash.
+- [ ] Publish the dataset off-repo (HF dataset or object store), pinned by revision. Confirm nothing is committed.
+- [ ] Validate: `stable-worldmodel` loads the dataset; a one-batch LeWM step runs.
+
+## P3 — World-model training / fine-tuning + MLOps (host/GPU)
+- [ ] Author the host-owned Hydra config (`data=atom01`, encoder/predictor/action-encoder shapes from P0).
+- [ ] Document the `uv run --with ...` training command and WandB setup.
+- [ ] Run the from-scratch baseline; capture config, seed, dataset revision, code SHA, package versions.
+- [ ] Run the warm-start ablation if a compatible checkpoint exists.
+- [ ] Add collapse / degenerate-cost diagnostics (loss curves, latent-variance / probe checks).
+- [ ] Produce `<name>_object.ckpt` + `<name>_weight.ckpt`.
+- [ ] Publish `config.json` + `weights.pt` to a pinned 40-char HF revision.
+- [ ] Write a short training debrief (curves, chosen arm, known limitations).
+- [ ] Validate: checkpoint loads via `AutoCostModel`; finite, non-degenerate costs over held-out candidates.
+
+## P4 — Checkpoint packaging + provider wiring (WorldForge `src/`)
+- [ ] Check tree state for the capability-protocols refactor; target the current provider surface.
+- [ ] Extend `LEWORLDMODEL_HF_ALLOWED_CONFIG_TARGETS` and the encoder-config validator in [src/worldforge/smoke/leworldmodel_checkpoint.py](../../src/worldforge/smoke/leworldmodel_checkpoint.py) for the audited Atom01 config; keep the allow-list exact/narrow; support an `atom01/<name>` policy path.
+- [ ] Add positive + negative unit tests for the widened allow-list and config validator.
+- [ ] Create `src/worldforge/providers/roboto.py` implementing `policy` (or the capability-protocol successor); lazy runtime imports only.
+- [ ] Implement the ZMQ client + host policy-server contract if P0 confirms a Python-version split; wire the host-supplied `action_translator`.
+- [ ] Env-gated registration (`ROBOTO_POLICY_HOST` / `ROBOTO_POLICY_PATH`); add the catalog entry.
+- [ ] Add `<provider_contracts>` row: `roboto` → `policy` (truthful), Atom01 LeWM checkpoint loadable by `leworldmodel`.
+- [ ] Unit + contract tests with fixtures (`assert_provider_contract` or `assert_capability_contract`); no live runtime on the unit path.
+- [ ] `worldforge doctor` reports `roboto` + `leworldmodel` configured under Atom01 env vars.
+- [ ] `scripts/check_optional_import_boundaries.py` clean. Full gate green.
+
+## P5 — Planning loop + showcase wrapper + evidence (WorldForge `src/`)
+- [ ] Create `src/worldforge/smoke/roboto_showcase.py` composing `roboto` (policy) + `leworldmodel` (score) via `World.plan(... planning_mode=...)` per P0.
+- [ ] Create `scripts/roboto-showcase` wrapper supplying runtime deps via `uv run --with`, with `--json-only` / `--no-tui` / `--no-rerun` / `--no-tensorboard` parity.
+- [ ] Emit JSON + run-manifest: truthful `mode` string, both providers' health, candidate/score shapes, `best_index`, provider events, `capability` field.
+- [ ] Wire optional Rerun / TensorBoard visuals via existing bridges (out of base deps).
+- [ ] Produce evaluation artifacts: world-model fidelity + downstream planning lift vs policy-only + cost calibration.
+- [ ] Deterministic showcase contract test (recorded/mock-backed) mirroring the PushT showcase assertions.
+- [ ] Decide real-capability vs scaffold labeling based on the planning-lift gate; document the finding.
+- [ ] Full gate green.
+
+## P6 — Optional sim-only CI + docs (gated)
+- [ ] Draft `.github/workflows/roboto-showcase.yml` (sim-only; recorded-replay or MuJoCo; never trains; never uploads checkpoint/dataset artifacts; `actions/cache` for HF + checkpoint). **Requires explicit approval before merge.**
+- [ ] Add `docs/src/providers/roboto.md`.
+- [ ] Add a playbook section for the data/training/eval pipeline.
+- [ ] Update README / AGENTS / CLAUDE `<provider_contracts>` for `roboto`.
+- [ ] Add CHANGELOG entry.
+- [ ] `uv run python scripts/generate_provider_docs.py --check` clean; manual docs review.
+- [ ] Full gate green including `bash scripts/test_package.sh`.
+
+## P7 — Real-hardware bring-up (GATED · DEFERRED)
+- [ ] (Deferred) Separate safety review + its own spec triad + approval before any physical actuation. Not built by this triad.
+
+## Post-merge
+- [ ] (Optional) Generalize the data→dataset→train→checkpoint pipeline into a reusable "new embodiment world model" playbook.
+- [ ] (Optional) Revisit Option B (vector-obs world model) if Option A's domain gap proves limiting.


### PR DESCRIPTION
## Summary

Adds a spec triad under `specs/roboto-showcase/` following the GitHub Spec Kit pattern (matching `specs/capability-protocols/`). It turns the spike in #321 into a research-gated, sim-first implementation plan to drive RoboParty's open-source Atom01 humanoid by composing a `roboto` **policy** with a fine-tuned **LeWorldModel** `Cost` via `World.plan(... planning_mode="policy+score")`, backed by an end-to-end dataset → training → checkpoint → evaluation pipeline.

- `spec.md` — outcome, grounded background, the central pixels-vs-proprioception problem, dataset engineering + MLOps detail, acceptance criteria, and 10 open questions.
- `plan.md` — phased plan: **P0 hard gate** → P1 data collection → P2 dataset → P3 training/fine-tune → P4 checkpoint + provider wiring → P5 planning loop + showcase + evidence → P6 optional sim-only CI/docs → **P7 real hardware (gated/deferred)**.
- `tasks.md` — checkable tasks per phase.

## Notes

- **Docs/specs only** — no code, no dependency, and no `src/worldforge/` changes. Base `pyproject.toml`/`uv.lock` untouched.
- **Boundaries preserved by design:** torch / IsaacSim / IsaacLab / ROS2 / RSL_RL / lewm / stable-worldmodel / checkpoints / datasets stay host-owned and out of base deps; real hardware is gated and deferred (P7), safety stays host-owned.
- Authored pre-research: LeWM internals are cited from the upstream README/arXiv, and the first P0 task is to re-verify them against upstream source.

Closes nothing; follows up #321.
