### PR TITLE
Add Go2 ControlBench decision-trace demo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,12 @@ releases may still include breaking changes when the public API needs to tighten
   with candidate scores, selected action, measured replay outcome, and counterfactual rejected
   actions. The demo is shaped after public `lerobot/svla_so101_pickplace` metadata but does not
   install LeRobot, torch, DimOS, or connect robot hardware.
+- Added `examples/go2-controlbench-decisiontrace/run.py`, a checkout-safe Go2 Air ControlBench
+  DecisionTrace replay that consumes a compact public
+  `espejelomar/go2-air-controlbench-v1` positive-regret trace, reranks candidate Unitree
+  sport-mode commands through WorldForge's `score` capability, and reports measured native-odom
+  regret against the best counterfactual command without importing DimOS, Unitree SDKs, Hugging
+  Face datasets, or connecting hardware.
 - Added a first-slice latent-MPC controller for score-provider planning. The new
   `worldforge.control` module exposes `LatentMPCController`, `PlannerConfig`,
   `ScoreCandidateEncoder`, `ScoreCandidateBatch`, and `ActionPlanCandidateEncoder`, and

--- a/README.md
+++ b/README.md
@@ -102,6 +102,17 @@ This is simulation/replay planning. It demonstrates policy inference, score-mode
 typed provider composition, candidate ranking, event capture, and visual replay. Hardware control,
 safety checks, robot-controller integration, and task-specific preprocessing stay host-owned.
 
+For measured decision evidence without a live robot, run the Go2 Air ControlBench trace replay:
+
+```bash
+uv run python examples/go2-controlbench-decisiontrace/run.py
+```
+
+It consumes a compact public `espejelomar/go2-air-controlbench-v1` DecisionTrace fixture, reranks
+candidate Unitree sport-mode commands through WorldForge's `score` capability, and reports measured
+native-odometry regret against the best counterfactual command. It does not import DimOS, Unitree
+SDKs, Hugging Face datasets, or connect robot hardware.
+
 <div align="center">
 <table>
   <tr>

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -104,10 +104,17 @@ checkpoint inference.
 | Example | Command | Runtime boundary |
 | --- | --- | --- |
 | `so101-replay-trace` | `uv run worldforge-demo-so101-replay-trace` | Scores deterministic SO-101 pick-and-place candidates and emits a reusable decision trace without LeRobot, torch, DimOS, or hardware. |
+| `go2-controlbench-decisiontrace` | `uv run python examples/go2-controlbench-decisiontrace/run.py` | Replays a public Go2 Air ControlBench trace, reranks candidate commands through `score`, and reports measured native-odom regret without DimOS, Unitree SDKs, Hugging Face downloads, or hardware. |
 
 The SO-101 replay trace records `observation -> goal -> candidate_actions -> candidate_scores ->
 selected_action -> outcome -> counterfactuals`. It is a checkout-safe replay fixture shaped after
 the public `lerobot/svla_so101_pickplace` metadata, not a hardware-success or policy-quality claim.
+
+The Go2 ControlBench DecisionTrace records the same evidence shape for navigation: target motion,
+candidate Unitree sport-mode commands, predicted-error scores, the score-selected command,
+counterfactual measured outcomes, and regret against the best measured command. It uses a bundled
+copy of a public `espejelomar/go2-air-controlbench-v1` trace; source outcomes are native Go2
+odometry means, not mocap-grade ground truth or live-robot execution by the demo.
 
 ## Service Host Reference
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -52,6 +52,7 @@ terminal and JSON paths remain available with `--no-tui`.
 | Example | Surface | Command |
 | --- | --- | --- |
 | `so101-replay-trace` | score provider, decision trace, counterfactuals, mock replay | `uv run worldforge-demo-so101-replay-trace` |
+| `go2-controlbench-decisiontrace` | score provider, public decision trace, measured regret | `uv run python examples/go2-controlbench-decisiontrace/run.py` |
 
 The SO-101 replay trace demo uses a deterministic pick-and-place decision point shaped after the
 public `lerobot/svla_so101_pickplace` metadata. It scores candidate 6D joint-action futures,
@@ -59,6 +60,12 @@ selects the lowest-cost manipulation action, executes the selected object placem
 local mock provider, and emits an `observation -> goal -> candidate_actions -> candidate_scores ->
 selected_action -> outcome -> counterfactuals` trace without installing LeRobot, torch, DimOS, or
 connecting robot hardware.
+
+The Go2 ControlBench DecisionTrace demo consumes a compact public trace from
+`espejelomar/go2-air-controlbench-v1`. It reranks candidate Unitree Go2 sport-mode commands through
+WorldForge's `score` capability, preserves the score-selected action, exposes the measured
+counterfactual that would have done better, and reports native-odometry regret without importing
+DimOS, Unitree SDKs, Hugging Face datasets, or controlling hardware.
 
 ## Service Host Reference
 

