### PR TITLE
Harden Go2 ControlBench trace validation

### DIFF
--- a/src/worldforge/demos/go2_controlbench_decisiontrace.py
+++ b/src/worldforge/demos/go2_controlbench_decisiontrace.py
@@ -334,6 +334,14 @@ def _validate_trace(payload: object) -> None:
         raise WorldForgeError(
             "Go2 ControlBench trace candidates, scores, and counterfactuals must align."
         )
+    for index, (candidate, counterfactual) in enumerate(
+        zip(candidates, counterfactuals, strict=True)
+    ):
+        if counterfactual["action"] != candidate:
+            raise WorldForgeError(
+                "Go2 ControlBench counterfactual action must match candidate action "
+                f"at index {index}."
+            )
 
     selected = _require_mapping(trace["selected_action"], "selected_action")
     selected_index = _index(selected.get("candidate_index"), name="selected_action.candidate_index")
@@ -386,15 +394,34 @@ def _counterfactual_records(value: object) -> list[JSONDict]:
             ),
             f"counterfactuals[{index}]",
         )
-        _validate_action(record["action"], name=f"counterfactuals[{index}].action")
+        action = _validate_action(record["action"], name=f"counterfactuals[{index}].action")
         _number(record["predicted_error"], name=f"counterfactuals[{index}].predicted_error")
         _number(record["measured_error"], name=f"counterfactuals[{index}].measured_error")
+        predicted = _require_mapping(
+            record["predicted_outcome"],
+            f"counterfactuals[{index}].predicted_outcome",
+        )
+        _number(
+            predicted.get("signed_planar_m"),
+            name=f"counterfactuals[{index}].predicted_outcome.signed_planar_m",
+        )
         measured = _require_mapping(
             record["measured_outcome"],
-            f"counterfactuals[{index}].measured",
+            f"counterfactuals[{index}].measured_outcome",
         )
-        _number(measured.get("signed_planar_m"), name=f"counterfactuals[{index}].signed_planar_m")
-        records.append(dict(record))
+        _number(
+            measured.get("signed_planar_m"),
+            name=f"counterfactuals[{index}].measured_outcome.signed_planar_m",
+        )
+        _index(measured.get("n"), name=f"counterfactuals[{index}].measured_outcome.n")
+        records.append(
+            {
+                **dict(record),
+                "action": action,
+                "predicted_outcome": dict(predicted),
+                "measured_outcome": dict(measured),
+            }
+        )
     return records
 
 

--- a/src/worldforge/demos/go2_controlbench_decisiontrace.py
+++ b/src/worldforge/demos/go2_controlbench_decisiontrace.py
@@ -23,7 +23,12 @@ from typing import Any
 
 from worldforge import ActionScoreResult, WorldForge
 from worldforge.artifact_io import write_json_artifact
-from worldforge.models import JSONDict, WorldForgeError, require_finite_number
+from worldforge.models import (
+    JSONDict,
+    WorldForgeError,
+    require_finite_number,
+    require_positive_int,
+)
 from worldforge.providers.base import ProviderProfileSpec
 
 _REPO_FIXTURE_RELATIVE_PATH = (
@@ -36,6 +41,7 @@ DEFAULT_TRACE_PATH = (
 )
 
 GO2_CONTROLBENCH_SCORE_PROVIDER = "go2-controlbench-deadband-affine-score"
+GO2_CONTROLBENCH_OUTCOME_KIND = "real_measured_native_odom_mean"
 GO2_CONTROLBENCH_DATASET_REFERENCE: JSONDict = {
     "repo_id": "espejelomar/go2-air-controlbench-v1",
     "config": "inverse_command_benchmark",
@@ -362,9 +368,9 @@ def _validate_trace(payload: object) -> None:
         trace["measured_or_analytic_outcome"],
         "measured_or_analytic_outcome",
     )
-    if measured.get("outcome_kind") != "real_measured_native_odom_mean":
+    if measured.get("outcome_kind") != GO2_CONTROLBENCH_OUTCOME_KIND:
         raise WorldForgeError(
-            "Go2 ControlBench measured outcome must be real_measured_native_odom_mean."
+            f"Go2 ControlBench measured outcome must be {GO2_CONTROLBENCH_OUTCOME_KIND}."
         )
     _number(measured.get("signed_planar_m"), name="measured_or_analytic_outcome.signed_planar_m")
 
@@ -413,7 +419,15 @@ def _counterfactual_records(value: object) -> list[JSONDict]:
             measured.get("signed_planar_m"),
             name=f"counterfactuals[{index}].measured_outcome.signed_planar_m",
         )
