### PR TITLE
Tune AI review routing for robotics PRs

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -18,6 +18,9 @@ reviews:
   auto_review:
     enabled: true
     drafts: false
+    base_branches:
+      - "feat/.*"
+      - "integration/.*"
     auto_incremental_review: true
     auto_pause_after_reviewed_commits: 5
     ignore_title_keywords:
@@ -50,6 +53,20 @@ reviews:
         - Flag unsafe deserialization, dynamic imports, Hydra/object instantiation from untrusted configs, and unpinned remote revisions.
         - Ensure safety messaging covers every code-execution surface before weights are loaded.
         - Keep torch, robotics, CUDA, and checkpoint dependencies host-owned and outside base install requirements.
+    - path: "src/worldforge/demos/**"
+      instructions: |
+        Review demos as checkout-safe decision-evidence surfaces, not live robotics control loops.
+        - WorldForge must add value by choosing, scoring, explaining, comparing, or exposing counterfactual robot decisions.
+        - Reject demos that only repackage DimOS, LeRobot, or simulator outputs without measurable decision evidence.
+        - Keep live hardware commands, transport setup, credentials, robot keys, and account binding outside WorldForge demos.
+        - Validate replay and simulator artifacts as untrusted inputs: bounded reads, regular files, finite numbers, JSON-native metadata, and redacted host paths.
+        - Require deterministic fixtures, no optional robotics imports on base paths, and clear operator docs with the command, success signal, and first triage step.
+    - path: "examples/**"
+      instructions: |
+        Examples must stay reproducible from a clean checkout.
+        - Prefer fixture-backed replay or simulator artifacts over live service, GPU, robot, or account dependencies.
+        - Keep wrappers thin and ensure public behavior is also covered by packaged demo tests when the example exposes a command.
+        - Documentation should state what artifact is consumed, what trace/report is emitted, and what evidence WorldForge adds beyond a script.
     - path: "src/worldforge/models.py"
       instructions: |
         Treat model changes as public API and persistence contract changes.
@@ -120,6 +137,11 @@ knowledge_base:
     scope: "local"
   web_search:
     enabled: true
+  linked_repositories:
+    - repository: "dimensionalOS/dimos"
+      instructions: |
+        Use DimOS as integration context for Go2/SO-101 runtime, simulation, replay, mapping, and transport surfaces.
+        WorldForge should not vendor DimOS runtime code or duplicate robot control. Reviews should check that WorldForge consumes host-owned DimOS artifacts, scores or compares candidate decisions, and emits reusable decision evidence.
 
 chat:
   auto_reply: true

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -20,6 +20,9 @@ reviews:
     drafts: false
     base_branches:
       - "feat/.*"
+      - "fix/.*"
+      - "docs/.*"
+      - "chore/.*"
       - "integration/.*"
     auto_incremental_review: true
     auto_pause_after_reviewed_commits: 5
@@ -137,11 +140,6 @@ knowledge_base:
     scope: "local"
   web_search:
     enabled: true
-  linked_repositories:
-    - repository: "dimensionalOS/dimos"
-      instructions: |
-        Use DimOS as integration context for Go2/SO-101 runtime, simulation, replay, mapping, and transport surfaces.
-        WorldForge should not vendor DimOS runtime code or duplicate robot control. Reviews should check that WorldForge consumes host-owned DimOS artifacts, scores or compares candidate decisions, and emits reusable decision evidence.
 
 chat:
   auto_reply: true

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -18,12 +18,13 @@ reviews:
   auto_review:
     enabled: true
     drafts: false
+    # CodeRabbit base_branches entries are regex patterns; path filters below use path globs.
     base_branches:
-      - "feat/.*"
-      - "fix/.*"
-      - "docs/.*"
-      - "chore/.*"
-      - "integration/.*"
+      - "^feat/.*$"
+      - "^fix/.*$"
+      - "^docs/.*$"
+      - "^chore/.*$"
+      - "^integration/.*$"
     auto_incremental_review: true
     auto_pause_after_reviewed_commits: 5
     ignore_title_keywords:

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -21,10 +21,13 @@ High-signal issue areas:
 - Secret handling: credentials, bearer tokens, API keys, signed URLs, and secret-like metadata must not reach provider events, logs, exceptions, transcripts, persisted worlds, or returned result metadata.
 - Capability truthfulness: providers must advertise only capabilities implemented end to end. Do not let score, policy, predict, generate, reason, embed, transfer, and plan become interchangeable labels.
 - Public contracts: JSON-native validation, finite numeric values, typed errors, stable serialization, and regression tests for every bug fix or documented failure mode.
+- Robotics decision evidence: Go2, SO-101, DimOS, LeRobot, replay, simulator, and MPC examples must show WorldForge choosing, scoring, explaining, comparing, or exposing counterfactual decisions.
+- Robotics runtime separation: examples must not require live hardware, robot account binding, transport secrets, torch, DimOS, or LeRobot in the base install path unless the runtime is explicitly optional and host-owned.
 """
 compliance_user_guidelines = """
 Use AGENTS.md, best_practices.md, and pr_compliance_checklist.yaml as repository-specific review standards.
 Treat checklist failures as real findings when the PR changes provider I/O, optional-runtime loading, persistence, planning, event logging, CI, packaging, or public documentation.