--- a/examples/go2-controlbench-decisiontrace/fixtures/positive_regret_trace.json
+++ b/examples/go2-controlbench-decisiontrace/fixtures/positive_regret_trace.json
@@ -1,0 +1,722 @@
+{
+  "schema_version": "decision_trace.v1-draft",
+  "trace_id": "combined_inverse_translation_target_0_010049",
+  "observation": {
+    "kind": "go2_air_controlbench_candidate_set",
+    "dataset": "combined",
+    "task": "translation_signed_planar",
+    "candidate_count": 14
+  },
+  "goal": {
+    "kind": "target_signed_planar_displacement",
+    "target": 0.010049,
+    "unit": "m"
+  },
+  "candidate_actions": [
+    {
+      "type": "unitree_go2_sport_move",
+      "params": {
+        "x": -0.05,
+        "y": 0.0,
+        "z": 0.0,
+        "duration_s": 0.6
+      },
+      "units": {
+        "x": "m/s",
+        "y": "m/s",
+        "z": "rad/s",
+        "duration_s": "s"
+      }
+    },
+    {
+      "type": "unitree_go2_sport_move",
+      "params": {
+        "x": -0.08,
+        "y": 0.0,
+        "z": 0.0,
+        "duration_s": 0.6
+      },
+      "units": {
+        "x": "m/s",
+        "y": "m/s",
+        "z": "rad/s",
+        "duration_s": "s"
+      }
+    },
+    {
+      "type": "unitree_go2_sport_move",
+      "params": {
+        "x": -0.1,
+        "y": 0.0,
+        "z": 0.0,
+        "duration_s": 0.6
+      },
+      "units": {
+        "x": "m/s",
+        "y": "m/s",
+        "z": "rad/s",
+        "duration_s": "s"
+      }
+    },
+    {
+      "type": "unitree_go2_sport_move",
+      "params": {
+        "x": -0.12,
+        "y": 0.0,
+        "z": 0.0,
+        "duration_s": 0.6
+      },
+      "units": {
+        "x": "m/s",
+        "y": "m/s",
+        "z": "rad/s",
+        "duration_s": "s"
+      }
+    },
+    {
+      "type": "unitree_go2_sport_move",
+      "params": {
+        "x": -0.15,
+        "y": 0.0,
+        "z": 0.0,
+        "duration_s": 0.6
+      },
+      "units": {
+        "x": "m/s",
+        "y": "m/s",
+        "z": "rad/s",
+        "duration_s": "s"
+      }
+    },
+    {
+      "type": "unitree_go2_sport_move",
+      "params": {
+        "x": -0.25,
+        "y": 0.0,
+        "z": 0.0,
+        "duration_s": 0.6
+      },
+      "units": {
+        "x": "m/s",
+        "y": "m/s",
+        "z": "rad/s",
+        "duration_s": "s"
+      }
+    },
+    {
+      "type": "unitree_go2_sport_move",
+      "params": {
+        "x": -0.4,
+        "y": 0.0,
+        "z": 0.0,
+        "duration_s": 0.75
+      },
+      "units": {
+        "x": "m/s",
+        "y": "m/s",
+        "z": "rad/s",
+        "duration_s": "s"
+      }
+    },
+    {
+      "type": "unitree_go2_sport_move",
+      "params": {
+        "x": 0.05,
+        "y": 0.0,
+        "z": 0.0,
+        "duration_s": 0.6
+      },
+      "units": {
+        "x": "m/s",
+        "y": "m/s",
+        "z": "rad/s",
+        "duration_s": "s"
+      }
+    },
+    {
+      "type": "unitree_go2_sport_move",
+      "params": {
+        "x": 0.08,
+        "y": 0.0,
+        "z": 0.0,
+        "duration_s": 0.6
+      },
+      "units": {
+        "x": "m/s",
+        "y": "m/s",
+        "z": "rad/s",
+        "duration_s": "s"
+      }
+    },
+    {
+      "type": "unitree_go2_sport_move",
+      "params": {
+        "x": 0.1,
+        "y": 0.0,
+        "z": 0.0,
+        "duration_s": 0.6
+      },
+      "units": {
+        "x": "m/s",
+        "y": "m/s",
+        "z": "rad/s",
+        "duration_s": "s"
+      }
+    },
+    {
+      "type": "unitree_go2_sport_move",
+      "params": {
+        "x": 0.12,
+        "y": 0.0,
+        "z": 0.0,
+        "duration_s": 0.6
+      },
+      "units": {
+        "x": "m/s",
+        "y": "m/s",
+        "z": "rad/s",
+        "duration_s": "s"
+      }
+    },
+    {
+      "type": "unitree_go2_sport_move",
+      "params": {
+        "x": 0.15,
+        "y": 0.0,
+        "z": 0.0,
+        "duration_s": 0.6
+      },
+      "units": {
+        "x": "m/s",
+        "y": "m/s",
+        "z": "rad/s",
+        "duration_s": "s"
+      }
+    },
+    {
+      "type": "unitree_go2_sport_move",
+      "params": {
+        "x": 0.25,
+        "y": 0.0,
+        "z": 0.0,
+        "duration_s": 0.6
+      },
+      "units": {
+        "x": "m/s",
+        "y": "m/s",
+        "z": "rad/s",
+        "duration_s": "s"
+      }
+    },
+    {
+      "type": "unitree_go2_sport_move",
+      "params": {
+        "x": 0.4,
+        "y": 0.0,
+        "z": 0.0,
+        "duration_s": 0.75
+      },
+      "units": {
+        "x": "m/s",
+        "y": "m/s",
+        "z": "rad/s",
+        "duration_s": "s"
+      }
+    }
+  ],
+  "scores": [
+    {
+      "candidate_index": 0,
+      "score_kind": "deadband_affine_predicted_absolute_error",
+      "value": 0.011451429386705595,
+      "lower_is_better": true
+    },
+    {
+      "candidate_index": 1,
+      "score_kind": "deadband_affine_predicted_absolute_error",
+      "value": 0.00521803600127763,
+      "lower_is_better": true
+    },
+    {
+      "candidate_index": 2,
+      "score_kind": "deadband_affine_predicted_absolute_error",
+      "value": 0.007248750769578318,
+      "lower_is_better": true
+    },
+    {
+      "candidate_index": 3,
+      "score_kind": "deadband_affine_predicted_absolute_error",
+      "value": 0.019715537540434265,
+      "lower_is_better": true
+    },
+    {
+      "candidate_index": 4,
+      "score_kind": "deadband_affine_predicted_absolute_error",
+      "value": 0.038415717696718185,
+      "lower_is_better": true
+    },
+    {
+      "candidate_index": 5,
+      "score_kind": "deadband_affine_predicted_absolute_error",
+      "value": 0.10074965155099794,
+      "lower_is_better": true
+    },
+    {
+      "candidate_index": 6,
+      "score_kind": "deadband_affine_predicted_absolute_error",
+      "value": 0.2565844861866973,
+      "lower_is_better": true
+    },
+    {
+      "candidate_index": 7,
+      "score_kind": "deadband_affine_predicted_absolute_error",
+      "value": 0.011451429386705595,
+      "lower_is_better": true
+    },
+    {
+      "candidate_index": 8,
+      "score_kind": "deadband_affine_predicted_absolute_error",
+      "value": 0.01768482277213356,
+      "lower_is_better": true
+    },
+    {
+      "candidate_index": 9,
+      "score_kind": "deadband_affine_predicted_absolute_error",
+      "value": 0.03015160954298951,
+      "lower_is_better": true
+    },
+    {
+      "candidate_index": 10,
+      "score_kind": "deadband_affine_predicted_absolute_error",
+      "value": 0.04261839631384545,
+      "lower_is_better": true
+    },
+    {
+      "candidate_index": 11,
+      "score_kind": "deadband_affine_predicted_absolute_error",
+      "value": 0.06131857647012938,
+      "lower_is_better": true
+    },
+    {
+      "candidate_index": 12,
+      "score_kind": "deadband_affine_predicted_absolute_error",
+      "value": 0.12365251032440913,
+      "lower_is_better": true
+    },
+    {
+      "candidate_index": 13,
+      "score_kind": "deadband_affine_predicted_absolute_error",
+      "value": 0.2794873449601086,
+      "lower_is_better": true
+    }
+  ],
+  "selected_action": {
+    "candidate_index": 1,
+    "name": "backward_0.08",
+    "selection_rule": "minimize predicted absolute error to target"
+  },
+  "counterfactuals": [
+    {
+      "action": {
+        "type": "unitree_go2_sport_move",
+        "params": {
+          "x": -0.05,
+          "y": 0.0,
+          "z": 0.0,
+          "duration_s": 0.6
+        },
+        "units": {
+          "x": "m/s",
+          "y": "m/s",
+          "z": "rad/s",
+          "duration_s": "s"
+        }
+      },
+      "predicted_outcome": {
+        "signed_planar_m": 0.021500429386705596
+      },
+      "measured_outcome": {
+        "signed_planar_m": -0.003025415739252825,
+        "n": 4,
+        "outcome_kind": "real_measured_native_odom_mean"
+      },
+      "predicted_error": 0.011451429386705595,
+      "measured_error": 0.013074415739252825
+    },
+    {
+      "action": {
+        "type": "unitree_go2_sport_move",
+        "params": {
+          "x": -0.08,
+          "y": 0.0,
+          "z": 0.0,
+          "duration_s": 0.6
+        },
+        "units": {
+          "x": "m/s",
+          "y": "m/s",
+          "z": "rad/s",
+          "duration_s": "s"
+        }
+      },
+      "predicted_outcome": {
+        "signed_planar_m": 0.01526703600127763
+      },
+      "measured_outcome": {
+        "signed_planar_m": -0.005524993526996725,
+        "n": 4,
+        "outcome_kind": "real_measured_native_odom_mean"
+      },
+      "predicted_error": 0.00521803600127763,
+      "measured_error": 0.015573993526996725
+    },
+    {
+      "action": {
+        "type": "unitree_go2_sport_move",
+        "params": {
+          "x": -0.1,
+          "y": 0.0,
+          "z": 0.0,
+          "duration_s": 0.6
+        },
+        "units": {
+          "x": "m/s",
+          "y": "m/s",
+          "z": "rad/s",
+          "duration_s": "s"
+        }
+      },
+      "predicted_outcome": {
+        "signed_planar_m": 0.002800249230421683
+      },
+      "measured_outcome": {
+        "signed_planar_m": -0.0067407874742332246,
+        "n": 4,
+        "outcome_kind": "real_measured_native_odom_mean"
+      },
+      "predicted_error": 0.007248750769578318,
+      "measured_error": 0.016789787474233226
+    },
+    {
+      "action": {
+        "type": "unitree_go2_sport_move",
+        "params": {
+          "x": -0.12,
+          "y": 0.0,
+          "z": 0.0,
+          "duration_s": 0.6
+        },
+        "units": {
+          "x": "m/s",
+          "y": "m/s",
+          "z": "rad/s",
+          "duration_s": "s"
+        }
+      },
+      "predicted_outcome": {
+        "signed_planar_m": -0.009666537540434263
+      },
+      "measured_outcome": {
+        "signed_planar_m": -0.0137566897217323,
+        "n": 4,
+        "outcome_kind": "real_measured_native_odom_mean"
+      },
+      "predicted_error": 0.019715537540434265,
+      "measured_error": 0.0238056897217323
+    },
+    {
+      "action": {
+        "type": "unitree_go2_sport_move",
+        "params": {
+          "x": -0.15,
+          "y": 0.0,
+          "z": 0.0,
+          "duration_s": 0.6
+        },
+        "units": {
+          "x": "m/s",
+          "y": "m/s",
+          "z": "rad/s",
+          "duration_s": "s"
+        }
+      },
+      "predicted_outcome": {
+        "signed_planar_m": -0.028366717696718186
+      },
+      "measured_outcome": {
+        "signed_planar_m": -0.029186572638938375,
+        "n": 4,
+        "outcome_kind": "real_measured_native_odom_mean"
+      },
+      "predicted_error": 0.038415717696718185,
+      "measured_error": 0.03923557263893838
+    },
+    {
+      "action": {
+        "type": "unitree_go2_sport_move",
+        "params": {
+          "x": -0.25,
+          "y": 0.0,
+          "z": 0.0,
+          "duration_s": 0.6
+        },
+        "units": {
+          "x": "m/s",
+          "y": "m/s",
+          "z": "rad/s",
+          "duration_s": "s"
+        }
+      },
+      "predicted_outcome": {
+        "signed_planar_m": -0.09070065155099793
+      },
+      "measured_outcome": {
+        "signed_planar_m": -0.1017664676203751,
+        "n": 17,
+        "outcome_kind": "real_measured_native_odom_mean"
+      },
+      "predicted_error": 0.10074965155099794,
+      "measured_error": 0.1118154676203751
+    },
+    {
+      "action": {
+        "type": "unitree_go2_sport_move",
+        "params": {
+          "x": -0.4,
+          "y": 0.0,
+          "z": 0.0,
+          "duration_s": 0.75
+        },
+        "units": {
+          "x": "m/s",
+          "y": "m/s",
+          "z": "rad/s",
+          "duration_s": "s"
+        }
+      },
+      "predicted_outcome": {
+        "signed_planar_m": -0.24653548618669735
+      },
+      "measured_outcome": {
+        "signed_planar_m": -0.2254609788432147,
+        "n": 17,
+        "outcome_kind": "real_measured_native_odom_mean"
+      },
+      "predicted_error": 0.2565844861866973,
+      "measured_error": 0.2355099788432147
+    },
+    {
+      "action": {
+        "type": "unitree_go2_sport_move",
+        "params": {
+          "x": 0.05,
+          "y": 0.0,
+          "z": 0.0,
+          "duration_s": 0.6
+        },
+        "units": {
+          "x": "m/s",
+          "y": "m/s",
+          "z": "rad/s",
+          "duration_s": "s"
+        }
+      },
+      "predicted_outcome": {
+        "signed_planar_m": 0.021500429386705596
+      },
+      "measured_outcome": {
+        "signed_planar_m": 0.010804728715941325,
+        "n": 4,
+        "outcome_kind": "real_measured_native_odom_mean"
+      },
+      "predicted_error": 0.011451429386705595,
+      "measured_error": 0.0007557287159413242
+    },
+    {
+      "action": {
+        "type": "unitree_go2_sport_move",
+        "params": {
+          "x": 0.08,
+          "y": 0.0,
+          "z": 0.0,
+          "duration_s": 0.6
+        },
+        "units": {
+          "x": "m/s",
+          "y": "m/s",
+          "z": "rad/s",
+          "duration_s": "s"
+        }
+      },
+      "predicted_outcome": {
+        "signed_planar_m": 0.027733822772133564
+      },
+      "measured_outcome": {
+        "signed_planar_m": 0.010049413320400375,
+        "n": 4,
+        "outcome_kind": "real_measured_native_odom_mean"
+      },
+      "predicted_error": 0.01768482277213356,
+      "measured_error": 4.133204003740898e-07
+    },
+    {
+      "action": {
+        "type": "unitree_go2_sport_move",
+        "params": {
+          "x": 0.1,
+          "y": 0.0,
+          "z": 0.0,
+          "duration_s": 0.6
+        },
+        "units": {
+          "x": "m/s",
+          "y": "m/s",
+          "z": "rad/s",
+          "duration_s": "s"
+        }
+      },
+      "predicted_outcome": {
+        "signed_planar_m": 0.04020060954298951
+      },
+      "measured_outcome": {
+        "signed_planar_m": 0.010772447510347975,
+        "n": 4,
+        "outcome_kind": "real_measured_native_odom_mean"
+      },
+      "predicted_error": 0.03015160954298951,
+      "measured_error": 0.0007234475103479743
+    },
+    {
+      "action": {
+        "type": "unitree_go2_sport_move",
+        "params": {
+          "x": 0.12,
+          "y": 0.0,
+          "z": 0.0,
+          "duration_s": 0.6
+        },
+        "units": {
+          "x": "m/s",
+          "y": "m/s",
+          "z": "rad/s",
+          "duration_s": "s"
+        }
+      },
+      "predicted_outcome": {
+        "signed_planar_m": 0.052667396313845455
+      },
+      "measured_outcome": {
+        "signed_planar_m": 0.01487927051391585,
+        "n": 4,
+        "outcome_kind": "real_measured_native_odom_mean"
+      },
+      "predicted_error": 0.04261839631384545,
+      "measured_error": 0.00483027051391585
+    },
+    {
+      "action": {
+        "type": "unitree_go2_sport_move",
+        "params": {
+          "x": 0.15,
+          "y": 0.0,
+          "z": 0.0,
+          "duration_s": 0.6
+        },
+        "units": {
+          "x": "m/s",
+          "y": "m/s",
+          "z": "rad/s",
+          "duration_s": "s"
+        }
+      },
+      "predicted_outcome": {
+        "signed_planar_m": 0.07136757647012938
+      },
+      "measured_outcome": {
+        "signed_planar_m": 0.031110738649204075,
+        "n": 4,
+        "outcome_kind": "real_measured_native_odom_mean"
+      },
+      "predicted_error": 0.06131857647012938,
+      "measured_error": 0.021061738649204076
+    },
+    {
+      "action": {
+        "type": "unitree_go2_sport_move",
+        "params": {
+          "x": 0.25,
+          "y": 0.0,
+          "z": 0.0,
+          "duration_s": 0.6
+        },
+        "units": {
+          "x": "m/s",
+          "y": "m/s",
+          "z": "rad/s",
+          "duration_s": "s"
+        }
+      },
+      "predicted_outcome": {
+        "signed_planar_m": 0.13370151032440913
+      },
+      "measured_outcome": {
+        "signed_planar_m": 0.1622878023528712,
+        "n": 17,
+        "outcome_kind": "real_measured_native_odom_mean"
+      },
+      "predicted_error": 0.12365251032440913,
+      "measured_error": 0.1522388023528712
+    },
+    {
+      "action": {
+        "type": "unitree_go2_sport_move",
+        "params": {
+          "x": 0.4,
+          "y": 0.0,
+          "z": 0.0,
+          "duration_s": 0.75
+        },
+        "units": {
+          "x": "m/s",
+          "y": "m/s",
+          "z": "rad/s",
+          "duration_s": "s"
+        }
+      },
+      "predicted_outcome": {
+        "signed_planar_m": 0.28953634496010855
+      },
+      "measured_outcome": {
+        "signed_planar_m": 0.296970103835988,
+        "n": 17,
+        "outcome_kind": "real_measured_native_odom_mean"
+      },
+      "predicted_error": 0.2794873449601086,
+      "measured_error": 0.286921103835988
+    }
+  ],
+  "predicted_outcome": {
+    "signed_planar_m": 0.01526703600127763
+  },
+  "measured_or_analytic_outcome": {
+    "outcome_kind": "real_measured_native_odom_mean",
+    "signed_planar_m": -0.005524993526996725,
+    "best_measured_candidate": "forward_0.08"
+  },
+  "regret": {
+    "unit": "m",
+    "selected_true_error": 0.015573993526996725,
+    "best_true_error": 4.133204003740898e-07,
+    "regret": 0.015573580206596351,
+    "hit_best": false
+  },
+  "reproducibility": {
+    "source_table": "tables/all_trials_plus_release05_normalized.csv",
+    "baseline_report": "tables/combined_baseline_model_report.json",
+    "script": "scripts/scripts_inverse_command_benchmark.py"
+  },
+  "claim_boundaries": [
+    "In-sample candidate-selection diagnostic, not held-out generalization.",
+    "Measured outcomes are native Go2 odometry means, not mocap ground truth."
+  ]
+}