-        _index(measured.get("n"), name=f"counterfactuals[{index}].measured_outcome.n")
+        require_positive_int(
+            measured.get("n"),
+            name=f"Go2 ControlBench counterfactuals[{index}].measured_outcome.n",
+        )
+        if measured.get("outcome_kind") != GO2_CONTROLBENCH_OUTCOME_KIND:
+            raise WorldForgeError(
+                "Go2 ControlBench counterfactual "
+                f"measured_outcome.outcome_kind must be {GO2_CONTROLBENCH_OUTCOME_KIND}."
+            )
         records.append(
             {
                 **dict(record),

--- a/src/worldforge/demos/go2_controlbench_decisiontrace.py
+++ b/src/worldforge/demos/go2_controlbench_decisiontrace.py
@@ -343,7 +343,7 @@ def _validate_trace(payload: object) -> None:
     for index, (candidate, counterfactual) in enumerate(
         zip(candidates, counterfactuals, strict=True)
     ):
-        if counterfactual["action"] != candidate:
+        if not _actions_equivalent(counterfactual["action"], candidate):
             raise WorldForgeError(
                 "Go2 ControlBench counterfactual action must match candidate action "
                 f"at index {index}."
@@ -419,9 +419,9 @@ def _counterfactual_records(value: object) -> list[JSONDict]:
             measured.get("signed_planar_m"),
             name=f"counterfactuals[{index}].measured_outcome.signed_planar_m",
         )
-        require_positive_int(
+        _positive_int(
             measured.get("n"),
-            name=f"Go2 ControlBench counterfactuals[{index}].measured_outcome.n",
+            name=f"counterfactuals[{index}].measured_outcome.n",
         )
         if measured.get("outcome_kind") != GO2_CONTROLBENCH_OUTCOME_KIND:
             raise WorldForgeError(
@@ -491,6 +491,24 @@ def _validate_action(value: object, *, name: str) -> JSONDict:
     }
 
 
+def _actions_equivalent(left: JSONDict, right: JSONDict) -> bool:
+    if left["type"] != right["type"]:
+        return False
+    if left["units"] != right["units"]:
+        return False
+    left_params = _require_mapping(left["params"], "left_action.params")
+    right_params = _require_mapping(right["params"], "right_action.params")
+    for field_name in ("x", "y", "z", "duration_s"):
+        left_value = _number(left_params.get(field_name), name=f"left_action.params.{field_name}")
+        right_value = _number(
+            right_params.get(field_name),
+            name=f"right_action.params.{field_name}",
+        )
+        if not math.isclose(left_value, right_value, rel_tol=1e-9, abs_tol=1e-9):
+            return False
+    return True
+
+
 def _command_name(action: JSONDict) -> str:
     params = _require_mapping(action["params"], "action.params")
     x = float(params["x"])
@@ -532,6 +550,10 @@ def _index(value: object, *, name: str) -> int:
 
 def _number(value: object, *, name: str) -> float:
     return require_finite_number(value, name=f"Go2 ControlBench {name}")
+
+
+def _positive_int(value: object, *, name: str) -> int:
+    return require_positive_int(value, name=f"Go2 ControlBench {name}")
 
 
 def _print_summary(summary: JSONDict) -> None:

--- a/tests/test_go2_controlbench_decisiontrace_demo.py
+++ b/tests/test_go2_controlbench_decisiontrace_demo.py
@@ -165,6 +165,33 @@ def test_go2_controlbench_fixture_rejects_selected_action_drift(tmp_path: Path) 
         load_go2_controlbench_trace(malformed)
 
 
+def test_go2_controlbench_fixture_rejects_incomplete_counterfactual_outcome(
+    tmp_path: Path,
+) -> None:
+    trace = load_go2_controlbench_trace(DEFAULT_TRACE_PATH)
+    del trace["counterfactuals"][0]["measured_outcome"]["n"]
+    malformed = tmp_path / "bad-counterfactual-outcome.json"
+    malformed.write_text(json.dumps(trace), encoding="utf-8")
+
+    with pytest.raises(WorldForgeError, match=r"counterfactuals\[0\].measured_outcome.n"):
+        load_go2_controlbench_trace(malformed)
+
+
+def test_go2_controlbench_fixture_rejects_counterfactual_action_drift(
+    tmp_path: Path,
+) -> None:
+    trace = load_go2_controlbench_trace(DEFAULT_TRACE_PATH)
+    trace["counterfactuals"][0], trace["counterfactuals"][1] = (
+        trace["counterfactuals"][1],
+        trace["counterfactuals"][0],
+    )
+    malformed = tmp_path / "bad-counterfactual-order.json"
+    malformed.write_text(json.dumps(trace), encoding="utf-8")
+
+    with pytest.raises(WorldForgeError, match="counterfactual action must match candidate action"):
+        load_go2_controlbench_trace(malformed)
+
+
 def test_go2_controlbench_examples_index_entry(
     capsys: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_go2_controlbench_decisiontrace_demo.py
+++ b/tests/test_go2_controlbench_decisiontrace_demo.py
@@ -187,8 +187,32 @@ def test_go2_controlbench_fixture_rejects_incomplete_predicted_outcome(
 
     with pytest.raises(
         WorldForgeError,
-        match=r"counterfactuals\[0\].predicted_outcome.signed_planar_m",
+        match=r"counterfactuals\[0\]\.predicted_outcome\.signed_planar_m",
     ):
+        load_go2_controlbench_trace(malformed)
+
+
+def test_go2_controlbench_fixture_rejects_zero_sample_counterfactual_outcome(
+    tmp_path: Path,
+) -> None:
+    trace = load_go2_controlbench_trace(DEFAULT_TRACE_PATH)
+    trace["counterfactuals"][0]["measured_outcome"]["n"] = 0
+    malformed = tmp_path / "bad-counterfactual-zero-samples.json"
+    malformed.write_text(json.dumps(trace), encoding="utf-8")
+
+    with pytest.raises(WorldForgeError, match=r"counterfactuals\[0\]\.measured_outcome\.n"):
+        load_go2_controlbench_trace(malformed)
+
+
+def test_go2_controlbench_fixture_rejects_counterfactual_outcome_kind_drift(
+    tmp_path: Path,
+) -> None:
+    trace = load_go2_controlbench_trace(DEFAULT_TRACE_PATH)
+    trace["counterfactuals"][0]["measured_outcome"]["outcome_kind"] = "analytic"
+    malformed = tmp_path / "bad-counterfactual-outcome-kind.json"
+    malformed.write_text(json.dumps(trace), encoding="utf-8")
+
+    with pytest.raises(WorldForgeError, match=r"measured_outcome\.outcome_kind"):
         load_go2_controlbench_trace(malformed)
 
 

--- a/tests/test_go2_controlbench_decisiontrace_demo.py
+++ b/tests/test_go2_controlbench_decisiontrace_demo.py
@@ -81,6 +81,41 @@ def test_go2_controlbench_demo_reranks_and_reports_measured_regret(tmp_path: Pat
     json.dumps(summary)
 
 
+def test_go2_controlbench_demo_uses_deterministic_tie_break(tmp_path: Path) -> None:
+    trace = load_go2_controlbench_trace(DEFAULT_TRACE_PATH)
+    tied_score = trace["scores"][1]["value"]
+    trace["scores"][0]["value"] = tied_score
+    trace["selected_action"] = {
+        "candidate_index": 0,
+        "name": "backward_0.05",
+        "selection_rule": "minimize predicted absolute error to target",
+    }
+
+    selected_error = trace["counterfactuals"][0]["measured_error"]
+    best_error = min(
+        counterfactual["measured_error"] for counterfactual in trace["counterfactuals"]
+    )
+    trace["regret"] = {
+        "unit": "m",
+        "selected_true_error": selected_error,
+        "best_true_error": best_error,
+        "regret": selected_error - best_error,
+        "hit_best": False,
+    }
+    trace_path = tmp_path / "equal-score-trace.json"
+    trace_path.write_text(json.dumps(trace), encoding="utf-8")
+
+    # A DEFAULT_TRACE_PATH mutation exercised through run_go2_controlbench_decisiontrace
+    # should keep GO2_CONTROLBENCH_SCORE_PROVIDER ties stable by candidate order.
+    result = run_go2_controlbench_decisiontrace(trace_path, tmp_path / "out")
+    summary = result.summary
+
+    assert summary["score_provider"] == GO2_CONTROLBENCH_SCORE_PROVIDER
+    assert summary["score_result"]["best_index"] == 0
+    assert summary["selected"]["name"] == "backward_0.05"
+    assert [row["candidate_index"] for row in summary["ranked_candidates"][:2]] == [0, 1]
+
+
 def test_go2_controlbench_report_lists_selected_and_counterfactual_best(tmp_path: Path) -> None:
     result = run_go2_controlbench_decisiontrace(DEFAULT_TRACE_PATH, tmp_path)
     report = render_go2_controlbench_report(result.summary)

--- a/tests/test_go2_controlbench_decisiontrace_demo.py
+++ b/tests/test_go2_controlbench_decisiontrace_demo.py
@@ -177,6 +177,21 @@ def test_go2_controlbench_fixture_rejects_incomplete_counterfactual_outcome(
         load_go2_controlbench_trace(malformed)
 
 
+def test_go2_controlbench_fixture_rejects_incomplete_predicted_outcome(
+    tmp_path: Path,
+) -> None:
+    trace = load_go2_controlbench_trace(DEFAULT_TRACE_PATH)
+    del trace["counterfactuals"][0]["predicted_outcome"]["signed_planar_m"]
+    malformed = tmp_path / "bad-counterfactual-predicted-outcome.json"
+    malformed.write_text(json.dumps(trace), encoding="utf-8")
+
+    with pytest.raises(
+        WorldForgeError,
+        match=r"counterfactuals\[0\].predicted_outcome.signed_planar_m",
+    ):
+        load_go2_controlbench_trace(malformed)
+
+
 def test_go2_controlbench_fixture_rejects_counterfactual_action_drift(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_go2_controlbench_decisiontrace_demo.py
+++ b/tests/test_go2_controlbench_decisiontrace_demo.py
@@ -216,6 +216,19 @@ def test_go2_controlbench_fixture_rejects_counterfactual_outcome_kind_drift(
         load_go2_controlbench_trace(malformed)
 
 
+def test_go2_controlbench_fixture_accepts_counterfactual_action_float_drift(
+    tmp_path: Path,
+) -> None:
+    trace = load_go2_controlbench_trace(DEFAULT_TRACE_PATH)
+    trace["counterfactuals"][0]["action"]["params"]["x"] += 1e-12
+    drifted = tmp_path / "counterfactual-action-float-drift.json"
+    drifted.write_text(json.dumps(trace), encoding="utf-8")
+
+    loaded = load_go2_controlbench_trace(drifted)
+
+    assert loaded["trace_id"] == trace["trace_id"]
+
+
 def test_go2_controlbench_fixture_rejects_counterfactual_action_drift(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Purpose

Follow-up to #338. The original Go2 ControlBench demo merged before the fork-review fixes landed, so this PR carries the Qodo/CodeRabbit hardening on top of current `main`.

## Summary

- Add deterministic equal-score tie-break coverage for the Go2 ControlBench score provider.
- Validate counterfactual predicted/measured outcome schema before report generation.
- Enforce counterfactual action alignment with candidate actions.
- Require positive measured sample counts and matching outcome provenance.

## Boundary

Still checkout-safe: no DimOS, Unitree SDK, Hugging Face download, robot hardware, or optional robotics runtime dependency. The local fixture read remains intentional for this example path.

## Validation

- `uv run pytest tests/test_go2_controlbench_decisiontrace_demo.py tests/test_so101_replay_trace_demo.py tests/test_dimos_go2_replay_arena.py -q` -> `41 passed`
- `uv run ruff check src/worldforge/demos/go2_controlbench_decisiontrace.py tests/test_go2_controlbench_decisiontrace_demo.py` -> passed
- `uv run ruff format --check src/worldforge/demos/go2_controlbench_decisiontrace.py tests/test_go2_controlbench_decisiontrace_demo.py` -> passed
- `uv run python examples/go2-controlbench-decisiontrace/run.py --json-only` -> selected `backward_0.08`, best measured `forward_0.08`, regret `0.015573580206596351`

Fork review mirror: omarespejel/worldforge#55.