+Treat robotics checklist failures as blocking when a PR only wraps DimOS, LeRobot, or simulator outputs without measurable WorldForge decision evidence.
 Do not block on cosmetic preferences unless they hide a correctness, security, or maintenance risk.
 """
 

--- a/best_practices.md
+++ b/best_practices.md
@@ -87,6 +87,23 @@ Planning output must be auditable.
 - Replays and demos should say clearly when they are mock replay, simulation, injected policy,
   checkpoint inference, or real robot control.
 
+## Robotics Decision Evidence
+
+WorldForge robotics work should treat DimOS, LeRobot, Go2, SO-101, simulators, and hardware drivers
+as host-owned runtime or artifact sources. WorldForge should not vendor those stacks, become the
+account-binding or transport layer, or send live motion commands from checkout-safe examples.
+
+- Use replay, simulator, or fixture artifacts as untrusted inputs: bounded reads, regular files,
+  finite numeric validation, JSON-native metadata, deterministic tie-breaking, and redacted host
+  paths.
+- WorldForge earns its place only when it chooses, scores, explains, compares, or exposes
+  counterfactual candidate decisions with reusable traces and measured or simulated outcomes.
+- If a robotics change only logs a DimOS, LeRobot, simulator, or hardcoded decision without
+  candidate scores, selected-action rationale, outcomes, or counterfactuals, treat it as out of
+  scope for WorldForge.
+- Keep DimOS-specific context curated in this repository's review guidance rather than importing an
+  arbitrary external repository into LLM review prompts.
+
 ## Tests And Documentation
 
 Every bug fix and documented failure mode needs a focused regression test.

--- a/pr_compliance_checklist.yaml
+++ b/pr_compliance_checklist.yaml
@@ -35,6 +35,18 @@ pr_compliances:
     success_criteria: "Optional integrations are behind extras, smoke commands, or host-owned setup, and import paths fail gracefully when optional dependencies are absent."
     failure_criteria: "The PR adds optional runtime dependencies to the base package or imports optional packages from core modules, CLI root paths, or non-optional provider surfaces."
 
+  - title: "Robotics decision evidence"
+    compliance_label: true
+    objective: "Robotics demos and adapters must demonstrate why WorldForge belongs in the decision loop."
+    success_criteria: "The PR shows WorldForge choosing, scoring, explaining, comparing, or exposing counterfactual Go2/SO-101 decisions with reusable traces and measurable outcome fields."
+    failure_criteria: "The PR only logs or repackages decisions already made by DimOS, LeRobot, a simulator, or a hardcoded script without candidate scores, selected-action rationale, outcomes, or counterfactuals."
+
+  - title: "Host-owned robotics runtime boundary"
+    compliance_label: true
+    objective: "WorldForge must not become the live robot runtime, account-binding flow, or hardware control stack."
+    success_criteria: "Go2, SO-101, DimOS, LeRobot, and simulator integrations consume bounded replay/sim artifacts or optional host-owned runtime hooks, avoid live motion commands by default, keep device secrets out of traces, and document hardware requirements separately."
+    failure_criteria: "The PR sends live robot commands from checkout-safe examples, vendors DimOS/LeRobot runtime code, requires robot dependencies in the base install, leaks host/device identifiers, or assumes account binding/hardware availability in CI."
+
   - title: "Regression tests and operator documentation"
     compliance_label: true
     objective: "Behavior changes must be testable and operationally clear."


### PR DESCRIPTION
## Summary
- enable CodeRabbit auto-review for stacked `feat/*`, `fix/*`, `docs/*`, `chore/*`, and `integration/*` PR bases using anchored CodeRabbit regex patterns
- add robotics decision-evidence instructions for demos/examples
- extend Qodo and compliance rules for Go2/SO-101 decision-evidence and host-owned runtime boundaries
- add curated DimOS/robotics review guidance in `best_practices.md` instead of importing external repo context into reviewer prompts

## Why
- CodeRabbit skipped omarespejel/worldforge#36 automatically because its base branch was not the default branch
- WorldForge robotics work needs reviewer guardrails for the kill criterion: choose, score, explain, compare, or expose counterfactuals, not just log runtime output
- fork-side Qodo review flagged broad external linked-repo context as an unnecessary prompt-surface expansion, so this keeps DimOS context curated locally

## Fork review evidence
- Fork PR: omarespejel/worldforge#37
- Qodo: 0 bugs, 0 rule violations after fixes
- CodeRabbit: no actionable comments after fixes
- Checks: Quality, Tests, Package contract, Security, pip-audit, Real LeRobot + LeWorldModel inference all passing

## Validation
- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".coderabbit.yaml"); YAML.load_file("pr_compliance_checklist.yaml"); puts "yaml ok"'`
- `uv run python -c 'import pathlib, tomllib; tomllib.loads(pathlib.Path(".pr_agent.toml").read_text()); print("toml ok")'`