--- a/examples/go2-controlbench-decisiontrace/run.py
+++ b/examples/go2-controlbench-decisiontrace/run.py
@@ -1,0 +1,15 @@
+"""Compatibility wrapper for the Go2 Air ControlBench DecisionTrace demo."""
+
+from __future__ import annotations
+
+from worldforge.demos.go2_controlbench_decisiontrace import (
+    main,
+    run_demo,
+    run_go2_controlbench_decisiontrace,
+)
+
+__all__ = ["main", "run_demo", "run_go2_controlbench_decisiontrace"]
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/worldforge/cli.py
+++ b/src/worldforge/cli.py
@@ -95,6 +95,18 @@ EXAMPLE_COMMANDS: tuple[dict[str, str], ...] = (
         ),
     },
     {
+        "task": "Robot decision traces",
+        "name": "go2-controlbench-decisiontrace",
+        "surface": "score provider, public decision trace, measured regret",
+        "requires": "base WorldForge package; bundled public Go2 ControlBench trace fixture",
+        "command": "uv run python examples/go2-controlbench-decisiontrace/run.py",
+        "description": (
+            "Replay a public Go2 Air ControlBench positive-regret trace, rerank commands through "
+            "the score capability, and report measured native-odom regret without DimOS, Unitree "
+            "SDKs, Hugging Face downloads, or hardware."
+        ),
+    },
+    {
         "task": "Batch evaluation host",
         "name": "batch-eval-host",
         "surface": "evaluation, benchmarking, run workspaces, budget gates",

--- a/src/worldforge/demos/go2_controlbench_decisiontrace.py
+++ b/src/worldforge/demos/go2_controlbench_decisiontrace.py
@@ -1,0 +1,559 @@
+"""Go2 Air ControlBench decision-trace replay demo.
+
+This demo is checkout-safe: it does not import DimOS, Unitree SDKs, Hugging Face
+datasets, or robot-control libraries, and it never connects to hardware. It consumes
+a compact public ``go2-air-controlbench-v1`` DecisionTrace fixture, reranks the
+candidate commands through ``forge.score_actions``, and reports the measured regret
+against native Go2 odometry outcomes.
+
+The goal is deliberately narrow: show the evidence layer WorldForge should own.
+The source dataset remains host-owned; robot execution, raw media, ArUco processing,
+and native-rate export stay outside the base package.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from worldforge import ActionScoreResult, WorldForge
+from worldforge.artifact_io import write_json_artifact
+from worldforge.models import JSONDict, WorldForgeError, require_finite_number
+from worldforge.providers.base import ProviderProfileSpec
+
+_REPO_FIXTURE_RELATIVE_PATH = (
+    Path("examples") / "go2-controlbench-decisiontrace" / "fixtures" / "positive_regret_trace.json"
+)
+DEFAULT_TRACE_PATH = (
+    Path.cwd() / _REPO_FIXTURE_RELATIVE_PATH
+    if (Path.cwd() / _REPO_FIXTURE_RELATIVE_PATH).is_file()
+    else Path(__file__).resolve().parents[3] / _REPO_FIXTURE_RELATIVE_PATH
+)
+
+GO2_CONTROLBENCH_SCORE_PROVIDER = "go2-controlbench-deadband-affine-score"
+GO2_CONTROLBENCH_DATASET_REFERENCE: JSONDict = {
+    "repo_id": "espejelomar/go2-air-controlbench-v1",
+    "config": "inverse_command_benchmark",
+    "trace_path": "decision_traces/decision_trace_inverse_command_combined_positive_regret.json",
+    "source": "Hugging Face public dataset",
+    "runtime_mode": "checkout_safe_public_trace_fixture_no_download",
+}
+
+
+@dataclass(frozen=True, slots=True)
+class Go2ControlBenchDecisionTraceResult:
+    trace: JSONDict
+    report_markdown: str
+    summary: JSONDict
+    decision_trace_path: Path
+    report_path: Path
+
+
+class Go2ControlBenchTraceScoreProvider:
+    """Score provider that replays public ControlBench predicted-error scores."""
+
+    name = GO2_CONTROLBENCH_SCORE_PROVIDER
+    profile = ProviderProfileSpec(
+        description=(
+            "Checkout-safe Go2 Air ControlBench scorer over public DecisionTrace candidates."
+        ),
+        implementation_status="demo",
+        is_local=True,
+        deterministic=True,
+    )
+
+    def score_actions(self, *, info: JSONDict, action_candidates: object) -> ActionScoreResult:
+        scores = _score_records(info)
+        candidates = _candidate_payloads(action_candidates)
+        if len(scores) != len(candidates):
+            raise WorldForgeError(
+                "Go2 ControlBench trace score count must match candidate action count."
+            )
+
+        values: list[float] = []
+        score_components: list[JSONDict] = []
+        for index, (score, candidate) in enumerate(zip(scores, candidates, strict=True)):
+            if int(score["candidate_index"]) != index:
+                raise WorldForgeError(
+                    "Go2 ControlBench score candidate_index must match candidate order."
+                )
+            values.append(float(score["value"]))
+            score_components.append(
+                {
+                    "candidate_index": index,
+                    "candidate_name": _command_name(candidate),
+                    "score_kind": str(score["score_kind"]),
+                    "predicted_absolute_error": float(score["value"]),
+                    "action": candidate,
+                }
+            )
+
+        best_index = min(range(len(values)), key=lambda candidate_index: values[candidate_index])
+        return ActionScoreResult(
+            provider=self.name,
+            scores=values,
+            best_index=best_index,
+            lower_is_better=True,
+            metadata={
+                "score_source": "public_controlbench_deadband_affine_prediction",
+                "trace_id": str(info.get("trace_id", "")),
+                "dataset_reference": dict(GO2_CONTROLBENCH_DATASET_REFERENCE),
+                "score_components": score_components,
+                "claim_boundary": (
+                    "In-sample command-selection diagnostic over observed command groups; "
+                    "not held-out learned-policy performance."
+                ),
+            },
+        )
+
+
+def load_go2_controlbench_trace(path: Path = DEFAULT_TRACE_PATH) -> JSONDict:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        message = f"Go2 ControlBench trace fixture not found: {path}"
+        if path == DEFAULT_TRACE_PATH:
+            message += (
+                ". The bundled default is repo-local; pass --trace with a public "
+                "DecisionTrace JSON file when running from an installed wheel."
+            )
+        raise WorldForgeError(message) from exc
+    except json.JSONDecodeError as exc:
+        raise WorldForgeError(f"Go2 ControlBench trace fixture is invalid JSON: {path}") from exc
+    _validate_trace(payload)
+    return payload
+
+
+def run_go2_controlbench_decisiontrace(
+    trace_path: Path = DEFAULT_TRACE_PATH,
+    output_dir: Path = Path(".worldforge/go2-controlbench-decisiontrace"),
+) -> Go2ControlBenchDecisionTraceResult:
+    trace = load_go2_controlbench_trace(trace_path)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    forge = WorldForge(auto_register_remote=False)
+    forge.register_cost(Go2ControlBenchTraceScoreProvider())
+    score_result = forge.score_actions(
+        GO2_CONTROLBENCH_SCORE_PROVIDER,
+        info={
+            "trace_id": trace["trace_id"],
+            "scores": trace["scores"],
+        },
+        action_candidates=trace["candidate_actions"],
+    ).to_dict()
+    summary = _summary(trace, score_result)
+    report_markdown = render_go2_controlbench_report(summary)
+
+    decision_trace_path = output_dir / "decision-trace.json"
+    report_path = output_dir / "report.md"
+    write_json_artifact(decision_trace_path, trace)
+    report_path.write_text(report_markdown, encoding="utf-8")
+    return Go2ControlBenchDecisionTraceResult(
+        trace=trace,
+        report_markdown=report_markdown,
+        summary=summary,
+        decision_trace_path=decision_trace_path,
+        report_path=report_path,
+    )
+
+
+def run_demo(*, emit: bool = True) -> JSONDict:
+    """Run the default public-trace replay and return a JSON-serializable summary."""
+
+    result = run_go2_controlbench_decisiontrace()
+    if emit:
+        _print_summary(result.summary)
+    return result.summary
+
+
+def render_go2_controlbench_report(summary: JSONDict) -> str:
+    trace = _require_mapping(summary["trace"], "summary.trace")
+    selected = _require_mapping(summary["selected"], "summary.selected")
+    best_measured = _require_mapping(summary["best_measured"], "summary.best_measured")
+    rows = summary["ranked_candidates"]
+    lines = [
+        "# Go2 Air ControlBench DecisionTrace",
+        "",
+        f"- Trace: `{trace['trace_id']}`",
+        f"- Dataset: `{GO2_CONTROLBENCH_DATASET_REFERENCE['repo_id']}`",
+        f"- Target: `{summary['target']:.6f} {summary['unit']}`",
+        f"- Selected by predicted score: `{selected['name']}`",
+        f"- Best measured candidate: `{best_measured['name']}`",
+        f"- Measured regret: `{summary['regret']:.6f} {summary['unit']}`",
+        f"- Hit measured best: `{summary['hit_best']}`",
+        "",
+        "## Ranked Candidates",
+        "",
+        "| Rank | Candidate | Predicted Error | Measured Error | Measured Outcome |",
+        "| ---: | --- | ---: | ---: | ---: |",
+    ]
+    for row in rows[:8]:
+        marker = " selected" if row["candidate_index"] == selected["candidate_index"] else ""
+        lines.append(
+            f"| {row['predicted_rank']} | `{row['name']}`{marker} | "
+            f"{row['predicted_error']:.6f} | {row['measured_error']:.6f} | "
+            f"{row['measured_outcome']:.6f} |"
+        )
+    lines.extend(
+        [
+            "",
+            "## What WorldForge Adds",
+            "",
+            (
+                "The demo reranks candidate Go2 commands through the WorldForge `score` "
+                "capability, preserves the selected action, exposes counterfactual measured "
+                "outcomes, and computes regret against the best measured candidate."
+            ),
+            "",
+            "## Boundary",
+            "",
+            (
+                "Checkout-safe public fixture only. The source outcomes are real measured native "
+                "Go2 odometry means from the public ControlBench dataset, not mocap-grade ground "
+                "truth. This is an in-sample command-selection diagnostic, not a world-model SOTA "
+                "or live-robot claim."
+            ),
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def _summary(trace: JSONDict, score_result: JSONDict) -> JSONDict:
+    candidates = list(trace["candidate_actions"])
+    counterfactuals = list(trace["counterfactuals"])
+    scores = list(score_result["scores"])
+    selected_index = int(score_result["best_index"])
+    target = _number(trace["goal"]["target"], name="goal.target")
+    unit = str(trace["goal"]["unit"])
+    ranked_indices = sorted(range(len(scores)), key=scores.__getitem__)
+    candidate_rows: list[JSONDict] = []
+    for index in ranked_indices:
+        counterfactual = _require_mapping(counterfactuals[index], f"counterfactuals[{index}]")
+        measured_outcome = _require_mapping(
+            counterfactual["measured_outcome"],
+            f"counterfactuals[{index}].measured_outcome",
+        )
+        candidate_rows.append(
+            {
+                "candidate_index": index,
+                "name": _command_name(candidates[index]),
+                "action": candidates[index],
+                "predicted_rank": ranked_indices.index(index) + 1,
+                "predicted_error": float(scores[index]),
+                "predicted_outcome": float(counterfactual["predicted_outcome"]["signed_planar_m"]),
+                "measured_outcome": float(measured_outcome["signed_planar_m"]),
+                "measured_error": abs(float(measured_outcome["signed_planar_m"]) - target),
+                "measured_n": int(measured_outcome["n"]),
+            }
+        )
+
+    selected_row = next(row for row in candidate_rows if row["candidate_index"] == selected_index)
+    best_measured_row = min(candidate_rows, key=lambda row: row["measured_error"])
+    regret = float(selected_row["measured_error"]) - float(best_measured_row["measured_error"])
+    recorded_regret = _require_mapping(trace["regret"], "regret")
+    if not math.isclose(regret, float(recorded_regret["regret"]), rel_tol=1e-9, abs_tol=1e-9):
+        raise WorldForgeError(
+            "Go2 ControlBench trace regret is inconsistent with measured counterfactuals."
+        )
+    return {
+        "demo_kind": "go2_controlbench_decisiontrace",
+        "runtime_mode": "checkout_safe_public_trace_fixture",
+        "uses_real_robot_hardware": False,
+        "uses_dimos_runtime": False,
+        "uses_unitree_sdk": False,
+        "planning_mode": "score",
+        "score_provider": GO2_CONTROLBENCH_SCORE_PROVIDER,
+        "dataset_reference": dict(GO2_CONTROLBENCH_DATASET_REFERENCE),
+        "trace": {
+            "trace_id": str(trace["trace_id"]),
+            "schema_version": str(trace["schema_version"]),
+            "source_outcome_kind": str(trace["measured_or_analytic_outcome"]["outcome_kind"]),
+            "claim_boundaries": list(trace["claim_boundaries"]),
+        },
+        "target": target,
+        "unit": unit,
+        "selected": selected_row,
+        "best_measured": best_measured_row,
+        "regret": regret,
+        "hit_best": bool(recorded_regret["hit_best"]),
+        "score_result": score_result,
+        "ranked_candidates": candidate_rows,
+        "worldforge_value": _worldforge_value(regret=regret, selected_index=selected_index),
+        "claim_boundary": (
+            "WorldForge consumes public measured-outcome evidence and exposes candidate "
+            "ranking/regret; hardware execution and dataset production remain host-owned."
+        ),
+    }
+
+
+def _worldforge_value(*, regret: float, selected_index: int) -> str:
+    if regret > 0.0:
+        return (
+            "exposed a positive measured regret for the score-selected action and preserved "
+            "the counterfactual command that would have done better"
+        )
+    if selected_index >= 0:
+        return "confirmed the score-selected action matched the best measured candidate"
+    return "no demonstrated value beyond logging; pivot if this persists"
+
+
+def _validate_trace(payload: object) -> None:
+    trace = _require_mapping(payload, "trace")
+    _require_fields(
+        trace,
+        (
+            "schema_version",
+            "trace_id",
+            "observation",
+            "goal",
+            "candidate_actions",
+            "scores",
+            "selected_action",
+            "counterfactuals",
+            "measured_or_analytic_outcome",
+            "regret",
+            "claim_boundaries",
+        ),
+        "trace",
+    )
+    if trace["schema_version"] != "decision_trace.v1-draft":
+        raise WorldForgeError(
+            "Go2 ControlBench trace schema_version must be decision_trace.v1-draft."
+        )
+
+    candidates = _candidate_payloads(trace["candidate_actions"])
+    scores = _score_records({"scores": trace["scores"]})
+    counterfactuals = _counterfactual_records(trace["counterfactuals"])
+    if len(candidates) != len(scores) or len(candidates) != len(counterfactuals):
+        raise WorldForgeError(
+            "Go2 ControlBench trace candidates, scores, and counterfactuals must align."
+        )
+
+    selected = _require_mapping(trace["selected_action"], "selected_action")
+    selected_index = _index(selected.get("candidate_index"), name="selected_action.candidate_index")
+    if selected_index >= len(candidates):
+        raise WorldForgeError("Go2 ControlBench selected_action.candidate_index is out of range.")
+    if str(selected.get("name")) != _command_name(candidates[selected_index]):
+        raise WorldForgeError("Go2 ControlBench selected_action.name does not match candidate.")
+    best_index = min(range(len(scores)), key=lambda index: float(scores[index]["value"]))
+    if selected_index != best_index:
+        raise WorldForgeError("Go2 ControlBench selected_action must match the lowest score.")
+
+    goal = _require_mapping(trace["goal"], "goal")
+    _number(goal.get("target"), name="goal.target")
+    if goal.get("unit") not in {"m", "rad"}:
+        raise WorldForgeError("Go2 ControlBench goal.unit must be 'm' or 'rad'.")
+
+    measured = _require_mapping(
+        trace["measured_or_analytic_outcome"],
+        "measured_or_analytic_outcome",
+    )
+    if measured.get("outcome_kind") != "real_measured_native_odom_mean":
+        raise WorldForgeError(
+            "Go2 ControlBench measured outcome must be real_measured_native_odom_mean."
+        )
+    _number(measured.get("signed_planar_m"), name="measured_or_analytic_outcome.signed_planar_m")
+
+    regret = _require_mapping(trace["regret"], "regret")
+    for field_name in ("selected_true_error", "best_true_error", "regret"):
+        _number(regret.get(field_name), name=f"regret.{field_name}")
+    if not isinstance(regret.get("hit_best"), bool):
+        raise WorldForgeError("Go2 ControlBench regret.hit_best must be a boolean.")
+    if not isinstance(trace["claim_boundaries"], list) or not trace["claim_boundaries"]:
+        raise WorldForgeError("Go2 ControlBench trace must include claim_boundaries.")
+
+
+def _counterfactual_records(value: object) -> list[JSONDict]:
+    if not isinstance(value, list) or not value:
+        raise WorldForgeError("Go2 ControlBench counterfactuals must be a non-empty list.")
+    records: list[JSONDict] = []
+    for index, raw in enumerate(value):
+        record = _require_mapping(raw, f"counterfactuals[{index}]")
+        _require_fields(
+            record,
+            (
+                "action",
+                "predicted_outcome",
+                "measured_outcome",
+                "predicted_error",
+                "measured_error",
+            ),
+            f"counterfactuals[{index}]",
+        )
+        _validate_action(record["action"], name=f"counterfactuals[{index}].action")
+        _number(record["predicted_error"], name=f"counterfactuals[{index}].predicted_error")
+        _number(record["measured_error"], name=f"counterfactuals[{index}].measured_error")
+        measured = _require_mapping(
+            record["measured_outcome"],
+            f"counterfactuals[{index}].measured",
+        )
+        _number(measured.get("signed_planar_m"), name=f"counterfactuals[{index}].signed_planar_m")
+        records.append(dict(record))
+    return records
+
+
+def _score_records(info: JSONDict) -> list[JSONDict]:
+    scores = info.get("scores")
+    if not isinstance(scores, list) or not scores:
+        raise WorldForgeError("Go2 ControlBench scoring requires a non-empty scores list.")
+    records: list[JSONDict] = []
+    for index, raw in enumerate(scores):
+        record = _require_mapping(raw, f"scores[{index}]")
+        _require_fields(
+            record,
+            ("candidate_index", "score_kind", "value", "lower_is_better"),
+            f"scores[{index}]",
+        )
+        candidate_index = _index(record["candidate_index"], name=f"scores[{index}].candidate_index")
+        if candidate_index != index:
+            raise WorldForgeError(
+                "Go2 ControlBench score candidate_index must match candidate order."
+            )
+        _number(record["value"], name=f"scores[{index}].value")
+        if record["lower_is_better"] is not True:
+            raise WorldForgeError("Go2 ControlBench scores must be lower_is_better.")
+        records.append(dict(record))
+    return records
+
+
+def _candidate_payloads(action_candidates: object) -> list[JSONDict]:
+    if not isinstance(action_candidates, list) or not action_candidates:
+        raise WorldForgeError("Go2 ControlBench candidates must be a non-empty list.")
+    candidates: list[JSONDict] = []
+    for index, raw in enumerate(action_candidates):
+        candidate = _validate_action(raw, name=f"candidate_actions[{index}]")
+        candidates.append(candidate)
+    return candidates
+
+
+def _validate_action(value: object, *, name: str) -> JSONDict:
+    action = _require_mapping(value, name)
+    _require_fields(action, ("type", "params", "units"), name)
+    if action["type"] != "unitree_go2_sport_move":
+        raise WorldForgeError(f"Go2 ControlBench {name}.type must be unitree_go2_sport_move.")
+    params = _require_mapping(action["params"], f"{name}.params")
+    units = _require_mapping(action["units"], f"{name}.units")
+    for field_name in ("x", "y", "z", "duration_s"):
+        _number(params.get(field_name), name=f"{name}.params.{field_name}")
+        if field_name not in units or not isinstance(units[field_name], str):
+            raise WorldForgeError(f"Go2 ControlBench {name}.units.{field_name} must be a string.")
+    return {
+        "type": action["type"],
+        "params": dict(params),
+        "units": dict(units),
+    }
+
+
+def _command_name(action: JSONDict) -> str:
+    params = _require_mapping(action["params"], "action.params")
+    x = float(params["x"])
+    z = float(params["z"])
+    if x < 0:
+        return f"backward_{abs(x):.2f}".rstrip("0").rstrip(".")
+    if x > 0:
+        return f"forward_{x:.2f}".rstrip("0").rstrip(".")
+    if z < 0:
+        return f"yaw_right_{abs(z):.2f}".rstrip("0").rstrip(".")
+    if z > 0:
+        return f"yaw_left_{z:.2f}".rstrip("0").rstrip(".")
+    return "hold_noop"
+
+
+def _require_mapping(value: object, field_name: str) -> JSONDict:
+    if not isinstance(value, Mapping):
+        raise WorldForgeError(f"Go2 ControlBench '{field_name}' must be a JSON object.")
+    return dict(value)
+
+
+def _require_fields(
+    payload: Mapping[str, Any],
+    field_names: Sequence[str],
+    parent_name: str,
+) -> None:
+    for field_name in field_names:
+        if field_name not in payload:
+            raise WorldForgeError(f"Go2 ControlBench {parent_name} is missing '{field_name}'.")
+
+
+def _index(value: object, *, name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise WorldForgeError(f"Go2 ControlBench {name} must be an integer.")
+    if value < 0:
+        raise WorldForgeError(f"Go2 ControlBench {name} must be non-negative.")
+    return value
+
+
+def _number(value: object, *, name: str) -> float:
+    return require_finite_number(value, name=f"Go2 ControlBench {name}")
+
+
+def _print_summary(summary: JSONDict) -> None:
+    print("WorldForge Go2 Air ControlBench DecisionTrace")
+    print("=" * 48)
+    print("Runtime: checkout-safe public trace fixture")
+    print("Hardware: not used by this demo")
+    print("Optional runtimes: DimOS/Unitree SDK/Hugging Face datasets not imported")
+    print("Planning: forge.score_actions(public predicted-error scores) -> measured regret")
+    print()
+    print(f"Trace: {summary['trace']['trace_id']}")
+    print(f"Target: {summary['target']:.6f} {summary['unit']}")
+    print(f"Selected: {summary['selected']['name']}")
+    print(f"Best measured: {summary['best_measured']['name']}")
+    print(f"Measured regret: {summary['regret']:.6f} {summary['unit']}")
+    print(f"WorldForge value: {summary['worldforge_value']}")
+    print()
+    print("JSON summary:")
+    print(json.dumps(summary, indent=2, sort_keys=True))
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--trace",
+        type=Path,
+        default=DEFAULT_TRACE_PATH,
+        help="DecisionTrace JSON fixture to replay.",
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=Path(".worldforge/go2-controlbench-decisiontrace"),
+        help="Directory for the copied trace and Markdown report.",
+    )
+    parser.add_argument(
+        "--json-only",
+        action="store_true",
+        help="Print only the JSON summary.",
+    )
+    return parser
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    result = run_go2_controlbench_decisiontrace(args.trace, args.out)
+    if args.json_only:
+        print(json.dumps(result.summary, indent=2, sort_keys=True))
+    else:
+        _print_summary(result.summary)
+        print(f"decision_trace={result.decision_trace_path}")
+        print(f"report={result.report_path}")
+    return 0
+
+
+__all__ = [
+    "DEFAULT_TRACE_PATH",
+    "GO2_CONTROLBENCH_DATASET_REFERENCE",
+    "GO2_CONTROLBENCH_SCORE_PROVIDER",
+    "Go2ControlBenchDecisionTraceResult",
+    "Go2ControlBenchTraceScoreProvider",
+    "load_go2_controlbench_trace",
+    "render_go2_controlbench_report",
+    "run_demo",
+    "run_go2_controlbench_decisiontrace",
+]

--- a/tests/test_examples_index.py
+++ b/tests/test_examples_index.py
@@ -17,6 +17,7 @@ def test_example_index_metadata_is_task_grouped() -> None:
         "Score planning",
         "Policy plus score planning",
         "Robot decision traces",
+        "Robot decision traces",
         "Batch evaluation host",
         "Robotics operator host",
         "Optional runtime smoke",

--- a/tests/test_go2_controlbench_decisiontrace_demo.py
+++ b/tests/test_go2_controlbench_decisiontrace_demo.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+from worldforge.cli import main as cli_main
+from worldforge.demos.go2_controlbench_decisiontrace import (
+    DEFAULT_TRACE_PATH,
+    GO2_CONTROLBENCH_SCORE_PROVIDER,
+    Go2ControlBenchTraceScoreProvider,
+    load_go2_controlbench_trace,
+    render_go2_controlbench_report,
+    run_go2_controlbench_decisiontrace,
+)
+from worldforge.models import WorldForgeError
+
+
+def _load_demo() -> ModuleType:
+    script_path = (
+        Path(__file__).resolve().parents[1]
+        / "examples"
+        / "go2-controlbench-decisiontrace"
+        / "run.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "go2_controlbench_decisiontrace_demo",
+        script_path,
+    )
+    if spec is None:
+        raise AssertionError("go2 controlbench demo module spec could not be created.")
+    if spec.loader is None:
+        raise AssertionError("go2 controlbench demo module spec has no loader.")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_go2_controlbench_trace_fixture_loads_public_positive_regret() -> None:
+    trace = load_go2_controlbench_trace(DEFAULT_TRACE_PATH)
+
+    assert trace["schema_version"] == "decision_trace.v1-draft"
+    assert trace["trace_id"] == "combined_inverse_translation_target_0_010049"
+    assert trace["observation"]["dataset"] == "combined"
+    assert trace["observation"]["task"] == "translation_signed_planar"
+    assert len(trace["candidate_actions"]) == 14
+    assert len(trace["scores"]) == 14
+    assert len(trace["counterfactuals"]) == 14
+    assert trace["selected_action"]["name"] == "backward_0.08"
+    assert trace["measured_or_analytic_outcome"]["best_measured_candidate"] == "forward_0.08"
+    assert trace["regret"]["regret"] > 0.015
+    json.dumps(trace)
+
+
+def test_go2_controlbench_demo_reranks_and_reports_measured_regret(tmp_path: Path) -> None:
+    result = run_go2_controlbench_decisiontrace(DEFAULT_TRACE_PATH, tmp_path)
+    summary = result.summary
+
+    assert result.decision_trace_path.is_file()
+    assert result.report_path.is_file()
+    assert summary["demo_kind"] == "go2_controlbench_decisiontrace"
+    assert summary["runtime_mode"] == "checkout_safe_public_trace_fixture"
+    assert summary["uses_real_robot_hardware"] is False
+    assert summary["uses_dimos_runtime"] is False
+    assert summary["uses_unitree_sdk"] is False
+    assert summary["planning_mode"] == "score"
+    assert summary["score_provider"] == GO2_CONTROLBENCH_SCORE_PROVIDER
+    assert summary["score_result"]["best_index"] == 1
+    assert summary["selected"]["name"] == "backward_0.08"
+    assert summary["best_measured"]["name"] == "forward_0.08"
+    assert summary["regret"] == pytest.approx(0.015573580206596351)
+    assert summary["hit_best"] is False
+    assert "positive measured regret" in summary["worldforge_value"]
+    assert summary["trace"]["source_outcome_kind"] == "real_measured_native_odom_mean"
+    assert result.report_path.read_text(encoding="utf-8") == result.report_markdown
+    assert "not mocap-grade ground truth" in result.report_markdown
+    json.dumps(summary)
+
+
+def test_go2_controlbench_report_lists_selected_and_counterfactual_best(tmp_path: Path) -> None:
+    result = run_go2_controlbench_decisiontrace(DEFAULT_TRACE_PATH, tmp_path)
+    report = render_go2_controlbench_report(result.summary)
+
+    assert "Go2 Air ControlBench DecisionTrace" in report
+    assert "Selected by predicted score: `backward_0.08`" in report
+    assert "Best measured candidate: `forward_0.08`" in report
+    assert "Measured regret" in report
+    assert "What WorldForge Adds" in report
+
+
+def test_go2_controlbench_demo_wrapper_runs_default_fixture() -> None:
+    demo = _load_demo()
+
+    summary = demo.run_demo(emit=False)
+
+    assert summary["demo_kind"] == "go2_controlbench_decisiontrace"
+    assert summary["selected"]["name"] == "backward_0.08"
+    assert summary["best_measured"]["name"] == "forward_0.08"
+
+
+def test_go2_controlbench_provider_rejects_missing_scores() -> None:
+    provider = Go2ControlBenchTraceScoreProvider()
+    trace = load_go2_controlbench_trace(DEFAULT_TRACE_PATH)
+
+    with pytest.raises(WorldForgeError, match="non-empty scores list"):
+        provider.score_actions(info={}, action_candidates=trace["candidate_actions"])
+
+
+def test_go2_controlbench_fixture_rejects_score_order_drift(tmp_path: Path) -> None:
+    trace = load_go2_controlbench_trace(DEFAULT_TRACE_PATH)
+    trace["scores"][0]["candidate_index"] = 1
+    malformed = tmp_path / "bad-trace.json"
+    malformed.write_text(json.dumps(trace), encoding="utf-8")
+
+    with pytest.raises(WorldForgeError, match="candidate_index must match candidate order"):
+        load_go2_controlbench_trace(malformed)
+
+
+def test_go2_controlbench_fixture_rejects_selected_action_drift(tmp_path: Path) -> None:
+    trace = load_go2_controlbench_trace(DEFAULT_TRACE_PATH)
+    trace["selected_action"]["name"] = "forward_0.08"
+    malformed = tmp_path / "bad-selected.json"
+    malformed.write_text(json.dumps(trace), encoding="utf-8")
+
+    with pytest.raises(WorldForgeError, match=r"selected_action\.name does not match"):
+        load_go2_controlbench_trace(malformed)
+
+
+def test_go2_controlbench_examples_index_entry(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(sys, "argv", ["worldforge", "examples", "--format", "json"])
+
+    assert cli_main() == 0
+
+    examples = json.loads(capsys.readouterr().out)
+    controlbench = next(
+        item for item in examples if item["name"] == "go2-controlbench-decisiontrace"
+    )
+    assert controlbench["command"] == "uv run python examples/go2-controlbench-decisiontrace/run.py"
+    assert "measured regret" in controlbench["surface"]


### PR DESCRIPTION
## Summary

Adds a checkout-safe Go2 Air ControlBench DecisionTrace replay example that consumes a compact public `espejelomar/go2-air-controlbench-v1` positive-regret trace, reranks candidate Unitree sport-mode commands through WorldForge's `score` capability, and reports measured native-odom regret against the best counterfactual command.

This is intentionally an example/evidence layer, not a robot runtime integration:

- no DimOS import
- no Unitree SDK import
- no Hugging Face dataset download
- no hardware connection
- no mocap-grade ground-truth claim
- no learned/world-model SOTA claim

## What changed

- Added `src/worldforge/demos/go2_controlbench_decisiontrace.py`.
- Added `examples/go2-controlbench-decisiontrace/run.py` and a compact public trace fixture.
- Added regression coverage for fixture validation, score reranking, measured regret, wrapper import, and examples-index discovery.
- Documented the demo in README, examples docs, examples README, CLI examples, and CHANGELOG.

## Validation

```bash
uv run python examples/go2-controlbench-decisiontrace/run.py --json-only
uv run pytest tests/test_go2_controlbench_decisiontrace_demo.py tests/test_so101_replay_trace_demo.py tests/test_dimos_go2_replay_arena.py -q
uv run pytest tests/test_docs_site.py tests/test_cli_help_snapshots.py -q
uv run python scripts/check_docs_commands.py
uv run python scripts/check_docs_snippets.py
uv run python scripts/check_optional_import_boundaries.py
uv run ruff check src tests examples scripts
uv run ruff format --check src tests examples scripts
```

All passed locally.

## Claim boundary

The bundled trace contains public measured native Go2 odometry means from the ControlBench preview. The demo does not execute hardware and does not claim external ground truth, policy quality, or learned-model performance. Its value is exposing the evidence contract: candidate commands -> predicted scores -> score-selected command -> counterfactual measured outcomes -> regret.
